### PR TITLE
fix: test and fix issues from `System.IO.Abstractions`

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryMock.cs
@@ -74,7 +74,8 @@ public sealed partial class FileSystemMock
 					FileSystemTypes.Directory,
 					searchPattern,
 					EnumerationOptionsHelper.FromSearchOption(searchOption))
-			   .Select(x => _fileSystem.GetSubdirectoryPath(x.FullPath, path));
+			   .Select(x => _fileSystem
+				   .GetSubdirectoryPath(x.FullPath, path, searchOption == SearchOption.AllDirectories));
 
 #if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS
 		/// <inheritdoc cref="IFileSystem.IDirectory.EnumerateDirectories(string, string, EnumerationOptions)" />
@@ -87,7 +88,8 @@ public sealed partial class FileSystemMock
 					FileSystemTypes.Directory,
 					searchPattern,
 					enumerationOptions)
-			   .Select(x => _fileSystem.GetSubdirectoryPath(x.FullPath, path));
+			   .Select(x => _fileSystem
+				   .GetSubdirectoryPath(x.FullPath, path, enumerationOptions.RecurseSubdirectories));
 #endif
 
 		/// <inheritdoc cref="IFileSystem.IDirectory.EnumerateFiles(string)" />
@@ -107,7 +109,8 @@ public sealed partial class FileSystemMock
 					FileSystemTypes.File,
 					searchPattern,
 					EnumerationOptionsHelper.FromSearchOption(searchOption))
-			   .Select(x => _fileSystem.GetSubdirectoryPath(x.FullPath, path));
+			   .Select(x => _fileSystem
+				   .GetSubdirectoryPath(x.FullPath, path, searchOption == SearchOption.AllDirectories));
 
 #if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS
 		/// <inheritdoc cref="IFileSystem.IDirectory.EnumerateFiles(string, string, EnumerationOptions)" />
@@ -119,7 +122,8 @@ public sealed partial class FileSystemMock
 					FileSystemTypes.File,
 					searchPattern,
 					enumerationOptions)
-			   .Select(x => _fileSystem.GetSubdirectoryPath(x.FullPath, path));
+			   .Select(x => _fileSystem
+				   .GetSubdirectoryPath(x.FullPath, path, enumerationOptions.RecurseSubdirectories));
 #endif
 
 		/// <inheritdoc cref="IFileSystem.IDirectory.EnumerateFileSystemEntries(string)" />
@@ -142,7 +146,8 @@ public sealed partial class FileSystemMock
 					FileSystemTypes.DirectoryOrFile,
 					searchPattern,
 					EnumerationOptionsHelper.FromSearchOption(searchOption))
-			   .Select(x => _fileSystem.GetSubdirectoryPath(x.FullPath, path));
+			   .Select(x => _fileSystem
+				   .GetSubdirectoryPath(x.FullPath, path, searchOption == SearchOption.AllDirectories));
 
 #if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS
 		/// <inheritdoc cref="IFileSystem.IDirectory.EnumerateFileSystemEntries(string, string, EnumerationOptions)" />
@@ -154,7 +159,8 @@ public sealed partial class FileSystemMock
 					FileSystemTypes.DirectoryOrFile,
 					searchPattern,
 					enumerationOptions)
-			   .Select(x => _fileSystem.GetSubdirectoryPath(x.FullPath, path));
+			   .Select(x => _fileSystem
+				   .GetSubdirectoryPath(x.FullPath, path, enumerationOptions.RecurseSubdirectories));
 #endif
 
 		/// <inheritdoc cref="IFileSystem.IDirectory.Exists(string)" />

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.FileSystemInfoMock.cs
@@ -142,9 +142,11 @@ public sealed partial class FileSystemMock
 
 		/// <inheritdoc cref="IFileSystem.IFileSystemInfo.Name" />
 		public string Name
-			=> FileSystem.Path.GetFileName(Location.FullPath.TrimEnd(
-				FileSystem.Path.DirectorySeparatorChar,
-				FileSystem.Path.AltDirectorySeparatorChar));
+			=> FileSystem.Path.GetPathRoot(Location.FullPath) == Location.FullPath
+				? Location.FullPath
+				: FileSystem.Path.GetFileName(Location.FullPath.TrimEnd(
+					FileSystem.Path.DirectorySeparatorChar,
+					FileSystem.Path.AltDirectorySeparatorChar));
 
 		/// <inheritdoc cref="IFileSystem.IFileSystemInfo.Refresh()" />
 		public void Refresh()

--- a/Source/Testably.Abstractions.Testing/Internal/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/FileSystemExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.Internal;
@@ -34,9 +35,14 @@ internal static class FileSystemExtensions
 
 	/// <summary>
 	///     Returns the relative subdirectory path from <paramref name="fullFilePath" /> to the <paramref name="givenPath" />.
