### PR TITLE
refactor: improve test coverage

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer.DirectoryCleaner.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer.DirectoryCleaner.cs
@@ -24,7 +24,7 @@ public static partial class FileSystemInitializer
 
         #region IDirectoryCleaner Members
 
-        /// <inheritdoc cref="IDirectoryCleaner.BasePath"/>
+        /// <inheritdoc cref="IDirectoryCleaner.BasePath" />
         public string BasePath { get; }
 
         /// <inheritdoc cref="IDisposable.Dispose()" />
@@ -70,7 +70,8 @@ public static partial class FileSystemInitializer
         ///     Force deletes the directory at the given <paramref name="path" />.<br />
         ///     Removes the <see cref="FileAttributes.ReadOnly" /> flag, if necessary.
         ///     <para />
-        ///     If <paramref name="recursive" /> is set (default <see langword="true" />), the sub directories are force deleted as well.
+        ///     If <paramref name="recursive" /> is set (default <see langword="true" />), the sub directories are force deleted as
+        ///     well.
         /// </summary>
         private void ForceDeleteDirectory(string path, bool recursive = true)
         {

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer.IFileSystemInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer.IFileSystemInitializer.cs
@@ -9,16 +9,17 @@ public static partial class FileSystemInitializer
         where TFileSystem : IFileSystem
     {
         /// <summary>
-        /// </summary>
-        TFileSystem FileSystem { get; }
-
-        /// <summary>
         ///     Gives access to the base directory in which the <see cref="FileSystem" /> was initialized.
         /// </summary>
         IFileSystem.IDirectoryInfo BaseDirectory
         {
             get;
         }
+
+        /// <summary>
+        ///     The file system.
+        /// </summary>
+        TFileSystem FileSystem { get; }
 
         /// <summary>
         ///     Gives access to the created files or directories in the order of the initialization.

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer.Initializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer.Initializer.cs
@@ -36,12 +36,12 @@ public static partial class FileSystemInitializer
 
         #region IFileSystemInitializer<TFileSystem> Members
 
-        /// <inheritdoc cref="IFileSystemInitializer{TFileSystem}.FileSystem" />
-        public TFileSystem FileSystem { get; }
-
         /// <inheritdoc cref="IFileSystemInitializer{TFileSystem}.BaseDirectory" />
         public IFileSystem.IDirectoryInfo BaseDirectory
             => FileSystem.DirectoryInfo.New(_basePath);
+
+        /// <inheritdoc cref="IFileSystemInitializer{TFileSystem}.FileSystem" />
+        public TFileSystem FileSystem { get; }
 
         /// <inheritdoc cref="IFileSystemInitializer{TFileSystem}.this[int]" />
         public IFileSystem.IFileSystemInfo this[int index]

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryMock.cs
@@ -169,13 +169,13 @@ public sealed partial class FileSystemMock
         public DateTime GetCreationTime(string path)
             => _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path))
-               .CreationTime.ToLocalTime();
+               .CreationTime.Get(DateTimeKind.Local);
 
         /// <inheritdoc cref="IFileSystem.IDirectory.GetCreationTimeUtc(string)" />
         public DateTime GetCreationTimeUtc(string path)
             => _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path))
-               .CreationTime.ToUniversalTime();
+               .CreationTime.Get(DateTimeKind.Utc);
 
         /// <inheritdoc cref="IFileSystem.IDirectory.GetCurrentDirectory()" />
         public string GetCurrentDirectory()
@@ -258,25 +258,25 @@ public sealed partial class FileSystemMock
         public DateTime GetLastAccessTime(string path)
             => _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path))
-               .LastAccessTime.ToLocalTime();
+               .LastAccessTime.Get(DateTimeKind.Local);
 
         /// <inheritdoc cref="IFileSystem.IDirectory.GetLastAccessTimeUtc(string)" />
         public DateTime GetLastAccessTimeUtc(string path)
             => _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path))
-               .LastAccessTime.ToUniversalTime();
+               .LastAccessTime.Get(DateTimeKind.Utc);
 
         /// <inheritdoc cref="IFileSystem.IDirectory.GetLastWriteTime(string)" />
         public DateTime GetLastWriteTime(string path)
             => _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path))
-               .LastWriteTime.ToLocalTime();
+               .LastWriteTime.Get(DateTimeKind.Local);
 
         /// <inheritdoc cref="IFileSystem.IDirectory.GetLastWriteTimeUtc(string)" />
         public DateTime GetLastWriteTimeUtc(string path)
             => _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path))
-               .LastWriteTime.ToUniversalTime();
+               .LastWriteTime.Get(DateTimeKind.Utc);
 
         /// <inheritdoc cref="IFileSystem.IDirectory.GetLogicalDrives()" />
         public string[] GetLogicalDrives()
@@ -315,7 +315,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IDirectory.SetCreationTimeUtc(string, DateTime)" />
         public void SetCreationTimeUtc(string path, DateTime creationTimeUtc)
             => LoadDirectoryInfoOrThrowNotFoundException(path)
-               .CreationTime = creationTimeUtc;
+               .CreationTimeUtc = creationTimeUtc;
 
         /// <inheritdoc cref="IFileSystem.IDirectory.SetCurrentDirectory(string)" />
         public void SetCurrentDirectory(string path)
@@ -329,7 +329,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IDirectory.SetLastAccessTimeUtc(string, DateTime)" />
         public void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc)
             => LoadDirectoryInfoOrThrowNotFoundException(path)
-               .LastAccessTime = lastAccessTimeUtc;
+               .LastAccessTimeUtc = lastAccessTimeUtc;
 
         /// <inheritdoc cref="IFileSystem.IDirectory.SetLastWriteTime(string, DateTime)" />
         public void SetLastWriteTime(string path, DateTime lastWriteTime)
@@ -339,7 +339,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IDirectory.SetLastWriteTimeUtc(string, DateTime)" />
         public void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc)
             => LoadDirectoryInfoOrThrowNotFoundException(path)
-               .LastWriteTime = lastWriteTimeUtc;
+               .LastWriteTimeUtc = lastWriteTimeUtc;
 
         #endregion
 

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DriveInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DriveInfoMock.cs
@@ -52,7 +52,7 @@ public sealed partial class FileSystemMock
             IsReady = true;
         }
 
-        #region IDriveInfoMock Members
+        #region IStorageDrive Members
 
         /// <inheritdoc cref="IFileSystem.IDriveInfo.AvailableFreeSpace" />
         public long AvailableFreeSpace

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileMock.cs
@@ -228,32 +228,32 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.GetCreationTime(string)" />
         public DateTime GetCreationTime(string path)
             => _fileSystem.Storage.GetContainer(
-                _fileSystem.Storage.GetLocation(path)).CreationTime.ToLocalTime();
+                _fileSystem.Storage.GetLocation(path)).CreationTime.Get(DateTimeKind.Local);
 
         /// <inheritdoc cref="IFileSystem.IFile.GetCreationTimeUtc(string)" />
         public DateTime GetCreationTimeUtc(string path)
             => _fileSystem.Storage.GetContainer(
-                _fileSystem.Storage.GetLocation(path)).CreationTime.ToUniversalTime();
+                _fileSystem.Storage.GetLocation(path)).CreationTime.Get(DateTimeKind.Utc);
 
         /// <inheritdoc cref="IFileSystem.IFile.GetLastAccessTime(string)" />
         public DateTime GetLastAccessTime(string path)
             => _fileSystem.Storage.GetContainer(
-                _fileSystem.Storage.GetLocation(path)).LastAccessTime.ToLocalTime();
+                _fileSystem.Storage.GetLocation(path)).LastAccessTime.Get(DateTimeKind.Local);
 
         /// <inheritdoc cref="IFileSystem.IFile.GetLastAccessTimeUtc(string)" />
         public DateTime GetLastAccessTimeUtc(string path)
             => _fileSystem.Storage.GetContainer(
-                _fileSystem.Storage.GetLocation(path)).LastAccessTime.ToUniversalTime();
+                _fileSystem.Storage.GetLocation(path)).LastAccessTime.Get(DateTimeKind.Utc);
 
         /// <inheritdoc cref="IFileSystem.IFile.GetLastWriteTime(string)" />
         public DateTime GetLastWriteTime(string path)
             => _fileSystem.Storage.GetContainer(
-                _fileSystem.Storage.GetLocation(path)).LastWriteTime.ToLocalTime();
+                _fileSystem.Storage.GetLocation(path)).LastWriteTime.Get(DateTimeKind.Local);
 
         /// <inheritdoc cref="IFileSystem.IFile.GetLastWriteTimeUtc(string)" />
         public DateTime GetLastWriteTimeUtc(string path)
             => _fileSystem.Storage.GetContainer(
-                _fileSystem.Storage.GetLocation(path)).LastWriteTime.ToUniversalTime();
+                _fileSystem.Storage.GetLocation(path)).LastWriteTime.Get(DateTimeKind.Utc);
 
         /// <inheritdoc cref="IFileSystem.IFile.Move(string, string)" />
         public void Move(string sourceFileName, string destFileName)
@@ -494,7 +494,7 @@ public sealed partial class FileSystemMock
                     FileSystem.Path.GetFullPath(path));
             }
 
-            fileInfo.CreationTime = creationTime;
+            fileInfo.CreationTime.Set(creationTime, DateTimeKind.Local);
         }
 
         /// <inheritdoc cref="IFileSystem.IFile.SetCreationTimeUtc(string, DateTime)" />
@@ -509,7 +509,7 @@ public sealed partial class FileSystemMock
                     FileSystem.Path.GetFullPath(path));
             }
 
-            fileInfo.CreationTime = creationTimeUtc;
+            fileInfo.CreationTime.Set(creationTimeUtc, DateTimeKind.Utc);
         }
 
         /// <inheritdoc cref="IFileSystem.IFile.SetLastAccessTime(string, DateTime)" />
@@ -524,7 +524,7 @@ public sealed partial class FileSystemMock
                     FileSystem.Path.GetFullPath(path));
             }
 
-            fileInfo.LastAccessTime = lastAccessTime;
+            fileInfo.LastAccessTime.Set(lastAccessTime, DateTimeKind.Local);
         }
 
         /// <inheritdoc cref="IFileSystem.IFile.SetLastAccessTimeUtc(string, DateTime)" />
@@ -539,7 +539,7 @@ public sealed partial class FileSystemMock
                     FileSystem.Path.GetFullPath(path));
             }
 
-            fileInfo.LastAccessTime = lastAccessTimeUtc;
+            fileInfo.LastAccessTime.Set(lastAccessTimeUtc, DateTimeKind.Utc);
         }
 
         /// <inheritdoc cref="IFileSystem.IFile.SetLastWriteTime(string, DateTime)" />
@@ -554,7 +554,7 @@ public sealed partial class FileSystemMock
                     FileSystem.Path.GetFullPath(path));
             }
 
-            fileInfo.LastWriteTime = lastWriteTime;
+            fileInfo.LastWriteTime.Set(lastWriteTime, DateTimeKind.Local);
         }
 
         /// <inheritdoc cref="IFileSystem.IFile.SetLastWriteTimeUtc(string, DateTime)" />
@@ -569,7 +569,7 @@ public sealed partial class FileSystemMock
                     FileSystem.Path.GetFullPath(path));
             }
 
-            fileInfo.LastWriteTime = lastWriteTimeUtc;
+            fileInfo.LastWriteTime.Set(lastWriteTimeUtc, DateTimeKind.Utc);
         }
 
         /// <inheritdoc cref="IFileSystem.IFile.WriteAllBytes(string, byte[])" />

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileMock.cs
@@ -71,7 +71,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.AppendAllText(string, string?, Encoding)" />
         public void AppendAllText(string path, string? contents, Encoding encoding)
         {
-            var fileInfo =
+            IStorageContainer fileInfo =
                 _fileSystem.Storage.GetOrCreateContainer(
                     _fileSystem.Storage.GetLocation(path),
                     InMemoryContainer.NewFile);
@@ -149,16 +149,15 @@ public sealed partial class FileSystemMock
         public IFileSystem.IFileSystemInfo CreateSymbolicLink(
             string path, string pathToTarget)
         {
-            var location = _fileSystem.Storage.GetLocation(path);
-            if (_fileSystem.Storage.TryAddContainer(location, InMemoryContainer.NewFile, out var container))
+            IStorageLocation location = _fileSystem.Storage.GetLocation(path);
+            if (_fileSystem.Storage.TryAddContainer(location, InMemoryContainer.NewFile,
+                out IStorageContainer? container))
             {
                 container.LinkTarget = pathToTarget;
                 return FileSystemInfoMock.New(location, _fileSystem);
             }
-            else
-            {
-                throw ExceptionFactory.CannotCreateFileAsAlreadyExists(path);
-            }
+
+            throw ExceptionFactory.CannotCreateFileAsAlreadyExists(path);
         }
 #endif
 
@@ -172,7 +171,7 @@ public sealed partial class FileSystemMock
 #endif
         public void Decrypt(string path)
         {
-            var fileInfo =
+            IStorageContainer fileInfo =
                 _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path));
             if (fileInfo is not NullContainer)
