### PR TITLE
refactor: improve Stryker coverage

### DIFF
--- a/Source/Testably.Abstractions.Testing/Internal/EncryptionHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/EncryptionHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -31,6 +32,7 @@ internal static class EncryptionHelper
 		return PerformCryptography(encryptor, plainBytes);
 	}
 
+	[ExcludeFromCodeCoverage]
 	private static Aes CreateAlgorithm()
 	{
 		byte[] bytes = Encoding.UTF8.GetBytes(

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
@@ -125,7 +125,7 @@ internal sealed class InMemoryLocation : IStorageLocation
 	public override string ToString()
 		=> FullPath;
 
-	private string NormalizeKey(string fullPath)
+	private static string NormalizeKey(string fullPath)
 	{
 #if FEATURE_PATH_ADVANCED
 		return Path.TrimEndingDirectorySeparator(fullPath);

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
@@ -21,14 +21,7 @@ internal sealed class InMemoryLocation : IStorageLocation
 		FullPath = fullPath
 		   .NormalizePath()
 		   .TrimOnWindows();
-#if FEATURE_PATH_ADVANCED
-		_key = Path.TrimEndingDirectorySeparator(FullPath);
-#else
-			_key = FileFeatureExtensionMethods.TrimEndingDirectorySeparator(
-				FullPath,
-				Path.DirectorySeparatorChar,
-				Path.AltDirectorySeparatorChar);
-#endif
+		_key = NormalizeKey(FullPath);
 		if (Framework.IsNetFramework)
 		{
 			friendlyName = friendlyName.TrimOnWindows();
@@ -67,7 +60,8 @@ internal sealed class InMemoryLocation : IStorageLocation
 			return _key.Equals(location._key, StringComparisonMode);
 		}
 
-		return FullPath.Equals(other.FullPath, StringComparisonMode);
+		return NormalizeKey(FullPath)
+		   .Equals(NormalizeKey(other.FullPath), StringComparisonMode);
 	}
 
 	/// <inheritdoc cref="object.Equals(object?)" />
@@ -78,7 +72,7 @@ internal sealed class InMemoryLocation : IStorageLocation
 #if NETSTANDARD2_0
 	/// <inheritdoc cref="object.GetHashCode()" />
 	public override int GetHashCode()
-			=> _key.ToLowerInvariant().GetHashCode();
+		=> _key.ToLowerInvariant().GetHashCode();
 #else
 	/// <inheritdoc cref="object.GetHashCode()" />
 	public override int GetHashCode()
@@ -130,4 +124,16 @@ internal sealed class InMemoryLocation : IStorageLocation
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()
 		=> FullPath;
+
+	private string NormalizeKey(string fullPath)
+	{
+#if FEATURE_PATH_ADVANCED
+		return Path.TrimEndingDirectorySeparator(fullPath);
+#else
+		return FileFeatureExtensionMethods.TrimEndingDirectorySeparator(
+			fullPath,
+			Path.DirectorySeparatorChar,
+			Path.AltDirectorySeparatorChar);
+#endif
+	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryContainerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryContainerTests.cs
@@ -1,4 +1,5 @@
-﻿using Testably.Abstractions.Testing.Storage;
+﻿using System.IO;
+using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.Tests.Storage;
 
@@ -20,6 +21,7 @@ public class InMemoryContainerTests
 
 		fileContainer.Decrypt();
 
+		fileContainer.Attributes.Should().NotHaveFlag(FileAttributes.Encrypted);
 		fileContainer.GetBytes().Should().BeEquivalentTo(bytes);
 	}
 
@@ -59,5 +61,42 @@ public class InMemoryContainerTests
 
 		fileContainer.Decrypt();
 		fileContainer.GetBytes().Should().BeEquivalentTo(bytes);
+	}
+
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryContainer))]
+	public void Encrypt_ShouldEncryptBytes(
+		string path, byte[] bytes)
+	{
+		FileSystemMock fileSystem = new();
+		FileSystemMock.DriveInfoMock drive =
+			FileSystemMock.DriveInfoMock.New("C", fileSystem);
+		IStorageLocation location = InMemoryLocation.New(drive, path);
+		IStorageContainer fileContainer = InMemoryContainer.NewFile(location, fileSystem);
+		fileContainer.WriteBytes(bytes);
+
+		fileContainer.Encrypt();
+
+		fileContainer.Attributes.Should().HaveFlag(FileAttributes.Encrypted);
+		fileContainer.GetBytes().Should().NotBeEquivalentTo(bytes);
+	}
+
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryContainer))]
+	public void RequestAccess_WithoutDrive_ShouldThrowDirectoryNotFoundException(
+		string path, byte[] bytes)
+	{
+		FileSystemMock fileSystem = new();
+		IStorageLocation location = InMemoryLocation.New(null, path);
+		IStorageContainer fileContainer = InMemoryContainer.NewFile(location, fileSystem);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			fileContainer.RequestAccess(FileAccess.Read, FileShare.Read);
+		});
+
+		exception.Should().BeOfType<DirectoryNotFoundException>();
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryContainerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryContainerTests.cs
@@ -86,7 +86,7 @@ public class InMemoryContainerTests
 	[AutoData]
 	[Trait(nameof(Testing), nameof(InMemoryContainer))]
 	public void RequestAccess_WithoutDrive_ShouldThrowDirectoryNotFoundException(
-		string path, byte[] bytes)
+		string path)
 	{
 		FileSystemMock fileSystem = new();
 		IStorageLocation location = InMemoryLocation.New(null, path);

--- a/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryContainerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryContainerTests.cs
@@ -1,0 +1,63 @@
+﻿using Testably.Abstractions.Testing.Storage;
+
+namespace Testably.Abstractions.Testing.Tests.Storage;
+
+public class InMemoryContainerTests
+{
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryContainer))]
+	public void Decrypt_Encrypted_ShouldDecryptBytes(
+		string path, byte[] bytes)
+	{
+		FileSystemMock fileSystem = new();
+		FileSystemMock.DriveInfoMock drive =
+			FileSystemMock.DriveInfoMock.New("C", fileSystem);
+		IStorageLocation location = InMemoryLocation.New(drive, path);
+		IStorageContainer fileContainer = InMemoryContainer.NewFile(location, fileSystem);
+		fileContainer.WriteBytes(bytes);
+		fileContainer.Encrypt();
+
+		fileContainer.Decrypt();
+
+		fileContainer.GetBytes().Should().BeEquivalentTo(bytes);
+	}
+
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryContainer))]
+	public void Decrypt_Unencrypted_ShouldDoNothing(
+		string path, byte[] bytes)
+	{
+		FileSystemMock fileSystem = new();
+		FileSystemMock.DriveInfoMock drive =
+			FileSystemMock.DriveInfoMock.New("C", fileSystem);
+		IStorageLocation location = InMemoryLocation.New(drive, path);
+		IStorageContainer fileContainer = InMemoryContainer.NewFile(location, fileSystem);
+		fileContainer.WriteBytes(bytes);
+
+		fileContainer.Decrypt();
+
+		fileContainer.GetBytes().Should().BeEquivalentTo(bytes);
+	}
+
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryContainer))]
+	public void Encrypt_Encrypted_ShouldDoNothing(
+		string path, byte[] bytes)
+	{
+		FileSystemMock fileSystem = new();
+		FileSystemMock.DriveInfoMock drive =
+			FileSystemMock.DriveInfoMock.New("C", fileSystem);
+		IStorageLocation location = InMemoryLocation.New(drive, path);
+		IStorageContainer fileContainer = InMemoryContainer.NewFile(location, fileSystem);
+		fileContainer.WriteBytes(bytes);
+		fileContainer.Encrypt();
+
+		fileContainer.Encrypt();
+
+		fileContainer.Decrypt();
+		fileContainer.GetBytes().Should().BeEquivalentTo(bytes);
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryLocationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryLocationTests.cs
@@ -1,0 +1,178 @@
+﻿using System.IO;
+using Testably.Abstractions.Testing.Storage;
+
+namespace Testably.Abstractions.Testing.Tests.Storage;
+
+public class InMemoryLocationTests
+{
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryLocation))]
+	public void Equals_ForDummyLocation_ShouldAlsoIgnoreTrailingDirectorySeparator(
+		string path)
+	{
+		string fullPath = Path.GetFullPath(path);
+		IStorageLocation location1 = InMemoryLocation.New(null, fullPath);
+		IStorageLocation location2 =
+			new DummyLocation(fullPath + Path.DirectorySeparatorChar);
+
+		bool result = location1.Equals(location2);
+
+		result.Should().BeTrue();
+	}
+
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryLocation))]
+	public void Equals_ForDummyLocation_ShouldCompareFullPath(
+		string path)
+	{
+		string fullPath = Path.GetFullPath(path);
+		IStorageLocation location1 = InMemoryLocation.New(null, fullPath);
+		IStorageLocation location2 = new DummyLocation(fullPath);
+
+		bool result = location1.Equals(location2);
+
+		result.Should().BeTrue();
+	}
+
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryLocation))]
+	public void Equals_ForInMemoryLocation_ShouldIgnoreTrailingDirectorySeparator(
+		string path)
+	{
+		string fullPath = Path.GetFullPath(path);
+		IStorageLocation location1 = InMemoryLocation.New(null, fullPath);
+		IStorageLocation location2 =
+			InMemoryLocation.New(null, fullPath + Path.DirectorySeparatorChar);
+
+		bool result = location1.Equals(location2);
+
+		result.Should().BeTrue();
+	}
+
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryLocation))]
+	public void Equals_ForInMemoryLocation_ShouldIgnoreTrailingDirectorySeparator(
+		string path1, string path2)
+	{
+		IStorageLocation location1 = InMemoryLocation.New(null, Path.GetFullPath(path1));
+		IStorageLocation location2 = InMemoryLocation.New(null, Path.GetFullPath(path2));
+
+		bool result = location1.Equals(location2);
+
+		result.Should().BeFalse();
+	}
+
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryLocation))]
+	public void
+		Equals_AsObject_ForInMemoryLocation_ShouldIgnoreTrailingDirectorySeparator(
+			string path1, string path2)
+	{
+		object location1 = InMemoryLocation.New(null, Path.GetFullPath(path1));
+		object location2 = InMemoryLocation.New(null, Path.GetFullPath(path2));
+
+		bool result = location1.Equals(location2);
+
+		result.Should().BeFalse();
+	}
+
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryLocation))]
+	public void Equals_Object_ForInMemoryLocation_ShouldIgnoreTrailingDirectorySeparator(
+		string path)
+	{
+		string fullPath = Path.GetFullPath(path);
+		object location1 = InMemoryLocation.New(null, fullPath);
+		object location2 =
+			InMemoryLocation.New(null, fullPath + Path.DirectorySeparatorChar);
+
+		bool result = location1.Equals(location2);
+
+		result.Should().BeTrue();
+	}
+
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryLocation))]
+	public void Equals_Null_ShouldReturnFalse(string path)
+	{
+		IStorageLocation location = InMemoryLocation.New(null, path);
+
+		bool result = location.Equals(null);
+
+		result.Should().BeFalse();
+	}
+
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryLocation))]
+	public void Equals_Object_Null_ShouldReturnFalse(string path)
+	{
+		object location = InMemoryLocation.New(null, path);
+
+		bool result = location.Equals(null);
+
+		result.Should().BeFalse();
+	}
+
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryLocation))]
+	public void Equals_SameInstance_ShouldReturnTrue(string path)
+	{
+		IStorageLocation location = InMemoryLocation.New(null, path);
+
+		bool result = location.Equals(location);
+
+		result.Should().BeTrue();
+	}
+
+	[Theory]
+	[AutoData]
+	[Trait(nameof(Testing), nameof(InMemoryLocation))]
+	public void Equals_Object_SameInstance_ShouldReturnTrue(string path)
+	{
+		object location = InMemoryLocation.New(null, path);
+
+		// ReSharper disable once EqualExpressionComparison
+		bool result = location.Equals(location);
+
+		result.Should().BeTrue();
+	}
+
+	private class DummyLocation : IStorageLocation
+	{
+		public DummyLocation(string fullPath)
+		{
+			FullPath = fullPath;
+			FriendlyName = fullPath;
+		}
+
+		#region IStorageLocation Members
+
+		/// <inheritdoc cref="IStorageLocation.Drive" />
+		public IStorageDrive? Drive => null;
+
+		/// <inheritdoc cref="IStorageLocation.FriendlyName" />
+		public string FriendlyName { get; }
+
+		/// <inheritdoc cref="IStorageLocation.FullPath" />
+		public string FullPath { get; }
+
+		/// <inheritdoc cref="IEquatable{IStorageLocation}.Equals(IStorageLocation)" />
+		public bool Equals(IStorageLocation? other)
+			=> throw new NotSupportedException();
+
+		/// <inheritdoc cref="IStorageLocation.GetParent()" />
+		public IStorageLocation GetParent()
+			=> throw new NotSupportedException();
+
+		#endregion
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryLocationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryLocationTests.cs
@@ -8,22 +8,6 @@ public class InMemoryLocationTests
 	[Theory]
 	[AutoData]
 	[Trait(nameof(Testing), nameof(InMemoryLocation))]
-	public void Equals_ForDummyLocation_ShouldAlsoIgnoreTrailingDirectorySeparator(
-		string path)
-	{
-		string fullPath = Path.GetFullPath(path);
-		IStorageLocation location1 = InMemoryLocation.New(null, fullPath);
-		IStorageLocation location2 =
-			new DummyLocation(fullPath + Path.DirectorySeparatorChar);
-
-		bool result = location1.Equals(location2);
-
-		result.Should().BeTrue();
-	}
-
-	[Theory]
-	[AutoData]
-	[Trait(nameof(Testing), nameof(InMemoryLocation))]
 	public void Equals_ForDummyLocation_ShouldCompareFullPath(
 		string path)
 	{
@@ -50,20 +34,6 @@ public class InMemoryLocationTests
 		bool result = location1.Equals(location2);
 
 		result.Should().BeTrue();
-	}
-
-	[Theory]
-	[AutoData]
-	[Trait(nameof(Testing), nameof(InMemoryLocation))]
-	public void Equals_ForInMemoryLocation_ShouldIgnoreTrailingDirectorySeparator(
-		string path1, string path2)
-	{
-		IStorageLocation location1 = InMemoryLocation.New(null, Path.GetFullPath(path1));
-		IStorageLocation location2 = InMemoryLocation.New(null, Path.GetFullPath(path2));
-
-		bool result = location1.Equals(location2);
-
-		result.Should().BeFalse();
 	}
 
 	[Theory]
@@ -104,7 +74,7 @@ public class InMemoryLocationTests
 	{
 		IStorageLocation location = InMemoryLocation.New(null, path);
 
-		bool result = location.Equals(null);
+		bool result = location.Equals(null!);
 
 		result.Should().BeFalse();
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Storage/NullContainerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Storage/NullContainerTests.cs
@@ -1,0 +1,18 @@
+﻿using Testably.Abstractions.Testing.Storage;
+
+namespace Testably.Abstractions.Testing.Tests.Storage;
+
+public class NullContainerTests
+{
+	[Fact]
+	[Trait(nameof(Testing), nameof(NullContainer))]
+	public void Constructor_ShouldSetFileAndTimeSystem()
+	{
+		FileSystemMock fileSystem = new();
+
+		IStorageContainer sut = NullContainer.New(fileSystem);
+
+		sut.FileSystem.Should().Be(fileSystem);
+		sut.TimeSystem.Should().Be(fileSystem.TimeSystem);
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.Times.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystemDirectoryTests.Times.cs
@@ -229,6 +229,8 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		   .Should().Be(creationTime.ToUniversalTime());
 		FileSystem.Directory.GetCreationTime(path)
 		   .Should().Be(creationTime);
+		FileSystem.Directory.GetCreationTime(path).Kind
+		   .Should().NotBe(DateTimeKind.Unspecified);
 	}
 
 	[SkippableTheory]
@@ -291,6 +293,8 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		   .Should().Be(creationTime);
 		FileSystem.Directory.GetCreationTime(path)
 		   .Should().Be(creationTime.ToLocalTime());
+		FileSystem.Directory.GetCreationTime(path).Kind
+		   .Should().NotBe(DateTimeKind.Unspecified);
 	}
 
 	[SkippableTheory]
@@ -347,6 +351,8 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		   .Should().Be(lastAccessTime.ToUniversalTime());
 		FileSystem.Directory.GetLastAccessTime(path)
 		   .Should().Be(lastAccessTime);
+		FileSystem.Directory.GetLastAccessTime(path).Kind
+		   .Should().NotBe(DateTimeKind.Unspecified);
 	}
 
 	[SkippableTheory]
@@ -403,6 +409,8 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		   .Should().Be(lastAccessTime);
 		FileSystem.Directory.GetLastAccessTime(path)
 		   .Should().Be(lastAccessTime.ToLocalTime());
+		FileSystem.Directory.GetLastAccessTime(path).Kind
+		   .Should().NotBe(DateTimeKind.Unspecified);
 	}
 
 	[SkippableTheory]