+	///     <br />
+	///     If <paramref name="recurseSubdirectories" /> is <see langword="false" /> and the <paramref name="givenPath" /> is
+	///     not rooted, the result is prefixed with the <paramref name="givenPath" />.
 	/// </summary>
 	internal static string GetSubdirectoryPath(this IFileSystem fileSystem,
-	                                           string fullFilePath, string givenPath)
+	                                           string fullFilePath,
+	                                           string givenPath,
+	                                           bool recurseSubdirectories)
 	{
 		if (fileSystem.Path.IsPathRooted(givenPath))
 		{
@@ -46,9 +52,18 @@ internal static class FileSystemExtensions
 		string currentDirectory = fileSystem.Directory.GetCurrentDirectory();
 		if (currentDirectory == string.Empty.PrefixRoot())
 		{
-			return fullFilePath.Substring(currentDirectory.Length);
+			fullFilePath = fullFilePath.Substring(currentDirectory.Length);
+		}
+		else
+		{
+			fullFilePath = fullFilePath.Substring(currentDirectory.Length + 1);
 		}
 
-		return fullFilePath.Substring(currentDirectory.Length + 1);
+		if (!recurseSubdirectories && !fullFilePath.StartsWith(givenPath))
+		{
+			return Path.Combine(givenPath, fullFilePath);
+		}
+
+		return fullFilePath;
 	}
 }

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -66,7 +66,7 @@ internal sealed class InMemoryStorage : IStorage
 				InMemoryContainer.NewFile(destination, _fileSystem);
 			if (_containers.TryAdd(destination, copiedContainer))
 			{
-				copiedContainer.WriteBytes(sourceContainer.GetBytes());
+				copiedContainer.WriteBytes(sourceContainer.GetBytes().ToArray());
 				Execute.NotOnWindows(()
 					=> sourceContainer.AdjustTimes(TimeAdjustments.LastAccessTime));
 
@@ -77,9 +77,6 @@ internal sealed class InMemoryStorage : IStorage
 						DateTimeKind.Local));
 				copiedContainer.LastWriteTime.Set(
 					sourceContainer.LastWriteTime.Get(DateTimeKind.Local),
-					DateTimeKind.Local);
-				copiedContainer.LastAccessTime.Set(
-					sourceContainer.LastAccessTime.Get(DateTimeKind.Local),
 					DateTimeKind.Local);
 				copiedContainer.AdjustTimes(TimeAdjustments.LastAccessTime);
 				return destination;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.EnumerateDirectories.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.EnumerateDirectories.cs
@@ -200,8 +200,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		result.Count().Should().Be(2);
 	}
 
-	[SkippableTheory]
-	[AutoData]
+	[SkippableFact]
 	public void EnumerateDirectories_AbsolutePath_ShouldNotIncludeTrailingSlash()
 	{
 		FileSystem.Directory.CreateDirectory("foo");
@@ -215,8 +214,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		result.Should().Contain(FileSystem.Path.Combine(BasePath, "bar"));
 	}
 
-	[SkippableTheory]
-	[AutoData]
+	[SkippableFact]
 	public void EnumerateDirectories_RelativePath_ShouldNotIncludeTrailingSlash()
 	{
 		string path = ".";
@@ -231,8 +229,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		result.Should().Contain(FileSystem.Path.Combine(path, "bar"));
 	}
 
