### PR TITLE
refactor: Add "coverage" type for conventional commits

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       pull-requests: read
       statuses: write
-    name: Ensure "Conventional Commit"
+    name: Ensure "Conventional Commits"
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       pull-requests: read
       statuses: write
-    name: Ensure "Conventional Commit" guideline
+    name: Ensure "Conventional Commit"
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v4
@@ -22,12 +22,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           types: |
-            fix
-            feat
-            doc
-            refactor
             chore
-            test
+            coverage
+            doc
+            feat
+            fix
+            refactor
           scopes: |
             file
             random

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       pull-requests: read
       statuses: write
-    name: Ensure "Conventional Commits"
+    name: Check "Conventional Commits"
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v4


### PR DESCRIPTION
Remove `test` and replace it with `coverage` as valid type for [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)