@@ -184,7 +183,8 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.Delete(string)" />
         public void Delete(string path)
         {
-            if (!_fileSystem.Storage.DeleteContainer(_fileSystem.Storage.GetLocation(path)))
+            if (!_fileSystem.Storage.DeleteContainer(
+                _fileSystem.Storage.GetLocation(path)))
             {
                 throw ExceptionFactory.FileNotFound(
                     _fileSystem.Path.GetFullPath(path));
@@ -197,7 +197,7 @@ public sealed partial class FileSystemMock
 #endif
         public void Encrypt(string path)
         {
-            var fileInfo =
+            IStorageContainer fileInfo =
                 _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path));
             if (fileInfo is not NullContainer)
@@ -214,7 +214,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.GetAttributes(string)" />
         public FileAttributes GetAttributes(string path)
         {
-            var container = _fileSystem.Storage
+            IStorageContainer container = _fileSystem.Storage
                .GetContainer(_fileSystem.Storage.GetLocation(path));
             if (container is NullContainer)
             {
@@ -228,7 +228,8 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.GetCreationTime(string)" />
         public DateTime GetCreationTime(string path)
             => _fileSystem.Storage.GetContainer(
-                _fileSystem.Storage.GetLocation(path)).CreationTime.Get(DateTimeKind.Local);
+                    _fileSystem.Storage.GetLocation(path)).CreationTime
+               .Get(DateTimeKind.Local);
 
         /// <inheritdoc cref="IFileSystem.IFile.GetCreationTimeUtc(string)" />
         public DateTime GetCreationTimeUtc(string path)
@@ -238,22 +239,26 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.GetLastAccessTime(string)" />
         public DateTime GetLastAccessTime(string path)
             => _fileSystem.Storage.GetContainer(
-                _fileSystem.Storage.GetLocation(path)).LastAccessTime.Get(DateTimeKind.Local);
+                    _fileSystem.Storage.GetLocation(path)).LastAccessTime
+               .Get(DateTimeKind.Local);
 
         /// <inheritdoc cref="IFileSystem.IFile.GetLastAccessTimeUtc(string)" />
         public DateTime GetLastAccessTimeUtc(string path)
             => _fileSystem.Storage.GetContainer(
-                _fileSystem.Storage.GetLocation(path)).LastAccessTime.Get(DateTimeKind.Utc);
+                    _fileSystem.Storage.GetLocation(path)).LastAccessTime
+               .Get(DateTimeKind.Utc);
 
         /// <inheritdoc cref="IFileSystem.IFile.GetLastWriteTime(string)" />
         public DateTime GetLastWriteTime(string path)
             => _fileSystem.Storage.GetContainer(
-                _fileSystem.Storage.GetLocation(path)).LastWriteTime.Get(DateTimeKind.Local);
+                    _fileSystem.Storage.GetLocation(path)).LastWriteTime
+               .Get(DateTimeKind.Local);
 
         /// <inheritdoc cref="IFileSystem.IFile.GetLastWriteTimeUtc(string)" />
         public DateTime GetLastWriteTimeUtc(string path)
             => _fileSystem.Storage.GetContainer(
-                _fileSystem.Storage.GetLocation(path)).LastWriteTime.Get(DateTimeKind.Utc);
+                    _fileSystem.Storage.GetLocation(path)).LastWriteTime
+               .Get(DateTimeKind.Utc);
 
         /// <inheritdoc cref="IFileSystem.IFile.Move(string, string)" />
         public void Move(string sourceFileName, string destFileName)
@@ -333,7 +338,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.ReadAllBytes(string)" />
         public byte[] ReadAllBytes(string path)
         {
-            var fileInfo =
+            IStorageContainer fileInfo =
                 _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path));
             if (fileInfo is not NullContainer)
@@ -393,7 +398,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.ReadAllText(string, Encoding)" />
         public string ReadAllText(string path, Encoding encoding)
         {
-            var fileInfo =
+            IStorageContainer fileInfo =
                 _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path));
             if (fileInfo is not NullContainer)
@@ -452,7 +457,9 @@ public sealed partial class FileSystemMock
         {
             try
             {
-                var targetLocation = _fileSystem.Storage.ResolveLinkTarget(_fileSystem.Storage.GetLocation(linkPath), returnFinalTarget);
+                IStorageLocation? targetLocation =
+                    _fileSystem.Storage.ResolveLinkTarget(
+                        _fileSystem.Storage.GetLocation(linkPath), returnFinalTarget);
                 if (targetLocation != null)
                 {
                     return FileSystemInfoMock.New(targetLocation, _fileSystem);
@@ -470,7 +477,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.SetAttributes(string, FileAttributes)" />
         public void SetAttributes(string path, FileAttributes fileAttributes)
         {
-            var fileInfo =
+            IStorageContainer fileInfo =
                 _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path));
             if (fileInfo is NullContainer)
@@ -485,7 +492,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.SetCreationTime(string, DateTime)" />
         public void SetCreationTime(string path, DateTime creationTime)
         {
-            var fileInfo =
+            IStorageContainer fileInfo =
                 _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path));
             if (fileInfo is NullContainer)
@@ -500,7 +507,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.SetCreationTimeUtc(string, DateTime)" />
         public void SetCreationTimeUtc(string path, DateTime creationTimeUtc)
         {
-            var fileInfo =
+            IStorageContainer fileInfo =
                 _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path));
             if (fileInfo is NullContainer)
@@ -515,7 +522,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.SetLastAccessTime(string, DateTime)" />
         public void SetLastAccessTime(string path, DateTime lastAccessTime)
         {
-            var fileInfo =
+            IStorageContainer fileInfo =
                 _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path));
             if (fileInfo is NullContainer)
@@ -530,7 +537,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.SetLastAccessTimeUtc(string, DateTime)" />
         public void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc)
         {
-            var fileInfo =
+            IStorageContainer fileInfo =
                 _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path));
             if (fileInfo is NullContainer)
@@ -545,7 +552,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.SetLastWriteTime(string, DateTime)" />
         public void SetLastWriteTime(string path, DateTime lastWriteTime)
         {
-            var fileInfo =
+            IStorageContainer fileInfo =
                 _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path));
             if (fileInfo is NullContainer)
@@ -560,7 +567,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.SetLastWriteTimeUtc(string, DateTime)" />
         public void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc)
         {
-            var fileInfo =
+            IStorageContainer fileInfo =
                 _fileSystem.Storage.GetContainer(
                     _fileSystem.Storage.GetLocation(path));
             if (fileInfo is NullContainer)
@@ -575,7 +582,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.WriteAllBytes(string, byte[])" />
         public void WriteAllBytes(string path, byte[] bytes)
         {
-            var fileInfo =
+            IStorageContainer fileInfo =
                 _fileSystem.Storage.GetOrCreateContainer(
                     _fileSystem.Storage.GetLocation(path),
                     InMemoryContainer.NewFile);
@@ -654,7 +661,7 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFile.WriteAllText(string, string?, Encoding)" />
         public void WriteAllText(string path, string? contents, Encoding encoding)
         {
-            var fileInfo =
+            IStorageContainer fileInfo =
                 _fileSystem.Storage.GetOrCreateContainer(
                     _fileSystem.Storage.GetLocation(path),
                     InMemoryContainer.NewFile);

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileSystemInfoMock.cs
@@ -133,7 +133,7 @@ public sealed partial class FileSystemMock
             => FileSystem.Path.GetFileName(FullName.TrimEnd(
                 FileSystem.Path.DirectorySeparatorChar,
                 FileSystem.Path.AltDirectorySeparatorChar));
-        
+
         /// <inheritdoc cref="IFileSystem.IFileSystemInfo.Refresh()" />
         public void Refresh()
         {

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileSystemInfoMock.cs
@@ -53,15 +53,15 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFileSystemInfo.CreationTime" />
         public DateTime CreationTime
         {
-            get => Container.CreationTime.ToLocalTime();
-            set => Container.CreationTime = value;
+            get => Container.CreationTime.Get(DateTimeKind.Local);
+            set => Container.CreationTime.Set(value, DateTimeKind.Local);
         }
 
         /// <inheritdoc cref="IFileSystem.IFileSystemInfo.CreationTimeUtc" />
         public DateTime CreationTimeUtc
         {
-            get => Container.CreationTime.ToUniversalTime();
-            set => Container.CreationTime = value;
+            get => Container.CreationTime.Get(DateTimeKind.Utc);
+            set => Container.CreationTime.Set(value, DateTimeKind.Utc);
         }
 
         /// <inheritdoc cref="IFileSystem.IFileSystemInfo.Delete()" />
@@ -97,29 +97,29 @@ public sealed partial class FileSystemMock
         /// <inheritdoc cref="IFileSystem.IFileSystemInfo.LastAccessTime" />
         public DateTime LastAccessTime
         {
-            get => Container.LastAccessTime.ToLocalTime();
-            set => Container.LastAccessTime = value;
+            get => Container.LastAccessTime.Get(DateTimeKind.Local);
+            set => Container.LastAccessTime.Set(value, DateTimeKind.Local);
         }
 
         /// <inheritdoc cref="IFileSystem.IFileSystemInfo.LastAccessTimeUtc" />
         public DateTime LastAccessTimeUtc
         {
-            get => Container.LastAccessTime.ToUniversalTime();
-            set => Container.LastAccessTime = value;
+            get => Container.LastAccessTime.Get(DateTimeKind.Utc);
+            set => Container.LastAccessTime.Set(value, DateTimeKind.Utc);
         }
 
         /// <inheritdoc cref="IFileSystem.IFileSystemInfo.LastWriteTime" />
         public DateTime LastWriteTime
         {
-            get => Container.LastWriteTime.ToLocalTime();
-            set => Container.LastWriteTime = value;
+            get => Container.LastWriteTime.Get(DateTimeKind.Local);
+            set => Container.LastWriteTime.Set(value, DateTimeKind.Local);
         }
 
         /// <inheritdoc cref="IFileSystem.IFileSystemInfo.LastWriteTimeUtc" />
         public DateTime LastWriteTimeUtc
         {
-            get => Container.LastWriteTime.ToUniversalTime();
-            set => Container.LastWriteTime = value;
+            get => Container.LastWriteTime.Get(DateTimeKind.Utc);
+            set => Container.LastWriteTime.Set(value, DateTimeKind.Utc);
         }
 
 #if FEATURE_FILESYSTEM_LINK

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.cs
@@ -29,14 +29,14 @@ public sealed partial class FileSystemMock : IFileSystem
     public ITimeSystem TimeSystem { get; }
 
     /// <summary>
-    ///     The underlying storage of directories and files.
-    /// </summary>
-    internal IStorage Storage { get; }
-
-    /// <summary>
     ///     The change handler used to notify about events occurring in the <see cref="FileSystemMock" />.
     /// </summary>
     internal ChangeHandlerImplementation ChangeHandler { get; }
+
+    /// <summary>
+    ///     The underlying storage of directories and files.
+    /// </summary>
+    internal IStorage Storage { get; }
 
     private readonly DirectoryMock _directoryMock;
     private readonly FileMock _fileMock;
@@ -58,20 +58,6 @@ public sealed partial class FileSystemMock : IFileSystem
         DriveInfo = new DriveInfoFactoryMock(this);
         FileInfo = new FileInfoFactoryMock(this);
         FileStream = new FileStreamFactoryMock(this);
-    }
-
-    /// <summary>
-    ///     Changes the parameters of the specified <paramref name="drive" />.
-    ///     <para />
-    ///     If the <paramref name="drive" /> does not exist, it will be created/mounted.
-    /// </summary>
-    public FileSystemMock WithDrive(string? drive,
-                                    Action<IStorageDrive>? driveCallback = null)
-    {
-        IStorageDrive driveInfoMock = Storage.GetOrAddDrive(
-            drive ?? "".PrefixRoot());
-        driveCallback?.Invoke(driveInfoMock);
-        return this;
     }
 
     #region IFileSystem Members
@@ -101,6 +87,20 @@ public sealed partial class FileSystemMock : IFileSystem
         => _pathMock;
 
     #endregion
+
+    /// <summary>
+    ///     Changes the parameters of the specified <paramref name="drive" />.
+    ///     <para />
+    ///     If the <paramref name="drive" /> does not exist, it will be created/mounted.
+    /// </summary>
+    public FileSystemMock WithDrive(string? drive,
+                                    Action<IStorageDrive>? driveCallback = null)
+    {
+        IStorageDrive driveInfoMock = Storage.GetOrAddDrive(
+            drive ?? "".PrefixRoot());
+        driveCallback?.Invoke(driveInfoMock);
+        return this;
+    }
 }
 
 /// <summary>

--- a/Source/Testably.Abstractions.Testing/Internal/EncryptionHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/EncryptionHelper.cs
@@ -8,18 +8,6 @@ namespace Testably.Abstractions.Testing.Internal;
 internal static class EncryptionHelper
 {
     /// <summary>
-    ///     Encrypts the <paramref name="plainBytes" /> with a fixed encryption algorithm.
-    /// </summary>
-    internal static byte[] Encrypt(byte[] plainBytes)
-    {
-        using Aes algorithm = CreateAlgorithm();
-        using ICryptoTransform? encryptor = algorithm
-           .CreateEncryptor(algorithm.Key, algorithm.IV);
-
-        return PerformCryptography(encryptor, plainBytes);
-    }
-
-    /// <summary>
     ///     Encrypts the <paramref name="cypherBytes" /> with a fixed encryption algorithm.
     /// </summary>
     internal static byte[] Decrypt(byte[] cypherBytes)
@@ -29,6 +17,18 @@ internal static class EncryptionHelper
            .CreateDecryptor(algorithm.Key, algorithm.IV);
 
         return PerformCryptography(decryptor, cypherBytes);
+    }
+
+    /// <summary>
+    ///     Encrypts the <paramref name="plainBytes" /> with a fixed encryption algorithm.
+    /// </summary>
+    internal static byte[] Encrypt(byte[] plainBytes)
+    {
+        using Aes algorithm = CreateAlgorithm();
+        using ICryptoTransform? encryptor = algorithm
+           .CreateEncryptor(algorithm.Key, algorithm.IV);
+
+        return PerformCryptography(encryptor, plainBytes);
     }
 
     private static Aes CreateAlgorithm()

--- a/Source/Testably.Abstractions.Testing/Internal/EnumerationOptionsHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/EnumerationOptionsHelper.cs
@@ -37,8 +37,10 @@ internal static class EnumerationOptionsHelper
             AttributesToSkip = 0,
             IgnoreInaccessible = false
         };
+
     /// <summary>
-    /// <see href="https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerableFactory.cs#L107" />
+    ///     <see
+    ///         href="https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerableFactory.cs#L107" />
     /// </summary>
     [ExcludeFromCodeCoverage]
     public static bool MatchesPattern(EnumerationOptions enumerationOptions, string name,

--- a/Source/Testably.Abstractions.Testing/Internal/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/ExceptionFactory.cs
@@ -29,7 +29,7 @@ internal static class ExceptionFactory
     internal static IOException FileAlreadyExists(string path)
         => new($"The file '{path}' already exists.");
 
-    public static IOException FileNameCannotBeResolved(string path)
+    internal static IOException FileNameCannotBeResolved(string path)
         => new($"The name of the file cannot be resolved by the system. : '{path}'");
 
     internal static FileNotFoundException FileNotFound(string path)
@@ -45,10 +45,10 @@ internal static class ExceptionFactory
             "Drive name must be a root directory (i.e. 'C:\\') or a drive letter ('C').",
             paramName);
 
-    public static IOException NetworkPathNotFound(string path)
+    internal static IOException NetworkPathNotFound(string path)
         => new($"The network path was not found. : '{path}'");
 
-    public static IOException NotEnoughDiskSpace(string name)
+    internal static IOException NotEnoughDiskSpace(string name)
         => new($"There is not enough space on the disk: '{name}'");
 
     internal static ArgumentException PathCannotBeEmpty(string paramName = "path")
@@ -81,7 +81,7 @@ internal static class ExceptionFactory
         => new(
             $"The process cannot access the file '{path}' because it is being used by another process.");
 
-    public static NotSupportedException StreamDoesNotSupportWriting()
+    internal static NotSupportedException StreamDoesNotSupportWriting()
         => new("Stream does not support writing.");
 
     internal static ArgumentOutOfRangeException TaskDelayOutOfRange(string paramName)

--- a/Source/Testably.Abstractions.Testing/Internal/Framework.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/Framework.cs
@@ -5,6 +5,8 @@ namespace Testably.Abstractions.Testing.Internal;
 
 internal static class Framework
 {
+    private static bool? _isNetFramework;
+
     [ExcludeFromCodeCoverage]
     public static bool IsNetFramework
     {
@@ -15,6 +17,4 @@ internal static class Framework
             return _isNetFramework.Value;
         }
     }
-
-    private static bool? _isNetFramework;
 }

