### PR TITLE
feat: implement Get/Set Attributes on `FileSystemInfo`

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileInfoMock.cs
@@ -27,14 +27,26 @@ public sealed partial class FileSystemMock
 
         /// <inheritdoc cref="IFileSystem.IFileInfo.Directory" />
         public IFileSystem.IDirectoryInfo? Directory
-            => DirectoryInfoMock.New(DirectoryName, FileSystem);
+            => DirectoryInfoMock.New(
+                FileSystem.Path.GetDirectoryName(OriginalPath),
+                FileSystem);
 
         /// <inheritdoc cref="IFileSystem.IFileInfo.DirectoryName" />
         public string? DirectoryName
-            => FileSystem.Path.GetDirectoryName(OriginalPath);
+            => Directory?.FullName;
 
         /// <inheritdoc cref="IFileSystem.IFileInfo.IsReadOnly" />
-        public bool IsReadOnly { get; set; }
+        public bool IsReadOnly
+        {
+            get => (Attributes & FileAttributes.ReadOnly) != 0;
+            set
+            {
+                if (value)
+                    Attributes |= FileAttributes.ReadOnly;
+                else
+                    Attributes &= ~FileAttributes.ReadOnly;
+            }
+        }
 
         /// <inheritdoc cref="IFileSystem.IFileInfo.Length" />
         public long Length

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileInfoMock.cs
@@ -89,6 +89,7 @@ public sealed partial class FileSystemMock
         {
             using (RequestAccess(FileAccess.Write, FileShare.Read))
             {
+                IsEncrypted = false;
                 WriteBytes(EncryptionHelper.Decrypt(GetBytes()));
             }
         }
@@ -101,6 +102,7 @@ public sealed partial class FileSystemMock
         {
             using (RequestAccess(FileAccess.Write, FileShare.Read))
             {
+                IsEncrypted = true;
                 WriteBytes(EncryptionHelper.Encrypt(GetBytes()));
             }
         }

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileMock.cs
@@ -176,7 +176,6 @@ public sealed partial class FileSystemMock
             if (fileInfo != null &&
                 fileInfo.Attributes.HasFlag(FileAttributes.Encrypted))
             {
-                fileInfo.Attributes &= ~FileAttributes.Encrypted;
                 fileInfo.Decrypt();
             }
         }
@@ -202,7 +201,6 @@ public sealed partial class FileSystemMock
             if (fileInfo != null &&
                 !fileInfo.Attributes.HasFlag(FileAttributes.Encrypted))
             {
-                fileInfo.Attributes |= FileAttributes.Encrypted;
                 fileInfo.Encrypt();
             }
         }

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileStreamMock.cs
@@ -49,7 +49,10 @@ public sealed partial class FileSystemMock
                                FileShare share,
                                int bufferSize,
                                FileOptions options)
-            : base(stream, path, (options & FileOptions.Asynchronous) != 0)
+            : base(
+                stream,
+                path == null ? null : fileSystem.Path.GetFullPath(path),
+                (options & FileOptions.Asynchronous) != 0)
         {
             ThrowIfInvalidModeAccess(mode, access);
 
@@ -108,6 +111,16 @@ public sealed partial class FileSystemMock
         {
             //TimeAdjustments.LastAccessTime
             return base.Read(buffer, offset, count);
+        }
+
+        /// <inheritdoc />
+        public override void SetLength(long value)
+        {
+            if (!_access.HasFlag(FileAccess.Write))
+            {
+                throw ExceptionFactory.StreamDoesNotSupportWriting();
+            }
+            base.SetLength(value);
         }
 
         /// <inheritdoc cref="FileSystemStream.Write(byte[], int, int)" />

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileSystemInfoMock.cs
@@ -98,6 +98,12 @@ public sealed partial class FileSystemMock
                              FileAttributes.System |
                              FileAttributes.Temporary;
                 }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    value &= FileAttributes.Hidden |
+                             FileAttributes.Directory |
+                             FileAttributes.ReadOnly;
+                }
                 else
                 {
                     value &= FileAttributes.Directory |

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileSystemInfoMock.cs
@@ -53,7 +53,40 @@ public sealed partial class FileSystemMock
         #region IFileSystemInfo Members
 
         /// <inheritdoc cref="IFileSystem.IFileSystemInfo.Attributes" />
-        public FileAttributes Attributes { get; set; }
+        public FileAttributes Attributes
+        {
+            get
+            {
+                FileAttributes attributes = _attributes;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
+                    System.IO.Path.GetFileName(FullName).StartsWith("."))
+                {
+                    attributes |= FileAttributes.Hidden;
+                }
+
+                if (attributes == 0)
+                {
+                    attributes = FileAttributes.Normal;
+                }
+
+                return attributes;
+            }
+            set
+            {
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    value &= FileAttributes.Directory |
+                             FileAttributes.Hidden |
+                             FileAttributes.Normal |
+                             FileAttributes.ReadOnly |
+                             FileAttributes.ReparsePoint;
+                }
+
+                _attributes = value;
+            }
+        }
+
+        private FileAttributes _attributes;
 
         /// <inheritdoc cref="IFileSystem.IFileSystemInfo.CreationTime" />
         public DateTime CreationTime

--- a/Source/Testably.Abstractions.Testing/Internal/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/ExceptionFactory.cs
@@ -81,6 +81,9 @@ internal static class ExceptionFactory
         => new(
             $"The process cannot access the file '{path}' because it is being used by another process.");
 
+    public static NotSupportedException StreamDoesNotSupportWriting()
+        => new("Stream does not support writing.");
+
     internal static ArgumentOutOfRangeException TaskDelayOutOfRange(string paramName)
         => new(paramName,
             "The value needs to be either -1 (signifying an infinite timeout), 0 or a positive integer.");

--- a/Source/Testably.Abstractions/FileSystem.FileSystemInfoWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem.FileSystemInfoWrapper.cs
@@ -20,7 +20,11 @@ public sealed partial class FileSystem
         #region IFileSystemInfo Members
 
         /// <inheritdoc cref="IFileSystem.IFileSystemInfo.Attributes" />
-        public FileAttributes Attributes { get; set; }
+        public FileAttributes Attributes
+        {
+            get => _instance.Attributes;
+            set => _instance.Attributes = value;
+        }
 
         /// <inheritdoc cref="IFileSystem.IFileSystemInfo.CreationTime" />
         public DateTime CreationTime

--- a/Tests/Testably.Abstractions.Tests/FileSystemDriveInfoFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDriveInfoFactoryTests.cs
@@ -23,6 +23,21 @@ public abstract class FileSystemDriveInfoFactoryTests<TFileSystem>
     #endregion
 
     [Fact]
