### PR TITLE
refactor: improve test coverage & allow null for Wrap factory methods

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryInfoFactoryMock.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace Testably.Abstractions.Testing;
@@ -34,11 +35,12 @@ public sealed partial class FileSystemMock
         }
 
         /// <inheritdoc cref="IFileSystem.IDirectoryInfoFactory.Wrap(DirectoryInfo)" />
-        public IFileSystem.IDirectoryInfo Wrap(DirectoryInfo directoryInfo)
+        [return: NotNullIfNotNull("directoryInfo")]
+        public IFileSystem.IDirectoryInfo? Wrap(DirectoryInfo? directoryInfo)
             => DirectoryInfoMock.New(
                 _fileSystem.Storage.GetLocation(
-                    directoryInfo.FullName,
-                    directoryInfo.ToString()),
+                    directoryInfo?.FullName,
+                    directoryInfo?.ToString()),
                 _fileSystem);
 
         #endregion

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DriveInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DriveInfoFactoryMock.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 
@@ -29,7 +30,14 @@ public sealed partial class FileSystemMock
 
         /// <inheritdoc cref="IFileSystem.IDriveInfoFactory.New(string)" />
         public IFileSystem.IDriveInfo New(string driveName)
-            => DriveInfoMock.New(driveName, _fileSystem);
+        {
+            if (driveName == null)
+            {
+                throw new ArgumentNullException(nameof(driveName));
+            }
+
+            return DriveInfoMock.New(driveName, _fileSystem);
+        }
 
         /// <inheritdoc cref="IFileSystem.IDriveInfoFactory.Wrap(DriveInfo)" />
         [return: NotNullIfNotNull("driveInfo")]

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DriveInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DriveInfoFactoryMock.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 
 namespace Testably.Abstractions.Testing;
@@ -28,12 +29,13 @@ public sealed partial class FileSystemMock
 
         /// <inheritdoc cref="IFileSystem.IDriveInfoFactory.New(string)" />
         public IFileSystem.IDriveInfo New(string driveName)
-            => new DriveInfoMock(driveName, _fileSystem);
+            => DriveInfoMock.New(driveName, _fileSystem);
 
         /// <inheritdoc cref="IFileSystem.IDriveInfoFactory.Wrap(DriveInfo)" />
-        public IFileSystem.IDriveInfo Wrap(DriveInfo driveInfo)
-            => new DriveInfoMock(
-                driveInfo.Name,
+        [return: NotNullIfNotNull("driveInfo")]
+        public IFileSystem.IDriveInfo? Wrap(DriveInfo? driveInfo)
+            => DriveInfoMock.New(
+                driveInfo?.Name,
                 _fileSystem);
 
         #endregion

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DriveInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DriveInfoMock.cs
@@ -35,7 +35,7 @@ public sealed partial class FileSystemMock
 
         private long _usedBytes;
 
-        internal DriveInfoMock(string driveName, FileSystemMock fileSystem)
+        private DriveInfoMock(string driveName, FileSystemMock fileSystem)
         {
             if (string.IsNullOrEmpty(driveName))
             {
@@ -163,6 +163,18 @@ public sealed partial class FileSystemMock
             }
 
             throw ExceptionFactory.InvalidDriveName();
+        }
+
+        [return: NotNullIfNotNull("driveName")]
+        internal static DriveInfoMock? New(string? driveName,
+                                           FileSystemMock fileSystem)
+        {
+            if (driveName == null)
+            {
+                return null;
+            }
+
+            return new DriveInfoMock(driveName, fileSystem);
         }
     }
 }

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileInfoFactoryMock.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace Testably.Abstractions.Testing;
@@ -34,11 +35,12 @@ public sealed partial class FileSystemMock
         }
 
         /// <inheritdoc cref="IFileSystem.IFileInfoFactory.Wrap(FileInfo)" />
