### PR TITLE
refactor: add separate testing test project

### DIFF
--- a/Source/Testably.Abstractions.Testing/Internal/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/PathHelper.cs
@@ -73,8 +73,7 @@ internal static class PathHelper
 			}
 
 			throw ExceptionFactory.PathHasIncorrectSyntax(
-				fileSystem.Path.Combine(fileSystem.Directory.GetCurrentDirectory(),
-					path));
+				fileSystem.Path.GetFullPath(path));
 		}
 	}
 

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -26,7 +26,7 @@ internal sealed class InMemoryStorage : IStorage
 	public InMemoryStorage(FileSystemMock fileSystem)
 	{
 		_fileSystem = fileSystem;
-		DriveInfoMock mainDrive = DriveInfoMock.New("".PrefixRoot(), _fileSystem);
+		DriveInfoMock mainDrive = DriveInfoMock.New(CurrentDirectory, _fileSystem);
 		_drives.TryAdd(mainDrive.Name, mainDrive);
 	}
 

--- a/Source/Testably.Abstractions.Testing/Testably.Abstractions.Testing.csproj
+++ b/Source/Testably.Abstractions.Testing/Testably.Abstractions.Testing.csproj
@@ -23,4 +23,10 @@
     </Compile>
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Testably.Abstractions.Testing.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/Testably.Abstractions.sln
+++ b/Testably.Abstractions.sln
@@ -44,6 +44,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\stryker.yml = .github\workflows\stryker.yml
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Testably.Abstractions.Testing.Tests", "Tests\Testably.Abstractions.Testing.Tests\Testably.Abstractions.Testing.Tests.csproj", "{44220872-B6CD-4776-91E9-426D828923D2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -70,6 +72,10 @@ Global
 		{5356838D-3796-45B6-8227-0F023093D9A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5356838D-3796-45B6-8227-0F023093D9A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5356838D-3796-45B6-8227-0F023093D9A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44220872-B6CD-4776-91E9-426D828923D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44220872-B6CD-4776-91E9-426D828923D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44220872-B6CD-4776-91E9-426D828923D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44220872-B6CD-4776-91E9-426D828923D2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -81,6 +87,7 @@ Global
 		{2FDB2AAE-E5CE-483E-A1A6-EC0B0A4AD67B} = {94F99274-3518-45D0-83A4-6F370D6FE74B}
 		{5E35E265-7110-47A0-9E3E-B5180BBB5AA6} = {94F99274-3518-45D0-83A4-6F370D6FE74B}
 		{8FD8E33B-2072-48CA-8164-DE2AA5DCB8FD} = {5E35E265-7110-47A0-9E3E-B5180BBB5AA6}
+		{44220872-B6CD-4776-91E9-426D828923D2} = {61F335A6-9CE0-4040-A34F-E70B1A55077D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EC4D8481-B9FD-41B5-832A-369210993DF4}

--- a/Tests/Testably.Abstractions.Testing.Tests/FilePlatformIndependenceExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FilePlatformIndependenceExtensionsTests.cs
@@ -1,7 +1,7 @@
 using System.IO;
 using System.Runtime.InteropServices;
 
-namespace Testably.Abstractions.Tests.Testing;
+namespace Testably.Abstractions.Testing.Tests;
 
 public class FilePlatformIndependenceExtensionsTests
 {

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 
-namespace Testably.Abstractions.Tests.Testing;
+namespace Testably.Abstractions.Testing.Tests;
 
 public class FileSystemInitializerTests
 {

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemMockTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
+using Testably.Abstractions.Testing.Tests.TestHelpers;
 
-namespace Testably.Abstractions.Tests.Testing;
+namespace Testably.Abstractions.Testing.Tests;
 
 public class FileSystemMockTests
 {

--- a/Tests/Testably.Abstractions.Testing.Tests/Internal/EncryptionHelperTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Internal/EncryptionHelperTests.cs
@@ -1,0 +1,34 @@
+﻿using Testably.Abstractions.Testing.Internal;
+
+namespace Testably.Abstractions.Testing.Tests.Internal;
+
+public class EncryptionHelperTests
+{
+	[Theory]
+	[AutoData]
+	public void Decrypt_ShouldBeDifferentThanBefore(byte[] bytes)
+	{
+		byte[] result = EncryptionHelper.Encrypt(bytes);
+
+		result.Should().NotBeEquivalentTo(bytes);
+	}
+
+	[Theory]
+	[AutoData]
+	public void Encrypt_ShouldBeDifferentThanBefore(byte[] bytes)
+	{
+		byte[] result = EncryptionHelper.Encrypt(bytes);
+
+		result.Should().NotBeEquivalentTo(bytes);
+	}
+
+	[Theory]
+	[AutoData]
+	public void Encrypt_ThenDecrypt_ShouldBeEquivalentToBefore(byte[] bytes)
+	{
+		byte[] encrypted = EncryptionHelper.Encrypt(bytes);
+		byte[] result = EncryptionHelper.Decrypt(encrypted);
+
+		result.Should().BeEquivalentTo(bytes);
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/Internal/FileSystemExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Internal/FileSystemExtensionsTests.cs
@@ -1,0 +1,25 @@
+﻿using Testably.Abstractions.Testing.Internal;
+
+namespace Testably.Abstractions.Testing.Tests.Internal;
+
+public class FileSystemExtensionsTests
+{
+	[Theory]
+	[AutoData]
+	public void GetMoveLocation_LocationNotUnderSource_ShouldThrowNotSupportedException(
+		string location, string source, string destination)
+	{
+		FileSystemMock sut = new();
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.GetMoveLocation(
+				sut.Storage.GetLocation(location),
+				sut.Storage.GetLocation(source),
+				sut.Storage.GetLocation(destination));
+		});
+
+		exception.Should().BeOfType<NotSupportedException>().Which.Message
+		   .Should().Contain($"'{sut.Path.GetFullPath(location)}'")
+		   .And.Contain($"'{sut.Path.GetFullPath(source)}'");
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/Internal/PathHelperTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Internal/PathHelperTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using Moq;
+using System.IO;
 using Testably.Abstractions.Testing.Internal;
 
 namespace Testably.Abstractions.Testing.Tests.Internal;
@@ -13,5 +14,48 @@ public class PathHelperTests
 		string result = path.RemoveLeadingDot();
 
 		result.Should().Be("foo");
+	}
+
+	[Fact]
+	public void
+		ThrowCommonExceptionsIfPathIsInvalid_StartWithNull_ShouldThrowArgumentException()
+	{
+		string path = "\0foo";
+
+		Exception? exception = Record.Exception(() =>
+		{
+			path.ThrowCommonExceptionsIfPathIsInvalid(new FileSystem());
+		});
+
+		exception.Should().BeOfType<ArgumentException>()
+		   .Which.Message.Should().Contain($"'{path}'");
+	}
+
+	[Theory]
+	[AutoData]
+	public void ThrowCommonExceptionsIfPathIsInvalid_WithInvalidCharacters(
+		char[] invalidChars)
+	{
+		Mock<IFileSystem> fileSystemMock = new();
+		Mock<IFileSystem.IPath> pathSystemMock = new();
+		fileSystemMock.Setup(m => m.Path).Returns(pathSystemMock.Object);
+		pathSystemMock.Setup(m => m.GetInvalidPathChars()).Returns(invalidChars);
+		pathSystemMock
+		   .Setup(m => m.GetFullPath(It.IsAny<string>()))
+		   .Returns<string>(s => s);
+		string path = invalidChars[0] + "foo";
+
+		Exception? exception = Record.Exception(() =>
+		{
+			path.ThrowCommonExceptionsIfPathIsInvalid(fileSystemMock.Object);
+		});
+
+#if NETFRAMEWORK
+		exception.Should().BeOfType<ArgumentException>()
+		   .Which.Message.Should().Contain($"'{path}'");
+#else
+		exception.Should().BeOfType<IOException>()
+		   .Which.Message.Should().Contain($"'{path}'");
+#endif
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Internal/PathHelperTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Internal/PathHelperTests.cs
@@ -1,0 +1,17 @@
+﻿using System.IO;
+using Testably.Abstractions.Testing.Internal;
+
+namespace Testably.Abstractions.Testing.Tests.Internal;
+
+public class PathHelperTests
+{
+	[Fact]
+	public void RemoveLeadingDot_MultipleLocalDirectories_ShouldBeRemoved()
+	{
+		string path = Path.Combine(".", ".", ".", "foo");
+
+		string result = path.RemoveLeadingDot();
+
+		result.Should().Be("foo");
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/NotificationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/NotificationTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading;
 
-namespace Testably.Abstractions.Tests.Testing;
+namespace Testably.Abstractions.Testing.Tests;
 
 public class NotificationTests
 {

--- a/Tests/Testably.Abstractions.Testing.Tests/RandomProviderGeneratorTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/RandomProviderGeneratorTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Testably.Abstractions.Tests.Testing;
+namespace Testably.Abstractions.Testing.Tests;
 
 public class RandomProviderGeneratorTests
 {
@@ -196,7 +196,7 @@ public class RandomProviderGeneratorTests
 	public void Operator_FromCallback(Guid value)
 	{
 		int maxRange = 100;
-		RandomProvider.Generator<Guid> sut = (Func<Guid>)(() => value);
+		RandomProvider.Generator<Guid> sut = () => value;
 
 		Guid[] results = new Guid[maxRange];
 		for (int i = 0; i < maxRange; i++)

--- a/Tests/Testably.Abstractions.Testing.Tests/RandomProviderGeneratorTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/RandomProviderGeneratorTests.cs
@@ -196,7 +196,7 @@ public class RandomProviderGeneratorTests
 	public void Operator_FromCallback(Guid value)
 	{
 		int maxRange = 100;
-		RandomProvider.Generator<Guid> sut = () => value;
+		RandomProvider.Generator<Guid> sut = (Func<Guid>)(() => value);
 
 		Guid[] results = new Guid[maxRange];
 		for (int i = 0; i < maxRange; i++)

--- a/Tests/Testably.Abstractions.Testing.Tests/RandomProviderTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/RandomProviderTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace Testably.Abstractions.Tests.Testing;
+namespace Testably.Abstractions.Testing.Tests;
 
 public class RandomProviderTests
 {

--- a/Tests/Testably.Abstractions.Testing.Tests/RandomSystemExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/RandomSystemExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace Testably.Abstractions.Tests.Testing;
+namespace Testably.Abstractions.Testing.Tests;
 
 public class RandomSystemExtensionsTests
 {

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Test.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Test.cs
@@ -9,23 +9,4 @@ public static class Test
 
 	public static bool RunsOnWindows
 		=> RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
-	public static void SkipIfLongRunningTestsShouldBeSkipped(IFileSystem fileSystem)
-	{
-#if DEBUG && !INCLUDE_LONGRUNNING_TESTS_ALSO_IN_DEBUG_MODE
-		Skip.If(fileSystem is FileSystem,
-			"Long-Running tests are skipped in DEBUG mode unless the build constant 'INCLUDE_LONG_RUNNING_TESTS_ALSO_IN_DEBUG_MODE' is set.");
-#endif
-	}
-
-	public static void SkipIfTestsOnRealFileSystemShouldBeSkipped(IFileSystem fileSystem)
-	{
-#if NCRUNCH
-		Skip.If(fileSystem is FileSystem, "NCrunch should not test the real file system.");
-#endif
-#if DEBUG && SKIP_TESTS_ON_REAL_FILESYSTEM
-		Skip.If(fileSystem is FileSystem,
-			"Tests against real FileSystem are skipped in DEBUG mode with the build constant 'SKIP_TESTS_ON_REAL_FILESYSTEM'.");
-#endif
-	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Test.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Test.cs
@@ -1,0 +1,31 @@
+using System.Runtime.InteropServices;
+
+namespace Testably.Abstractions.Testing.Tests.TestHelpers;
+
+public static class Test
+{
+	public static bool RunsOnLinux
+		=> RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+	public static bool RunsOnWindows
+		=> RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+	public static void SkipIfLongRunningTestsShouldBeSkipped(IFileSystem fileSystem)
+	{
+#if DEBUG && !INCLUDE_LONGRUNNING_TESTS_ALSO_IN_DEBUG_MODE
+		Skip.If(fileSystem is FileSystem,
+			"Long-Running tests are skipped in DEBUG mode unless the build constant 'INCLUDE_LONG_RUNNING_TESTS_ALSO_IN_DEBUG_MODE' is set.");
+#endif
+	}
+
+	public static void SkipIfTestsOnRealFileSystemShouldBeSkipped(IFileSystem fileSystem)
+	{
+#if NCRUNCH
+		Skip.If(fileSystem is FileSystem, "NCrunch should not test the real file system.");
+#endif
+#if DEBUG && SKIP_TESTS_ON_REAL_FILESYSTEM
+		Skip.If(fileSystem is FileSystem,
+			"Tests against real FileSystem are skipped in DEBUG mode with the build constant 'SKIP_TESTS_ON_REAL_FILESYSTEM'.");
+#endif
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/TimeTestHelper.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/TimeTestHelper.cs
@@ -1,0 +1,17 @@
+namespace Testably.Abstractions.Testing.Tests.TestHelpers;
+
+public static class TimeTestHelper
+{
+	public static TimeSpan GetRandomInterval(double secondsMultiplier = 60)
+	{
+		Random random = new();
+		return TimeSpan.FromSeconds(random.NextDouble() * secondsMultiplier);
+	}
+
+	public static DateTime GetRandomTime(DateTimeKind kind = DateTimeKind.Unspecified)
+	{
+		Random random = new();
+		return new DateTime(1970, 1, 1, 0, 0, 0, kind)
+		   .AddSeconds(random.Next());
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Usings.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Usings.cs
@@ -1,0 +1,5 @@
+﻿global using AutoFixture.Xunit2;
+global using FluentAssertions;
+global using System;
+global using Testably.Abstractions.Testing;
+global using Xunit;

--- a/Tests/Testably.Abstractions.Testing.Tests/Testably.Abstractions.Testing.Tests.csproj
+++ b/Tests/Testably.Abstractions.Testing.Tests/Testably.Abstractions.Testing.Tests.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Condition="'$(NCrunch)' == '1'">
+    <TargetFrameworks>net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Source\Testably.Abstractions.Testing\Testably.Abstractions.Testing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeProviderTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeProviderTests.cs
@@ -1,7 +1,8 @@
 ﻿using System.Collections.Concurrent;
 using System.Threading.Tasks;
+using Testably.Abstractions.Testing.Tests.TestHelpers;
 
-namespace Testably.Abstractions.Tests.Testing;
+namespace Testably.Abstractions.Testing.Tests;
 
 public class TimeProviderTests
 {

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystemMockCallbackHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystemMockCallbackHandlerTests.cs
@@ -1,6 +1,18 @@
 ﻿using System.Threading;
+using Testably.Abstractions.Testing.Tests.TestHelpers;
+/* Unmerged change from project 'Testably.Abstractions.Testing.Tests (net5.0)'
+Before:
+using Testably.Abstractions.Testing.Tests.TestHelpers;
+After:
+using Testably;
+using Testably.Abstractions;
+using Testably.Abstractions.Testing;
+using Testably.Abstractions.Testing.Tests;
+using Testably.Abstractions.Testing.Tests;
+using Testably.Abstractions.Testing.Tests.TestHelpers;
+*/
 
-namespace Testably.Abstractions.Tests.Testing;
+namespace Testably.Abstractions.Testing.Tests;
 
 public class TimeSystemMockCallbackHandlerTests
 {

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystemMockCallbackHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystemMockCallbackHandlerTests.cs
@@ -1,16 +1,5 @@
 ﻿using System.Threading;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
-/* Unmerged change from project 'Testably.Abstractions.Testing.Tests (net5.0)'
-Before:
-using Testably.Abstractions.Testing.Tests.TestHelpers;
-After:
-using Testably;
-using Testably.Abstractions;
-using Testably.Abstractions.Testing;
-using Testably.Abstractions.Testing.Tests;
-using Testably.Abstractions.Testing.Tests;
-using Testably.Abstractions.Testing.Tests.TestHelpers;
-*/
 
 namespace Testably.Abstractions.Testing.Tests;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystemMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystemMockTests.cs
@@ -1,0 +1,90 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Testably.Abstractions.Testing.Tests;
+
+public class TimeSystemMockTests
+{
+	[Fact]
+	public async Task Delay_Infinite_ShouldNotThrowException()
+	{
+		TimeSystemMock timeSystem = new();
+		Exception? exception =
+			await Record.ExceptionAsync(() => timeSystem.Task.Delay(Timeout.Infinite));
+
+		exception.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task Delay_InfiniteTimeSpan_ShouldNotThrowException()
+	{
+		TimeSystemMock timeSystem = new();
+		Exception? exception =
+			await Record.ExceptionAsync(()
+				=> timeSystem.Task.Delay(Timeout.InfiniteTimeSpan));
+
+		exception.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task Delay_LessThanInfinite_ShouldNotThrowException()
+	{
+		TimeSystemMock timeSystem = new();
+		Exception? exception =
+			await Record.ExceptionAsync(() => timeSystem.Task.Delay(-2));
+
+		exception.Should().BeOfType<ArgumentOutOfRangeException>();
+	}
+
+	[Fact]
+	public async Task Delay_LessThanInfiniteTimeSpan_ShouldNotThrowException()
+	{
+		TimeSystemMock timeSystem = new();
+		Exception? exception =
+			await Record.ExceptionAsync(()
+				=> timeSystem.Task.Delay(TimeSpan.FromMilliseconds(-2)));
+
+		exception.Should().BeOfType<ArgumentOutOfRangeException>();
+	}
+
+	[Fact]
+	public void Sleep_Infinite_ShouldNotThrowException()
+	{
+		TimeSystemMock timeSystem = new();
+		Exception? exception =
+			Record.Exception(() => timeSystem.Thread.Sleep(Timeout.Infinite));
+
+		exception.Should().BeNull();
+	}
+
+	[Fact]
+	public void Sleep_InfiniteTimeSpan_ShouldNotThrowException()
+	{
+		TimeSystemMock timeSystem = new();
+		Exception? exception =
+			Record.Exception(() => timeSystem.Thread.Sleep(Timeout.InfiniteTimeSpan));
+
+		exception.Should().BeNull();
+	}
+
+	[Fact]
+	public void Sleep_LessThanInfinite_ShouldNotThrowException()
+	{
+		TimeSystemMock timeSystem = new();
+		Exception? exception =
+			Record.Exception(() => timeSystem.Thread.Sleep(-2));
+
+		exception.Should().BeOfType<ArgumentOutOfRangeException>();
+	}
+
+	[Fact]
+	public void Sleep_LessThanInfiniteTimeSpan_ShouldNotThrowException()
+	{
+		TimeSystemMock timeSystem = new();
+		Exception? exception =
+			Record.Exception(()
+				=> timeSystem.Thread.Sleep(TimeSpan.FromMilliseconds(-2)));
+
+		exception.Should().BeOfType<ArgumentOutOfRangeException>();
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/DependencyInjectionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/DependencyInjectionTests.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-namespace Testably.Abstractions.Tests.Testing;
+namespace Testably.Abstractions.Tests;
 
 public class DependencyInjectionTests
 {

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/TimeTestHelper.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/TimeTestHelper.cs
@@ -13,12 +13,6 @@ public static class TimeTestHelper
 		return time.AddMilliseconds(-25);
 	}
 
-	public static TimeSpan GetRandomInterval(double secondsMultiplier = 60)
-	{
-		Random random = new();
-		return TimeSpan.FromSeconds(random.NextDouble() * secondsMultiplier);
-	}
-
 	public static DateTime GetRandomTime(DateTimeKind kind = DateTimeKind.Unspecified)
 	{
 		Random random = new();

--- a/Tests/stryker-config-testing.json
+++ b/Tests/stryker-config-testing.json
@@ -5,13 +5,15 @@
       "module": "Testably.Abstractions.Testing"
     },
     "test-projects": [
-      "./Tests/Testably.Abstractions.Tests/Testably.Abstractions.Tests.csproj"
+      "./Tests/Testably.Abstractions.Tests/Testably.Abstractions.Tests.csproj",
+      "./Tests/Testably.Abstractions.Testing.Tests/Testably.Abstractions.Testing.Tests.csproj"
     ],
     "project": "Testably.Abstractions.Testing.csproj",
     "target-framework": "net6.0",
     "reporters": [ "html", "progress", "cleartext" ],
     "mutation-level": "Advanced",
     "ignore-methods": [
+      "*Exception.ctor",
       "ValidateDriveLetter" // Only tested under windows
     ]
   }


### PR DESCRIPTION
Add separate test project for `Testably.Abstractions.Testing` which gets access to internal methods/classes.