### PR TITLE
fix: various edge case inconsistencies

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileMock.cs
@@ -234,8 +234,17 @@ public sealed partial class FileSystemMock
 
 		/// <inheritdoc cref="IFileSystem.IFile.Exists(string?)" />
 		public bool Exists([NotNullWhen(true)] string? path)
-			=> FileInfoMock.New(_fileSystem.Storage.GetLocation(path), _fileSystem)
-			  ?.Exists ?? false;
+		{
+			if (string.IsNullOrEmpty(path))
+			{
+				return false;
+			}
+
+			return FileInfoMock.New(
+					_fileSystem.Storage.GetLocation(path),
+					_fileSystem)
+			   .Exists;
+		}
 
 		/// <inheritdoc cref="IFileSystem.IFile.GetAttributes(string)" />
 		public FileAttributes GetAttributes(string path)

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileMock.cs
@@ -385,7 +385,7 @@ public sealed partial class FileSystemMock
 					FileStreamFactoryMock.DefaultShare))
 				{
 					fileInfo.AdjustTimes(TimeAdjustments.LastAccessTime);
-					return fileInfo.GetBytes();
+					return fileInfo.GetBytes().ToArray();
 				}
 			}
 

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileSystemInfoMock.cs
@@ -82,7 +82,7 @@ public sealed partial class FileSystemMock
 		{
 			if (!FileSystem.Storage.DeleteContainer(Location))
 			{
-				throw ExceptionFactory.DirectoryNotFound(FullName);
+				throw ExceptionFactory.DirectoryNotFound(Location.FullPath);
 			}
 
 			Refresh();
@@ -101,7 +101,7 @@ public sealed partial class FileSystemMock
 
 		/// <inheritdoc cref="IFileSystem.IFileSystemInfo.Extension" />
 		public string Extension
-			=> FileSystem.Path.GetExtension(FullName);
+			=> FileSystem.Path.GetExtension(Location.FullPath);
 
 		/// <inheritdoc cref="IFileSystem.IFileSystemInfo.FullName" />
 		public string FullName => Location.FullPath;
@@ -142,7 +142,7 @@ public sealed partial class FileSystemMock
 
 		/// <inheritdoc cref="IFileSystem.IFileSystemInfo.Name" />
 		public string Name
-			=> FileSystem.Path.GetFileName(FullName.TrimEnd(
+			=> FileSystem.Path.GetFileName(Location.FullPath.TrimEnd(
 				FileSystem.Path.DirectorySeparatorChar,
 				FileSystem.Path.AltDirectorySeparatorChar));
 
@@ -164,7 +164,7 @@ public sealed partial class FileSystemMock
 			{
 				IStorageLocation? targetLocation =
 					FileSystem.Storage.ResolveLinkTarget(
-						FileSystem.Storage.GetLocation(FullName),
+						Location,
 						returnFinalTarget);
 				if (targetLocation != null)
 				{

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -146,7 +146,7 @@ internal sealed class InMemoryStorage : IStorage
 		enumerationOptions ??= EnumerationOptionsHelper.Compatible;
 
 		foreach (KeyValuePair<IStorageLocation, IStorageContainer> item in _containers
-		   .Where(x => x.Key.FullPath.StartsWith(location.FullPath) &&
+		   .Where(x => x.Key.FullPath.StartsWith(location.FullPath, InMemoryLocation.StringComparisonMode) &&
 		               !x.Key.Equals(location)))
 		{
 			string? parentPath =
@@ -154,7 +154,7 @@ internal sealed class InMemoryStorage : IStorage
 					item.Key.FullPath.TrimEnd(_fileSystem.Path
 					   .DirectorySeparatorChar));
 			if (!enumerationOptions.RecurseSubdirectories &&
-			    parentPath != location.FullPath)
+			    parentPath?.Equals(location.FullPath, InMemoryLocation.StringComparisonMode) != true)
 			{
 				continue;
 			}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.EnumerateFiles.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.EnumerateFiles.cs
@@ -25,6 +25,21 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void EnumerateFiles_Path_ShouldBeCaseInsensitiveOnWindows(string path)
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		FileSystem.Initialize()
+		   .WithSubdirectory(path.ToUpper()).Initialized(s => s
+			   .WithAFile());
+
+		string[] result = FileSystem.Directory.GetFiles(path.ToLower());
+
+		result.Length.Should().Be(1);
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void
 		EnumerateFiles_SearchOptionAllDirectories_FullPath_ShouldReturnAllFilesWithFullPath(
 			string path)
@@ -98,6 +113,17 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 			result.Should()
 			   .BeEmpty($"{fileName} should not match {searchPattern}");
 		}
+	}
+
+	[SkippableFact]
+	public void EnumerateFiles_SearchPatternWithTooManyAsterisk_ShouldWorkConsistently()
+	{
+		FileSystem.Initialize()
+		   .WithFile("result.test.001.txt");
+
+		string[] result = FileSystem.Directory.GetFiles(".", "*.test.*.*.*.*");
+
+		result.Length.Should().Be(1);
 	}
 
 #if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.GetDirectories.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.GetDirectories.cs
@@ -167,6 +167,17 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		result.Should().Contain(FileSystem.Path.Combine(path, "bar"));
 	}
 
+	[SkippableFact]
+	public void GetDirectories_WithRelativePath_ShouldReturnRelativePaths()
+	{
+		string path = $"foo{FileSystem.Path.DirectorySeparatorChar}bar";
+		FileSystem.Directory.CreateDirectory(path);
+
+		string[] result = FileSystem.Directory.GetDirectories("foo");
+
+		result.Should().BeEquivalentTo(path);
+	}
+
 	[SkippableTheory]
 	[AutoData]
 	public void GetDirectories_WithSearchPattern_ShouldReturnMatchingSubdirectory(

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/FileSystemDirectoryInfoTests.MoveTo.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/FileSystemDirectoryInfoTests.MoveTo.cs
@@ -37,6 +37,24 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void MoveTo_ShouldUpdatePropertiesOfDirectoryInfo(
+		string source, string destination)
+	{
+		FileSystem.InitializeIn(source)
+		   .WithAFile()
+		   .WithASubdirectory().Initialized(s => s
+			   .WithAFile()
+			   .WithASubdirectory());
+		IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New(source);
+
+		sut.MoveTo(destination);
+
+		sut.FullName.TrimEnd(FileSystem.Path.DirectorySeparatorChar)
+		   .Should().Be(FileSystem.Path.GetFullPath(destination));
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void MoveTo_WithLockedFile_ShouldNotMoveDirectoryAtAll(
 		string source, string destination)
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Create.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Create.cs
@@ -24,6 +24,10 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 
 		FileTestHelper.CheckFileAccess(stream).Should().Be(FileAccess.ReadWrite);
 		FileTestHelper.CheckFileShare(FileSystem, path).Should().Be(FileShare.None);
+		stream.CanRead.Should().BeTrue();
+		stream.CanWrite.Should().BeTrue();
+		stream.CanSeek.Should().BeTrue();
+		stream.CanTimeout.Should().BeFalse();
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Exists.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Exists.cs
@@ -10,4 +10,12 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 
 		result.Should().BeFalse();
 	}
+
+	[SkippableFact]
+	public void Exists_Empty_ShouldReturnFalse()
+	{
+		bool result = FileSystem.File.Exists(string.Empty);
+
+		result.Should().BeFalse();
+	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Move.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Move.cs
@@ -7,6 +7,27 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
+	public void Move_CaseOnlyChange_ShouldMoveFileWithContent(
+		string name, string contents)
+	{
+		string sourceName = name.ToLower();
+		string destinationName = name.ToUpper();
+		FileSystem.File.WriteAllText(sourceName, contents);
+
+		FileSystem.File.Move(sourceName, destinationName);
+
+		if (!Test.RunsOnWindows)
+		{
+			// sourceName and destinationName are treated identical on Windows
+			FileSystem.File.Exists(sourceName).Should().BeFalse();
+		}
+
+		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void Move_DestinationExists_ShouldThrowIOExceptionAndNotMoveFile(
 		string sourceName,
 		string destinationName,
@@ -67,6 +88,20 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void Move_ShouldMoveFileWithContent(
+		string sourceName, string destinationName, string contents)
+	{
+		FileSystem.File.WriteAllText(sourceName, contents);
+
+		FileSystem.File.Move(sourceName, destinationName);
+
+		FileSystem.File.Exists(sourceName).Should().BeFalse();
+		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void Move_ShouldNotAdjustTimes(string source, string destination)
 	{
 		Test.SkipIfLongRunningTestsShouldBeSkipped(FileSystem);
@@ -91,20 +126,6 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 		lastWriteTime.Should()
 		   .BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 		   .BeOnOrBefore(creationTimeEnd);
-	}
-
-	[SkippableTheory]
-	[AutoData]
-	public void Move_ShouldMoveFileWithContent(
-		string sourceName, string destinationName, string contents)
-	{
-		FileSystem.File.WriteAllText(sourceName, contents);
-
-		FileSystem.File.Move(sourceName, destinationName);
-
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
-		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Move.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Move.cs
@@ -16,9 +16,9 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 
 		FileSystem.File.Move(sourceName, destinationName);
 
-		if (!Test.RunsOnWindows)
+		if (Test.RunsOnLinux)
 		{
-			// sourceName and destinationName are treated identical on Windows
+			// sourceName and destinationName are considered different only on Linux
 			FileSystem.File.Exists(sourceName).Should().BeFalse();
 		}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.OpenRead.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.OpenRead.cs
@@ -29,5 +29,9 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 		FileTestHelper.CheckFileAccess(stream).Should().Be(FileAccess.Read);
 		FileTestHelper.CheckFileShare(FileSystem, path).Should().Be(
 			Test.RunsOnWindows ? FileShare.Read : FileShare.ReadWrite);
+		stream.CanRead.Should().BeTrue();
+		stream.CanWrite.Should().BeFalse();
+		stream.CanSeek.Should().BeTrue();
+		stream.CanTimeout.Should().BeFalse();
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.OpenWrite.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.OpenWrite.cs
@@ -24,5 +24,9 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 
 		FileTestHelper.CheckFileAccess(stream).Should().Be(FileAccess.Write);
 		FileTestHelper.CheckFileShare(FileSystem, path).Should().Be(FileShare.None);
+		stream.CanRead.Should().BeFalse();
+		stream.CanWrite.Should().BeTrue();
+		stream.CanSeek.Should().BeTrue();
+		stream.CanTimeout.Should().BeFalse();
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.ReadAllBytes.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.ReadAllBytes.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 
@@ -51,6 +52,19 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 		lastWriteTime.Should()
 		   .BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 		   .BeOnOrBefore(creationTimeEnd);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void ReadAllBytes_ShouldNotGetAReferenceToFileContent(
+		string path, byte[] contents)
+	{
+		FileSystem.File.WriteAllBytes(path, contents.ToArray());
+
+		byte[] results = FileSystem.File.ReadAllBytes(path);
+		results[0] = (byte)~results[0];
+
+		FileSystem.File.ReadAllBytes(path).Should().BeEquivalentTo(contents);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/FileSystemFileInfoFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/FileSystemFileInfoFactoryTests.cs
@@ -19,8 +19,7 @@ public abstract class FileSystemFileInfoFactoryTests<TFileSystem>
 		Test.SkipIfTestsOnRealFileSystemShouldBeSkipped(FileSystem);
 	}
 
-	[SkippableTheory]
-	[AutoData]
+	[SkippableFact]
 	public void New_EmptyString_ShouldThrowArgumentException()
 	{
 		Exception? exception = Record.Exception(() =>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/FileSystemFileInfoFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/FileSystemFileInfoFactoryTests.cs
@@ -19,6 +19,18 @@ public abstract class FileSystemFileInfoFactoryTests<TFileSystem>
 		Test.SkipIfTestsOnRealFileSystemShouldBeSkipped(FileSystem);
 	}
 
+	[SkippableTheory]
+	[AutoData]
+	public void New_EmptyString_ShouldThrowArgumentException()
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			_ = FileSystem.FileInfo.New(string.Empty);
+		});
+
+		exception.Should().BeOfType<ArgumentException>();
+	}
+
 	[SkippableFact]
 	public void New_Null_ShouldThrowArgumentNullException()
 	{


### PR DESCRIPTION
- Fix a bug in `File.Exists` when providing an empty string as `path` parameter
- Make path case insensitive when enumerating on directories also in .NET Framework
- GetBytes don't return the array instance so that the file content is read-only

*Also add some tests that cover certain other edge cases, that were already implemented correctly.*