--- a/Source/Testably.Abstractions.Testing/Internal/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/PathHelper.cs
@@ -30,7 +30,6 @@ internal static class PathHelper
         return false;
     }
 
-
     internal static string
         NormalizeAndTrimPath(this string path, IFileSystem fileSystem)
         => fileSystem.Path
@@ -72,6 +71,7 @@ internal static class PathHelper
             {
                 throw ExceptionFactory.PathHasIllegalCharacters(path);
             }
+
             throw ExceptionFactory.PathHasIncorrectSyntax(
                 fileSystem.Path.Combine(fileSystem.Directory.GetCurrentDirectory(),
                     path));

--- a/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
@@ -6,7 +6,8 @@ namespace Testably.Abstractions.Testing.Storage;
 /// <summary>
 ///     A container for a stored file or directory in the <see cref="IStorage" />.
 /// </summary>
-internal interface IStorageContainer : IFileSystem.IFileSystemExtensionPoint, ITimeSystem.ITimeSystemExtensionPoint
+internal interface IStorageContainer : IFileSystem.IFileSystemExtensionPoint,
+    ITimeSystem.ITimeSystemExtensionPoint
 {
     /// <inheritdoc cref="System.IO.FileSystemInfo.Attributes" />
     FileAttributes Attributes { get; set; }
@@ -73,9 +74,19 @@ internal interface IStorageContainer : IFileSystem.IFileSystemExtensionPoint, IT
     /// </summary>
     void WriteBytes(byte[] bytes);
 
+    /// <summary>
+    ///     A container to allow reading/writing <see cref="DateTime" />s with consistent <see cref="DateTimeKind" />.
+    /// </summary>
     public interface ITimeContainer
     {
+        /// <summary>
+        ///     Get the <see cref="DateTime" /> in the given <paramref name="kind" />.
+        /// </summary>
         DateTime Get(DateTimeKind kind);
+
+        /// <summary>
+        ///     Set the <see cref="DateTime" /> to the <paramref name="time" /> in the given <paramref name="kind" />.
+        /// </summary>
         void Set(DateTime time, DateTimeKind kind);
     }
 }

--- a/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
@@ -12,18 +12,18 @@ internal interface IStorageContainer : IFileSystem.IFileSystemExtensionPoint, IT
     FileAttributes Attributes { get; set; }
 
     /// <inheritdoc cref="System.IO.FileSystemInfo.CreationTime" />
-    DateTime CreationTime { get; set; }
+    ITimeContainer CreationTime { get; }
 
     /// <inheritdoc cref="System.IO.FileSystemInfo.LastAccessTime" />
-    public DateTime LastAccessTime { get; set; }
+    ITimeContainer LastAccessTime { get; }
 
     /// <inheritdoc cref="System.IO.FileSystemInfo.LastWriteTime" />
-    public DateTime LastWriteTime { get; set; }
+    ITimeContainer LastWriteTime { get; }
 
     /// <summary>
     ///     If this instance represents a link, returns the link target's path, otherwise returns <see langword="null" />.
     /// </summary>
-    public string? LinkTarget { get; set; }
+    string? LinkTarget { get; set; }
 
     /// <summary>
     ///     The type of the container indicates if it is a <see cref="ContainerTypes.File" /> or
@@ -72,4 +72,10 @@ internal interface IStorageContainer : IFileSystem.IFileSystemExtensionPoint, IT
     ///     Writes the <paramref name="bytes" /> to the <see cref="IFileSystem.IFileInfo" />.
     /// </summary>
     void WriteBytes(byte[] bytes);
+
+    public interface ITimeContainer
+    {
+        DateTime Get(DateTimeKind kind);
+        void Set(DateTime time, DateTimeKind kind);
+    }
 }

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -235,7 +235,7 @@ internal class InMemoryContainer : IStorageContainer
 
         #region ITimeContainer Members
 
-        /// <inheritdoc />
+        /// <inheritdoc cref="ITimeContainer.Get(DateTimeKind)" />
         public DateTime Get(DateTimeKind kind)
             => kind switch
             {
@@ -244,7 +244,7 @@ internal class InMemoryContainer : IStorageContainer
                 _ => _time
             };
 
-        /// <inheritdoc />
+        /// <inheritdoc cref="ITimeContainer.Set(DateTime, DateTimeKind)" />
         public void Set(DateTime time, DateTimeKind kind)
         {
             if (time.Kind == DateTimeKind.Unspecified)

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -229,7 +229,7 @@ internal class InMemoryContainer : IStorageContainer
         _fileHandles.TryRemove(guid, out _);
     }
 
-    private class TimeContainer : ITimeContainer
+    private sealed class TimeContainer : ITimeContainer
     {
         private DateTime _time;
 

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -130,6 +130,8 @@ internal sealed class NullContainer : IStorageContainer
         private readonly DateTime _time =
             new(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc);
 
+        #region ITimeContainer Members
+
         /// <inheritdoc cref="IStorageContainer.ITimeContainer.Get(DateTimeKind)" />
         public DateTime Get(DateTimeKind kind)
             => kind switch
@@ -144,5 +146,7 @@ internal sealed class NullContainer : IStorageContainer
         {
             // Do nothing!
         }
+
+        #endregion
     }
 }

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using Testably.Abstractions.Testing.Internal;
 
 namespace Testably.Abstractions.Testing.Storage;
 
@@ -18,7 +19,7 @@ internal sealed class NullContainer : IStorageContainer
     public FileAttributes Attributes
     {
         get => (FileAttributes)(-1);
-        set => _ = value;
+        set => throw ExceptionFactory.FileNotFound("");
     }
 
     /// <inheritdoc cref="IStorageContainer.CreationTime" />
@@ -143,9 +144,7 @@ internal sealed class NullContainer : IStorageContainer
 
         /// <inheritdoc cref="IStorageContainer.ITimeContainer.Set(DateTime, DateTimeKind)" />
         public void Set(DateTime time, DateTimeKind kind)
-        {
-            // Do nothing!
-        }
+            => throw ExceptionFactory.FileNotFound(string.Empty);
 
         #endregion
     }

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -1,19 +1,11 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace Testably.Abstractions.Testing.Storage;
 
 internal sealed class NullContainer : IStorageContainer
 {
-    /// <summary>
-    ///     The default time returned by the file system if no time has been set.
-    ///     <seealso href="https://learn.microsoft.com/en-us/windows/win32/sysinfo/file-times" />:
-    ///     A file time is a 64-bit value that represents the number of 100-nanosecond intervals that have elapsed
-    ///     since 12:00 A.M. January 1, 1601 Coordinated Universal Time (UTC).
-    /// </summary>
-    private static readonly DateTime NullTime =
-        new(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc);
-
     private NullContainer(IFileSystem fileSystem, ITimeSystem timeSystem)
     {
         FileSystem = fileSystem;
@@ -30,30 +22,19 @@ internal sealed class NullContainer : IStorageContainer
     }
 
     /// <inheritdoc cref="IStorageContainer.CreationTime" />
-    public DateTime CreationTime
-    {
-        get => NullTime;
-        set => _ = value;
-    }
+    public IStorageContainer.ITimeContainer CreationTime { get; } = new NullTime();
 
     /// <inheritdoc cref="IFileSystem.IFileSystemExtensionPoint.FileSystem" />
     public IFileSystem FileSystem { get; }
 
     /// <inheritdoc cref="IStorageContainer.LastAccessTime" />
-    public DateTime LastAccessTime
-    {
-        get => NullTime;
-        set => _ = value;
-    }
+    public IStorageContainer.ITimeContainer LastAccessTime { get; } = new NullTime();
 
     /// <inheritdoc cref="IStorageContainer.LastWriteTime" />
-    public DateTime LastWriteTime
-    {
-        get => NullTime;
-        set => _ = value;
-    }
+    public IStorageContainer.ITimeContainer LastWriteTime { get; } = new NullTime();
 
     /// <inheritdoc cref="IStorageContainer.LinkTarget" />
+    [ExcludeFromCodeCoverage]
     public string? LinkTarget
     {
         get => null;
@@ -61,6 +42,7 @@ internal sealed class NullContainer : IStorageContainer
     }
 
     /// <inheritdoc cref="ITimeSystem.ITimeSystemExtensionPoint.TimeSystem" />
+    [ExcludeFromCodeCoverage]
     public ITimeSystem TimeSystem { get; }
 
     /// <inheritdoc cref="IStorageContainer.Type" />
@@ -68,38 +50,45 @@ internal sealed class NullContainer : IStorageContainer
         => ContainerTypes.DirectoryOrFile;
 
     /// <inheritdoc cref="IStorageContainer.AppendBytes(byte[])" />
+    [ExcludeFromCodeCoverage]
     public void AppendBytes(byte[] bytes)
     {
         // Do nothing in NullContainer
     }
 
     /// <inheritdoc cref="IStorageContainer.ClearBytes()" />
+    [ExcludeFromCodeCoverage]
     public void ClearBytes()
     {
         // Do nothing in NullContainer
     }
 
     /// <inheritdoc cref="IStorageContainer.Decrypt()" />
+    [ExcludeFromCodeCoverage]
     public void Decrypt()
     {
         // Do nothing in NullContainer
     }
 
     /// <inheritdoc cref="IStorageContainer.Encrypt()" />
+    [ExcludeFromCodeCoverage]
     public void Encrypt()
     {
         // Do nothing in NullContainer
     }
 
     /// <inheritdoc cref="IStorageContainer.GetBytes()" />
+    [ExcludeFromCodeCoverage]
     public byte[] GetBytes()
         => Array.Empty<byte>();
 
     /// <inheritdoc cref="IStorageContainer.RequestAccess(FileAccess, FileShare)" />
+    [ExcludeFromCodeCoverage]
     public IStorageAccessHandle RequestAccess(FileAccess access, FileShare share)
         => new NullStorageAccessHandle();
 
     /// <inheritdoc cref="IStorageContainer.WriteBytes(byte[])" />
+    [ExcludeFromCodeCoverage]
     public void WriteBytes(byte[] bytes)
     {
         // Do nothing in NullContainer
@@ -110,6 +99,7 @@ internal sealed class NullContainer : IStorageContainer
     internal static IStorageContainer New(FileSystemMock fileSystem)
         => new NullContainer(fileSystem, fileSystem.TimeSystem);
 
+    [ExcludeFromCodeCoverage]
     private sealed class NullStorageAccessHandle : IStorageAccessHandle
     {
         #region IStorageAccessHandle Members
@@ -127,5 +117,32 @@ internal sealed class NullContainer : IStorageContainer
         }
 
         #endregion
+    }
+
+    /// <summary>
+    ///     The default time returned by the file system if no time has been set.
+    ///     <seealso href="https://learn.microsoft.com/en-us/windows/win32/sysinfo/file-times" />:
+    ///     A file time is a 64-bit value that represents the number of 100-nanosecond intervals that have elapsed
+    ///     since 12:00 A.M. January 1, 1601 Coordinated Universal Time (UTC).
+    /// </summary>
+    private sealed class NullTime : IStorageContainer.ITimeContainer
+    {
+        private readonly DateTime _time =
+            new(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc);
+
+        /// <inheritdoc cref="IStorageContainer.ITimeContainer.Get(DateTimeKind)" />
+        public DateTime Get(DateTimeKind kind)
+            => kind switch
+            {
+                DateTimeKind.Utc => _time.ToUniversalTime(),
+                DateTimeKind.Local => _time.ToLocalTime(),
+                _ => _time
+            };
+
+        /// <inheritdoc cref="IStorageContainer.ITimeContainer.Set(DateTime, DateTimeKind)" />
+        public void Set(DateTime time, DateTimeKind kind)
+        {
+            // Do nothing!
+        }
     }
 }

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Runtime.InteropServices;
 using Testably.Abstractions.Testing.Internal;
 
 namespace Testably.Abstractions.Testing.Storage;
