### PR TITLE
fix: incorrect simplification in Notification

### DIFF
--- a/Source/Testably.Abstractions.Testing/Notification.cs
+++ b/Source/Testably.Abstractions.Testing/Notification.cs
@@ -99,6 +99,7 @@ public static class Notification
 			{
 				_count = count;
 				_filter = filter;
+				_reset.Reset();
 				executeWhenWaiting?.Invoke();
 				if (!_reset.Wait(timeout))
 				{


### PR DESCRIPTION
In #80 the simplification in `Notification` was incorrect.
Add a test to demonstrate the incorrect behaviour and undo the incorrect changes.