### PR TITLE
feat: Add symbols snupgk packages

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -24,8 +24,8 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-	<IncludeSymbols>true</IncludeSymbols>
-	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <NoWarn>1701;1702</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -24,6 +24,8 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+	<IncludeSymbols>true</IncludeSymbols>
+	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <NoWarn>1701;1702</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
Automatically create [`snupkg` symbol packages](https://github.com/NuGet/docs.microsoft.com-nuget/blob/main/docs/create-packages/Symbol-Packages-snupkg.md) to be pushed alongside the normal nuget packages.