@@ -19,7 +20,7 @@ internal sealed class NullContainer : IStorageContainer
     public FileAttributes Attributes
     {
         get => (FileAttributes)(-1);
-        set => throw ExceptionFactory.FileNotFound("");
+        set => throw ExceptionFactory.FileNotFound(string.Empty);
     }
 
     /// <inheritdoc cref="IStorageContainer.CreationTime" />
@@ -144,7 +145,14 @@ internal sealed class NullContainer : IStorageContainer
 
         /// <inheritdoc cref="IStorageContainer.ITimeContainer.Set(DateTime, DateTimeKind)" />
         public void Set(DateTime time, DateTimeKind kind)
-            => throw ExceptionFactory.FileNotFound(string.Empty);
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw ExceptionFactory.FileNotFound(string.Empty);
+            }
+
+            throw ExceptionFactory.DirectoryNotFound(string.Empty);
+        }
 
         #endregion
     }

--- a/Source/Testably.Abstractions.Testing/Storage/StorageContainerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/StorageContainerExtensions.cs
@@ -15,17 +15,17 @@ internal static class StorageContainerExtensions
         DateTime now = container.TimeSystem.DateTime.UtcNow;
         if (timeAdjustments.HasFlag(TimeAdjustments.CreationTime))
         {
-            container.CreationTime = now;
+            container.CreationTime.Set(now, DateTimeKind.Utc);
         }
 
         if (timeAdjustments.HasFlag(TimeAdjustments.LastAccessTime))
         {
-            container.LastAccessTime = now;
+            container.LastAccessTime.Set(now, DateTimeKind.Utc);
         }
 
         if (timeAdjustments.HasFlag(TimeAdjustments.LastWriteTime))
         {
-            container.LastWriteTime = now;
+            container.LastWriteTime.Set(now, DateTimeKind.Utc);
         }
     }
 }

--- a/Source/Testably.Abstractions/FileSystem.DriveInfoWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem.DriveInfoWrapper.cs
@@ -21,9 +21,6 @@ public sealed partial class FileSystem
 
         #region IDriveInfo Members
 
-        /// <inheritdoc cref="IFileSystem.IFileSystemExtensionPoint.FileSystem" />
-        public IFileSystem FileSystem { get; }
-
         /// <inheritdoc cref="IFileSystem.IDriveInfo.AvailableFreeSpace" />
         public long AvailableFreeSpace
             => _instance.AvailableFreeSpace;
@@ -35,6 +32,9 @@ public sealed partial class FileSystem
         /// <inheritdoc cref="IFileSystem.IDriveInfo.DriveType" />
         public DriveType DriveType
             => _instance.DriveType;
+
+        /// <inheritdoc cref="IFileSystem.IFileSystemExtensionPoint.FileSystem" />
+        public IFileSystem FileSystem { get; }
 
         /// <inheritdoc cref="IFileSystem.IDriveInfo.IsReady" />
         public bool IsReady

--- a/Source/Testably.Abstractions/FileSystem.FileWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem.FileWrapper.cs
@@ -1,15 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Text;
-#if NET6_0_OR_GREATER
+﻿#if NET6_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
 #if FEATURE_FILESYSTEM_ASYNC
 using System.Threading;
 using System.Threading.Tasks;
 #endif
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text;
 using static Testably.Abstractions.IFileSystem;
 
 namespace Testably.Abstractions;

--- a/Source/Testably.Abstractions/Helpers/GuidSystemBase.cs
+++ b/Source/Testably.Abstractions/Helpers/GuidSystemBase.cs
@@ -22,14 +22,16 @@ public abstract class GuidSystemBase : IRandomSystem.IGuid
 
     #region IGuid Members
 
-    /// <inheritdoc cref="IRandomSystem.IRandomSystemExtensionPoint.RandomSystem" />
-    public IRandomSystem RandomSystem { get; }
-
     /// <inheritdoc cref="IRandomSystem.IGuid.Empty" />
     public Guid Empty => Guid.Empty;
 
+    /// <inheritdoc cref="IRandomSystem.IRandomSystemExtensionPoint.RandomSystem" />
+    public IRandomSystem RandomSystem { get; }
+
     /// <inheritdoc cref="IRandomSystem.IGuid.NewGuid()" />
     public abstract Guid NewGuid();
+
+    #endregion
 
 #if FEATURE_GUID_PARSE
     /// <inheritdoc cref="IRandomSystem.IGuid.Parse(string)" />
@@ -67,6 +69,4 @@ public abstract class GuidSystemBase : IRandomSystem.IGuid
                               out Guid result)
         => Guid.TryParseExact(input, format, out result);
 #endif
-
-    #endregion
 }

--- a/Source/Testably.Abstractions/IFileSystem.IFile.cs
+++ b/Source/Testably.Abstractions/IFileSystem.IFile.cs
@@ -139,7 +139,8 @@ public partial interface IFileSystem
         FileSystemStream Open(string path, FileMode mode, FileAccess access);
 
         /// <inheritdoc cref="File.Open(string, FileMode, FileAccess, FileShare)" />
-        FileSystemStream Open(string path, FileMode mode, FileAccess access, FileShare share);
+        FileSystemStream Open(string path, FileMode mode, FileAccess access,
+                              FileShare share);
 
 #if FEATURE_FILESYSTEM_STREAM_OPTIONS
         /// <inheritdoc cref="File.Open(string, FileStreamOptions)" />

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryInfoTests.EnumerateDirectories.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryInfoTests.EnumerateDirectories.cs
@@ -20,7 +20,8 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
                .WithSubdirectory(path).Initialized(s => s
                    .WithSubdirectory("foo/xyz")
                    .WithSubdirectory("bar"));
-        var baseDirectory = (IFileSystem.IDirectoryInfo)initialized[0];
+        IFileSystem.IDirectoryInfo baseDirectory =
+            (IFileSystem.IDirectoryInfo)initialized[0];
 
         IFileSystem.IDirectoryInfo[] result = baseDirectory
            .EnumerateDirectories("*", SearchOption.AllDirectories).ToArray();

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryInfoTests.GetDirectories.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryInfoTests.GetDirectories.cs
@@ -20,7 +20,8 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
                .WithSubdirectory(path).Initialized(s => s
                    .WithSubdirectory("foo/xyz")
                    .WithSubdirectory("bar"));
-        var baseDirectory = (IFileSystem.IDirectoryInfo)initialized[0];
+        IFileSystem.IDirectoryInfo baseDirectory =
+            (IFileSystem.IDirectoryInfo)initialized[0];
 
         IFileSystem.IDirectoryInfo[] result = baseDirectory
            .GetDirectories("*", SearchOption.AllDirectories);

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryInfoTests.cs
@@ -5,8 +5,6 @@ namespace Testably.Abstractions.Tests;
 public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
     where TFileSystem : IFileSystem
 {
-    #region Test Setup
-
     public abstract string BasePath { get; }
     public TFileSystem FileSystem { get; }
     public ITimeSystem TimeSystem { get; }
@@ -21,8 +19,6 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
         Test.SkipIfTestsOnRealFileSystemShouldBeSkipped(FileSystem);
     }
 
-    #endregion
-
     [SkippableTheory]
     [AutoData]
     [FileSystemTests.DirectoryInfo("MissingFile")]
@@ -31,7 +27,11 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
     {
         IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New("Missing File");
         sut.Attributes.Should().Be((FileAttributes)(-1));
-        sut.Attributes = fileAttributes;
+        Exception? exception = Record.Exception(() =>
+        {
+            sut.Attributes = fileAttributes;
+        });
+        exception.Should().BeOfType<FileNotFoundException>();
         sut.Attributes.Should().Be((FileAttributes)(-1));
     }
 
@@ -42,7 +42,11 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
     {
         IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New("Missing File");
         sut.CreationTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
-        sut.CreationTime = creationTime;
+        Exception? exception = Record.Exception(() =>
+        {
+            sut.CreationTime = creationTime;
+        });
+        exception.Should().BeOfType<FileNotFoundException>();
         sut.CreationTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
     }
 
@@ -54,7 +58,11 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
     {
         IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New("Missing File");
         sut.CreationTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
-        sut.CreationTimeUtc = creationTimeUtc;
+        Exception? exception = Record.Exception(() =>
+        {
+            sut.CreationTimeUtc = creationTimeUtc;
+        });
+        exception.Should().BeOfType<FileNotFoundException>();
         sut.CreationTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
     }
 
@@ -65,7 +73,11 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
     {
         IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New("Missing File");
         sut.LastAccessTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
-        sut.LastAccessTime = lastAccessTime;
+        Exception? exception = Record.Exception(() =>
+        {
+            sut.LastAccessTime = lastAccessTime;
+        });
+        exception.Should().BeOfType<FileNotFoundException>();
         sut.LastAccessTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
     }
 
@@ -77,7 +89,11 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
     {
         IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New("Missing File");
         sut.LastAccessTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
-        sut.LastAccessTimeUtc = lastAccessTimeUtc;
+        Exception? exception = Record.Exception(() =>
+        {
+            sut.LastAccessTimeUtc = lastAccessTimeUtc;
+        });
+        exception.Should().BeOfType<FileNotFoundException>();
         sut.LastAccessTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
     }
 
@@ -88,7 +104,11 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
     {
         IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New("Missing File");
         sut.LastWriteTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
-        sut.LastWriteTime = lastWriteTime;
+        Exception? exception = Record.Exception(() =>
+        {
+            sut.LastWriteTime = lastWriteTime;
+        });
+        exception.Should().BeOfType<FileNotFoundException>();
         sut.LastWriteTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
     }
 
@@ -100,7 +120,11 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
     {
         IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New("Missing File");
         sut.LastWriteTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
-        sut.LastWriteTimeUtc = lastWriteTimeUtc;
+        Exception? exception = Record.Exception(() =>
+        {
+            sut.LastWriteTimeUtc = lastWriteTimeUtc;
+        });
+        exception.Should().BeOfType<FileNotFoundException>();
         sut.LastWriteTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
     }
 

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryInfoTests.cs
@@ -46,7 +46,14 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
         {
             sut.CreationTime = creationTime;
         });
-        exception.Should().BeOfType<FileNotFoundException>();
+        if (Test.RunsOnWindows)
+        {
+            exception.Should().BeOfType<FileNotFoundException>();
+        }
+        else
+        {
+            exception.Should().BeOfType<DirectoryNotFoundException>();
+        }
         sut.CreationTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
     }
 
@@ -62,7 +69,14 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
         {
             sut.CreationTimeUtc = creationTimeUtc;
         });
-        exception.Should().BeOfType<FileNotFoundException>();
+        if (Test.RunsOnWindows)
+        {
+            exception.Should().BeOfType<FileNotFoundException>();
+        }
+        else
+        {
+            exception.Should().BeOfType<DirectoryNotFoundException>();
+        }
         sut.CreationTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
     }
 
@@ -77,7 +91,14 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
         {
             sut.LastAccessTime = lastAccessTime;
         });
-        exception.Should().BeOfType<FileNotFoundException>();
+        if (Test.RunsOnWindows)
+        {
+            exception.Should().BeOfType<FileNotFoundException>();
+        }
+        else
+        {
+            exception.Should().BeOfType<DirectoryNotFoundException>();
+        }
         sut.LastAccessTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
     }
 
@@ -93,7 +114,14 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
         {
             sut.LastAccessTimeUtc = lastAccessTimeUtc;
         });
-        exception.Should().BeOfType<FileNotFoundException>();
+        if (Test.RunsOnWindows)
+        {
+            exception.Should().BeOfType<FileNotFoundException>();
+        }
+        else
+        {
+            exception.Should().BeOfType<DirectoryNotFoundException>();
+        }
         sut.LastAccessTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
     }
 
@@ -108,7 +136,14 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
         {
             sut.LastWriteTime = lastWriteTime;
         });
-        exception.Should().BeOfType<FileNotFoundException>();
+        if (Test.RunsOnWindows)
+        {
+            exception.Should().BeOfType<FileNotFoundException>();
+        }
+        else
+        {
+            exception.Should().BeOfType<DirectoryNotFoundException>();
+        }
         sut.LastWriteTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
     }
 
@@ -124,7 +159,14 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
         {
             sut.LastWriteTimeUtc = lastWriteTimeUtc;
         });
