### PR TITLE
refactor: rename `Execute` to `ExecuteWhileWaiting` for notifications

### DIFF
--- a/Source/Testably.Abstractions.Testing/Notification.cs
+++ b/Source/Testably.Abstractions.Testing/Notification.cs
@@ -11,9 +11,10 @@ namespace Testably.Abstractions.Testing;
 public static class Notification
 {
 	/// <summary>
-	///     Executes the <paramref name="callback" /> and returns the <paramref name="awaitable" />.
+	///     Executes the <paramref name="callback" /> while waiting for the notification.
 	/// </summary>
-	public static IAwaitableCallback<TValue> Execute<TValue>(
+	/// <returns>The <paramref name="awaitable" /> callback.</returns>
+	public static IAwaitableCallback<TValue> ExecuteWhileWaiting<TValue>(
 		this IAwaitableCallback<TValue> awaitable, Action callback)
 	{
 		return new CallbackWaiterWithValue<TValue, object?>(awaitable, () =>
@@ -24,9 +25,10 @@ public static class Notification
 	}
 
 	/// <summary>
-	///     Executes the <paramref name="callback" /> and returns the <paramref name="awaitable" />.
+	///     Executes the <paramref name="callback" /> while waiting for the notification.
 	/// </summary>
-	public static IAwaitableCallback<TValue, TFunc> Execute<TValue, TFunc>(
+	/// <returns>The <paramref name="awaitable" /> callback.</returns>
+	public static IAwaitableCallback<TValue, TFunc> ExecuteWhileWaiting<TValue, TFunc>(
 		this IAwaitableCallback<TValue> awaitable, Func<TFunc> callback)
 	{
 		return new CallbackWaiterWithValue<TValue, TFunc>(awaitable, callback);

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/FileSystemMockExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/FileSystemMockExtensionsTests.cs
@@ -25,7 +25,7 @@ public class FileSystemMockExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnCreated(FileSystemTypes.Directory, _ => isNotified = true)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.Delete(path);
 				})
@@ -47,7 +47,7 @@ public class FileSystemMockExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnCreated(FileSystemTypes.Directory, _ => isNotified = true, path2)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.CreateDirectory(path1);
 				})
@@ -72,7 +72,7 @@ public class FileSystemMockExtensionsTests
 			FileSystem.Notify
 			   .OnCreated(FileSystemTypes.Directory, _ => isNotified = true,
 					searchPattern: searchPattern)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.CreateDirectory(path);
 				})
@@ -100,7 +100,7 @@ public class FileSystemMockExtensionsTests
 
 		FileSystem.Notify
 		   .OnCreated(FileSystemTypes.Directory, _ => isNotified = true)
-		   .Execute(() =>
+		   .ExecuteWhileWaiting(() =>
 			{
 				FileSystem.Directory.CreateDirectory(path);
 			})
@@ -122,7 +122,7 @@ public class FileSystemMockExtensionsTests
 			FileSystem.Notify
 			   .OnCreated(FileSystemTypes.Directory, _ => isNotified = true,
 					predicate: _ => expectedResult)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.CreateDirectory(path);
 				})
@@ -153,7 +153,7 @@ public class FileSystemMockExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnCreated(FileSystemTypes.File, _ => isNotified = true)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.Delete(path);
 				})
@@ -175,7 +175,7 @@ public class FileSystemMockExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnCreated(FileSystemTypes.File, _ => isNotified = true, path2)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.WriteAllText(path1, null);
 				})
@@ -200,7 +200,7 @@ public class FileSystemMockExtensionsTests
 			FileSystem.Notify
 			   .OnCreated(FileSystemTypes.File, _ => isNotified = true,
 					searchPattern: searchPattern)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.WriteAllText(path, null);
 				})
@@ -228,7 +228,7 @@ public class FileSystemMockExtensionsTests
 
 		FileSystem.Notify
 		   .OnCreated(FileSystemTypes.File, _ => isNotified = true)
-		   .Execute(() =>
+		   .ExecuteWhileWaiting(() =>
 			{
 				FileSystem.File.WriteAllText(path, null);
 			})
@@ -250,7 +250,7 @@ public class FileSystemMockExtensionsTests
 			FileSystem.Notify
 			   .OnCreated(FileSystemTypes.File, _ => isNotified = true,
 					predicate: _ => expectedResult)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.WriteAllText(path, null);
 				})