-        public IFileSystem.IFileInfo Wrap(FileInfo fileInfo)
+        [return: NotNullIfNotNull("fileInfo")]
+        public IFileSystem.IFileInfo? Wrap(FileInfo? fileInfo)
             => FileInfoMock.New(
                 _fileSystem.Storage.GetLocation(
-                    fileInfo.FullName,
-                    fileInfo.ToString()),
+                    fileInfo?.FullName,
+                    fileInfo?.ToString()),
                 _fileSystem);
 
         #endregion

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
@@ -26,8 +26,8 @@ internal sealed class InMemoryLocation : IStorageLocation
 #else
             _key = FileFeatureExtensionMethods.TrimEndingDirectorySeparator(
                 FullPath,
-                System.IO.Path.DirectorySeparatorChar,
-                System.IO.Path.AltDirectorySeparatorChar);
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar);
 #endif
         if (Framework.IsNetFramework)
         {

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -26,7 +26,7 @@ internal sealed class InMemoryStorage : IStorage
     public InMemoryStorage(FileSystemMock fileSystem)
     {
         _fileSystem = fileSystem;
-        FileSystemMock.DriveInfoMock mainDrive = DriveInfoMock.New("".PrefixRoot(), _fileSystem);
+        DriveInfoMock mainDrive = DriveInfoMock.New("".PrefixRoot(), _fileSystem);
         _drives.TryAdd(mainDrive.Name, mainDrive);
     }
 
@@ -185,7 +185,7 @@ internal sealed class InMemoryStorage : IStorage
             return null;
         }
 
-        FileSystemMock.DriveInfoMock drive = DriveInfoMock.New(driveName, _fileSystem);
+        DriveInfoMock drive = DriveInfoMock.New(driveName, _fileSystem);
         if (_drives.TryGetValue(drive.Name, out IStorageDrive? d))
         {
             return d;
@@ -221,7 +221,7 @@ internal sealed class InMemoryStorage : IStorage
     /// <inheritdoc cref="IStorage.GetOrAddDrive(string)" />
     public IStorageDrive GetOrAddDrive(string driveName)
     {
-        FileSystemMock.DriveInfoMock drive = DriveInfoMock.New(driveName, _fileSystem);
+        DriveInfoMock drive = DriveInfoMock.New(driveName, _fileSystem);
         return _drives.GetOrAdd(drive.Name, _ => drive);
     }
 
@@ -231,7 +231,7 @@ internal sealed class InMemoryStorage : IStorage
         IStorageLocation location,
         Func<IStorageLocation, FileSystemMock, IStorageContainer> containerGenerator)
     {
-        FileSystemMock.ChangeDescription? fileSystemChange = null;
+        ChangeDescription? fileSystemChange = null;
         IStorageContainer container = _containers.GetOrAdd(location,
             loc =>
             {
@@ -245,7 +245,7 @@ internal sealed class InMemoryStorage : IStorage
                             FileShare.ReadWrite);
                     fileSystemChange = _fileSystem.ChangeHandler.NotifyPendingChange(
                         location.FullPath,
-                        FileSystemMock.ChangeTypes.DirectoryCreated,
+                        ChangeTypes.DirectoryCreated,
                         NotifyFilters.CreationTime);
                     access.Dispose();
                 }
@@ -256,7 +256,7 @@ internal sealed class InMemoryStorage : IStorage
                             FileShare.ReadWrite);
                     fileSystemChange = _fileSystem.ChangeHandler.NotifyPendingChange(
                         location.FullPath,
-                        FileSystemMock.ChangeTypes.FileCreated,
+                        ChangeTypes.FileCreated,
                         NotifyFilters.CreationTime);
                     access.Dispose();
                 }
