### PR TITLE
feat: change current time in `TimeSystemMock` to be "AsyncLocal"

### DIFF
--- a/Source/Testably.Abstractions.Testing/TimeSystemMock.ITimeProvider.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystemMock.ITimeProvider.cs
@@ -39,5 +39,15 @@ public sealed partial class TimeSystemMock
 		///     Sets the currently simulated system time to the specified <paramref name="value" />.
 		/// </summary>
 		void SetTo(DateTime value);
+
+		/// <summary>
+		///     Synchronizes the currently simulated system time across all async contexts.
+		/// </summary>
+		/// <remarks>
+		///     This means that in multi-thread or async environments after this call all clocks start with the value from the
+		///     calling async context.<br />
+		///     (see also <see href="https://learn.microsoft.com/en-us/dotnet/api/system.threading.asynclocal-1" />)
+		/// </remarks>
+		void SynchronizeClock();
 	}
 }

--- a/Source/Testably.Abstractions.Testing/TimeSystemMock.TimeProviderMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystemMock.TimeProviderMock.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace Testably.Abstractions.Testing;
 
@@ -6,12 +7,11 @@ public sealed partial class TimeSystemMock
 {
 	internal sealed class TimeProviderMock : ITimeProvider
 	{
-		private DateTime _now;
-		private readonly object _lock = new();
+		private static readonly AsyncLocal<DateTime> Now = new();
 
 		public TimeProviderMock(DateTime now)
 		{
-			_now = now;
+			Now.Value = now;
 		}
 
 		#region ITimeProvider Members
@@ -34,25 +34,19 @@ public sealed partial class TimeSystemMock
 		/// <inheritdoc cref="TimeSystemMock.ITimeProvider.AdvanceBy(TimeSpan)" />
 		public void AdvanceBy(TimeSpan interval)
 		{
-			lock (_lock)
-			{
-				_now = _now.Add(interval);
-			}
+			Now.Value = Now.Value.Add(interval);
 		}
 
 		/// <inheritdoc cref="TimeSystemMock.ITimeProvider.Read()" />
 		public DateTime Read()
 		{
-			return _now;
+			return Now.Value;
 		}
 
 		/// <inheritdoc cref="TimeSystemMock.ITimeProvider.SetTo(DateTime)" />
 		public void SetTo(DateTime value)
 		{
-			lock (_lock)
-			{
-				_now = value;
-			}
+			Now.Value = value;
 		}
 
 		#endregion

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystemMock/TimeSystemMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystemMock/TimeSystemMockTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Testing.Tests.TimeSystemMock;
@@ -47,6 +50,88 @@ public class TimeSystemMockTests
 
 		exception.Should().BeOfType<ArgumentOutOfRangeException>()
 		   .Which.ParamName.Should().Be("delay");
+	}
+
+	[Fact]
+	public async Task ParallelTasks_ShouldHaveDistinctTimes()
+	{
+		int parallelTasks = 10;
+		int stepsPerTask = 20;
+		Testing.TimeSystemMock timeSystem = new();
+		DateTime start = timeSystem.DateTime.UtcNow;
+		ConcurrentDictionary<int, List<int>> delaysPerTask = new();
+
+		for (int i = 1; i <= parallelTasks; i++)
+		{
+			int taskId = i;
+			TimeSpan taskDelay = TimeSpan.FromSeconds(taskId);
+			await Task.Run(async () =>
+			{
+				for (int j = 0; j < stepsPerTask; j++)
+				{
+					await timeSystem.Task.Delay(taskDelay);
+					int diff = (int)(timeSystem.DateTime.UtcNow - start)
+					   .TotalMilliseconds;
+					delaysPerTask.AddOrUpdate(taskId,
+						_ => new List<int> { diff },
+						(_, l) =>
+						{
+							l.Add(diff);
+							return l;
+						});
+				}
+			});
+		}
+
+		for (int i = 1; i <= parallelTasks; i++)
+		{
+			int delayPerTask = i * 1000;
+			delaysPerTask[i].Should().BeEquivalentTo(
+				Enumerable.Range(1, stepsPerTask).Select(x => x * delayPerTask));
+		}
+	}
+
+	[Fact]
+	public void ParallelThreads_ShouldHaveDistinctTimes()
+	{
+		int parallelThreads = 10;
+		int stepsPerThread = 20;
+		Testing.TimeSystemMock timeSystem = new();
+		DateTime start = timeSystem.DateTime.UtcNow;
+		ConcurrentDictionary<int, List<int>> delaysPerThread = new();
+		CountdownEvent ms = new CountdownEvent(parallelThreads);
+
+		for (int i = 1; i <= parallelThreads; i++)
+		{
+			int threadId = i;
+			TimeSpan threadDelay = TimeSpan.FromSeconds(threadId);
+			new Thread(() =>
+			{
+				for (int j = 0; j < stepsPerThread; j++)
+				{
+					timeSystem.Thread.Sleep(threadDelay);
+					int diff = (int)(timeSystem.DateTime.UtcNow - start)
+					   .TotalMilliseconds;
+					delaysPerThread.AddOrUpdate(threadId,
+						_ => new List<int> { diff },
+						(_, l) =>
+						{
+							l.Add(diff);
+							return l;
+						});
+				}
+
+				ms.Signal();
+			}).Start();
+		}
+
+		ms.Wait(1000).Should().BeTrue();
+		for (int i = 1; i <= parallelThreads; i++)
+		{
+			int delayPerThread = i * 1000;
+			delaysPerThread[i].Should().BeEquivalentTo(
+				Enumerable.Range(1, stepsPerThread).Select(x => x * delayPerThread));
+		}
 	}
 
 	[Fact]


### PR DESCRIPTION
This allows different tasks or threads to have distinct times.