@@ -459,6 +467,8 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		   .Should().Be(lastWriteTime.ToUniversalTime());
 		FileSystem.Directory.GetLastWriteTime(path)
 		   .Should().Be(lastWriteTime);
+		FileSystem.Directory.GetLastWriteTime(path).Kind
+		   .Should().NotBe(DateTimeKind.Unspecified);
 	}
 
 	[SkippableTheory]
@@ -515,5 +525,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		   .Should().Be(lastWriteTime);
 		FileSystem.Directory.GetLastWriteTime(path)
 		   .Should().Be(lastWriteTime.ToLocalTime());
+		FileSystem.Directory.GetLastWriteTime(path).Kind
+		   .Should().NotBe(DateTimeKind.Unspecified);
 	}
 }

--- a/Tests/stryker-config-testing.json
+++ b/Tests/stryker-config-testing.json
@@ -13,7 +13,7 @@
     "reporters": [ "html", "progress", "cleartext" ],
     "mutation-level": "Advanced",
     "ignore-methods": [
-      "*Exception.ctor",
+      "ExceptionFactory.*",
       "ValidateDriveLetter" // Only tested under windows
     ]
   }


### PR DESCRIPTION
Add tests or simplify implementation due to Stryker analysis:
- Exclude dummy encryption and ExceptionFactory manipulation from stryker
- Add tests for `NullContainer`, `InMemoryLocation` and `InMemoryContainer`