### PR TITLE
feat: implement missing methods on `DirectoryMock`

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryMock.cs
@@ -450,7 +450,7 @@ public sealed partial class FileSystemMock
 
             IFileSystem.IDirectoryInfo? directory =
                 _fileSystem.Storage.GetOrAddDirectory(path);
-            return directory ?? throw new NotImplementedException();
+            return directory ?? throw new NotSupportedException("Internal error: directory could not be created!");
         }
 
         private static Func<Exception> DirectoryNotFoundException(string path)

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryMock.cs
@@ -305,7 +305,7 @@ public sealed partial class FileSystemMock
 
         /// <inheritdoc cref="IFileSystem.IDirectory.GetParent(string)" />
         public IFileSystem.IDirectoryInfo? GetParent(string path)
-            => throw new NotImplementedException();
+            => _fileSystem.DirectoryInfo.New(path).Parent;
 
         /// <inheritdoc cref="IFileSystem.IDirectory.Move(string, string)" />
         public void Move(string sourceDirName, string destDirName)

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryMock.cs
@@ -301,7 +301,7 @@ public sealed partial class FileSystemMock
 
         /// <inheritdoc cref="IFileSystem.IDirectory.GetLogicalDrives()" />
         public string[] GetLogicalDrives()
-            => throw new NotImplementedException();
+            => _fileSystem.DriveInfo.GetDrives().Select(x => x.Name).ToArray();
 
         /// <inheritdoc cref="IFileSystem.IDirectory.GetParent(string)" />
         public IFileSystem.IDirectoryInfo? GetParent(string path)

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileInfoMock.cs
@@ -25,8 +25,6 @@ public sealed partial class FileSystemMock
         {
         }
 
-        #region IWritableFileInfo Members
-
         /// <inheritdoc cref="IFileSystem.IFileInfo.Directory" />
         public IFileSystem.IDirectoryInfo? Directory
             => DirectoryInfoMock.New(DirectoryName, FileSystem);
@@ -148,8 +146,6 @@ public sealed partial class FileSystemMock
             Drive?.ChangeUsedBytes(0 - _bytes.Length);
             _bytes = Array.Empty<byte>();
         }
-
-        #endregion
 
         [return: NotNullIfNotNull("path")]
         internal static FileInfoMock? New(string? path, FileSystemMock fileSystem)

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.cs
@@ -21,4 +21,14 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
     }
 
     #endregion
+
+    [Fact]
+    [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.GetLogicalDrives))]
+    public void GetLogicalDrives_ShouldNotBeEmpty()
+    {
+        string[] result = FileSystem.Directory.GetLogicalDrives();
+
+        result.Should().NotBeEmpty();
+        result.Should().Contain("".PrefixRoot());
+    }
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.cs
@@ -31,4 +31,21 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
         result.Should().NotBeEmpty();
         result.Should().Contain("".PrefixRoot());
     }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.GetParent))]
+    public void GetParent_ArbitraryPaths_ShouldNotBeNull(string path1,
+                                                         string path2,
+                                                         string path3)
+    {
+        string path = FileSystem.Path.Combine(path1, path2, path3);
+        IFileSystem.IDirectoryInfo expectedParent = FileSystem.DirectoryInfo.New(
+            FileSystem.Path.Combine(path1, path2));
+
+        IFileSystem.IDirectoryInfo? result = FileSystem.Directory.GetParent(path);
+
+        result.Should().NotBeNull();
+        result!.FullName.Should().Be(expectedParent.FullName);
+    }
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystemDriveInfoFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDriveInfoFactoryTests.cs
@@ -159,6 +159,6 @@ public abstract class FileSystemDriveInfoFactoryTests<TFileSystem>
             }
         }
 
-        return driveInfo ?? throw new NotImplementedException("No unmapped drive found!");
+        return driveInfo ?? throw new NotSupportedException("No unmapped drive found!");
     }
 }


### PR DESCRIPTION
Implement the following methods in the DirectoryMock:
- `GetLogicalDrives()`
- `GetParent()`