-        exception.Should().BeOfType<FileNotFoundException>();
+        if (Test.RunsOnWindows)
+        {
+            exception.Should().BeOfType<FileNotFoundException>();
+        }
+        else
+        {
+            exception.Should().BeOfType<DirectoryNotFoundException>();
+        }
         sut.LastWriteTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
     }
 

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryInfoTests.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace Testably.Abstractions.Tests;
 
 public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
@@ -20,6 +22,87 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
     }
 
     #endregion
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.DirectoryInfo("MissingFile")]
+    public void MissingFile_Attributes_ShouldAlwaysBeNegativeOne(
+        FileAttributes fileAttributes)
+    {
+        IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New("Missing File");
+        sut.Attributes.Should().Be((FileAttributes)(-1));
+        sut.Attributes = fileAttributes;
+        sut.Attributes.Should().Be((FileAttributes)(-1));
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.DirectoryInfo("MissingFile")]
+    public void MissingFile_CreationTime_ShouldAlwaysBeNullTime(DateTime creationTime)
+    {
+        IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New("Missing File");
+        sut.CreationTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
+        sut.CreationTime = creationTime;
+        sut.CreationTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.DirectoryInfo("MissingFile")]
+    public void MissingFile_CreationTimeUtc_ShouldAlwaysBeNullTime(
+        DateTime creationTimeUtc)
+    {
+        IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New("Missing File");
+        sut.CreationTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
+        sut.CreationTimeUtc = creationTimeUtc;
+        sut.CreationTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.DirectoryInfo("MissingFile")]
+    public void MissingFile_LastAccessTime_ShouldAlwaysBeNullTime(DateTime lastAccessTime)
+    {
+        IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New("Missing File");
+        sut.LastAccessTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
+        sut.LastAccessTime = lastAccessTime;
+        sut.LastAccessTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.DirectoryInfo("MissingFile")]
+    public void MissingFile_LastAccessTimeUtc_ShouldAlwaysBeNullTime(
+        DateTime lastAccessTimeUtc)
+    {
+        IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New("Missing File");
+        sut.LastAccessTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
+        sut.LastAccessTimeUtc = lastAccessTimeUtc;
+        sut.LastAccessTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.DirectoryInfo("MissingFile")]
+    public void MissingFile_LastWriteTime_ShouldAlwaysBeNullTime(DateTime lastWriteTime)
+    {
+        IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New("Missing File");
+        sut.LastWriteTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
+        sut.LastWriteTime = lastWriteTime;
+        sut.LastWriteTime.Should().Be(FileTestHelper.NullTime.ToLocalTime());
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.DirectoryInfo("MissingFile")]
+    public void MissingFile_LastWriteTimeUtc_ShouldAlwaysBeNullTime(
+        DateTime lastWriteTimeUtc)
+    {
+        IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New("Missing File");
+        sut.LastWriteTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
+        sut.LastWriteTimeUtc = lastWriteTimeUtc;
+        sut.LastWriteTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
+    }
 
     [SkippableTheory]
     [AutoData]

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.CreateDirectory.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.CreateDirectory.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 #if !NETFRAMEWORK
@@ -65,7 +66,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
     [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.CreateDirectory))]
     public void CreateDirectory_IllegalCharacters_ShouldThrowArgumentException()
     {
-        var invalidChars = FileSystem.Path
+        IEnumerable<char> invalidChars = FileSystem.Path
            .GetInvalidPathChars().Where(c => c != '\0')
            .Concat(new[] { '*', '?' });
         foreach (char invalidChar in invalidChars)
@@ -82,7 +83,9 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
                 exception.Should().BeOfType<ArgumentException>();
 #else
                 string expectedMessage = $"'{Path.Combine(BasePath, path)}'";
-                exception.Should().BeOfType<IOException>($"'{invalidChar}' is an invalid path character.")
+                exception.Should()
+                   .BeOfType<IOException>(
+                        $"'{invalidChar}' is an invalid path character.")
                    .Which.Message.Should().Contain(expectedMessage);
 #endif
             }
@@ -215,7 +218,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 
         IFileSystem.IDirectoryInfo result =
             FileSystem.Directory.CreateDirectory(nameWithSuffix);
-            
+
         result.Name.Should().Be(expectedName.TrimEnd(
             FileSystem.Path.DirectorySeparatorChar,
             FileSystem.Path.AltDirectorySeparatorChar));

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.ResolveLinkTarget.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.ResolveLinkTarget.cs
@@ -6,8 +6,6 @@ namespace Testably.Abstractions.Tests;
 public abstract partial class FileSystemDirectoryTests<TFileSystem>
     where TFileSystem : IFileSystem
 {
-    #region Test Setup
-
     /// <summary>
     ///     The maximum number of symbolic links that are followed.<br />
     ///     <see href="https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks" />
@@ -15,7 +13,22 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
     private static int MaxResolveLinks =>
         Test.RunsOnWindows ? 63 : 40;
 
-    #endregion
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.ResolveLinkTarget))]
+    public void ResolveLinkTarget_AbsolutePath_ShouldFollowSymbolicLink(
+        string path, string pathToTarget)
+    {
+        string targetFullPath = FileSystem.Path.GetFullPath(pathToTarget);
+        FileSystem.Directory.CreateDirectory(pathToTarget);
+        FileSystem.Directory.CreateSymbolicLink(path, targetFullPath);
+
+        IFileSystem.IFileSystemInfo? target =
+            FileSystem.Directory.ResolveLinkTarget(path, false);
+
+        target!.FullName.Should().Be(targetFullPath);
+        target.Exists.Should().BeTrue();
+    }
 
     [SkippableTheory]
     [AutoData]
@@ -153,23 +166,6 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
     [AutoData]
     [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.ResolveLinkTarget))]
     public void ResolveLinkTarget_RelativePath_ShouldFollowSymbolicLinkUnderWindows(
-        string path, string pathToTarget)
-    {
-        string targetFullPath = FileSystem.Path.GetFullPath(pathToTarget);
-        FileSystem.Directory.CreateDirectory(pathToTarget);
-        FileSystem.Directory.CreateSymbolicLink(path, targetFullPath);
-
-        IFileSystem.IFileSystemInfo? target =
-            FileSystem.Directory.ResolveLinkTarget(path, false);
-
-        target!.FullName.Should().Be(targetFullPath);
-        target.Exists.Should().BeTrue();
-    }
-
-    [SkippableTheory]
-    [AutoData]
-    [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.ResolveLinkTarget))]
-    public void ResolveLinkTarget_AbsolutePath_ShouldFollowSymbolicLink(
         string path, string pathToTarget)
     {
         string targetFullPath = FileSystem.Path.GetFullPath(pathToTarget);

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.Times.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.Times.cs
@@ -6,24 +6,12 @@ namespace Testably.Abstractions.Tests;
 public abstract partial class FileSystemDirectoryTests<TFileSystem>
     where TFileSystem : IFileSystem
 {
-    #region Test Setup
-
-    /// <summary>
-    ///     The default time returned by the file system if no time has been set.
-    ///     <seealso href="https://learn.microsoft.com/en-us/windows/win32/sysinfo/file-times" />:
-    ///     A file time is a 64-bit value that represents the number of 100-nanosecond intervals that have elapsed
-    ///     since 12:00 A.M. January 1, 1601 Coordinated Universal Time (UTC).
-    /// </summary>
-    internal readonly DateTime NullTime = new(1601, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
-    #endregion
-
     [SkippableTheory]
     [AutoData]
     [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.GetCreationTime))]
     public void GetCreationTime_PathNotFound_ShouldReturnNullTime(string path)
     {
-        DateTime expectedTime = NullTime.ToLocalTime();
+        DateTime expectedTime = FileTestHelper.NullTime.ToLocalTime();
 
         DateTime result = FileSystem.Directory.GetCreationTime(path);
 
@@ -35,7 +23,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
     [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.GetCreationTimeUtc))]
     public void GetCreationTimeUtc_PathNotFound_ShouldReturnNullTime(string path)
     {
-        DateTime expectedTime = NullTime.ToUniversalTime();
+        DateTime expectedTime = FileTestHelper.NullTime.ToUniversalTime();
 
         DateTime result = FileSystem.Directory.GetCreationTimeUtc(path);
 
@@ -47,7 +35,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
     [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.GetLastAccessTime))]
     public void GetLastAccessTime_PathNotFound_ShouldReturnNullTime(string path)
     {
-        DateTime expectedTime = NullTime.ToLocalTime();
+        DateTime expectedTime = FileTestHelper.NullTime.ToLocalTime();
 
         DateTime result = FileSystem.Directory.GetLastAccessTime(path);
 
@@ -59,7 +47,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
     [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.GetLastAccessTimeUtc))]
     public void GetLastAccessTimeUtc_PathNotFound_ShouldReturnNullTime(string path)
     {
-        DateTime expectedTime = NullTime.ToUniversalTime();
+        DateTime expectedTime = FileTestHelper.NullTime.ToUniversalTime();
 
         DateTime result = FileSystem.Directory.GetLastAccessTimeUtc(path);
 
@@ -71,7 +59,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
     [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.GetLastWriteTime))]
     public void GetLastWriteTime_PathNotFound_ShouldReturnNullTime(string path)
     {
-        DateTime expectedTime = NullTime.ToLocalTime();
+        DateTime expectedTime = FileTestHelper.NullTime.ToLocalTime();
 
         DateTime result = FileSystem.Directory.GetLastWriteTime(path);
 
@@ -83,7 +71,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
     [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.GetLastWriteTimeUtc))]
     public void GetLastWriteTimeUtc_PathNotFound_ShouldReturnNullTime(string path)
     {
-        DateTime expectedTime = NullTime.ToUniversalTime();
+        DateTime expectedTime = FileTestHelper.NullTime.ToUniversalTime();
 
         DateTime result = FileSystem.Directory.GetLastWriteTimeUtc(path);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.Times.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.Times.cs
@@ -338,9 +338,6 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
     public void SetLastAccessTime_Unspecified_ShouldChangeLastAccessTime(
         string path, DateTime lastAccessTime)
     {
-        Skip.IfNot(Test.RunsOnWindows,
-            "Linux does not have a creation timestamp: https://unix.stackexchange.com/a/102692");
-
         lastAccessTime = DateTime.SpecifyKind(lastAccessTime, DateTimeKind.Unspecified);
         FileSystem.Directory.CreateDirectory(path);
 
@@ -397,9 +394,6 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
     public void SetLastAccessTimeUtc_Unspecified_ShouldChangeLastAccessTime(
         string path, DateTime lastAccessTime)
     {
-        Skip.IfNot(Test.RunsOnWindows,
-            "Linux does not have a creation timestamp: https://unix.stackexchange.com/a/102692");
-
         lastAccessTime = DateTime.SpecifyKind(lastAccessTime, DateTimeKind.Unspecified);
         FileSystem.Directory.CreateDirectory(path);
 
@@ -456,9 +450,6 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
     public void SetLastWriteTime_Unspecified_ShouldChangeLastWriteTime(
         string path, DateTime lastWriteTime)
     {
-        Skip.IfNot(Test.RunsOnWindows,
-            "Linux does not have a creation timestamp: https://unix.stackexchange.com/a/102692");
-
         lastWriteTime = DateTime.SpecifyKind(lastWriteTime, DateTimeKind.Unspecified);
         FileSystem.Directory.CreateDirectory(path);
 
@@ -515,9 +506,6 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
     public void SetLastWriteTimeUtc_Unspecified_ShouldChangeLastWriteTime(
         string path, DateTime lastWriteTime)
     {
-        Skip.IfNot(Test.RunsOnWindows,
-            "Linux does not have a creation timestamp: https://unix.stackexchange.com/a/102692");
-
         lastWriteTime = DateTime.SpecifyKind(lastWriteTime, DateTimeKind.Unspecified);
         FileSystem.Directory.CreateDirectory(path);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.Times.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.Times.cs
@@ -213,6 +213,26 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 
     [SkippableTheory]
     [AutoData]
+    [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.SetCreationTime))]
+    public void SetCreationTime_Unspecified_ShouldChangeCreationTime(
+        string path, DateTime creationTime)
+    {
+        Skip.IfNot(Test.RunsOnWindows,
+            "Linux does not have a creation timestamp: https://unix.stackexchange.com/a/102692");
+
+        creationTime = DateTime.SpecifyKind(creationTime, DateTimeKind.Unspecified);
+        FileSystem.Directory.CreateDirectory(path);
+
+        FileSystem.Directory.SetCreationTime(path, creationTime);
+
+        FileSystem.Directory.GetCreationTimeUtc(path)
+           .Should().Be(creationTime.ToUniversalTime());
+        FileSystem.Directory.GetCreationTime(path)
+           .Should().Be(creationTime);
+    }
+
+    [SkippableTheory]
+    [AutoData]
     [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.SetCreationTimeUtc))]
     public void SetCreationTimeUtc_PathNotFound_ShouldThrowCorrectException(
         string path, DateTime creationTime)
@@ -251,6 +271,26 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 
         FileSystem.Directory.GetCreationTime(path)
            .Should().Be(expectedTime);
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.SetCreationTime))]
+    public void SetCreationTimeUtc_Unspecified_ShouldChangeCreationTime(
+        string path, DateTime creationTime)
+    {
+        Skip.IfNot(Test.RunsOnWindows,
+            "Linux does not have a creation timestamp: https://unix.stackexchange.com/a/102692");
+
+        creationTime = DateTime.SpecifyKind(creationTime, DateTimeKind.Unspecified);
+        FileSystem.Directory.CreateDirectory(path);
+
+        FileSystem.Directory.SetCreationTimeUtc(path, creationTime);
+
+        FileSystem.Directory.GetCreationTimeUtc(path)
+           .Should().Be(creationTime);
+        FileSystem.Directory.GetCreationTime(path)
+           .Should().Be(creationTime.ToLocalTime());
     }
 
     [SkippableTheory]