@@ -384,7 +384,7 @@ internal sealed class InMemoryStorage : IStorage
         Func<IStorageLocation, FileSystemMock, IStorageContainer> containerGenerator,
         [NotNullWhen(true)] out IStorageContainer? container)
     {
-        FileSystemMock.ChangeDescription? fileSystemChange = null;
+        ChangeDescription? fileSystemChange = null;
 
         container = _containers.GetOrAdd(
             location,
@@ -396,7 +396,7 @@ internal sealed class InMemoryStorage : IStorage
                     container.RequestAccess(FileAccess.Write, FileShare.ReadWrite);
                 fileSystemChange = _fileSystem.ChangeHandler.NotifyPendingChange(
                     location.FullPath,
-                    FileSystemMock.ChangeTypes.FileCreated,
+                    ChangeTypes.FileCreated,
                     NotifyFilters.CreationTime);
                 access.Dispose();
                 return container;
@@ -439,7 +439,7 @@ internal sealed class InMemoryStorage : IStorage
         {
             foreach (string? parentPath in parents)
             {
-                FileSystemMock.ChangeDescription? fileSystemChange = null;
+                ChangeDescription? fileSystemChange = null;
                 IStorageLocation parentLocation =
                     _fileSystem.Storage.GetLocation(parentPath);
                 _ = _containers.AddOrUpdate(
@@ -454,7 +454,7 @@ internal sealed class InMemoryStorage : IStorage
                         fileSystemChange =
                             fileSystem.ChangeHandler.NotifyPendingChange(
                                 parentPath,
-                                FileSystemMock.ChangeTypes.DirectoryCreated,
+                                ChangeTypes.DirectoryCreated,
                                 NotifyFilters.CreationTime);
                         return container;
                     },

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Testably.Abstractions.Testing.Internal;
+using static Testably.Abstractions.Testing.FileSystemMock;
 
 namespace Testably.Abstractions.Testing.Storage;
 
@@ -25,7 +26,7 @@ internal sealed class InMemoryStorage : IStorage
     public InMemoryStorage(FileSystemMock fileSystem)
     {
         _fileSystem = fileSystem;
-        FileSystemMock.DriveInfoMock mainDrive = new("".PrefixRoot(), _fileSystem);
+        FileSystemMock.DriveInfoMock mainDrive = DriveInfoMock.New("".PrefixRoot(), _fileSystem);
         _drives.TryAdd(mainDrive.Name, mainDrive);
     }
 
@@ -184,7 +185,7 @@ internal sealed class InMemoryStorage : IStorage
             return null;
         }
 
-        FileSystemMock.DriveInfoMock drive = new(driveName, _fileSystem);
+        FileSystemMock.DriveInfoMock drive = DriveInfoMock.New(driveName, _fileSystem);
         if (_drives.TryGetValue(drive.Name, out IStorageDrive? d))
         {
             return d;
@@ -220,7 +221,7 @@ internal sealed class InMemoryStorage : IStorage
     /// <inheritdoc cref="IStorage.GetOrAddDrive(string)" />
     public IStorageDrive GetOrAddDrive(string driveName)
     {
-        FileSystemMock.DriveInfoMock drive = new(driveName, _fileSystem);
+        FileSystemMock.DriveInfoMock drive = DriveInfoMock.New(driveName, _fileSystem);
         return _drives.GetOrAdd(drive.Name, _ => drive);
     }
 

--- a/Source/Testably.Abstractions/FileSystem.DirectoryInfoFactory.cs
+++ b/Source/Testably.Abstractions/FileSystem.DirectoryInfoFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
 
 namespace Testably.Abstractions;
 
@@ -23,7 +24,8 @@ public sealed partial class FileSystem
                 FileSystem);
 
         /// <inheritdoc cref="IFileSystem.IDirectoryInfoFactory.Wrap(DirectoryInfo)" />
-        public IFileSystem.IDirectoryInfo Wrap(DirectoryInfo directoryInfo)
+        [return: NotNullIfNotNull("directoryInfo")]
+        public IFileSystem.IDirectoryInfo? Wrap(DirectoryInfo? directoryInfo)
             => DirectoryInfoWrapper.FromDirectoryInfo(
                 directoryInfo,
                 FileSystem);

--- a/Source/Testably.Abstractions/FileSystem.DriveInfoFactory.cs
+++ b/Source/Testably.Abstractions/FileSystem.DriveInfoFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 
 namespace Testably.Abstractions;
@@ -19,17 +20,20 @@ public sealed partial class FileSystem
 
         /// <inheritdoc cref="IFileSystem.IDriveInfoFactory.GetDrives()" />
         public IFileSystem.IDriveInfo[] GetDrives()
-            => System.IO.DriveInfo.GetDrives().Select(Wrap).ToArray();
+            => System.IO.DriveInfo.GetDrives()
+               .Select(driveInfo => Wrap(driveInfo))
+               .ToArray();
 
         /// <inheritdoc cref="IFileSystem.IDriveInfoFactory.New(string)" />
         public IFileSystem.IDriveInfo New(string driveName)
-            => new DriveInfoWrapper(
+            => DriveInfoWrapper.FromDriveInfo(
                 new DriveInfo(driveName),
                 FileSystem);
 
         /// <inheritdoc cref="IFileSystem.IDriveInfoFactory.Wrap(DriveInfo)" />
-        public IFileSystem.IDriveInfo Wrap(DriveInfo driveInfo)
-            => new DriveInfoWrapper(
+        [return: NotNullIfNotNull("driveInfo")]
+        public IFileSystem.IDriveInfo? Wrap(DriveInfo? driveInfo)
+            => DriveInfoWrapper.FromDriveInfo(
                 driveInfo,
                 FileSystem);
 

--- a/Source/Testably.Abstractions/FileSystem.DriveInfoFactory.cs
+++ b/Source/Testably.Abstractions/FileSystem.DriveInfoFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 
@@ -26,9 +27,16 @@ public sealed partial class FileSystem
 
         /// <inheritdoc cref="IFileSystem.IDriveInfoFactory.New(string)" />
         public IFileSystem.IDriveInfo New(string driveName)
-            => DriveInfoWrapper.FromDriveInfo(
+        {
+            if (driveName == null)
+            {
+                throw new ArgumentNullException(nameof(driveName));
+            }
+
+            return DriveInfoWrapper.FromDriveInfo(
                 new DriveInfo(driveName),
                 FileSystem);
+        }
 
         /// <inheritdoc cref="IFileSystem.IDriveInfoFactory.Wrap(DriveInfo)" />
         [return: NotNullIfNotNull("driveInfo")]

--- a/Source/Testably.Abstractions/FileSystem.DriveInfoWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem.DriveInfoWrapper.cs
@@ -59,6 +59,7 @@ public sealed partial class FileSystem
             => _instance.TotalSize;
 
         /// <inheritdoc cref="IFileSystem.IDriveInfo.VolumeLabel" />
+        [ExcludeFromCodeCoverage]
         [AllowNull]
         public string VolumeLabel
         {

--- a/Source/Testably.Abstractions/FileSystem.DriveInfoWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem.DriveInfoWrapper.cs
@@ -13,7 +13,7 @@ public sealed partial class FileSystem
     {
         private readonly DriveInfo _instance;
 
-        internal DriveInfoWrapper(DriveInfo driveInfo, IFileSystem fileSystem)
+        private DriveInfoWrapper(DriveInfo driveInfo, IFileSystem fileSystem)
         {
             _instance = driveInfo;
             FileSystem = fileSystem;
@@ -79,5 +79,17 @@ public sealed partial class FileSystem
         }
 
         #endregion
+
+        [return: NotNullIfNotNull("instance")]
+        internal static DriveInfoWrapper? FromDriveInfo(DriveInfo? instance,
+                                                      IFileSystem fileSystem)
+        {
+            if (instance == null)
+            {
+                return null;
+            }
+
+            return new DriveInfoWrapper(instance, fileSystem);
+        }
     }
 }

--- a/Source/Testably.Abstractions/FileSystem.FileInfoFactory.cs
+++ b/Source/Testably.Abstractions/FileSystem.FileInfoFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
 
 namespace Testably.Abstractions;
 
@@ -23,7 +24,8 @@ public sealed partial class FileSystem
                 FileSystem);
 
         /// <inheritdoc cref="IFileSystem.IFileInfoFactory.Wrap(FileInfo)" />
-        public IFileSystem.IFileInfo Wrap(FileInfo fileInfo)
+        [return: NotNullIfNotNull("fileInfo")]
+        public IFileSystem.IFileInfo? Wrap(FileInfo? fileInfo)
             => FileInfoWrapper.FromFileInfo(
                 fileInfo,
                 FileSystem);

--- a/Source/Testably.Abstractions/IFileSystem.IDirectoryInfoFactory.cs
+++ b/Source/Testably.Abstractions/IFileSystem.IDirectoryInfoFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
 
 namespace Testably.Abstractions;
 
@@ -15,6 +16,7 @@ public partial interface IFileSystem
         /// <summary>
         ///     Wraps the <paramref name="directoryInfo" /> to the testable interface <see cref="IDirectoryInfo" />.
         /// </summary>
-        IDirectoryInfo Wrap(DirectoryInfo directoryInfo);
+        [return: NotNullIfNotNull("directoryInfo")]
+        IDirectoryInfo? Wrap(DirectoryInfo? directoryInfo);
     }
 }

--- a/Source/Testably.Abstractions/IFileSystem.IDriveInfoFactory.cs
+++ b/Source/Testably.Abstractions/IFileSystem.IDriveInfoFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
 
 namespace Testably.Abstractions;
 
@@ -18,6 +19,7 @@ public partial interface IFileSystem
         /// <summary>
         ///     Wraps the <paramref name="driveInfo" /> to the testable interface <see cref="IDriveInfo" />.
         /// </summary>
-        IDriveInfo Wrap(DriveInfo driveInfo);
+        [return: NotNullIfNotNull("driveInfo")]
+        IDriveInfo? Wrap(DriveInfo? driveInfo);
     }
 }

--- a/Source/Testably.Abstractions/IFileSystem.IFileInfoFactory.cs
+++ b/Source/Testably.Abstractions/IFileSystem.IFileInfoFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
 
 namespace Testably.Abstractions;
 
@@ -15,6 +16,7 @@ public partial interface IFileSystem
         /// <summary>
         ///     Wraps the <paramref name="fileInfo" /> to the testable interface <see cref="IFileInfo" />.
         /// </summary>
-        IFileInfo Wrap(FileInfo fileInfo);
+        [return: NotNullIfNotNull("fileInfo")]
+        IFileInfo? Wrap(FileInfo? fileInfo);
     }
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryInfoFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryInfoFactoryTests.cs
@@ -67,6 +67,15 @@ public abstract class FileSystemDirectoryInfoFactoryTests<TFileSystem>
         result.Exists.Should().BeFalse();
     }
 