@@ -280,7 +280,7 @@ public class FileSystemMockExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnDeleted(FileSystemTypes.Directory, _ => isNotified = true)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.CreateDirectory(path);
 				})
@@ -304,7 +304,7 @@ public class FileSystemMockExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnDeleted(FileSystemTypes.Directory, _ => isNotified = true, path2)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.Delete(path1);
 				})
@@ -330,7 +330,7 @@ public class FileSystemMockExtensionsTests
 			FileSystem.Notify
 			   .OnDeleted(FileSystemTypes.Directory, _ => isNotified = true,
 					searchPattern: searchPattern)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.Delete(path);
 				})
@@ -359,7 +359,7 @@ public class FileSystemMockExtensionsTests
 
 		FileSystem.Notify
 		   .OnDeleted(FileSystemTypes.Directory, _ => isNotified = true)
-		   .Execute(() =>
+		   .ExecuteWhileWaiting(() =>
 			{
 				FileSystem.Directory.Delete(path);
 			})
@@ -382,7 +382,7 @@ public class FileSystemMockExtensionsTests
 			FileSystem.Notify
 			   .OnDeleted(FileSystemTypes.Directory, _ => isNotified = true,
 					predicate: _ => expectedResult)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.Delete(path);
 				})
@@ -412,7 +412,7 @@ public class FileSystemMockExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnDeleted(FileSystemTypes.File, _ => isNotified = true)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.WriteAllText(path, null);
 				})
@@ -436,7 +436,7 @@ public class FileSystemMockExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnDeleted(FileSystemTypes.File, _ => isNotified = true, path2)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.Delete(path1);
 				})
@@ -462,7 +462,7 @@ public class FileSystemMockExtensionsTests
 			FileSystem.Notify
 			   .OnDeleted(FileSystemTypes.File, _ => isNotified = true,
 					searchPattern: searchPattern)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.Delete(path);
 				})
@@ -491,7 +491,7 @@ public class FileSystemMockExtensionsTests
 
 		FileSystem.Notify
 		   .OnDeleted(FileSystemTypes.File, _ => isNotified = true)
-		   .Execute(() =>
+		   .ExecuteWhileWaiting(() =>
 			{
 				FileSystem.File.Delete(path);
 			})
@@ -514,7 +514,7 @@ public class FileSystemMockExtensionsTests
 			FileSystem.Notify
 			   .OnDeleted(FileSystemTypes.File, _ => isNotified = true,
 					predicate: _ => expectedResult)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.Delete(path);
 				})
@@ -544,7 +544,7 @@ public class FileSystemMockExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnChanged(FileSystemTypes.File, _ => isNotified = true)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.WriteAllText(path, null);
 				})
@@ -568,7 +568,7 @@ public class FileSystemMockExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnChanged(FileSystemTypes.File, _ => isNotified = true, path2)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.AppendAllText(path1, "foo");
 				})
@@ -594,7 +594,7 @@ public class FileSystemMockExtensionsTests
 			FileSystem.Notify
 			   .OnChanged(FileSystemTypes.File, _ => isNotified = true,
 					searchPattern: searchPattern)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.AppendAllText(path, "foo");
 				})
@@ -623,7 +623,7 @@ public class FileSystemMockExtensionsTests
 
 		FileSystem.Notify
 		   .OnChanged(FileSystemTypes.File, _ => isNotified = true)
-		   .Execute(() =>
+		   .ExecuteWhileWaiting(() =>
 			{
 				FileSystem.File.AppendAllText(path, "foo");
 			})
@@ -646,7 +646,7 @@ public class FileSystemMockExtensionsTests
 			FileSystem.Notify
 			   .OnChanged(FileSystemTypes.File, _ => isNotified = true,
 					predicate: _ => expectedResult)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.AppendAllText(path, "foo");
 				})

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/InterceptionHandlerExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/InterceptionHandlerExtensionsTests.cs
@@ -31,7 +31,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.Delete(path);
 				})
@@ -60,7 +60,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.Delete(path1);
 				})
@@ -91,7 +91,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.AppendAllText(path, "foo");
 				})