@@ -294,6 +334,26 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 
     [SkippableTheory]
     [AutoData]
+    [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.SetLastAccessTime))]
+    public void SetLastAccessTime_Unspecified_ShouldChangeLastAccessTime(
+        string path, DateTime lastAccessTime)
+    {
+        Skip.IfNot(Test.RunsOnWindows,
+            "Linux does not have a creation timestamp: https://unix.stackexchange.com/a/102692");
+
+        lastAccessTime = DateTime.SpecifyKind(lastAccessTime, DateTimeKind.Unspecified);
+        FileSystem.Directory.CreateDirectory(path);
+
+        FileSystem.Directory.SetLastAccessTime(path, lastAccessTime);
+
+        FileSystem.Directory.GetLastAccessTimeUtc(path)
+           .Should().Be(lastAccessTime.ToUniversalTime());
+        FileSystem.Directory.GetLastAccessTime(path)
+           .Should().Be(lastAccessTime);
+    }
+
+    [SkippableTheory]
+    [AutoData]
     [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.SetLastAccessTimeUtc))]
     public void SetLastAccessTimeUtc_PathNotFound_ShouldThrowCorrectException(
         string path, DateTime lastAccessTime)
@@ -329,6 +389,26 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 
         FileSystem.Directory.GetLastAccessTime(path)
            .Should().Be(expectedTime);
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.SetLastAccessTime))]
+    public void SetLastAccessTimeUtc_Unspecified_ShouldChangeLastAccessTime(
+        string path, DateTime lastAccessTime)
+    {
+        Skip.IfNot(Test.RunsOnWindows,
+            "Linux does not have a creation timestamp: https://unix.stackexchange.com/a/102692");
+
+        lastAccessTime = DateTime.SpecifyKind(lastAccessTime, DateTimeKind.Unspecified);
+        FileSystem.Directory.CreateDirectory(path);
+
+        FileSystem.Directory.SetLastAccessTimeUtc(path, lastAccessTime);
+
+        FileSystem.Directory.GetLastAccessTimeUtc(path)
+           .Should().Be(lastAccessTime);
+        FileSystem.Directory.GetLastAccessTime(path)
+           .Should().Be(lastAccessTime.ToLocalTime());
     }
 
     [SkippableTheory]
@@ -372,6 +452,26 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 
     [SkippableTheory]
     [AutoData]
+    [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.SetLastWriteTime))]
+    public void SetLastWriteTime_Unspecified_ShouldChangeLastWriteTime(
+        string path, DateTime lastWriteTime)
+    {
+        Skip.IfNot(Test.RunsOnWindows,
+            "Linux does not have a creation timestamp: https://unix.stackexchange.com/a/102692");
+
+        lastWriteTime = DateTime.SpecifyKind(lastWriteTime, DateTimeKind.Unspecified);
+        FileSystem.Directory.CreateDirectory(path);
+
+        FileSystem.Directory.SetLastWriteTime(path, lastWriteTime);
+
+        FileSystem.Directory.GetLastWriteTimeUtc(path)
+           .Should().Be(lastWriteTime.ToUniversalTime());
+        FileSystem.Directory.GetLastWriteTime(path)
+           .Should().Be(lastWriteTime);
+    }
+
+    [SkippableTheory]
+    [AutoData]
     [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.SetLastWriteTimeUtc))]
     public void SetLastWriteTimeUtc_PathNotFound_ShouldThrowCorrectException(
         string path, DateTime lastWriteTime)
@@ -407,5 +507,25 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 
         FileSystem.Directory.GetLastWriteTime(path)
            .Should().Be(expectedTime);
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.SetLastWriteTime))]
+    public void SetLastWriteTimeUtc_Unspecified_ShouldChangeLastWriteTime(
+        string path, DateTime lastWriteTime)
+    {
+        Skip.IfNot(Test.RunsOnWindows,
+            "Linux does not have a creation timestamp: https://unix.stackexchange.com/a/102692");
+
+        lastWriteTime = DateTime.SpecifyKind(lastWriteTime, DateTimeKind.Unspecified);
+        FileSystem.Directory.CreateDirectory(path);
+
+        FileSystem.Directory.SetLastWriteTimeUtc(path, lastWriteTime);
+
+        FileSystem.Directory.GetLastWriteTimeUtc(path)
+           .Should().Be(lastWriteTime);
+        FileSystem.Directory.GetLastWriteTime(path)
+           .Should().Be(lastWriteTime.ToLocalTime());
     }
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileInfoFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileInfoFactoryTests.cs
@@ -71,7 +71,7 @@ public abstract class FileSystemFileInfoFactoryTests<TFileSystem>
         //var stream = FileSystem.File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Write);
         IFileSystem.IFileInfo sut = FileSystem.FileInfo.New(path);
 
-        var result = sut.Length;
+        long result = sut.Length;
 
         //stream.Dispose();
 

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileStreamTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileStreamTests.cs
@@ -194,7 +194,7 @@ public abstract partial class FileSystemFileStreamTests<TFileSystem>
     [FileSystemTests.FileStream]
     public async Task ReadAsync_ShouldFillBuffer(string path, byte[] contents)
     {
-        CancellationTokenSource cts = new (10000);
+        CancellationTokenSource cts = new(10000);
         byte[] buffer = new byte[contents.Length];
         await FileSystem.File.WriteAllBytesAsync(path, contents, cts.Token);
         await using FileSystemStream stream = FileSystem.File.OpenRead(path);

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileSystemInfoTests.ResolveLinkTarget.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileSystemInfoTests.ResolveLinkTarget.cs
@@ -6,16 +6,12 @@ namespace Testably.Abstractions.Tests;
 public abstract partial class FileSystemFileSystemInfoTests<TFileSystem>
     where TFileSystem : IFileSystem
 {
-    #region Test Setup
-
     /// <summary>
     ///     The maximum number of symbolic links that are followed.<br />
     ///     <see href="https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks" />
     /// </summary>
     private static int MaxResolveLinks =>
         Test.RunsOnWindows ? 63 : 40;
-
-    #endregion
 
     [SkippableTheory]
     [AutoData]

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileSystemInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileSystemInfoTests.cs
@@ -5,8 +5,6 @@ namespace Testably.Abstractions.Tests;
 public abstract partial class FileSystemFileSystemInfoTests<TFileSystem>
     where TFileSystem : IFileSystem
 {
-    #region Test Setup
-
     public abstract string BasePath { get; }
     public TFileSystem FileSystem { get; }
     public ITimeSystem TimeSystem { get; }
@@ -21,7 +19,42 @@ public abstract partial class FileSystemFileSystemInfoTests<TFileSystem>
         Test.SkipIfTestsOnRealFileSystemShouldBeSkipped(FileSystem);
     }
 
-    #endregion
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.FileSystemInfo(
+        nameof(IFileSystem.IFileSystemInfo.Attributes))]
+    public void SetAttributes_Hidden_OnFileStartingWithDot_ShouldBeSet(string path)
+    {
+        Skip.IfNot(Test.RunsOnLinux);
+
+        path = $".{path}";
+        FileSystem.File.WriteAllText(path, null);
+
+        FileAttributes result1 = FileSystem.File.GetAttributes(path);
+        FileSystem.File.SetAttributes(path, FileAttributes.Normal);
+        FileAttributes result2 = FileSystem.File.GetAttributes(path);
+
+        result1.Should().Be(FileAttributes.Hidden);
+        result2.Should().Be(FileAttributes.Hidden);
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.FileSystemInfo(
+        nameof(IFileSystem.IFileSystemInfo.Attributes))]
+    public void SetAttributes_Hidden_OnNormalFile_ShouldBeIgnored(string path)
+    {
+        Skip.IfNot(Test.RunsOnLinux);
+
+        FileSystem.File.WriteAllText(path, null);
+
+        FileAttributes result1 = FileSystem.File.GetAttributes(path);
+        FileSystem.File.SetAttributes(path, FileAttributes.Hidden);
+        FileAttributes result2 = FileSystem.File.GetAttributes(path);
+
+        result1.Should().Be(FileAttributes.Normal);
+        result2.Should().Be(FileAttributes.Normal);
+    }
 
     [SkippableTheory]
     [InlineAutoData(FileAttributes.Compressed)]
@@ -41,33 +74,6 @@ public abstract partial class FileSystemFileSystemInfoTests<TFileSystem>
         FileAttributes result = FileSystem.File.GetAttributes(path);
 
         result.Should().Be(FileAttributes.Normal);
-    }
-
-    [SkippableTheory]
-    [InlineAutoData(FileAttributes.Archive)]
-    [InlineAutoData(FileAttributes.NoScrubData)]
-    [InlineAutoData(FileAttributes.NotContentIndexed)]
-    [InlineAutoData(FileAttributes.Offline)]
-    [InlineAutoData(FileAttributes.System)]
-    [InlineAutoData(FileAttributes.Temporary)]
-    [FileSystemTests.FileSystemInfo(
-        nameof(IFileSystem.IFileSystemInfo.Attributes))]
-    public void SetAttributes_ShouldOnlyWorkOnWindows(FileAttributes attributes,
-                                                      string path)
-    {
-        FileSystem.File.WriteAllText(path, null);
-        FileSystem.File.SetAttributes(path, attributes);
-
-        FileAttributes result = FileSystem.File.GetAttributes(path);
-
-        if (Test.RunsOnWindows)
-        {
-            result.Should().Be(attributes);
-        }
-        else
-        {
-            result.Should().Be(FileAttributes.Normal);
-        }
     }
 
     [SkippableTheory]
@@ -109,39 +115,29 @@ public abstract partial class FileSystemFileSystemInfoTests<TFileSystem>
     }
 
     [SkippableTheory]
-    [AutoData]
+    [InlineAutoData(FileAttributes.Archive)]
+    [InlineAutoData(FileAttributes.NoScrubData)]
+    [InlineAutoData(FileAttributes.NotContentIndexed)]
+    [InlineAutoData(FileAttributes.Offline)]
+    [InlineAutoData(FileAttributes.System)]
+    [InlineAutoData(FileAttributes.Temporary)]
     [FileSystemTests.FileSystemInfo(
         nameof(IFileSystem.IFileSystemInfo.Attributes))]
-    public void SetAttributes_Hidden_OnNormalFile_ShouldBeIgnored(string path)
+    public void SetAttributes_ShouldOnlyWorkOnWindows(FileAttributes attributes,
+                                                      string path)
     {
-        Skip.IfNot(Test.RunsOnLinux);
-
         FileSystem.File.WriteAllText(path, null);
+        FileSystem.File.SetAttributes(path, attributes);
 
-        FileAttributes result1 = FileSystem.File.GetAttributes(path);
-        FileSystem.File.SetAttributes(path, FileAttributes.Hidden);
-        FileAttributes result2 = FileSystem.File.GetAttributes(path);
+        FileAttributes result = FileSystem.File.GetAttributes(path);
 
-        result1.Should().Be(FileAttributes.Normal);
-        result2.Should().Be(FileAttributes.Normal);
-    }
-
-    [SkippableTheory]
-    [AutoData]
-    [FileSystemTests.FileSystemInfo(
-        nameof(IFileSystem.IFileSystemInfo.Attributes))]
-    public void SetAttributes_Hidden_OnFileStartingWithDot_ShouldBeSet(string path)
-    {
-        Skip.IfNot(Test.RunsOnLinux);
-
-        path = $".{path}";
-        FileSystem.File.WriteAllText(path, null);
-
-        FileAttributes result1 = FileSystem.File.GetAttributes(path);
-        FileSystem.File.SetAttributes(path, FileAttributes.Normal);
-        FileAttributes result2 = FileSystem.File.GetAttributes(path);
-
-        result1.Should().Be(FileAttributes.Hidden);
-        result2.Should().Be(FileAttributes.Hidden);
+        if (Test.RunsOnWindows)
+        {
+            result.Should().Be(attributes);
+        }
+        else
+        {
+            result.Should().Be(FileAttributes.Normal);
+        }
     }
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileTests.Open.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileTests.Open.cs
@@ -99,9 +99,7 @@ public abstract partial class FileSystemFileTests<TFileSystem>
         FileSystem.File.WriteAllText(path, null);
         FileStreamOptions options = new()
         {
-            Mode = FileMode.Open,
-            Access = access,
-            Share = share
+            Mode = FileMode.Open, Access = access, Share = share
         };
 
         using FileSystemStream stream = FileSystem.File.Open(path, options);

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileTests.ResolveLinkTarget.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileTests.ResolveLinkTarget.cs
@@ -6,8 +6,6 @@ namespace Testably.Abstractions.Tests;
 public abstract partial class FileSystemFileTests<TFileSystem>
     where TFileSystem : IFileSystem
 {
-    #region Test Setup
-
     /// <summary>
     ///     The maximum number of symbolic links that are followed.<br />
     ///     <see href="https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks" />
@@ -15,7 +13,22 @@ public abstract partial class FileSystemFileTests<TFileSystem>
     private static int MaxResolveLinks =>
         Test.RunsOnWindows ? 63 : 40;
 
-    #endregion
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.File(nameof(IFileSystem.IFile.ResolveLinkTarget))]
+    public void ResolveLinkTarget_AbsolutePath_ShouldFollowSymbolicLink(
+        string path, string pathToTarget)
+    {
+        string targetFullPath = FileSystem.Path.GetFullPath(pathToTarget);
+        FileSystem.File.WriteAllText(pathToTarget, null);
+        FileSystem.File.CreateSymbolicLink(path, targetFullPath);
+
+        IFileSystem.IFileSystemInfo? target =
+            FileSystem.File.ResolveLinkTarget(path, false);
+
+        target!.FullName.Should().Be(targetFullPath);
+        target.Exists.Should().BeTrue();
+    }
 
     [SkippableTheory]
     [AutoData]