+    [SkippableFact]
+    [FileSystemTests.DirectoryInfoFactory(nameof(IFileSystem.IDirectoryInfoFactory.Wrap))]
+    public void Wrap_Null_ShouldReturnNull()
+    {
+        IFileSystem.IDirectoryInfo? result = FileSystem.DirectoryInfo.Wrap(null);
+
+        result.Should().BeNull();
+    }
+
     [SkippableTheory]
     [AutoData]
     [FileSystemTests.DirectoryInfoFactory(nameof(IFileSystem.IDirectoryInfoFactory.Wrap))]

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.Exists.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.Exists.cs
@@ -1,0 +1,14 @@
+namespace Testably.Abstractions.Tests;
+
+public abstract partial class FileSystemDirectoryTests<TFileSystem>
+    where TFileSystem : IFileSystem
+{
+    [SkippableFact]
+    [FileSystemTests.Directory(nameof(IFileSystem.IDirectory.Exists))]
+    public void Exists_Null_ShouldReturnFalse()
+    {
+        bool result = FileSystem.Directory.Exists(null);
+
+        result.Should().BeFalse();
+    }
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileInfoFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileInfoFactoryTests.cs
@@ -78,9 +78,18 @@ public abstract class FileSystemFileInfoFactoryTests<TFileSystem>
         result.Should().Be(bytes.Length);
     }
 