@@ -129,7 +129,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.AppendAllText(path, "foo");
 				})
@@ -166,7 +166,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.Delete(path);
 				})
@@ -194,7 +194,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.CreateDirectory(path1);
 				})
@@ -224,7 +224,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.CreateDirectory(path);
 				})
@@ -261,7 +261,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.CreateDirectory(path);
 				})
@@ -298,7 +298,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.Delete(path);
 				})
@@ -326,7 +326,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.WriteAllText(path1, null);
 				})
@@ -356,7 +356,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.WriteAllText(path, null);
 				})
@@ -393,7 +393,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.WriteAllText(path, null);
 				})
@@ -429,7 +429,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.CreateDirectory(path);
 				})
@@ -458,7 +458,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.Delete(path1);
 				})
@@ -489,7 +489,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.Delete(path);
 				})
@@ -527,7 +527,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.Delete(path);
 				})
@@ -563,7 +563,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.WriteAllText(path, null);
 				})
@@ -592,7 +592,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.Delete(path1);
 				})
@@ -623,7 +623,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.Delete(path);
 				})
@@ -661,7 +661,7 @@ public class InterceptionHandlerExtensionsTests
 		{
 			FileSystem.Notify
 			   .OnEvent()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.File.Delete(path);
 				})

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/InterceptionHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/InterceptionHandlerTests.cs
@@ -23,7 +23,7 @@ public class InterceptionHandlerTests
 		{
 			FileSystem.Notify
 			   .OnChange()
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.CreateDirectory(path);
 				})
@@ -45,7 +45,7 @@ public class InterceptionHandlerTests
 		{
 			FileSystem.Notify
 			   .OnChange(c => receivedPath = c.Path)
-			   .Execute(() =>
+			   .ExecuteWhileWaiting(() =>
 				{
 					FileSystem.Directory.CreateDirectory(path);
 				})

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/NotificationHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/NotificationHandlerTests.cs
@@ -32,7 +32,7 @@ public class NotificationHandlerTests
 					eventCount++;
 				},
 				c => c.ChangeType == WatcherChangeTypes.Created)
-		   .Execute(() =>
+		   .ExecuteWhileWaiting(() =>
 			{
 				FileSystem.Directory.CreateDirectory(path);
 			})
@@ -57,7 +57,7 @@ public class NotificationHandlerTests
 		   .OnChange(c => receivedPath = c.Path,
 				c => c.ChangeType == expectedChangeType &&
 				     c.FileSystemType == expectedFileSystemType)
-		   .Execute(() =>
+		   .ExecuteWhileWaiting(() =>
 			{
 				callback.Invoke(FileSystem, path);
 			})

--- a/Tests/Testably.Abstractions.Testing.Tests/Notification/NotificationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Notification/NotificationTests.cs
@@ -159,7 +159,7 @@ public class NotificationTests
 					{
 						isCalledFromSecondThread = true;
 					}
-				}).Execute(() => listening.Set());
+				}).ExecuteWhileWaiting(() => listening.Set());
 		new Thread(() =>
 		{
 			listening.Wait(1000);
@@ -191,10 +191,12 @@ public class NotificationTests
 		int receivedMilliseconds = -1;
 		bool isExecuted = false;
 
-		timeSystem.On.ThreadSleep(t =>
+		timeSystem.On
+		   .ThreadSleep(t =>
 			{
 				receivedMilliseconds = (int)t.TotalMilliseconds;
-			}).Execute(() =>
+			})
+		   .ExecuteWhileWaiting(() =>
 			{
 				timeSystem.Thread.Sleep(milliseconds);
 			})
@@ -216,10 +218,12 @@ public class NotificationTests
 		int receivedMilliseconds = -1;
 		bool isExecuted = false;
 
-		string actualResult = timeSystem.On.ThreadSleep(t =>
+		string actualResult = timeSystem.On
+		   .ThreadSleep(t =>
 			{
 				receivedMilliseconds = (int)t.TotalMilliseconds;
-			}).Execute(() =>
+			})
+		   .ExecuteWhileWaiting(() =>
 			{
 				timeSystem.Thread.Sleep(milliseconds);
 				return result;


### PR DESCRIPTION
Clarify functionality of the extension methods `Execute` in the `Notification` class by renaming it to `ExecuteWhileWaiting`