@@ -146,23 +159,6 @@ public abstract partial class FileSystemFileTests<TFileSystem>
     [AutoData]
     [FileSystemTests.File(nameof(IFileSystem.IFile.ResolveLinkTarget))]
     public void ResolveLinkTarget_RelativePath_ShouldFollowSymbolicLinkUnderWindows(
-        string path, string pathToTarget)
-    {
-        string targetFullPath = FileSystem.Path.GetFullPath(pathToTarget);
-        FileSystem.File.WriteAllText(pathToTarget, null);
-        FileSystem.File.CreateSymbolicLink(path, targetFullPath);
-
-        IFileSystem.IFileSystemInfo? target =
-            FileSystem.File.ResolveLinkTarget(path, false);
-
-        target!.FullName.Should().Be(targetFullPath);
-        target.Exists.Should().BeTrue();
-    }
-
-    [SkippableTheory]
-    [AutoData]
-    [FileSystemTests.File(nameof(IFileSystem.IFile.ResolveLinkTarget))]
-    public void ResolveLinkTarget_AbsolutePath_ShouldFollowSymbolicLink(
         string path, string pathToTarget)
     {
         string targetFullPath = FileSystem.Path.GetFullPath(pathToTarget);

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileTests.Times.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileTests.Times.cs
@@ -5,24 +5,12 @@ namespace Testably.Abstractions.Tests;
 public abstract partial class FileSystemFileTests<TFileSystem>
     where TFileSystem : IFileSystem
 {
-    #region Test Setup
-
-    /// <summary>
-    ///     The default time returned by the file system if no time has been set.
-    ///     <seealso href="https://learn.microsoft.com/en-us/windows/win32/sysinfo/file-times" />:
-    ///     A file time is a 64-bit value that represents the number of 100-nanosecond intervals that have elapsed
-    ///     since 12:00 A.M. January 1, 1601 Coordinated Universal Time (UTC).
-    /// </summary>
-    internal readonly DateTime NullTime = new(1601, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
-    #endregion
-
     [SkippableTheory]
     [AutoData]
     [FileSystemTests.File(nameof(IFileSystem.IFile.GetCreationTime))]
     public void GetCreationTime_PathNotFound_ShouldReturnNullTime(string path)
     {
-        DateTime expectedTime = NullTime.ToLocalTime();
+        DateTime expectedTime = FileTestHelper.NullTime.ToLocalTime();
 
         DateTime result = FileSystem.File.GetCreationTime(path);
 
@@ -34,7 +22,7 @@ public abstract partial class FileSystemFileTests<TFileSystem>
     [FileSystemTests.File(nameof(IFileSystem.IFile.GetCreationTimeUtc))]
     public void GetCreationTimeUtc_PathNotFound_ShouldReturnNullTime(string path)
     {
-        DateTime expectedTime = NullTime.ToUniversalTime();
+        DateTime expectedTime = FileTestHelper.NullTime.ToUniversalTime();
 
         DateTime result = FileSystem.File.GetCreationTimeUtc(path);
 
@@ -46,7 +34,7 @@ public abstract partial class FileSystemFileTests<TFileSystem>
     [FileSystemTests.File(nameof(IFileSystem.IFile.GetLastAccessTime))]
     public void GetLastAccessTime_PathNotFound_ShouldReturnNullTime(string path)
     {
-        DateTime expectedTime = NullTime.ToLocalTime();
+        DateTime expectedTime = FileTestHelper.NullTime.ToLocalTime();
 
         DateTime result = FileSystem.File.GetLastAccessTime(path);
 
@@ -58,7 +46,7 @@ public abstract partial class FileSystemFileTests<TFileSystem>
     [FileSystemTests.File(nameof(IFileSystem.IFile.GetLastAccessTimeUtc))]
     public void GetLastAccessTimeUtc_PathNotFound_ShouldReturnNullTime(string path)
     {
-        DateTime expectedTime = NullTime.ToUniversalTime();
+        DateTime expectedTime = FileTestHelper.NullTime.ToUniversalTime();
 
         DateTime result = FileSystem.File.GetLastAccessTimeUtc(path);
 
@@ -70,7 +58,7 @@ public abstract partial class FileSystemFileTests<TFileSystem>
     [FileSystemTests.File(nameof(IFileSystem.IFile.GetLastWriteTime))]
     public void GetLastWriteTime_PathNotFound_ShouldReturnNullTime(string path)
     {
-        DateTime expectedTime = NullTime.ToLocalTime();
+        DateTime expectedTime = FileTestHelper.NullTime.ToLocalTime();
 
         DateTime result = FileSystem.File.GetLastWriteTime(path);
 
@@ -82,7 +70,7 @@ public abstract partial class FileSystemFileTests<TFileSystem>
     [FileSystemTests.File(nameof(IFileSystem.IFile.GetLastWriteTimeUtc))]
     public void GetLastWriteTimeUtc_PathNotFound_ShouldReturnNullTime(string path)
     {
-        DateTime expectedTime = NullTime.ToUniversalTime();
+        DateTime expectedTime = FileTestHelper.NullTime.ToUniversalTime();
 
         DateTime result = FileSystem.File.GetLastWriteTimeUtc(path);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileTests.WriteAllBytes.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileTests.WriteAllBytes.cs
@@ -1,5 +1,3 @@
-using System.IO;
-using System.Linq;
 using System.Text;
 
 namespace Testably.Abstractions.Tests;

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileTests.cs
@@ -6,8 +6,6 @@ namespace Testably.Abstractions.Tests;
 public abstract partial class FileSystemFileTests<TFileSystem>
     where TFileSystem : IFileSystem
 {
-    #region Test Setup
-
     private const string SpecialCharactersContent = "_€_Ä_Ö_Ü";
 
     public abstract string BasePath { get; }
@@ -24,10 +22,6 @@ public abstract partial class FileSystemFileTests<TFileSystem>
         Test.SkipIfTestsOnRealFileSystemShouldBeSkipped(FileSystem);
     }
 
-    #endregion
-
-    #region Helpers
-
     private static IEnumerable<object[]> GetEncodingDifference()
     {
         yield return new object[]
@@ -35,6 +29,4 @@ public abstract partial class FileSystemFileTests<TFileSystem>
             SpecialCharactersContent, Encoding.ASCII, Encoding.UTF8
         };
     }
-
-    #endregion
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystemMockInterceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemMockInterceptionTests.cs
@@ -2,8 +2,6 @@ namespace Testably.Abstractions.Tests;
 
 public class FileSystemMockInterceptionTests
 {
-    #region Test Setup
-
     public FileSystemMock FileSystem { get; }
 
     public FileSystemMockInterceptionTests()
@@ -11,31 +9,6 @@ public class FileSystemMockInterceptionTests
         FileSystem = new FileSystemMock();
 
         Test.SkipIfTestsOnRealFileSystemShouldBeSkipped(FileSystem);
-    }
-
-    #endregion
-
-    [SkippableTheory]
-    [AutoData]
-    [FileSystemTests.Intercept]
-    public void CreateDirectory_CustomException_ShouldOnlyTriggerChangeOccurring(
-        string path, Exception exceptionToThrow)
-    {
-        string? receivedPath = null;
-        FileSystem.Intercept.Change(_ => throw exceptionToThrow);
-        Exception? exception = Record.Exception(() =>
-        {
-            FileSystem.Notify
-               .OnChange(c => receivedPath = c.Path)
-               .Execute(() =>
-                {
-                    FileSystem.Directory.CreateDirectory(path);
-                })
-               .Wait(timeout: 500);
-        });
-
-        exception.Should().Be(exceptionToThrow);
-        receivedPath.Should().BeNull();
     }
 
     [SkippableTheory]
@@ -62,5 +35,28 @@ public class FileSystemMockInterceptionTests
 
         FileSystem.Directory.Exists(path).Should().BeFalse();
         exception.Should().Be(exceptionToThrow);
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.Intercept]
+    public void CreateDirectory_CustomException_ShouldOnlyTriggerChangeOccurring(
+        string path, Exception exceptionToThrow)
+    {
+        string? receivedPath = null;
+        FileSystem.Intercept.Change(_ => throw exceptionToThrow);
+        Exception? exception = Record.Exception(() =>
+        {
+            FileSystem.Notify
+               .OnChange(c => receivedPath = c.Path)
+               .Execute(() =>
+                {
+                    FileSystem.Directory.CreateDirectory(path);
+                })
+               .Wait(timeout: 500);
+        });
+
+        exception.Should().Be(exceptionToThrow);
+        receivedPath.Should().BeNull();
     }
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystemMockNotificationTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemMockNotificationTests.cs
@@ -5,8 +5,6 @@ namespace Testably.Abstractions.Tests;
 
 public class FileSystemMockNotificationTests
 {
-    #region Test Setup
-
     public FileSystemMock FileSystem { get; }
     private readonly ITestOutputHelper _testOutputHelper;
 
@@ -17,8 +15,6 @@ public class FileSystemMockNotificationTests
 
         Test.SkipIfTestsOnRealFileSystemShouldBeSkipped(FileSystem);
     }
-
-    #endregion
 
     [SkippableTheory]
     [AutoData]
@@ -71,8 +67,6 @@ public class FileSystemMockNotificationTests
         receivedPath.Should().Be(FileSystem.Path.GetFullPath(path));
     }
 
-    #region Helpers
-
     public static IEnumerable<object?[]> NotificationTriggeringMethods()
     {
         yield return new object?[]
@@ -88,6 +82,4 @@ public class FileSystemMockNotificationTests
             FileSystemMock.ChangeTypes.FileCreated, $"path_{Guid.NewGuid()}"
         };
     }
-
-    #endregion
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemTests.cs
@@ -12,7 +12,7 @@ public abstract class FileSystemTests<TFileSystem>
     protected FileSystemTests(TFileSystem fileSystem)
     {
         FileSystem = fileSystem;
-        
+
         Test.SkipIfTestsOnRealFileSystemShouldBeSkipped(FileSystem);
     }
 

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/FileTestHelper.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/FileTestHelper.cs
@@ -4,8 +4,6 @@ namespace Testably.Abstractions.Tests.TestHelpers;
 
 public static class FileTestHelper
 {
-    #region Test Setup
-
     /// <summary>
     ///     The default time returned by the file system if no time has been set.
     ///     <seealso href="https://learn.microsoft.com/en-us/windows/win32/sysinfo/file-times" />:
@@ -14,8 +12,6 @@ public static class FileTestHelper
     /// </summary>
     internal static readonly DateTime NullTime = new(1601, 1, 1, 0, 0, 0,
         DateTimeKind.Utc);
-
-    #endregion
 
     public static FileAccess CheckFileAccess(FileSystemStream stream)
     {

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/FileTestHelper.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/FileTestHelper.cs
@@ -12,7 +12,8 @@ public static class FileTestHelper
     ///     A file time is a 64-bit value that represents the number of 100-nanosecond intervals that have elapsed
     ///     since 12:00 A.M. January 1, 1601 Coordinated Universal Time (UTC).
     /// </summary>
-    internal static readonly DateTime NullTime = new(1601, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    internal static readonly DateTime NullTime = new(1601, 1, 1, 0, 0, 0,
+        DateTimeKind.Utc);
 
     #endregion
 

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/FileTestHelper.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/FileTestHelper.cs
@@ -4,6 +4,18 @@ namespace Testably.Abstractions.Tests.TestHelpers;
 
 public static class FileTestHelper
 {
+    #region Test Setup
+
+    /// <summary>
+    ///     The default time returned by the file system if no time has been set.
+    ///     <seealso href="https://learn.microsoft.com/en-us/windows/win32/sysinfo/file-times" />:
+    ///     A file time is a 64-bit value that represents the number of 100-nanosecond intervals that have elapsed
+    ///     since 12:00 A.M. January 1, 1601 Coordinated Universal Time (UTC).
+    /// </summary>
+    internal static readonly DateTime NullTime = new(1601, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    #endregion
+
     public static FileAccess CheckFileAccess(FileSystemStream stream)
     {
         FileAccess fileAccess = 0;

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/Test.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/Test.cs
@@ -12,6 +12,9 @@ public static class Test
 
     public static void SkipIfTestsOnRealFileSystemShouldBeSkipped(IFileSystem fileSystem)
     {
+#if NCRUNCH
+        Skip.If(fileSystem is FileSystem, "NCrunch should not test the real file system.");
+#endif
 #if DEBUG && SKIP_TESTS_ON_REAL_FILESYSTEM
         Skip.If(fileSystem is FileSystem,
             "Tests against real FileSystem are skipped in DEBUG mode with the build constant 'SKIP_TESTS_ON_REAL_FILESYSTEM'.");

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/Test.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/Test.cs
@@ -4,11 +4,19 @@ namespace Testably.Abstractions.Tests.TestHelpers;
 
 public static class Test
 {
+    public static bool RunsOnLinux
+        => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
     public static bool RunsOnWindows
         => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
-    public static bool RunsOnLinux
-        => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+    public static void SkipIfLongRunningTestsShouldBeSkipped(IFileSystem fileSystem)
+    {
+#if DEBUG && !INCLUDE_LONGRUNNING_TESTS_ALSO_IN_DEBUG_MODE
+        Skip.If(fileSystem is FileSystem,
+            "Long-Running tests are skipped in DEBUG mode unless the build constant 'INCLUDE_LONG_RUNNING_TESTS_ALSO_IN_DEBUG_MODE' is set.");
+#endif
+    }
 
     public static void SkipIfTestsOnRealFileSystemShouldBeSkipped(IFileSystem fileSystem)
     {
@@ -18,14 +26,6 @@ public static class Test
 #if DEBUG && SKIP_TESTS_ON_REAL_FILESYSTEM
         Skip.If(fileSystem is FileSystem,
             "Tests against real FileSystem are skipped in DEBUG mode with the build constant 'SKIP_TESTS_ON_REAL_FILESYSTEM'.");
-#endif
-    }
-
-    public static void SkipIfLongRunningTestsShouldBeSkipped(IFileSystem fileSystem)
-    {
-#if DEBUG && !INCLUDE_LONGRUNNING_TESTS_ALSO_IN_DEBUG_MODE
-        Skip.If(fileSystem is FileSystem,
-            "Long-Running tests are skipped in DEBUG mode unless the build constant 'INCLUDE_LONG_RUNNING_TESTS_ALSO_IN_DEBUG_MODE' is set.");
 #endif
     }
 }

--- a/Tests/Testably.Abstractions.Tests/Testing/FileSystemMockTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Testing/FileSystemMockTests.cs
@@ -21,21 +21,6 @@ public class FileSystemMockTests
         drive.VolumeLabel.Should().NotBeNullOrEmpty();
     }
 
-    [SkippableTheory]
-    [InlineData("D:\\")]
-    [Trait(nameof(Testing), nameof(FileSystemMock))]
-    public void WithDrive_NewName_ShouldCreateNewDrives(string driveName)
-    {
-        Skip.IfNot(Test.RunsOnWindows, "Linux does not support different drives.");
-        FileSystemMock sut = new();
-        sut.WithDrive(driveName);
-
-        IFileSystem.IDriveInfo[] drives = sut.DriveInfo.GetDrives();
-
-        drives.Length.Should().Be(2);
-        drives.Should().ContainSingle(d => d.Name == driveName);
-    }
-
     [Fact]
     [Trait(nameof(Testing), nameof(FileSystemMock))]
     public void WithDrive_ExistingName_ShouldUpdateDrive()
@@ -65,18 +50,22 @@ public class FileSystemMockTests
         drive.AvailableFreeSpace.Should().Be(totalSize);
     }
 
-    [Theory]
-    [AutoData]
+    #region Helpers
+
+    [SkippableTheory]
+    [InlineData("D:\\")]
     [Trait(nameof(Testing), nameof(FileSystemMock))]
-    public void WithDrive_WithCallback_ShouldUp22dateDrive(long totalSize)
+    public void WithDrive_NewName_ShouldCreateNewDrives(string driveName)
     {
+        Skip.IfNot(Test.RunsOnWindows, "Linux does not support different drives.");
         FileSystemMock sut = new();
-        sut.WithDrive(d => d.SetTotalSize(totalSize));
+        sut.WithDrive(driveName);
 
-        IFileSystem.IDriveInfo drive = sut.DriveInfo.GetDrives().Single();
+        IFileSystem.IDriveInfo[] drives = sut.DriveInfo.GetDrives();
 
-        drive.TotalSize.Should().Be(totalSize);
-        drive.TotalFreeSpace.Should().Be(totalSize);
-        drive.AvailableFreeSpace.Should().Be(totalSize);
+        drives.Length.Should().Be(2);
+        drives.Should().ContainSingle(d => d.Name == driveName);
     }
+
+    #endregion
 }

--- a/Tests/Testably.Abstractions.Tests/Testing/RandomProviderTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Testing/RandomProviderTests.cs
@@ -108,24 +108,6 @@ public class RandomProviderTests
     [Theory]
     [AutoData]
     [Trait(nameof(Testing), nameof(RandomProvider))]
-    public void GenerateRandom_Next_WithoutGenerator_ShouldReturnRandomValues(int seed)
-    {
-        List<int> results = new();
-        RandomSystemMock.IRandomProvider randomProvider =
-            RandomProvider.Generate();
-
-        IRandomSystem.IRandom random = randomProvider.GetRandom(seed);
-        for (int i = 0; i < 10; i++)
-        {
-            results.Add(random.Next());
-        }
-
-        results.Should().OnlyHaveUniqueItems();
-    }
-
-    [Theory]
-    [AutoData]
-    [Trait(nameof(Testing), nameof(RandomProvider))]
     public void GenerateRandom_Next_WithMaxValue_ShouldReturnSpecifiedValue(
         int seed, int value)
     {
@@ -139,6 +121,28 @@ public class RandomProviderTests
         for (int i = 0; i < 100; i++)
         {
             results.Add(random.Next(maxValue));
+        }
+
+        results.Should().AllBeEquivalentTo(expectedValue);
+    }
+
+    [Theory]
+    [AutoData]
+    [Trait(nameof(Testing), nameof(RandomProvider))]
+    public void GenerateRandom_Next_WithMinAndMaxValue_Larger_ShouldReturnSpecifiedValue(
+        int seed, int value)
+    {
+        int minValue = value - 10;
+        int maxValue = value - 1;
+        List<int> results = new();
+        RandomSystemMock.IRandomProvider randomProvider =
+            RandomProvider.Generate(intGenerator: value);
+        int expectedValue = maxValue - 1;
+
+        IRandomSystem.IRandom random = randomProvider.GetRandom(seed);
+        for (int i = 0; i < 100; i++)
+        {
+            results.Add(random.Next(minValue, maxValue));
         }
 
         results.Should().AllBeEquivalentTo(expectedValue);
@@ -168,23 +172,19 @@ public class RandomProviderTests
     [Theory]
     [AutoData]
     [Trait(nameof(Testing), nameof(RandomProvider))]
-    public void GenerateRandom_Next_WithMinAndMaxValue_Larger_ShouldReturnSpecifiedValue(
-        int seed, int value)
+    public void GenerateRandom_Next_WithoutGenerator_ShouldReturnRandomValues(int seed)
     {
-        int minValue = value - 10;
-        int maxValue = value - 1;
         List<int> results = new();
         RandomSystemMock.IRandomProvider randomProvider =
-            RandomProvider.Generate(intGenerator: value);
-        int expectedValue = maxValue - 1;
+            RandomProvider.Generate();
 
         IRandomSystem.IRandom random = randomProvider.GetRandom(seed);
-        for (int i = 0; i < 100; i++)
+        for (int i = 0; i < 10; i++)
         {
-            results.Add(random.Next(minValue, maxValue));
+            results.Add(random.Next());
         }
 
-        results.Should().AllBeEquivalentTo(expectedValue);
+        results.Should().OnlyHaveUniqueItems();
     }
 
     [Theory]
@@ -206,6 +206,26 @@ public class RandomProviderTests
         }
 
         results.Should().AllBeEquivalentTo(value);
+    }
+
+    [Theory]
+    [AutoData]
+    [Trait(nameof(Testing), nameof(RandomProvider))]
+    public void GenerateRandom_NextBytes_WithoutGenerator_ShouldReturnRandomValues(
+        int seed)
+    {
+        List<byte[]> results = new();
+        RandomSystemMock.IRandomProvider randomProvider = RandomProvider.Generate();
+
+        IRandomSystem.IRandom random = randomProvider.GetRandom(seed);
+        for (int i = 0; i < 10; i++)
+        {
+            byte[] buffer = new byte[10];
+            random.NextBytes(buffer);
+            results.Add(buffer);
+        }
+
+        results.Should().OnlyHaveUniqueItems();
     }
 
     [Theory]
@@ -233,18 +253,36 @@ public class RandomProviderTests
     [Theory]
     [AutoData]
     [Trait(nameof(Testing), nameof(RandomProvider))]
-    public void GenerateRandom_NextBytes_WithoutGenerator_ShouldReturnRandomValues(
+    public void GenerateRandom_NextDouble_ShouldReturnSpecifiedValue(
+        int seed, double value)
+    {
+        List<double> results = new();
+        RandomSystemMock.IRandomProvider randomProvider =
+            RandomProvider.Generate(doubleGenerator: value);
+
+        IRandomSystem.IRandom random = randomProvider.GetRandom(seed);
+        for (int i = 0; i < 100; i++)
+        {
+            results.Add(random.NextDouble());
+        }
+
+        results.Should().AllBeEquivalentTo(value);
+    }
+
+    [Theory]
+    [AutoData]
+    [Trait(nameof(Testing), nameof(RandomProvider))]
+    public void GenerateRandom_NextDouble_WithoutGenerator_ShouldReturnRandomValues(
         int seed)
     {
-        List<byte[]> results = new();
-        RandomSystemMock.IRandomProvider randomProvider = RandomProvider.Generate();
+        List<double> results = new();
+        RandomSystemMock.IRandomProvider randomProvider =
+            RandomProvider.Generate();
 
         IRandomSystem.IRandom random = randomProvider.GetRandom(seed);
         for (int i = 0; i < 10; i++)
         {
-            byte[] buffer = new byte[10];
-            random.NextBytes(buffer);
-            results.Add(buffer);
+            results.Add(random.NextDouble());
         }
 
         results.Should().OnlyHaveUniqueItems();
@@ -314,44 +352,6 @@ public class RandomProviderTests
         results.Should().OnlyHaveUniqueItems();
     }
 #endif
-
-    [Theory]
-    [AutoData]
-    [Trait(nameof(Testing), nameof(RandomProvider))]
-    public void GenerateRandom_NextDouble_ShouldReturnSpecifiedValue(
-        int seed, double value)
-    {
-        List<double> results = new();
-        RandomSystemMock.IRandomProvider randomProvider =
-            RandomProvider.Generate(doubleGenerator: value);
-
-        IRandomSystem.IRandom random = randomProvider.GetRandom(seed);
-        for (int i = 0; i < 100; i++)
-        {
-            results.Add(random.NextDouble());
-        }
-
-        results.Should().AllBeEquivalentTo(value);
-    }
-
-    [Theory]
-    [AutoData]
-    [Trait(nameof(Testing), nameof(RandomProvider))]
-    public void GenerateRandom_NextDouble_WithoutGenerator_ShouldReturnRandomValues(
-        int seed)
-    {
-        List<double> results = new();
-        RandomSystemMock.IRandomProvider randomProvider =
-            RandomProvider.Generate();
-
-        IRandomSystem.IRandom random = randomProvider.GetRandom(seed);
-        for (int i = 0; i < 10; i++)
-        {
-            results.Add(random.NextDouble());
-        }
-
-        results.Should().OnlyHaveUniqueItems();
-    }
 
 #if FEATURE_RANDOM_ADVANCED
     [Theory]

--- a/Tests/Testably.Abstractions.Tests/Testing/RandomProviderTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Testing/RandomProviderTests.cs
@@ -337,7 +337,8 @@ public class RandomProviderTests
     [Theory]
     [AutoData]
     [Trait(nameof(Testing), nameof(RandomProvider))]
-    public void GenerateRandom_NextDouble_WithoutGenerator_ShouldReturnRandomValues(int seed)
+    public void GenerateRandom_NextDouble_WithoutGenerator_ShouldReturnRandomValues(
+        int seed)
     {
         List<double> results = new();
         RandomSystemMock.IRandomProvider randomProvider =
@@ -375,7 +376,8 @@ public class RandomProviderTests
     [Theory]
     [AutoData]
     [Trait(nameof(Testing), nameof(RandomProvider))]
-    public void GenerateRandom_NextSingle_WithoutGenerator_ShouldReturnRandomValues(int seed)
+    public void GenerateRandom_NextSingle_WithoutGenerator_ShouldReturnRandomValues(
+        int seed)
     {
         List<float> results = new();
         RandomSystemMock.IRandomProvider randomProvider =
@@ -434,8 +436,9 @@ public class RandomProviderTests
     [Theory]
     [AutoData]
     [Trait(nameof(Testing), nameof(RandomProvider))]
-    public void GenerateRandom_NextInt64_WithMinAndMaxValue_Smaller_ShouldReturnSpecifiedValue(
-        int seed, long value)
+    public void
+        GenerateRandom_NextInt64_WithMinAndMaxValue_Smaller_ShouldReturnSpecifiedValue(
+            int seed, long value)
     {
         long minValue = value + 1;
         long maxValue = minValue + 10;
@@ -456,8 +459,9 @@ public class RandomProviderTests
     [Theory]
     [AutoData]
     [Trait(nameof(Testing), nameof(RandomProvider))]
-    public void GenerateRandom_NextInt64_WithMinAndMaxValue_Larger_ShouldReturnSpecifiedValue(
-        int seed, long value)
+    public void
+        GenerateRandom_NextInt64_WithMinAndMaxValue_Larger_ShouldReturnSpecifiedValue(
+            int seed, long value)
     {
         long minValue = value - 10;
         long maxValue = value - 1;
@@ -478,7 +482,8 @@ public class RandomProviderTests
     [Theory]
     [AutoData]
     [Trait(nameof(Testing), nameof(RandomProvider))]
-    public void GenerateRandom_NextInt64_WithoutGenerator_ShouldReturnRandomValues(int seed)
+    public void GenerateRandom_NextInt64_WithoutGenerator_ShouldReturnRandomValues(
+        int seed)
     {
         List<long> results = new();
         RandomSystemMock.IRandomProvider randomProvider =


### PR DESCRIPTION
Improve test coverage and consider `DateTimeKind.Unspecified` when reading/writing times on `FileSystemInfo`.