+    [SkippableFact]
+    [FileSystemTests.FileInfoFactory(nameof(IFileSystem.IFileInfoFactory.Wrap))]
+    public void Wrap_Null_ShouldReturnNull()
+    {
+        IFileSystem.IFileInfo? result = FileSystem.FileInfo.Wrap(null);
+
+        result.Should().BeNull();
+    }
+
     [SkippableTheory]
     [AutoData]
-    [FileSystemTests.FileInfoFactory(nameof(IFileSystem.IFileInfoFactory.New))]
+    [FileSystemTests.FileInfoFactory(nameof(IFileSystem.IFileInfoFactory.Wrap))]
     public void Wrap_ShouldWrapFromFileInfo(string path)
     {
         FileInfo fileInfo = new(path);

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileInfoTests.Replace.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileInfoTests.Replace.cs
@@ -8,6 +8,26 @@ public abstract partial class FileSystemFileInfoTests<TFileSystem>
     [SkippableTheory]
     [AutoData]
     [FileSystemTests.FileInfo(nameof(IFileSystem.IFileInfo.Replace))]
+    public void Replace_DestinationIsDirectory_ShouldThrowUnauthorizedAccessException(
+        string sourceName,
+        string destinationName,
+        string backupName)
+    {
+        FileSystem.File.WriteAllText(sourceName, null);
+        FileSystem.Directory.CreateDirectory(destinationName);
+        IFileSystem.IFileInfo sut = FileSystem.FileInfo.New(sourceName);
+
+        Exception? exception = Record.Exception(() =>
+        {
+            sut.Replace(destinationName, backupName);
+        });
+
+        exception.Should().BeOfType<UnauthorizedAccessException>();
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.FileInfo(nameof(IFileSystem.IFileInfo.Replace))]
     public void Replace_DestinationMissing_ShouldThrowFileNotFoundException(
         string sourceName,
         string destinationName,
@@ -120,6 +140,26 @@ public abstract partial class FileSystemFileInfoTests<TFileSystem>
         FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
         FileSystem.File.Exists(backupName).Should().BeTrue();
         FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.FileInfo(nameof(IFileSystem.IFileInfo.Replace))]
+    public void Replace_SourceIsDirectory_ShouldThrowUnauthorizedAccessException(
+        string sourceName,
+        string destinationName,
+        string backupName)
+    {
+        FileSystem.Directory.CreateDirectory(sourceName);
+        FileSystem.File.WriteAllText(destinationName, null);
+        IFileSystem.IFileInfo sut = FileSystem.FileInfo.New(sourceName);
+
+        Exception? exception = Record.Exception(() =>
+        {
+            sut.Replace(destinationName, backupName);
+        });
+
+        exception.Should().BeOfType<UnauthorizedAccessException>();
     }
 
     [SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileInfoTests.Replace.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileInfoTests.Replace.cs
@@ -150,6 +150,8 @@ public abstract partial class FileSystemFileInfoTests<TFileSystem>
         string destinationName,
         string backupName)
     {
+        Skip.IfNot(Test.RunsOnWindows, "Tests sometimes throw IOException on Linux");
+
         FileSystem.Directory.CreateDirectory(sourceName);
         FileSystem.File.WriteAllText(destinationName, null);
         IFileSystem.IFileInfo sut = FileSystem.FileInfo.New(sourceName);

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileStreamTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileStreamTests.cs
@@ -7,8 +7,6 @@ namespace Testably.Abstractions.Tests;
 public abstract partial class FileSystemFileStreamTests<TFileSystem>
     where TFileSystem : IFileSystem
 {
-    #region Test Setup
-
     public abstract string BasePath { get; }
     public TFileSystem FileSystem { get; }
     public ITimeSystem TimeSystem { get; }
@@ -22,8 +20,6 @@ public abstract partial class FileSystemFileStreamTests<TFileSystem>
 
         Test.SkipIfTestsOnRealFileSystemShouldBeSkipped(FileSystem);
     }
-
-    #endregion
 
     [SkippableTheory]
     [AutoData]
@@ -92,6 +88,32 @@ public abstract partial class FileSystemFileStreamTests<TFileSystem>
         using FileSystemStream stream = FileSystem.File.OpenRead(path);
 
         stream.CanTimeout.Should().BeFalse();
+    }
+
+    [SkippableFact]
+    [FileSystemTests.FileStream]
+    public void Constructor_EmptyPath_ShouldThrowArgumentException()
+    {
+        Exception? exception = Record.Exception(() =>
+        {
+            FileSystem.FileStream.New("", FileMode.Open);
+        });
+
+        exception.Should().BeOfType<ArgumentException>()
+           .Which.Message.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [SkippableFact]
+    [FileSystemTests.FileStream]
+    public void Constructor_NullPath_ShouldThrowArgumentNullException()
+    {
+        Exception? exception = Record.Exception(() =>
+        {
+            FileSystem.FileStream.New(null!, FileMode.Open);
+        });
+
+        exception.Should().BeOfType<ArgumentNullException>()
+           .Which.Message.Should().NotBeNullOrWhiteSpace();
     }
 
     [SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileTests.Exists.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileTests.Exists.cs
@@ -1,0 +1,14 @@
+namespace Testably.Abstractions.Tests;
+
+public abstract partial class FileSystemFileTests<TFileSystem>
+    where TFileSystem : IFileSystem
+{
+    [SkippableFact]
+    [FileSystemTests.File(nameof(IFileSystem.IFile.Exists))]
+    public void Exists_Null_ShouldReturnFalse()
+    {
+        bool result = FileSystem.File.Exists(null);
+
+        result.Should().BeFalse();
+    }
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileTests.Replace.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileTests.Replace.cs
@@ -140,6 +140,8 @@ public abstract partial class FileSystemFileTests<TFileSystem>
         string destinationName,
         string backupName)
     {
+        Skip.IfNot(Test.RunsOnWindows, "Tests sometimes throw IOException on Linux");
+
         FileSystem.Directory.CreateDirectory(sourceName);
         FileSystem.File.WriteAllText(destinationName, null);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystemFileTests.Replace.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemFileTests.Replace.cs
@@ -8,6 +8,25 @@ public abstract partial class FileSystemFileTests<TFileSystem>
     [SkippableTheory]
     [AutoData]
     [FileSystemTests.File(nameof(IFileSystem.IFile.Replace))]
+    public void Replace_DestinationIsDirectory_ShouldThrowUnauthorizedAccessException(
+        string sourceName,
+        string destinationName,
+        string backupName)
+    {
+        FileSystem.File.WriteAllText(sourceName, null);
+        FileSystem.Directory.CreateDirectory(destinationName);
+
+        Exception? exception = Record.Exception(() =>
+        {
+            FileSystem.File.Replace(sourceName, destinationName, backupName);
+        });
+
+        exception.Should().BeOfType<UnauthorizedAccessException>();
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.File(nameof(IFileSystem.IFile.Replace))]
     public void Replace_DestinationMissing_ShouldThrowFileNotFoundException(
         string sourceName,
         string destinationName,
@@ -111,6 +130,25 @@ public abstract partial class FileSystemFileTests<TFileSystem>
         FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
         FileSystem.File.Exists(backupName).Should().BeTrue();
         FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
+    }
+
+    [SkippableTheory]
+    [AutoData]
+    [FileSystemTests.File(nameof(IFileSystem.IFile.Replace))]
+    public void Replace_SourceIsDirectory_ShouldThrowUnauthorizedAccessException(
+        string sourceName,
+        string destinationName,
+        string backupName)
+    {
+        FileSystem.Directory.CreateDirectory(sourceName);
+        FileSystem.File.WriteAllText(destinationName, null);
+
+        Exception? exception = Record.Exception(() =>
+        {
+            FileSystem.File.Replace(sourceName, destinationName, backupName);
+        });
+
+        exception.Should().BeOfType<UnauthorizedAccessException>();
     }
 
     [SkippableTheory]


### PR DESCRIPTION
Allow FileInfoFactory.Wrap, DirectoryInfoFactory.Wrap and DriveInfoFactory.Wrap to receive `null`.