-	[SkippableTheory]
-	[AutoData]
+	[SkippableFact]
 	public void EnumerateDirectories_RelativePathToParentDirectory_ShouldNotIncludeTrailingSlash()
 	{
 		string path = "foo/..";

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.EnumerateDirectories.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.EnumerateDirectories.cs
@@ -199,4 +199,51 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 
 		result.Count().Should().Be(2);
 	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void EnumerateDirectories_AbsolutePath_ShouldNotIncludeTrailingSlash()
+	{
+		FileSystem.Directory.CreateDirectory("foo");
+		FileSystem.Directory.CreateDirectory("bar");
+
+		List<string> result = FileSystem.Directory
+		   .EnumerateDirectories(BasePath)
+		   .ToList();
+
+		result.Should().Contain(FileSystem.Path.Combine(BasePath, "foo"));
+		result.Should().Contain(FileSystem.Path.Combine(BasePath, "bar"));
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void EnumerateDirectories_RelativePath_ShouldNotIncludeTrailingSlash()
+	{
+		string path = ".";
+		FileSystem.Directory.CreateDirectory("foo");
+		FileSystem.Directory.CreateDirectory("bar");
+
+		List<string> result = FileSystem.Directory
+		   .EnumerateDirectories(path)
+		   .ToList();
+
+		result.Should().Contain(FileSystem.Path.Combine(path, "foo"));
+		result.Should().Contain(FileSystem.Path.Combine(path, "bar"));
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void EnumerateDirectories_RelativePathToParentDirectory_ShouldNotIncludeTrailingSlash()
+	{
+		string path = "foo/..";
+		FileSystem.Directory.CreateDirectory("foo");
+		FileSystem.Directory.CreateDirectory("bar");
+
+		List<string> result = FileSystem.Directory
+		   .EnumerateDirectories(path)
+		   .ToList();
+
+		result.Should().Contain(FileSystem.Path.Combine(path, "foo"));
+		result.Should().Contain(FileSystem.Path.Combine(path, "bar"));
+	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.EnumerateDirectories.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.EnumerateDirectories.cs
@@ -7,6 +7,20 @@ namespace Testably.Abstractions.Tests.FileSystem.Directory;
 public abstract partial class FileSystemDirectoryTests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
+	[SkippableFact]
+	public void EnumerateDirectories_AbsolutePath_ShouldNotIncludeTrailingSlash()
+	{
+		FileSystem.Directory.CreateDirectory("foo");
+		FileSystem.Directory.CreateDirectory("bar");
+
+		List<string> result = FileSystem.Directory
+		   .EnumerateDirectories(BasePath)
+		   .ToList();
+
+		result.Should().Contain(FileSystem.Path.Combine(BasePath, "foo"));
+		result.Should().Contain(FileSystem.Path.Combine(BasePath, "bar"));
+	}
+
 	[SkippableTheory]
 	[AutoData]
 	public void
@@ -22,6 +36,37 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		   .Which.Message.Should()
 		   .Be($"Could not find a part of the path '{expectedPath}'.");
 		FileSystem.Directory.Exists(path).Should().BeFalse();
+	}
+
+	[SkippableFact]
+	public void EnumerateDirectories_RelativePath_ShouldNotIncludeTrailingSlash()
+	{
+		string path = ".";
+		FileSystem.Directory.CreateDirectory("foo");
+		FileSystem.Directory.CreateDirectory("bar");
+
+		List<string> result = FileSystem.Directory
+		   .EnumerateDirectories(path)
+		   .ToList();
+
+		result.Should().Contain(FileSystem.Path.Combine(path, "foo"));
+		result.Should().Contain(FileSystem.Path.Combine(path, "bar"));
+	}
+
+	[SkippableFact]
+	public void
+		EnumerateDirectories_RelativePathToParentDirectory_ShouldNotIncludeTrailingSlash()
+	{
+		string path = "foo/..";
+		FileSystem.Directory.CreateDirectory("foo");
+		FileSystem.Directory.CreateDirectory("bar");
+
+		List<string> result = FileSystem.Directory
+		   .EnumerateDirectories(path)
+		   .ToList();
+
+		result.Should().Contain(FileSystem.Path.Combine(path, "foo"));
+		result.Should().Contain(FileSystem.Path.Combine(path, "bar"));
 	}
 
 	[SkippableTheory]
@@ -198,49 +243,5 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		   .EnumerateDirectories(path, "xyz", SearchOption.AllDirectories);
 
 		result.Count().Should().Be(2);
-	}
-
-	[SkippableFact]
-	public void EnumerateDirectories_AbsolutePath_ShouldNotIncludeTrailingSlash()
-	{
-		FileSystem.Directory.CreateDirectory("foo");
-		FileSystem.Directory.CreateDirectory("bar");
-
-		List<string> result = FileSystem.Directory
-		   .EnumerateDirectories(BasePath)
-		   .ToList();
-
-		result.Should().Contain(FileSystem.Path.Combine(BasePath, "foo"));
-		result.Should().Contain(FileSystem.Path.Combine(BasePath, "bar"));
-	}
-
-	[SkippableFact]
-	public void EnumerateDirectories_RelativePath_ShouldNotIncludeTrailingSlash()
-	{
-		string path = ".";
-		FileSystem.Directory.CreateDirectory("foo");
-		FileSystem.Directory.CreateDirectory("bar");
-
-		List<string> result = FileSystem.Directory
-		   .EnumerateDirectories(path)
-		   .ToList();
-
-		result.Should().Contain(FileSystem.Path.Combine(path, "foo"));
-		result.Should().Contain(FileSystem.Path.Combine(path, "bar"));
-	}
-
-	[SkippableFact]
-	public void EnumerateDirectories_RelativePathToParentDirectory_ShouldNotIncludeTrailingSlash()
-	{
-		string path = "foo/..";
-		FileSystem.Directory.CreateDirectory("foo");
-		FileSystem.Directory.CreateDirectory("bar");
-
-		List<string> result = FileSystem.Directory
-		   .EnumerateDirectories(path)
-		   .ToList();
-
-		result.Should().Contain(FileSystem.Path.Combine(path, "foo"));
-		result.Should().Contain(FileSystem.Path.Combine(path, "bar"));
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.EnumerateFiles.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.EnumerateFiles.cs
@@ -116,6 +116,19 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 	}
 
 	[SkippableFact]
+	public void
+		EnumerateFiles_SearchPatternForFileWithoutExtension_ShouldWorkConsistently()
+	{
+		FileSystem.Initialize()
+		   .WithFile("file_without_extension")
+		   .WithFile("file.with.an.extension");
+
+		string[] result = FileSystem.Directory.GetFiles(".", "*.");
+
+		result.Length.Should().Be(1);
+	}
+
+	[SkippableFact]
 	public void EnumerateFiles_SearchPatternWithTooManyAsterisk_ShouldWorkConsistently()
 	{
 		FileSystem.Initialize()

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/FileSystemDirectoryInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/FileSystemDirectoryInfoTests.cs
@@ -169,17 +169,6 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
 		sut.LastWriteTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
 	}
 
-	[SkippableFact]
-	[AutoData]
-	public void Root_Name_ShouldBeCorrect()
-	{
-		var rootName = FileTestHelper.RootDrive();
-		IFileSystem.IDirectoryInfo sut =
-			FileSystem.DirectoryInfo.New(rootName);
-
-		sut.Name.Should().Be(rootName);
-	}
-
 	[SkippableTheory]
 	[AutoData]
 	public void Parent_ArbitraryPaths_ShouldNotBeNull(string path1,
@@ -204,6 +193,17 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
 			FileSystem.DirectoryInfo.New(FileTestHelper.RootDrive());
 
 		sut.Parent.Should().BeNull();
+	}
+
+	[SkippableFact]
+	[AutoData]
+	public void Root_Name_ShouldBeCorrect()
+	{
+		string rootName = FileTestHelper.RootDrive();
+		IFileSystem.IDirectoryInfo sut =
+			FileSystem.DirectoryInfo.New(rootName);
+
+		sut.Name.Should().Be(rootName);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/FileSystemDirectoryInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/FileSystemDirectoryInfoTests.cs
@@ -169,6 +169,17 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
 		sut.LastWriteTimeUtc.Should().Be(FileTestHelper.NullTime.ToUniversalTime());
 	}
 
+	[SkippableFact]
+	[AutoData]
+	public void Root_Name_ShouldBeCorrect()
+	{
+		var rootName = FileTestHelper.RootDrive();
+		IFileSystem.IDirectoryInfo sut =
+			FileSystem.DirectoryInfo.New(rootName);
+
+		sut.Name.Should().Be(rootName);
+	}
+
 	[SkippableTheory]
 	[AutoData]
 	public void Parent_ArbitraryPaths_ShouldNotBeNull(string path1,

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Copy.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Copy.cs
@@ -164,8 +164,8 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 			binaryWriter.Write("Some text");
 		}
 
-		FileSystem.FileInfo.New(source).Length.Should()
-		   .BeGreaterThan(FileSystem.FileInfo.New(destination).Length);
+		FileSystem.File.ReadAllText(source).Should()
+		   .NotBe(FileSystem.File.ReadAllText(destination));
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Copy.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Copy.cs
@@ -7,6 +7,67 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
+	public void Copy_DestinationExists_ShouldThrowIOExceptionAndNotCopyFile(
+		string sourceName,
+		string destinationName,
+		string sourceContents,
+		string destinationContents)
+	{
+		FileSystem.File.WriteAllText(sourceName, sourceContents);
+		FileSystem.File.WriteAllText(destinationName, destinationContents);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.Copy(sourceName, destinationName);
+		});
+
+		exception.Should().BeOfType<IOException>();
+		FileSystem.File.Exists(sourceName).Should().BeTrue();
+		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
+		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
+	}
+
+#if FEATURE_FILE_MOVETO_OVERWRITE
+	[SkippableTheory]
+	[AutoData]
+	public void Copy_DestinationExists_WithOverwrite_ShouldOverwriteDestination(
+		string sourceName,
+		string destinationName,
+		string sourceContents,
+		string destinationContents)
+	{
+		FileSystem.File.WriteAllText(sourceName, sourceContents);
+		FileSystem.File.WriteAllText(destinationName, destinationContents);
+
+		FileSystem.File.Copy(sourceName, destinationName, true);
+
+		FileSystem.File.Exists(sourceName).Should().BeTrue();
+		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
+		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
+	}
+#endif
+
+	[SkippableTheory]
+	[AutoData]
+	public void Copy_ReadOnly_ShouldCopyFile(
+		string sourceName, string destinationName, string contents)
+	{
+		FileSystem.File.WriteAllText(sourceName, contents);
+		FileSystem.File.SetAttributes(sourceName, FileAttributes.ReadOnly);
+
+		FileSystem.File.Copy(sourceName, destinationName);
+
+		FileSystem.File.Exists(sourceName).Should().BeTrue();
+		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.File.GetAttributes(destinationName)
+		   .Should().HaveFlag(FileAttributes.ReadOnly);
+		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void Copy_ShouldAdjustTimes(
 		string source, string destination)
 	{
@@ -69,67 +130,6 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void Copy_DestinationExists_ShouldThrowIOExceptionAndNotCopyFile(
-		string sourceName,
-		string destinationName,
-		string sourceContents,
-		string destinationContents)
-	{
-		FileSystem.File.WriteAllText(sourceName, sourceContents);
-		FileSystem.File.WriteAllText(destinationName, destinationContents);
-
-		Exception? exception = Record.Exception(() =>
-		{
-			FileSystem.File.Copy(sourceName, destinationName);
-		});
-
-		exception.Should().BeOfType<IOException>();
-		FileSystem.File.Exists(sourceName).Should().BeTrue();
-		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
-		FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
-	}
-
-#if FEATURE_FILE_MOVETO_OVERWRITE
-	[SkippableTheory]
-	[AutoData]
-	public void Copy_DestinationExists_WithOverwrite_ShouldOverwriteDestination(
-		string sourceName,
-		string destinationName,
-		string sourceContents,
-		string destinationContents)
-	{
-		FileSystem.File.WriteAllText(sourceName, sourceContents);
-		FileSystem.File.WriteAllText(destinationName, destinationContents);
-
-		FileSystem.File.Copy(sourceName, destinationName, true);
-
-		FileSystem.File.Exists(sourceName).Should().BeTrue();
-		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
-		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-	}
-#endif
-
-	[SkippableTheory]
-	[AutoData]
-	public void Copy_ReadOnly_ShouldCopyFile(
-		string sourceName, string destinationName, string contents)
-	{
-		FileSystem.File.WriteAllText(sourceName, contents);
-		FileSystem.File.SetAttributes(sourceName, FileAttributes.ReadOnly);
-
-		FileSystem.File.Copy(sourceName, destinationName);
-
-		FileSystem.File.Exists(sourceName).Should().BeTrue();
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
-		FileSystem.File.GetAttributes(destinationName)
-		   .Should().HaveFlag(FileAttributes.ReadOnly);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
-	}
-
-	[SkippableTheory]
-	[AutoData]
 	public void Copy_ShouldCopyFileWithContent(
 		string sourceName, string destinationName, string contents)
 	{
@@ -144,6 +144,28 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 		FileSystem.File.ReadAllText(sourceName).Should().Be(contents);
 		FileSystem.File.Exists(destinationName).Should().BeTrue();
 		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void Copy_ShouldNotUseAReferenceToFileContent(
+		string source, string destination, string contents)
+	{
+		FileSystem.File.WriteAllText(source, contents);
+
+		FileSystem.File.Copy(source, destination);
+
+		using (FileSystemStream stream =
+			FileSystem.File.Open(source, FileMode.Open, FileAccess.ReadWrite))
+		{
+			BinaryWriter binaryWriter = new(stream);
+
+			binaryWriter.Seek(0, SeekOrigin.Begin);
+			binaryWriter.Write("Some text");
+		}
+
+		FileSystem.FileInfo.New(source).Length.Should()
+		   .BeGreaterThan(FileSystem.FileInfo.New(destination).Length);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Exists.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Exists.cs
@@ -4,17 +4,17 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
 	[SkippableFact]
-	public void Exists_Null_ShouldReturnFalse()
+	public void Exists_Empty_ShouldReturnFalse()
 	{
-		bool result = FileSystem.File.Exists(null);
+		bool result = FileSystem.File.Exists(string.Empty);
 
 		result.Should().BeFalse();
 	}
 
 	[SkippableFact]
-	public void Exists_Empty_ShouldReturnFalse()
+	public void Exists_Null_ShouldReturnFalse()
 	{
-		bool result = FileSystem.File.Exists(string.Empty);
+		bool result = FileSystem.File.Exists(null);
 
 		result.Should().BeFalse();
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/MockFileSystemTests.cs
@@ -24,6 +24,14 @@ public sealed class MockFileSystemTests
 		   .SetCurrentDirectoryToEmptyTemporaryDirectory();
 	}
 
+	#region IDisposable Members
+
+	/// <inheritdoc cref="IDisposable.Dispose()" />
+	public void Dispose()
+		=> _directoryCleaner.Dispose();
+
+	#endregion
+
 	[SkippableTheory]
 	[AutoData]
 	public void Move_DifferentDrive_ShouldAdjustAvailableFreeSpace(
@@ -83,12 +91,4 @@ public sealed class MockFileSystemTests
 		FileSystem.File.ReadAllBytes(destinationName).Should().BeEquivalentTo(bytes1);
 	}
 #endif
-
-	#region IDisposable Members
-
-	/// <inheritdoc cref="IDisposable.Dispose()" />
-	public void Dispose()
-		=> _directoryCleaner.Dispose();
-
-	#endregion
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/FileSystemFileInfoTests.MoveTo.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/FileSystemFileInfoTests.MoveTo.cs
@@ -74,6 +74,57 @@ public abstract partial class FileSystemFileInfoTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void MoveTo_ShouldAddArchiveAttributeOnWindows(
+		string sourceName,
+		string destinationName,
+		string contents,
+		FileAttributes fileAttributes)
+	{
+		FileSystem.File.WriteAllText(sourceName, contents);
+		FileSystem.File.SetAttributes(sourceName, fileAttributes);
+		FileAttributes expectedAttributes = FileSystem.File.GetAttributes(sourceName);
+		if (Test.RunsOnWindows)
+		{
+			expectedAttributes |= FileAttributes.Archive;
+		}
+
+		IFileSystem.IFileInfo sut = FileSystem.FileInfo.New(sourceName);
+
+		sut.MoveTo(destinationName);
+
+		FileSystem.File.GetAttributes(destinationName)
+		   .Should().Be(expectedAttributes);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void MoveTo_ShouldKeepMetadata(
+		string sourceName,
+		string destinationName,
+		string contents)
+	{
+		Test.SkipIfLongRunningTestsShouldBeSkipped(FileSystem);
+
+		FileSystem.File.WriteAllText(sourceName, contents);
+		DateTime sourceCreationTime = FileSystem.File.GetCreationTime(sourceName);
+		DateTime sourceLastAccessTime = FileSystem.File.GetLastAccessTime(sourceName);
+		DateTime sourceLastWriteTime = FileSystem.File.GetLastWriteTime(sourceName);
+		IFileSystem.IFileInfo sut = FileSystem.FileInfo.New(sourceName);
+
+		TimeSystem.Thread.Sleep(1000);
+
+		sut.MoveTo(destinationName);
+
+		FileSystem.File.GetCreationTime(destinationName)
+		   .Should().Be(sourceCreationTime);
+		FileSystem.File.GetLastAccessTime(destinationName)
+		   .Should().Be(sourceLastAccessTime);
+		FileSystem.File.GetLastWriteTime(destinationName)
+		   .Should().Be(sourceLastWriteTime);
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void MoveTo_ShouldMoveFileWithContent(
 		string sourceName, string destinationName, string contents)
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/FileSystemFileStreamTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/FileSystemFileStreamTests.cs
@@ -148,6 +148,25 @@ public abstract partial class FileSystemFileStreamTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void Dispose_ShouldDisposeStream(
+		string path, string contents)
+	{
+		FileSystem.File.WriteAllText(path, contents);
+
+		using Stream stream = FileSystem.File.OpenRead(path);
+		stream.Dispose();
+
+		Exception? exception = Record.Exception(() =>
+		{
+			// ReSharper disable once AccessToDisposedClosure
+			stream.ReadByte();
+		});
+
+		exception.Should().BeOfType<ObjectDisposedException>();
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void EndRead_ShouldNotAdjustTimes(string path, byte[] contents)
 	{
 		Test.SkipBrittleTestsOnRealFileSystem(FileSystem);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.ExtensionPoints.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.ExtensionPoints.cs
@@ -1,0 +1,69 @@
+namespace Testably.Abstractions.Tests.FileSystem;
+
+public abstract partial class FileSystemTests<TFileSystem>
+	where TFileSystem : IFileSystem
+{
+	[SkippableFact]
+	public void Directory_ShouldSetExtensionPoint()
+	{
+		IFileSystem result = FileSystem.Directory.FileSystem;
+
+		result.Should().Be(FileSystem);
+	}
+
+	[SkippableFact]
+	public void DirectoryInfo_ShouldSetExtensionPoint()
+	{
+		IFileSystem result = FileSystem.DirectoryInfo.FileSystem;
+
+		result.Should().Be(FileSystem);
+	}
+
+	[SkippableFact]
+	public void DriveInfo_ShouldSetExtensionPoint()
+	{
+		IFileSystem result = FileSystem.DriveInfo.FileSystem;
+
+		result.Should().Be(FileSystem);
+	}
+
+	[SkippableFact]
+	public void File_ShouldSetExtensionPoint()
+	{
+		IFileSystem result = FileSystem.File.FileSystem;
+
+		result.Should().Be(FileSystem);
+	}
+
+	[SkippableFact]
+	public void FileInfo_ShouldSetExtensionPoint()
+	{
+		IFileSystem result = FileSystem.FileInfo.FileSystem;
+
+		result.Should().Be(FileSystem);
+	}
+
+	[SkippableFact]
+	public void FileStream_ShouldSetExtensionPoint()
+	{
+		IFileSystem result = FileSystem.FileStream.FileSystem;
+
+		result.Should().Be(FileSystem);
+	}
+
+	[SkippableFact]
+	public void FileSystemWatcherFactory_ShouldSetExtensionPoint()
+	{
+		IFileSystem result = FileSystem.FileSystemWatcher.FileSystem;
+
+		result.Should().Be(FileSystem);
+	}
+
+	[SkippableFact]
+	public void Path_ShouldSetExtensionPoint()
+	{
+		IFileSystem result = FileSystem.Path.FileSystem;
+
+		result.Should().Be(FileSystem);
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.cs
@@ -1,15 +1,19 @@
 namespace Testably.Abstractions.Tests.FileSystem;
 
-public abstract class FileSystemTests<TFileSystem>
+public abstract partial class FileSystemTests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
 	#region Test Setup
 
+	public abstract string BasePath { get; }
 	public TFileSystem FileSystem { get; }
+	public ITimeSystem TimeSystem { get; }
 
-	protected FileSystemTests(TFileSystem fileSystem)
+	protected FileSystemTests(TFileSystem fileSystem,
+	                          ITimeSystem timeSystem)
 	{
 		FileSystem = fileSystem;
+		TimeSystem = timeSystem;
 
 		Test.SkipIfTestsOnRealFileSystemShouldBeSkipped(FileSystem);
 	}
@@ -17,66 +21,15 @@ public abstract class FileSystemTests<TFileSystem>
 	#endregion
 
 	[SkippableFact]
-	public void Directory_ShouldSetExtensionPoint()
+	public void Paths_UnderWindows_ShouldUseNormalSlashAndBackslashInterchangeable()
 	{
-		IFileSystem result = FileSystem.Directory.FileSystem;
+		Skip.IfNot(Test.RunsOnWindows);
 
-		result.Should().Be(FileSystem);
-	}
+		FileSystem.Directory.CreateDirectory("foo\\bar");
+		FileSystem.File.WriteAllText("foo\\bar\\file.txt", "some content");
 
-	[SkippableFact]
-	public void DirectoryInfo_ShouldSetExtensionPoint()
-	{
-		IFileSystem result = FileSystem.DirectoryInfo.FileSystem;
-
-		result.Should().Be(FileSystem);
-	}
-
-	[SkippableFact]
-	public void DriveInfo_ShouldSetExtensionPoint()
-	{
-		IFileSystem result = FileSystem.DriveInfo.FileSystem;
-
-		result.Should().Be(FileSystem);
-	}
-
-	[SkippableFact]
-	public void File_ShouldSetExtensionPoint()
-	{
-		IFileSystem result = FileSystem.File.FileSystem;
-
-		result.Should().Be(FileSystem);
-	}
-
-	[SkippableFact]
-	public void FileInfo_ShouldSetExtensionPoint()
-	{
-		IFileSystem result = FileSystem.FileInfo.FileSystem;
-
-		result.Should().Be(FileSystem);
-	}
-
-	[SkippableFact]
-	public void FileStream_ShouldSetExtensionPoint()
-	{
-		IFileSystem result = FileSystem.FileStream.FileSystem;
-
-		result.Should().Be(FileSystem);
-	}
-
-	[SkippableFact]
-	public void FileSystemWatcherFactory_ShouldSetExtensionPoint()
-	{
-		IFileSystem result = FileSystem.FileSystemWatcher.FileSystem;
-
-		result.Should().Be(FileSystem);
-	}
-
-	[SkippableFact]
-	public void Path_ShouldSetExtensionPoint()
-	{
-		IFileSystem result = FileSystem.Path.FileSystem;
-
-		result.Should().Be(FileSystem);
+		FileSystem.File.Exists("foo/bar/file.txt").Should().BeTrue();
+		FileSystem.Directory.GetFiles("foo/bar").Length
+		   .Should().Be(1);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.cs
@@ -3,8 +3,6 @@ namespace Testably.Abstractions.Tests.FileSystem;
 public abstract partial class FileSystemTests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
-	#region Test Setup
-
 	public abstract string BasePath { get; }
 	public TFileSystem FileSystem { get; }
 	public ITimeSystem TimeSystem { get; }
@@ -17,8 +15,6 @@ public abstract partial class FileSystemTests<TFileSystem>
 
 		Test.SkipIfTestsOnRealFileSystemShouldBeSkipped(FileSystem);
 	}
-
-	#endregion
 
 	[SkippableFact]
 	public void Paths_UnderWindows_ShouldUseNormalSlashAndBackslashInterchangeable()

--- a/Tests/Testably.Abstractions.Tests/FileSystem/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/MockFileSystemTests.cs
@@ -23,11 +23,7 @@ public sealed class MockFileSystemTests : FileSystemTests<FileSystemMock>
 		   .SetCurrentDirectoryToEmptyTemporaryDirectory();
 	}
 
-	#region IDisposable Members
-
 	/// <inheritdoc cref="IDisposable.Dispose()" />
 	public void Dispose()
 		=> _directoryCleaner.Dispose();
-
-	#endregion
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/MockFileSystemTests.cs
@@ -6,7 +6,28 @@ namespace Testably.Abstractions.Tests.FileSystem;
 [SystemTest(nameof(DriveInfoFactory.MockFileSystemTests))]
 public sealed class MockFileSystemTests : FileSystemTests<FileSystemMock>
 {
-	public MockFileSystemTests() : base(new FileSystemMock())
+	/// <inheritdoc cref="FileSystemFileSystemInfoTests{TFileSystem}.BasePath" />
+	public override string BasePath => _directoryCleaner.BasePath;
+
+	private readonly FileSystemInitializer.IDirectoryCleaner _directoryCleaner;
+
+	public MockFileSystemTests() : this(new FileSystemMock())
 	{
 	}
+
+	private MockFileSystemTests(FileSystemMock fileSystemMock) : base(
+		fileSystemMock,
+		fileSystemMock.TimeSystem)
+	{
+		_directoryCleaner = FileSystem
+		   .SetCurrentDirectoryToEmptyTemporaryDirectory();
+	}
+
+	#region IDisposable Members
+
+	/// <inheritdoc cref="IDisposable.Dispose()" />
+	public void Dispose()
+		=> _directoryCleaner.Dispose();
+
+	#endregion
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/FileSystemPathTests.GetFullPath.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/FileSystemPathTests.GetFullPath.cs
@@ -1,0 +1,18 @@
+namespace Testably.Abstractions.Tests.FileSystem.Path;
+
+public abstract partial class FileSystemPathTests<TFileSystem>
+	where TFileSystem : IFileSystem
+{
+	[SkippableTheory]
+	[InlineData(@"top\..\most\file", @"most\file")]
+	[InlineData(@"top\..\most\..\dir\file", @"dir\file")]
+	[InlineData(@"top\../..\most\file", @"most\file")]
+	public void GetFullPath_ShouldNormalizeProvidedPath(string input, string expected)
+	{
+		string expectedRootedPath = FileTestHelper.RootDrive(expected);
+
+		string result = FileSystem.Path.GetFullPath(FileTestHelper.RootDrive(input));
+
+		result.Should().Be(expectedRootedPath);
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/FileSystemPathTests.GetFullPath.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/FileSystemPathTests.GetFullPath.cs
@@ -4,12 +4,13 @@ public abstract partial class FileSystemPathTests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
 	[SkippableTheory]
-	[InlineData(@"top\..\most\file", @"most\file")]
-	[InlineData(@"top\..\most\..\dir\file", @"dir\file")]
-	[InlineData(@"top\../..\most\file", @"most\file")]
+	[InlineData(@"top/../most/file", @"most/file")]
+	[InlineData(@"top/../most/../dir/file", @"dir/file")]
+	[InlineData(@"top/../../most/file", @"most/file")]
 	public void GetFullPath_ShouldNormalizeProvidedPath(string input, string expected)
 	{
-		string expectedRootedPath = FileTestHelper.RootDrive(expected);
+		string expectedRootedPath = FileTestHelper.RootDrive(
+			expected.Replace('/', FileSystem.Path.DirectorySeparatorChar));
 
 		string result = FileSystem.Path.GetFullPath(FileTestHelper.RootDrive(input));
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/RealFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/RealFileSystemTests.cs
@@ -1,5 +1,6 @@
 #if !DEBUG || !DISABLE_TESTS_REALFILESYSTEM
 using Testably.Abstractions.Tests.TestHelpers.Traits;
+using Xunit.Abstractions;
 
 namespace Testably.Abstractions.Tests.FileSystem;
 
@@ -7,8 +8,24 @@ namespace Testably.Abstractions.Tests.FileSystem;
 [SystemTest(nameof(DriveInfoFactory.RealFileSystemTests))]
 public sealed class RealFileSystemTests : FileSystemTests<Abstractions.FileSystem>
 {
-	public RealFileSystemTests() : base(new Abstractions.FileSystem())
+	/// <inheritdoc cref="FileSystemFileSystemInfoTests{TFileSystem}.BasePath" />
+	public override string BasePath => _directoryCleaner.BasePath;
+
+	private readonly FileSystemInitializer.IDirectoryCleaner _directoryCleaner;
+
+	public RealFileSystemTests(ITestOutputHelper testOutputHelper)
+		: base(new Abstractions.FileSystem(), new Abstractions.TimeSystem())
 	{
+		_directoryCleaner = FileSystem
+		   .SetCurrentDirectoryToEmptyTemporaryDirectory(testOutputHelper.WriteLine);
 	}
+
+	#region IDisposable Members
+
+	/// <inheritdoc cref="IDisposable.Dispose()" />
+	public void Dispose()
+		=> _directoryCleaner.Dispose();
+
+	#endregion
 }
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/RealFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/RealFileSystemTests.cs
@@ -20,12 +20,8 @@ public sealed class RealFileSystemTests : FileSystemTests<Abstractions.FileSyste
 		   .SetCurrentDirectoryToEmptyTemporaryDirectory(testOutputHelper.WriteLine);
 	}
 
-	#region IDisposable Members
-
 	/// <inheritdoc cref="IDisposable.Dispose()" />
 	public void Dispose()
 		=> _directoryCleaner.Dispose();
-
-	#endregion
 }
 #endif

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/Test.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/Test.cs
@@ -25,7 +25,8 @@ public static class Test
 	public static bool RunsOnWindows
 		=> RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
-	public static void SkipBrittleTestsOnRealFileSystem(IFileSystem fileSystem, bool condition = true)
+	public static void SkipBrittleTestsOnRealFileSystem(
+		IFileSystem fileSystem, bool condition = true)
 	{
 		Skip.If(fileSystem is Abstractions.FileSystem && condition,
 			"Brittle tests are skipped on the real file system.");

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/DateTime/RealTimeSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/DateTime/RealTimeSystemTests.cs
@@ -8,13 +8,9 @@ public static class RealTimeSystemTests
 	[SystemTest(nameof(Tests.TimeSystem.RealTimeSystemTests))]
 	public sealed class DateTimeTests : TimeSystemDateTimeTests<Abstractions.TimeSystem>
 	{
-		#region Test Setup
-
 		public DateTimeTests() : base(new Abstractions.TimeSystem())
 		{
 		}
-
-		#endregion
 
 		[SkippableFact]
 		public void Now_ShouldReturnDefaultValue()

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/Task/RealTimeSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/Task/RealTimeSystemTests.cs
@@ -10,13 +10,9 @@ public static class RealTimeSystemTests
 	[SystemTest(nameof(Tests.TimeSystem.RealTimeSystemTests))]
 	public sealed class TaskTests : TimeSystemTaskTests<Abstractions.TimeSystem>
 	{
-		#region Test Setup
-
 		public TaskTests() : base(new Abstractions.TimeSystem())
 		{
 		}
-
-		#endregion
 
 		[SkippableFact]
 		public async System.Threading.Tasks.Task


### PR DESCRIPTION
Test or fix the following issues from [System.IO.Abstractions](https://github.com/TestableIO/System.IO.Abstractions/issues):
- [\#353: TestingHelper.File.Copy initialises contents via object reference](https://github.com/TestableIO/System.IO.Abstractions/issues/353)
- [\#397: Casting MockFileStream to Stream and then disposing it does not cause subsequent calls to throw ObjectDisposedException](https://github.com/TestableIO/System.IO.Abstractions/issues/397)
- [\#402: EnumerateDirectories returns directories with trailing \ slash](https://github.com/TestableIO/System.IO.Abstractions/issues/402)
- [\#405: MockFileSystem consistency issue with slash/backslash paths on Windows](https://github.com/TestableIO/System.IO.Abstractions/issues/405)
- [\#425: Path normalization doesn't match standard C#'s functionality](https://github.com/TestableIO/System.IO.Abstractions/issues/425)
- [\#439: MockFileSystem.Directory.EnumerateFiles does not return files with no extension when Search Pattern is "*."](https://github.com/TestableIO/System.IO.Abstractions/issues/439)
- [\#557: MockFile.Move does not preserve file metadata when moving a file](https://github.com/TestableIO/System.IO.Abstractions/issues/557)
- [\#635: Different Behaviour for Directory.GetParent(..) with root folder as argument](https://github.com/TestableIO/System.IO.Abstractions/issues/635)
- [\#697: DirectoryInfo.Name returns different result for root path between mock and real file system](https://github.com/TestableIO/System.IO.Abstractions/issues/697)