### PR TITLE
doc: update image source in README.md for nuget.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Testably.Abstractions](/Docs/Images/social-preview.png)
+![Testably.Abstractions](https://raw.githubusercontent.com/Testably/Testably.Abstractions/main/Docs/Images/social-preview.png)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_Testably.Abstractions&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Testably_Testably.Abstractions)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=Testably_Testably.Abstractions&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=Testably_Testably.Abstractions)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Testably_Testably.Abstractions&metric=coverage)](https://sonarcloud.io/summary/new_code?id=Testably_Testably.Abstractions)


### PR DESCRIPTION
The images in the `README.md` have to come from trusted sources to be displayed correctly on nuget.org.
According to [this linked resource](https://learn.microsoft.com/en-us/nuget/nuget-org/package-readme-on-nuget-org#allowed-domains-for-images-and-badges), one of the sources is `raw.githubusercontent.com`, so changing the image url in the README.md should display without warning on the packages on nuget.org, e.g. [Testably.Abstractions](https://www.nuget.org/packages/Testably.Abstractions/).