+    [FileSystemTests.DriveInfoFactory(nameof(IFileSystem.IDriveInfoFactory.New))]
+    public void New_DefaultDrive_ShouldBeFixed()
+    {
+        IFileSystem.IDriveInfo result = FileSystem.DriveInfo.New("".PrefixRoot());
+
+        result.AvailableFreeSpace.Should().BeGreaterThan(0);
+        result.DriveFormat.Should().NotBeNull();
+        result.DriveType.Should().Be(DriveType.Fixed);
+        result.IsReady.Should().BeTrue();
+        result.RootDirectory.FullName.Should().Be("".PrefixRoot());
+        result.TotalFreeSpace.Should().BeGreaterThan(0);
+        result.TotalSize.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
     [FileSystemTests.DriveInfoFactory(nameof(IFileSystem.IDriveInfoFactory.GetDrives))]
     public void GetDrives_ShouldNotBeEmpty()
     {
@@ -132,8 +147,9 @@ public abstract class FileSystemDriveInfoFactoryTests<TFileSystem>
         IFileSystem.IDriveInfo driveInfo = GetUnmappedDrive();
 
         path = $"{driveInfo.Name}{path}";
-        IFileSystem.IDirectoryInfo directoryInfo = FileSystem.DirectoryInfo.New(FileSystem.Path.Combine(path, subPath));
-        var parent = directoryInfo.Parent;
+        IFileSystem.IDirectoryInfo directoryInfo =
+            FileSystem.DirectoryInfo.New(FileSystem.Path.Combine(path, subPath));
+        IFileSystem.IDirectoryInfo? parent = directoryInfo.Parent;
 
         Exception? exception = Record.Exception(() =>
         {

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileInfoTests.cs
@@ -56,19 +56,12 @@ public abstract partial class FileSystemFileInfoTests<TFileSystem>
     {
         FileSystem.File.WriteAllText(path, null);
         IFileSystem.IFileInfo fileInfo = FileSystem.FileInfo.New(path);
-        fileInfo.Attributes = FileAttributes.ReadOnly | FileAttributes.Hidden;
+        fileInfo.Attributes = FileAttributes.ReadOnly;
 
         fileInfo.IsReadOnly = false;
 
         fileInfo.IsReadOnly.Should().BeFalse();
-        if (Test.RunsOnLinux)
-        {
-            fileInfo.Attributes.Should().Be(FileAttributes.Normal);
-        }
-        else
-        {
-            fileInfo.Attributes.Should().Be(FileAttributes.Hidden);
-        }
+        fileInfo.Attributes.Should().Be(FileAttributes.Normal);
     }
 
     [Theory]

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileInfoTests.cs
@@ -61,13 +61,13 @@ public abstract partial class FileSystemFileInfoTests<TFileSystem>
         fileInfo.IsReadOnly = false;
 
         fileInfo.IsReadOnly.Should().BeFalse();
-        if (Test.RunsOnWindows)
+        if (Test.RunsOnLinux)
         {
-            fileInfo.Attributes.Should().Be(FileAttributes.Hidden);
+            fileInfo.Attributes.Should().Be(FileAttributes.Normal);
         }
         else
         {
-            fileInfo.Attributes.Should().Be(FileAttributes.Normal);
+            fileInfo.Attributes.Should().Be(FileAttributes.Hidden);
         }
     }
 

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileInfoTests.cs
@@ -56,12 +56,19 @@ public abstract partial class FileSystemFileInfoTests<TFileSystem>
     {
         FileSystem.File.WriteAllText(path, null);
         IFileSystem.IFileInfo fileInfo = FileSystem.FileInfo.New(path);
-        fileInfo.Attributes = FileAttributes.ReadOnly | FileAttributes.Encrypted;
+        fileInfo.Attributes = FileAttributes.ReadOnly | FileAttributes.Hidden;
 
         fileInfo.IsReadOnly = false;
 
         fileInfo.IsReadOnly.Should().BeFalse();
-        fileInfo.Attributes.Should().Be(FileAttributes.Encrypted);
+        if (Test.RunsOnWindows)
+        {
+            fileInfo.Attributes.Should().Be(FileAttributes.Hidden);
+        }
+        else
+        {
+            fileInfo.Attributes.Should().Be(FileAttributes.Normal);
+        }
     }
 
     [Theory]

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileInfoTests.cs
@@ -1,8 +1,12 @@
+using System.IO;
+
 namespace Testably.Abstractions.Tests;
 
 public abstract partial class FileSystemFileInfoTests<TFileSystem>
     where TFileSystem : IFileSystem
 {
+    #region Test Setup
+
     public abstract string BasePath { get; }
     public TFileSystem FileSystem { get; }
     public ITimeSystem TimeSystem { get; }
@@ -13,5 +17,90 @@ public abstract partial class FileSystemFileInfoTests<TFileSystem>
     {
         FileSystem = fileSystem;
         TimeSystem = timeSystem;
+    }
+
+    #endregion
+
+    [Fact]
+    [FileSystemTests.FileInfo]
+    public void Directory_ShouldReturnParentDirectory()
+    {
+        FileSystemInitializer.IFileSystemDirectoryInitializer<TFileSystem> initialized =
+            FileSystem.Initialize()
+               .WithASubdirectory().Initialized(s => s
+                   .WithAFile());
+        IFileSystem.IFileInfo? file = initialized[1] as IFileSystem.IFileInfo;
+
+        file?.Directory.Should().NotBeNull();
+        file!.Directory!.FullName.Should().Be(initialized[0].FullName);
+    }
+
+    [Fact]
+    [FileSystemTests.FileInfo]
+    public void DirectoryName_ShouldReturnNameOfParentDirectory()
+    {
+        FileSystemInitializer.IFileSystemDirectoryInitializer<TFileSystem> initialized =
+            FileSystem.Initialize()
+               .WithASubdirectory().Initialized(s => s
+                   .WithAFile());
+        IFileSystem.IFileInfo? file = initialized[1] as IFileSystem.IFileInfo;
+
+        file?.Should().NotBeNull();
+        file!.DirectoryName.Should().Be(initialized[0].FullName);
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileInfo]
+    public void IsReadOnly_SetToFalse_ShouldRemoveReadOnlyAttribute(string path)
+    {
+        FileSystem.File.WriteAllText(path, null);
+        IFileSystem.IFileInfo fileInfo = FileSystem.FileInfo.New(path);
+        fileInfo.Attributes = FileAttributes.ReadOnly | FileAttributes.Encrypted;
+
+        fileInfo.IsReadOnly = false;
+
+        fileInfo.IsReadOnly.Should().BeFalse();
+        fileInfo.Attributes.Should().Be(FileAttributes.Encrypted);
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileInfo]
+    public void IsReadOnly_SetToTrue_ShouldAddReadOnlyAttribute(string path)
+    {
+        FileSystem.File.WriteAllText(path, null);
+        IFileSystem.IFileInfo fileInfo = FileSystem.FileInfo.New(path);
+
+        fileInfo.IsReadOnly = true;
+
+        fileInfo.IsReadOnly.Should().BeTrue();
+        fileInfo.Attributes.HasFlag(FileAttributes.ReadOnly).Should().BeTrue();
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileInfo]
+    public void IsReadOnly_ShouldChangeWhenSettingReadOnlyAttribute(string path)
+    {
+        FileSystem.File.WriteAllText(path, null);
+        IFileSystem.IFileInfo fileInfo = FileSystem.FileInfo.New(path);
+
+        fileInfo.Attributes = FileAttributes.ReadOnly | FileAttributes.Encrypted;
+
+        fileInfo.IsReadOnly.Should().BeTrue();
+        fileInfo.Attributes.HasFlag(FileAttributes.ReadOnly).Should().BeTrue();
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileInfo]
+    public void IsReadOnly_ShouldInitializeToReadOnlyAttribute(string path)
+    {
+        FileSystem.File.WriteAllText(path, null);
+        IFileSystem.IFileInfo fileInfo = FileSystem.FileInfo.New(path);
+
+        fileInfo.IsReadOnly.Should().BeFalse();
+        fileInfo.Attributes.HasFlag(FileAttributes.ReadOnly).Should().BeFalse();
     }
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileStreamTests.FileAccess.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileStreamTests.FileAccess.cs
@@ -1,0 +1,245 @@
+using System.Collections.Concurrent;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Testably.Abstractions.Tests;
+
+public abstract partial class FileSystemFileStreamTests<TFileSystem>
+    where TFileSystem : IFileSystem
+{
+    [Theory]
+    [InlineAutoData(FileAccess.Read, FileShare.Read,
+        FileAccess.ReadWrite, FileShare.Read)]
+    [InlineAutoData(FileAccess.ReadWrite, FileShare.Read,
+        FileAccess.Read, FileShare.Read)]
+    [InlineAutoData(FileAccess.ReadWrite, FileShare.ReadWrite,
+        FileAccess.ReadWrite, FileShare.Read)]
+    [InlineAutoData(FileAccess.ReadWrite, FileShare.ReadWrite,
+        FileAccess.ReadWrite, FileShare.Write)]
+    [InlineAutoData(FileAccess.Read, FileShare.Read,
+        FileAccess.ReadWrite, FileShare.ReadWrite)]
+    [FileSystemTests.FileStream(nameof(FileAccess))]
+    public void FileAccess_ConcurrentAccessWithInvalidScenarios_ShouldThrowIOException(
+        FileAccess access1, FileShare share1,
+        FileAccess access2, FileShare share2,
+        string path, string contents)
+    {
+        FileSystem.File.WriteAllText(path, contents);
+
+        Exception? exception = Record.Exception(() =>
+        {
+            _ = FileSystem.FileStream.New(path, FileMode.Open,
+                access1, share1);
+            _ = FileSystem.FileStream.New(path, FileMode.Open,
+                access2, share2);
+        });
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            exception.Should().BeOfType<IOException>(
+                    $"Access {access1}, Share {share1} of file 1 is incompatible with Access {access2}, Share {share2} of file 2")
+               .Which.Message.Should().Contain($"'{FileSystem.Path.GetFullPath(path)}'");
+        }
+        else
+        {
+            exception.Should().BeNull();
+        }
+    }
+
+    [Theory]
+    [InlineAutoData(FileAccess.Read, FileShare.Read, FileAccess.Read, FileShare.Read)]
+    [InlineAutoData(FileAccess.Read, FileShare.ReadWrite, FileAccess.ReadWrite,
+        FileShare.Read)]
+    [FileSystemTests.FileStream(nameof(FileAccess))]
+    public void FileAccess_ConcurrentReadAccessWithValidScenarios_ShouldNotThrowException(
+        FileAccess access1, FileShare share1,
+        FileAccess access2, FileShare share2,
+        string path, string contents)
+    {
+        FileSystem.File.WriteAllText(path, contents);
+
+        FileSystemStream stream1 = FileSystem.FileStream.New(path, FileMode.Open,
+            access1, share1);
+        FileSystemStream stream2 = FileSystem.FileStream.New(path, FileMode.Open,
+            access2, share2);
+
+        using StreamReader sr1 = new(stream1, Encoding.UTF8);
+        using StreamReader sr2 = new(stream2, Encoding.UTF8);
+        string result1 = sr1.ReadToEnd();
+        string result2 = sr2.ReadToEnd();
+
+        result1.Should().Be(contents);
+        result2.Should().Be(contents);
+    }
+
+    [Theory]
+    [InlineAutoData(FileAccess.Write, FileShare.Write, FileAccess.Write, FileShare.Write)]
+    [InlineAutoData(FileAccess.ReadWrite, FileShare.ReadWrite, FileAccess.ReadWrite,
+        FileShare.ReadWrite)]
+    [FileSystemTests.FileStream(nameof(FileAccess))]
+    public void
+        FileAccess_ConcurrentWriteAccessWithValidScenarios_ShouldNotThrowException(
+            FileAccess access1, FileShare share1,
+            FileAccess access2, FileShare share2,
+            string path, string contents1, string contents2)
+    {
+        FileSystem.File.WriteAllText(path, null);
+
+        FileSystemStream stream1 = FileSystem.FileStream.New(path, FileMode.Open,
+            access1, share1);
+        FileSystemStream stream2 = FileSystem.FileStream.New(path, FileMode.Open,
+            access2, share2);
+
+        byte[] bytes1 = Encoding.UTF8.GetBytes(contents1);
+        stream1.Write(bytes1, 0, bytes1.Length);
+        stream1.Flush();
+        byte[] bytes2 = Encoding.UTF8.GetBytes(contents2);
+        stream2.Write(bytes2, 0, bytes2.Length);
+        stream2.Flush();
+
+        stream1.Dispose();
+        stream2.Dispose();
+        string result = FileSystem.File.ReadAllText(path);
+
+        result.Should().Be(contents2);
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream(nameof(FileAccess))]
+    public void FileAccess_ReadAfterFirstAppend_ShouldContainBothContents(
+        string path, string contents1, string contents2)
+    {
+        FileSystem.File.WriteAllText(path, null);
+
+        FileSystemStream stream1 = FileSystem.FileStream.New(path, FileMode.Append,
+            FileAccess.Write, FileShare.Write);
+
+        byte[] bytes1 = Encoding.UTF8.GetBytes(contents1);
+        stream1.Write(bytes1, 0, bytes1.Length);
+        stream1.Flush();
+
+        FileSystemStream stream2 = FileSystem.FileStream.New(path, FileMode.Append,
+            FileAccess.Write, FileShare.Write);
+        byte[] bytes2 = Encoding.UTF8.GetBytes(contents2);
+        stream2.Write(bytes2, 0, bytes2.Length);
+        stream2.Flush();
+
+        stream1.Dispose();
+        stream2.Dispose();
+        string result = FileSystem.File.ReadAllText(path);
+        result.Should().Be(contents1 + contents2);
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream(nameof(FileAccess))]
+    public void FileAccess_ReadBeforeFirstAppend_ShouldOnlyContainSecondContent(
+        string path, string contents1, string contents2)
+    {
+        FileSystem.File.WriteAllText(path, null);
+
+        FileSystemStream stream1 = FileSystem.FileStream.New(path, FileMode.Append,
+            FileAccess.Write, FileShare.Write);
+        FileSystemStream stream2 = FileSystem.FileStream.New(path, FileMode.Append,
+            FileAccess.Write, FileShare.Write);
+
+        byte[] bytes1 = Encoding.UTF8.GetBytes(contents1);
+        stream1.Write(bytes1, 0, bytes1.Length);
+        stream1.Flush();
+        byte[] bytes2 = Encoding.UTF8.GetBytes(contents2);
+        stream2.Write(bytes2, 0, bytes2.Length);
+        stream2.Flush();
+
+        stream1.Dispose();
+        stream2.Dispose();
+        string result = FileSystem.File.ReadAllText(path);
+
+        result.Should().Be(contents2);
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream(nameof(FileAccess))]
+    public void FileAccess_ReadWhileWriteLockActive_ShouldThrowIOException(
+        string path, string contents)
+    {
+        FileSystemStream stream = FileSystem.FileStream.New(path, FileMode.Create);
+
+        byte[] bytes = Encoding.UTF8.GetBytes(contents);
+        stream.Write(bytes, 0, bytes.Length);
+
+        Exception? exception = Record.Exception(() =>
+        {
+            FileSystem.File.ReadAllText(path);
+        });
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            exception.Should().BeOfType<IOException>()
+               .Which.Message.Should().Contain($"'{FileSystem.Path.GetFullPath(path)}'");
+        }
+        else
+        {
+            exception.Should().BeNull();
+        }
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream(nameof(FileAccess))]
+    public void MultipleParallelReads_ShouldBeAllowed(string path, string contents)
+    {
+        FileSystem.File.WriteAllText(path, contents);
+        ConcurrentBag<string> results = new();
+
+        ParallelLoopResult wait = Parallel.For(0, 100, _ =>
+        {
+            FileSystemStream stream = FileSystem.FileStream.New(path, FileMode.Open,
+                FileAccess.Read, FileShare.Read);
+            using StreamReader sr = new(stream, Encoding.UTF8);
+            results.Add(sr.ReadToEnd());
+        });
+
+        while (!wait.IsCompleted)
+        {
+            Thread.Sleep(10);
+        }
+
+        results.Should().HaveCount(100);
+        results.Should().AllBeEquivalentTo(contents);
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream(nameof(FileAccess))]
+    public void Read_ShouldCreateValidFileStream(string path, string contents)
+    {
+        FileSystem.File.WriteAllText(path, contents, Encoding.UTF8);
+        FileSystemStream stream = FileSystem.FileStream.New(path, FileMode.Open);
+        using StreamReader sr = new(stream, Encoding.UTF8);
+        string result = sr.ReadToEnd();
+
+        result.Should().Be(contents);
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream(nameof(FileAccess))]
+    public void Write_ShouldCreateValidFileStream(string path, string contents)
+    {
+        FileSystemStream stream = FileSystem.FileStream.New(path, FileMode.CreateNew);
+
+        byte[] bytes = Encoding.UTF8.GetBytes(contents);
+        stream.Write(bytes, 0, bytes.Length);
+
+        stream.Dispose();
+
+        string result = FileSystem.File.ReadAllText(path);
+
+        result.Should().Be(contents);
+    }
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileStreamTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileStreamTests.cs
@@ -131,8 +131,7 @@ public abstract partial class FileSystemFileStreamTests<TFileSystem>
     [Theory]
     [AutoData]
     [FileSystemTests.FileStream]
-    public void Name_ShouldReturnFullPath(
-        string path, string contents)
+    public void Name_ShouldReturnFullPath(string path)
     {
         string expectedName = FileSystem.Path.GetFullPath(path);
         using FileSystemStream stream = FileSystem.File.Create(path);
@@ -193,11 +192,12 @@ public abstract partial class FileSystemFileStreamTests<TFileSystem>
     [FileSystemTests.FileStream]
     public async Task ReadAsync_ShouldFillBuffer(string path, byte[] contents)
     {
+        CancellationTokenSource cts = new (10000);
         byte[] buffer = new byte[contents.Length];
-        await FileSystem.File.WriteAllBytesAsync(path, contents);
+        await FileSystem.File.WriteAllBytesAsync(path, contents, cts.Token);
         await using FileSystemStream stream = FileSystem.File.OpenRead(path);
 
-        int result = await stream.ReadAsync(buffer, 0, contents.Length);
+        int result = await stream.ReadAsync(buffer, 0, contents.Length, cts.Token);
 
         result.Should().Be(contents.Length);
         buffer.Should().BeEquivalentTo(contents);
@@ -351,12 +351,13 @@ public abstract partial class FileSystemFileStreamTests<TFileSystem>
     [FileSystemTests.FileStream]
     public async Task WriteAsync_ShouldFillBuffer(string path, byte[] contents)
     {
+        CancellationTokenSource cts = new(10000);
         await using FileSystemStream stream = FileSystem.File.Create(path);
 
-        await stream.WriteAsync(contents, 0, contents.Length);
+        await stream.WriteAsync(contents, 0, contents.Length, cts.Token);
 
         await stream.DisposeAsync();
-        (await FileSystem.File.ReadAllBytesAsync(path))
+        (await FileSystem.File.ReadAllBytesAsync(path, cts.Token))
            .Should().BeEquivalentTo(contents);
     }
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileStreamTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileStreamTests.cs
@@ -1,13 +1,10 @@
-using System.Collections.Concurrent;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests;
 
-public abstract class FileSystemFileStreamTests<TFileSystem>
+public abstract partial class FileSystemFileStreamTests<TFileSystem>
     where TFileSystem : IFileSystem
 {
     #region Test Setup
@@ -27,235 +24,374 @@ public abstract class FileSystemFileStreamTests<TFileSystem>
     #endregion
 
     [Theory]
-    [InlineAutoData(FileAccess.Read, FileShare.Read,
-        FileAccess.ReadWrite, FileShare.Read)]
-    [InlineAutoData(FileAccess.ReadWrite, FileShare.Read,
-        FileAccess.Read, FileShare.Read)]
-    [InlineAutoData(FileAccess.ReadWrite, FileShare.ReadWrite,
-        FileAccess.ReadWrite, FileShare.Read)]
-    [InlineAutoData(FileAccess.ReadWrite, FileShare.ReadWrite,
-        FileAccess.ReadWrite, FileShare.Write)]
-    [InlineAutoData(FileAccess.Read, FileShare.Read,
-        FileAccess.ReadWrite, FileShare.ReadWrite)]
-    [FileSystemTests.FileStream("Access")]
-    public void FileAccess_ConcurrentAccessWithInvalidScenarios_ShouldThrowIOException(
-        FileAccess access1, FileShare share1,
-        FileAccess access2, FileShare share2,
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void BeginRead_ShouldCopyContentsToBuffer(
+        string path, byte[] contents)
+    {
+        ManualResetEventSlim ms = new();
+        FileSystem.File.WriteAllBytes(path, contents);
+        using FileSystemStream readStream = FileSystem.File.OpenRead(path);
+
+        byte[] buffer = new byte[contents.Length];
+        readStream.BeginRead(buffer, 0, buffer.Length, ar =>
+        {
+            // ReSharper disable once AccessToDisposedClosure
+            readStream.EndRead(ar);
+            ms.Set();
+        }, null);
+
+        ms.Wait(1000);
+        buffer.Should().BeEquivalentTo(contents);
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void BeginWrite_ShouldCopyContentsToFile(
+        string path, byte[] contents)
+    {
+        ManualResetEventSlim ms = new();
+        using FileSystemStream writeStream = FileSystem.File.Create(path);
+
+        writeStream.BeginWrite(contents, 0, contents.Length, ar =>
+        {
+            // ReSharper disable once AccessToDisposedClosure
+            writeStream.EndWrite(ar);
+            ms.Set();
+        }, null);
+
+        ms.Wait(1000);
+        writeStream.Dispose();
+        FileSystem.File.ReadAllBytes(path).Should().BeEquivalentTo(contents);
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void CanSeek_ShouldReturnTrue(
+        string path, string contents)
+    {
+        FileSystem.File.WriteAllText(path, contents);
+
+        using FileSystemStream stream = FileSystem.File.OpenRead(path);
+
+        stream.CanSeek.Should().BeTrue();
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void CanTimeout_ShouldReturnFalse(
+        string path, string contents)
+    {
+        FileSystem.File.WriteAllText(path, contents);
+
+        using FileSystemStream stream = FileSystem.File.OpenRead(path);
+
+        stream.CanTimeout.Should().BeFalse();
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void CopyTo_ShouldCopyBytes(
+        string path, byte[] contents)
+    {
+        byte[] buffer = new byte[contents.Length];
+        FileSystem.File.WriteAllBytes(path, contents);
+        using FileSystemStream stream = FileSystem.File.OpenRead(path);
+        using MemoryStream destination = new(buffer);
+
+        stream.CopyTo(destination);
+
+        destination.Flush();
+        buffer.Should().BeEquivalentTo(contents);
+    }
+
+#if FEATURE_FILESYSTEM_ASYNC
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public async Task CopyToAsync_ShouldCopyBytes(
+        string path, byte[] contents)
+    {
+        byte[] buffer = new byte[contents.Length];
+        await FileSystem.File.WriteAllBytesAsync(path, contents);
+        await using FileSystemStream stream = FileSystem.File.OpenRead(path);
+        using MemoryStream destination = new(buffer);
+
+        await stream.CopyToAsync(destination);
+
+        await destination.FlushAsync();
+        buffer.Should().BeEquivalentTo(contents);
+    }
+#endif
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void Name_ShouldReturnFullPath(
+        string path, string contents)
+    {
+        string expectedName = FileSystem.Path.GetFullPath(path);
+        using FileSystemStream stream = FileSystem.File.Create(path);
+
+        stream.Name.Should().Be(expectedName);
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void Position_ShouldChangeWhenReading(
+        string path, string contents)
+    {
+        FileSystem.File.WriteAllText(path, contents);
+
+        using FileSystemStream stream = FileSystem.File.OpenRead(path);
+
+        stream.Position.Should().Be(0);
+        stream.ReadByte();
+        stream.Position.Should().Be(1);
+    }
+
+#if FEATURE_SPAN
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void Read_AsSpan_ShouldFillBuffer(string path, byte[] contents)
+    {
+        byte[] buffer = new byte[contents.Length];
+        FileSystem.File.WriteAllBytes(path, contents);
+        using FileSystemStream stream = FileSystem.File.OpenRead(path);
+
+        int result = stream.Read(buffer.AsSpan());
+
+        result.Should().Be(contents.Length);
+        buffer.Should().BeEquivalentTo(contents);
+    }
+#endif
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void Read_ShouldFillBuffer(string path, byte[] contents)
+    {
+        byte[] buffer = new byte[contents.Length];
+        FileSystem.File.WriteAllBytes(path, contents);
+        using FileSystemStream stream = FileSystem.File.OpenRead(path);
+
+        int result = stream.Read(buffer, 0, contents.Length);
+
+        result.Should().Be(contents.Length);
+        buffer.Should().BeEquivalentTo(contents);
+    }
+
+#if FEATURE_FILESYSTEM_ASYNC
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public async Task ReadAsync_ShouldFillBuffer(string path, byte[] contents)
+    {
+        byte[] buffer = new byte[contents.Length];
+        await FileSystem.File.WriteAllBytesAsync(path, contents);
+        await using FileSystemStream stream = FileSystem.File.OpenRead(path);
+
+        int result = await stream.ReadAsync(buffer, 0, contents.Length);
+
+        result.Should().Be(contents.Length);
+        buffer.Should().BeEquivalentTo(contents);
+    }
+#endif
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void ReadByte_ShouldReadSingleByteAndAdvancePosition(
+        string path, byte[] contents)
+    {
+        FileSystem.File.WriteAllBytes(path, contents);
+
+        using FileSystemStream stream = FileSystem.File.OpenRead(path);
+
+        int result1 = stream.ReadByte();
+        int result2 = stream.ReadByte();
+
+        stream.Position.Should().Be(2);
+        result1.Should().Be(contents[0]);
+        result2.Should().Be(contents[1]);
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void ReadTimeout_ShouldThrowInvalidOperationException(
         string path, string contents)
     {
         FileSystem.File.WriteAllText(path, contents);
 
         Exception? exception = Record.Exception(() =>
         {
-            _ = FileSystem.FileStream.New(path, FileMode.Open,
-                access1, share1);
-            _ = FileSystem.FileStream.New(path, FileMode.Open,
-                access2, share2);
+            using FileSystemStream stream = FileSystem.File.OpenRead(path);
+            _ = stream.ReadTimeout;
         });
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            exception.Should().BeOfType<IOException>(
-                    $"Access {access1}, Share {share1} of file 1 is incompatible with Access {access2}, Share {share2} of file 2")
-               .Which.Message.Should().Contain($"'{FileSystem.Path.GetFullPath(path)}'");
-        }
-        else
-        {
-            exception.Should().BeNull();
-        }
+        exception.Should().BeOfType<InvalidOperationException>();
     }
 
     [Theory]
-    [InlineAutoData(FileAccess.Read, FileShare.Read, FileAccess.Read, FileShare.Read)]
-    [InlineAutoData(FileAccess.Read, FileShare.ReadWrite, FileAccess.ReadWrite,
-        FileShare.Read)]
-    [FileSystemTests.FileStream("Access")]
-    public void FileAccess_ConcurrentReadAccessWithValidScenarios_ShouldNotThrowException(
-        FileAccess access1, FileShare share1,
-        FileAccess access2, FileShare share2,
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void Seek_Begin_ShouldSetAbsolutePositionFromBegin(
         string path, string contents)
     {
         FileSystem.File.WriteAllText(path, contents);
 
-        FileSystemStream stream1 = FileSystem.FileStream.New(path, FileMode.Open,
-            access1, share1);
-        FileSystemStream stream2 = FileSystem.FileStream.New(path, FileMode.Open,
-            access2, share2);
+        using FileSystemStream stream = FileSystem.File.OpenRead(path);
 
-        using StreamReader sr1 = new(stream1, Encoding.UTF8);
-        using StreamReader sr2 = new(stream2, Encoding.UTF8);
-        string result1 = sr1.ReadToEnd();
-        string result2 = sr2.ReadToEnd();
-
-        result1.Should().Be(contents);
-        result2.Should().Be(contents);
-    }
-
-    [Theory]
-    [InlineAutoData(FileAccess.Write, FileShare.Write, FileAccess.Write, FileShare.Write)]
-    [InlineAutoData(FileAccess.ReadWrite, FileShare.ReadWrite, FileAccess.ReadWrite,
-        FileShare.ReadWrite)]
-    [FileSystemTests.FileStream("Access")]
-    public void
-        FileAccess_ConcurrentWriteAccessWithValidScenarios_ShouldNotThrowException(
-            FileAccess access1, FileShare share1,
-            FileAccess access2, FileShare share2,
-            string path, string contents1, string contents2)
-    {
-        FileSystem.File.WriteAllText(path, null);
-
-        FileSystemStream stream1 = FileSystem.FileStream.New(path, FileMode.Open,
-            access1, share1);
-        FileSystemStream stream2 = FileSystem.FileStream.New(path, FileMode.Open,
-            access2, share2);
-
-        byte[] bytes1 = Encoding.UTF8.GetBytes(contents1);
-        stream1.Write(bytes1, 0, bytes1.Length);
-        stream1.Flush();
-        byte[] bytes2 = Encoding.UTF8.GetBytes(contents2);
-        stream2.Write(bytes2, 0, bytes2.Length);
-        stream2.Flush();
-
-        stream1.Dispose();
-        stream2.Dispose();
-        string result = FileSystem.File.ReadAllText(path);
-
-        result.Should().Be(contents2);
+        stream.Position.Should().Be(0);
+        stream.Seek(4, SeekOrigin.Begin);
+        stream.Position.Should().Be(4);
     }
 
     [Theory]
     [AutoData]
-    [FileSystemTests.FileStream("Access")]
-    public void FileAccess_ReadAfterFirstAppend_ShouldContainBothContents(
-        string path, string contents1, string contents2)
+    [FileSystemTests.FileStream]
+    public void Seek_Current_ShouldSetRelativePosition(string path, string contents)
     {
-        FileSystem.File.WriteAllText(path, null);
+        FileSystem.File.WriteAllText(path, contents);
 
-        FileSystemStream stream1 = FileSystem.FileStream.New(path, FileMode.Append,
-            FileAccess.Write, FileShare.Write);
+        using FileSystemStream stream = FileSystem.File.OpenRead(path);
 
-        byte[] bytes1 = Encoding.UTF8.GetBytes(contents1);
-        stream1.Write(bytes1, 0, bytes1.Length);
-        stream1.Flush();
-
-        FileSystemStream stream2 = FileSystem.FileStream.New(path, FileMode.Append,
-            FileAccess.Write, FileShare.Write);
-        byte[] bytes2 = Encoding.UTF8.GetBytes(contents2);
-        stream2.Write(bytes2, 0, bytes2.Length);
-        stream2.Flush();
-
-        stream1.Dispose();
-        stream2.Dispose();
-        string result = FileSystem.File.ReadAllText(path);
-        result.Should().Be(contents1 + contents2);
+        stream.Position.Should().Be(0);
+        stream.Seek(4, SeekOrigin.Current);
+        stream.Position.Should().Be(4);
+        stream.Seek(3, SeekOrigin.Current);
+        stream.Position.Should().Be(7);
+        stream.Seek(-1, SeekOrigin.Current);
+        stream.Position.Should().Be(6);
     }
 
     [Theory]
     [AutoData]
-    [FileSystemTests.FileStream("Access")]
-    public void FileAccess_ReadBeforeFirstAppend_ShouldOnlyContainSecondContent(
-        string path, string contents1, string contents2)
+    [FileSystemTests.FileStream]
+    public void Seek_End_ShouldSetAbsolutePositionFromEnd(string path, string contents)
     {
-        FileSystem.File.WriteAllText(path, null);
+        FileSystem.File.WriteAllText(path, contents);
 
-        FileSystemStream stream1 = FileSystem.FileStream.New(path, FileMode.Append,
-            FileAccess.Write, FileShare.Write);
-        FileSystemStream stream2 = FileSystem.FileStream.New(path, FileMode.Append,
-            FileAccess.Write, FileShare.Write);
+        using FileSystemStream stream = FileSystem.File.OpenRead(path);
 
-        byte[] bytes1 = Encoding.UTF8.GetBytes(contents1);
-        stream1.Write(bytes1, 0, bytes1.Length);
-        stream1.Flush();
-        byte[] bytes2 = Encoding.UTF8.GetBytes(contents2);
-        stream2.Write(bytes2, 0, bytes2.Length);
-        stream2.Flush();
-
-        stream1.Dispose();
-        stream2.Dispose();
-        string result = FileSystem.File.ReadAllText(path);
-
-        result.Should().Be(contents2);
+        stream.Position.Should().Be(0);
+        stream.Seek(-4, SeekOrigin.End);
+        stream.Position.Should().Be(contents.Length - 4);
     }
 
     [Theory]
     [AutoData]
-    [FileSystemTests.FileStream("Access")]
-    public void FileAccess_ReadWhileWriteLockActive_ShouldThrowIOException(
-        string path, string contents)
+    [FileSystemTests.FileStream]
+    public void SetLength(string path, int length)
     {
-        FileSystemStream stream = FileSystem.FileStream.New(path, FileMode.Create);
+        using FileSystemStream stream = FileSystem.File.Create(path);
 
-        byte[] bytes = Encoding.UTF8.GetBytes(contents);
-        stream.Write(bytes, 0, bytes.Length);
+        stream.SetLength(length);
+
+        stream.Length.Should().Be(length);
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void SetLength_ReadOnlyStream_ShouldThrowNotSupportedException(
+        string path, int length)
+    {
+        FileSystem.File.WriteAllText(path, null);
 
         Exception? exception = Record.Exception(() =>
         {
-            FileSystem.File.ReadAllText(path);
+            using FileSystemStream stream = FileSystem.File.OpenRead(path);
+            stream.SetLength(length);
         });
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            exception.Should().BeOfType<IOException>()
-               .Which.Message.Should().Contain($"'{FileSystem.Path.GetFullPath(path)}'");
-        }
-        else
-        {
-            exception.Should().BeNull();
-        }
+        exception.Should().BeOfType<NotSupportedException>();
     }
 
+#if FEATURE_SPAN
     [Theory]
     [AutoData]
-    [FileSystemTests.FileStream("Access")]
-    public void MultipleParallelReads_ShouldBeAllowed(string path, string contents)
+    [FileSystemTests.FileStream]
+    public void Write_AsSpan_ShouldFillBuffer(string path, byte[] contents)
     {
-        FileSystem.File.WriteAllText(path, contents);
-        ConcurrentBag<string> results = new();
+        using FileSystemStream stream = FileSystem.File.Create(path);
 
-        ParallelLoopResult wait = Parallel.For(0, 100, _ =>
-        {
-            FileSystemStream stream = FileSystem.FileStream.New(path, FileMode.Open,
-                FileAccess.Read, FileShare.Read);
-            using StreamReader sr = new(stream, Encoding.UTF8);
-            results.Add(sr.ReadToEnd());
-        });
-
-        while (!wait.IsCompleted)
-        {
-            Thread.Sleep(10);
-        }
-
-        results.Should().HaveCount(100);
-        results.Should().AllBeEquivalentTo(contents);
-    }
-
-    [Theory]
-    [AutoData]
-    [FileSystemTests.FileStream(nameof(FileSystemStream.Read))]
-    public void Read_ShouldCreateValidFileStream(string path, string contents)
-    {
-        FileSystem.File.WriteAllText(path, contents, Encoding.UTF8);
-        FileSystemStream stream = FileSystem.FileStream.New(path, FileMode.Open);
-        using StreamReader sr = new(stream, Encoding.UTF8);
-        string result = sr.ReadToEnd();
-
-        result.Should().Be(contents);
-    }
-
-    [Theory]
-    [AutoData]
-    [FileSystemTests.FileStream(nameof(FileSystemStream.Write))]
-    public void Write_ShouldCreateValidFileStream(string path, string contents)
-    {
-        FileSystemStream stream = FileSystem.FileStream.New(path, FileMode.CreateNew);
-
-        byte[] bytes = Encoding.UTF8.GetBytes(contents);
-        stream.Write(bytes, 0, bytes.Length);
+        stream.Write(contents.AsSpan());
 
         stream.Dispose();
+        FileSystem.File.ReadAllBytes(path)
+           .Should().BeEquivalentTo(contents);
+    }
+#endif
 
-        string result = FileSystem.File.ReadAllText(path);
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void Write_ShouldFillBuffer(string path, byte[] contents)
+    {
+        using FileSystemStream stream = FileSystem.File.Create(path);
 
-        result.Should().Be(contents);
+        stream.Write(contents, 0, contents.Length);
+
+        stream.Dispose();
+        FileSystem.File.ReadAllBytes(path)
+           .Should().BeEquivalentTo(contents);
+    }
+
+#if FEATURE_FILESYSTEM_ASYNC
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public async Task WriteAsync_ShouldFillBuffer(string path, byte[] contents)
+    {
+        await using FileSystemStream stream = FileSystem.File.Create(path);
+
+        await stream.WriteAsync(contents, 0, contents.Length);
+
+        await stream.DisposeAsync();
+        (await FileSystem.File.ReadAllBytesAsync(path))
+           .Should().BeEquivalentTo(contents);
+    }
+#endif
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void WriteByte_ShouldWriteSingleByteAndAdvancePosition(
+        string path, byte byte1, byte byte2)
+    {
+        using FileSystemStream stream = FileSystem.File.Create(path);
+
+        stream.WriteByte(byte1);
+        stream.WriteByte(byte2);
+
+        stream.Position.Should().Be(2);
+        stream.Dispose();
+        FileSystem.File.ReadAllBytes(path)
+           .Should().BeEquivalentTo(new[] { byte1, byte2 });
+    }
+
+    [Theory]
+    [AutoData]
+    [FileSystemTests.FileStream]
+    public void WriteTimeout_ShouldThrowInvalidOperationException(
+        string path, string contents)
+    {
+        FileSystem.File.WriteAllText(path, contents);
+
+        Exception? exception = Record.Exception(() =>
+        {
+            using FileSystemStream stream = FileSystem.File.OpenRead(path);
+            _ = stream.WriteTimeout;
+        });
+
+        exception.Should().BeOfType<InvalidOperationException>();
     }
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileStreamTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileStreamTests.cs
@@ -197,7 +197,9 @@ public abstract partial class FileSystemFileStreamTests<TFileSystem>
         await FileSystem.File.WriteAllBytesAsync(path, contents, cts.Token);
         await using FileSystemStream stream = FileSystem.File.OpenRead(path);
 
+#pragma warning disable CA1835
         int result = await stream.ReadAsync(buffer, 0, contents.Length, cts.Token);
+#pragma warning restore CA1835
 
         result.Should().Be(contents.Length);
         buffer.Should().BeEquivalentTo(contents);
@@ -354,7 +356,9 @@ public abstract partial class FileSystemFileStreamTests<TFileSystem>
         CancellationTokenSource cts = new(10000);
         await using FileSystemStream stream = FileSystem.File.Create(path);
 
+#pragma warning disable CA1835
         await stream.WriteAsync(contents, 0, contents.Length, cts.Token);
+#pragma warning restore CA1835
 
         await stream.DisposeAsync();
         (await FileSystem.File.ReadAllBytesAsync(path, cts.Token))

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileSystemInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileSystemInfoTests.cs
@@ -80,7 +80,7 @@ public abstract partial class FileSystemFileSystemInfoTests<TFileSystem>
 
         FileAttributes result = FileSystem.File.GetAttributes(path);
 
-        if (!Test.RunsOnLinux)
+        if (Test.RunsOnLinux)
         {
             result.Should().Be(FileAttributes.Normal);
         }

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileSystemInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileSystemInfoTests.cs
@@ -31,7 +31,7 @@ public abstract partial class FileSystemFileSystemInfoTests<TFileSystem>
     [FileSystemTests.FileSystemInfo(
         nameof(IFileSystem.IFileSystemInfo.Attributes))]
     public void SetAttributes_ShouldBeIgnoredOnAllPlatforms(FileAttributes attributes,
-                                                     string path)
+        string path)
     {
         FileSystem.File.WriteAllText(path, null);
         FileSystem.File.SetAttributes(path, attributes);
@@ -43,7 +43,6 @@ public abstract partial class FileSystemFileSystemInfoTests<TFileSystem>
 
     [Theory]
     [InlineAutoData(FileAttributes.Archive)]
-    [InlineAutoData(FileAttributes.Hidden)]
     [InlineAutoData(FileAttributes.NoScrubData)]
     [InlineAutoData(FileAttributes.NotContentIndexed)]
     [InlineAutoData(FileAttributes.Offline)]
@@ -51,8 +50,8 @@ public abstract partial class FileSystemFileSystemInfoTests<TFileSystem>
     [InlineAutoData(FileAttributes.Temporary)]
     [FileSystemTests.FileSystemInfo(
         nameof(IFileSystem.IFileSystemInfo.Attributes))]
-    public void SetAttributes_ShouldBeIgnoredOnLinux(FileAttributes attributes,
-                                                     string path)
+    public void SetAttributes_ShouldOnlyWorkOnWindows(FileAttributes attributes,
+                                                      string path)
     {
         FileSystem.File.WriteAllText(path, null);
         FileSystem.File.SetAttributes(path, attributes);
@@ -66,6 +65,28 @@ public abstract partial class FileSystemFileSystemInfoTests<TFileSystem>
         else
         {
             result.Should().Be(FileAttributes.Normal);
+        }
+    }
+
+    [Theory]
+    [InlineAutoData(FileAttributes.Hidden)]
+    [FileSystemTests.FileSystemInfo(
+        nameof(IFileSystem.IFileSystemInfo.Attributes))]
+    public void SetAttributes_ShouldBeIgnoredOnLinux(FileAttributes attributes,
+                                                     string path)
+    {
+        FileSystem.File.WriteAllText(path, null);
+        FileSystem.File.SetAttributes(path, attributes);
+
+        FileAttributes result = FileSystem.File.GetAttributes(path);
+
+        if (!Test.RunsOnLinux)
+        {
+            result.Should().Be(FileAttributes.Normal);
+        }
+        else
+        {
+            result.Should().Be(attributes);
         }
     }
 

--- a/Tests/Testably.Abstractions.Tests/FileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemTests.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using Testably.Abstractions.Tests.TestHelpers.Traits;
 
 namespace Testably.Abstractions.Tests;
@@ -172,8 +171,8 @@ public static class FileSystemTests
     /// </summary>
     public class FileStream : TestabilityTraitAttribute
     {
-        public FileStream(string method) : base(nameof(IFileSystem),
-            nameof(FileSystemStream), method)
+        public FileStream(string? method = null) : base(nameof(IFileSystem),
+            nameof(FileSystemStream), method ?? " (other) ")
         {
         }
     }

--- a/Tests/Testably.Abstractions.Tests/FileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemTests.cs
@@ -36,6 +36,15 @@ public abstract class FileSystemTests<TFileSystem>
 
     [Fact]
     [FileSystemTests.ExtensionPoint]
+    public void DriveInfo_ShouldSetExtensionPoint()
+    {
+        IFileSystem result = FileSystem.DriveInfo.FileSystem;
+
+        result.Should().Be(FileSystem);
+    }
+
+    [Fact]
+    [FileSystemTests.ExtensionPoint]
     public void File_ShouldSetExtensionPoint()
     {
         IFileSystem result = FileSystem.File.FileSystem;
@@ -48,6 +57,15 @@ public abstract class FileSystemTests<TFileSystem>
     public void FileInfo_ShouldSetExtensionPoint()
     {
         IFileSystem result = FileSystem.FileInfo.FileSystem;
+
+        result.Should().Be(FileSystem);
+    }
+
+    [Fact]
+    [FileSystemTests.ExtensionPoint]
+    public void FileStream_ShouldSetExtensionPoint()
+    {
+        IFileSystem result = FileSystem.FileStream.FileSystem;
 
         result.Should().Be(FileSystem);
     }

--- a/Tests/Testably.Abstractions.Tests/FileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemTests.cs
@@ -72,8 +72,8 @@ public static class FileSystemTests
     /// </summary>
     public class Directory : TestabilityTraitAttribute
     {
-        public Directory(string method) : base(nameof(IFileSystem),
-            nameof(IFileSystem.IDirectory), method)
+        public Directory(string? method = null) : base(nameof(IFileSystem),
+            nameof(IFileSystem.IDirectory), method ?? " (other) ")
         {
         }
     }
@@ -83,8 +83,8 @@ public static class FileSystemTests
     /// </summary>
     public class DirectoryInfo : TestabilityTraitAttribute
     {
-        public DirectoryInfo(string method) : base(nameof(IFileSystem),
-            nameof(IFileSystem.IDirectoryInfo), method)
+        public DirectoryInfo(string? method = null) : base(nameof(IFileSystem),
+            nameof(IFileSystem.IDirectoryInfo), method ?? " (other) ")
         {
         }
     }
@@ -94,8 +94,8 @@ public static class FileSystemTests
     /// </summary>
     public class DirectoryInfoFactory : TestabilityTraitAttribute
     {
-        public DirectoryInfoFactory(string method) : base(nameof(IFileSystem),
-            nameof(IFileSystem.IDirectoryInfoFactory), method)
+        public DirectoryInfoFactory(string? method = null) : base(nameof(IFileSystem),
+            nameof(IFileSystem.IDirectoryInfoFactory), method ?? " (other) ")
         {
         }
     }
@@ -105,8 +105,8 @@ public static class FileSystemTests
     /// </summary>
     public class DriveInfo : TestabilityTraitAttribute
     {
-        public DriveInfo(string method) : base(nameof(IFileSystem),
-            nameof(IFileSystem.IDriveInfo), method)
+        public DriveInfo(string? method = null) : base(nameof(IFileSystem),
+            nameof(IFileSystem.IDriveInfo), method ?? " (other) ")
         {
         }
     }
@@ -116,8 +116,8 @@ public static class FileSystemTests
     /// </summary>
     public class DriveInfoFactory : TestabilityTraitAttribute
     {
-        public DriveInfoFactory(string method) : base(nameof(IFileSystem),
-            nameof(IFileSystem.IDriveInfoFactory), method)
+        public DriveInfoFactory(string? method = null) : base(nameof(IFileSystem),
+            nameof(IFileSystem.IDriveInfoFactory), method ?? " (other) ")
         {
         }
     }
@@ -138,8 +138,8 @@ public static class FileSystemTests
     /// </summary>
     public class File : TestabilityTraitAttribute
     {
-        public File(string method) : base(nameof(IFileSystem),
-            nameof(IFileSystem.IFile), method)
+        public File(string? method = null) : base(nameof(IFileSystem),
+            nameof(IFileSystem.IFile), method ?? " (other) ")
         {
         }
     }
@@ -149,8 +149,8 @@ public static class FileSystemTests
     /// </summary>
     public class FileInfo : TestabilityTraitAttribute
     {
-        public FileInfo(string method) : base(nameof(IFileSystem),
-            nameof(IFileSystem.IFileInfo), method)
+        public FileInfo(string? method = null) : base(nameof(IFileSystem),
+            nameof(IFileSystem.IFileInfo), method ?? " (other) ")
         {
         }
     }
@@ -160,8 +160,8 @@ public static class FileSystemTests
     /// </summary>
     public class FileInfoFactory : TestabilityTraitAttribute
     {
-        public FileInfoFactory(string method) : base(nameof(IFileSystem),
-            nameof(IFileSystem.IFileInfoFactory), method)
+        public FileInfoFactory(string? method = null) : base(nameof(IFileSystem),
+            nameof(IFileSystem.IFileInfoFactory), method ?? " (other) ")
         {
         }
     }
@@ -182,8 +182,8 @@ public static class FileSystemTests
     /// </summary>
     public class FileStreamFactory : TestabilityTraitAttribute
     {
-        public FileStreamFactory(string method) : base(nameof(IFileSystem),
-            nameof(IFileSystem.IFileStreamFactory), method)
+        public FileStreamFactory(string? method = null) : base(nameof(IFileSystem),
+            nameof(IFileSystem.IFileStreamFactory), method ?? " (other) ")
         {
         }
     }
@@ -193,8 +193,8 @@ public static class FileSystemTests
     /// </summary>
     public class FileSystemInfo : TestabilityTraitAttribute
     {
-        public FileSystemInfo(string method) : base(nameof(IFileSystem),
-            nameof(IFileSystem.IFileSystemInfo), method)
+        public FileSystemInfo(string? method = null) : base(nameof(IFileSystem),
+            nameof(IFileSystem.IFileSystemInfo), method ?? " (other) ")
         {
         }
     }
@@ -205,7 +205,7 @@ public static class FileSystemTests
     public class Intercept : TestabilityTraitAttribute
     {
         public Intercept(string? method = null) : base(nameof(FileSystemMock),
-            nameof(FileSystemMock.Intercept), method)
+            nameof(FileSystemMock.Intercept), method ?? " (other) ")
         {
         }
     }
@@ -216,7 +216,7 @@ public static class FileSystemTests
     public class Notify : TestabilityTraitAttribute
     {
         public Notify(string? method = null) : base(nameof(FileSystemMock),
-            nameof(FileSystemMock.Notify), method)
+            nameof(FileSystemMock.Notify), method ?? " (other) ")
         {
         }
     }
@@ -226,7 +226,7 @@ public static class FileSystemTests
     /// </summary>
     public class Path : TestabilityTraitAttribute
     {
-        public Path(string method) : base(nameof(IFileSystem),
+        public Path(string? method = null) : base(nameof(IFileSystem),
             nameof(IFileSystem.IPath),
             method)
         {

--- a/Tests/Testably.Abstractions.Tests/Testing/FileSystemInitializerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Testing/FileSystemInitializerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
 
 namespace Testably.Abstractions.Tests.Testing;
 
@@ -143,5 +144,29 @@ public class FileSystemInitializerTests
         sut.Initialize().WithSubdirectory(directoryName);
 
         sut.Directory.EnumerateDirectories(".", directoryName).Should().ContainSingle();
+    }
+
+    [Theory]
+    [AutoData]
+    public void
+        TestingException_SerializationAndDeserialization_ShouldKeepMessageAndInnerException(
+            string message, Exception innerException)
+    {
+        FileSystemInitializer.TestingException originalException =
+            new(message, innerException);
+
+        byte[] buffer = new byte[4096];
+        using MemoryStream ms = new(buffer);
+        using MemoryStream ms2 = new(buffer);
+        BinaryFormatter formatter = new();
+#pragma warning disable SYSLIB0011 //BinaryFormatter serialization is obsolete - only used in unit test
+        formatter.Serialize(ms, originalException);
+        FileSystemInitializer.TestingException deserializedException =
+            (FileSystemInitializer.TestingException)formatter.Deserialize(ms2);
+#pragma warning restore SYSLIB0011
+
+        Assert.Equal(originalException.InnerException?.Message,
+            deserializedException.InnerException?.Message);
+        Assert.Equal(originalException.Message, deserializedException.Message);
     }
 }


### PR DESCRIPTION
Implement the logic with getting/setting attributes that differ on different operating systems.

Additionally improve unit test coverage and fix some minor bugs:
- `IFileInfo.DirectoryName`
  returned only the name and not the full path in FileInfoMock
- `IFileInfo.IsReadOnly`
  was not yet implemented in FileInfoMock
- `FileSystemStream.SetLength`
  should throw an exception when the stream has no write access
- `FileInfoWrapper`
  didn't use Attributes from wrapped instance