### PR TITLE
fix: throw `DirectoryNotFoundException` when the destination directory does not exist

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer.DirectoryCleaner.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer.DirectoryCleaner.cs
@@ -112,15 +112,15 @@ public static partial class FileSystemInitializer
 
 			do
 			{
-				basePath = _fileSystem.Path.Combine(
+				string localBasePath = _fileSystem.Path.Combine(
 					_fileSystem.Path.GetTempPath(),
 					_fileSystem.Path.GetFileNameWithoutExtension(_fileSystem.Path
 					   .GetRandomFileName()));
+				Execute.OnMac(() => localBasePath = "/private" + localBasePath);
+				basePath = localBasePath;
 			} while (_fileSystem.Directory.Exists(basePath));
 
 			_fileSystem.Directory.CreateDirectory(basePath);
-
-			Execute.OnMac(() => basePath = "/private" + basePath);
 
 			_logger?.Invoke($"Use '{basePath}' as current directory.");
 			_fileSystem.Directory.SetCurrentDirectory(basePath);

--- a/Source/Testably.Abstractions.Testing/Internal/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/ExceptionFactory.cs
@@ -31,8 +31,10 @@ internal static class ExceptionFactory
 	internal static IOException DirectoryNotEmpty(string path)
 		=> new($"Directory not empty : '{path}'");
 
-	internal static DirectoryNotFoundException DirectoryNotFound(string path)
-		=> new($"Could not find a part of the path '{path}'.");
+	internal static DirectoryNotFoundException DirectoryNotFound(string? path = null)
+		=> new(path == null
+			? "Could not find a part of the path."
+			: $"Could not find a part of the path '{path}'.");
 
 	internal static IOException FileAlreadyExists(string path)
 		=> new($"The file '{path}' already exists.");

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -606,7 +606,7 @@ internal sealed class InMemoryStorage : IStorage
 		var parentLocation = location.GetParent();
 		if (parentLocation != null && !_containers.TryGetValue(parentLocation, out _))
 		{
-			throw ExceptionFactory.DirectoryNotFound(parentLocation.FullPath);
+			throw ExceptionFactory.DirectoryNotFound();
 		}
 	}
 

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -604,7 +604,9 @@ internal sealed class InMemoryStorage : IStorage
 	private void ThrowIfParentDoesNotExist(IStorageLocation location)
 	{
 		var parentLocation = location.GetParent();
-		if (parentLocation != null && !_containers.TryGetValue(parentLocation, out _))
+		if (parentLocation != null &&
+		    _fileSystem.Path.GetPathRoot(parentLocation.FullPath) != parentLocation.FullPath &&
+		    !_containers.TryGetValue(parentLocation, out _))
 		{
 			throw ExceptionFactory.DirectoryNotFound();
 		}

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -42,6 +42,8 @@ internal sealed class InMemoryStorage : IStorage
 	                              IStorageLocation destination,
 	                              bool overwrite = false)
 	{
+		ThrowIfParentDoesNotExist(destination);
+
 		if (!_containers.TryGetValue(source,
 			out IStorageContainer? sourceContainer))
 		{
@@ -281,6 +283,8 @@ internal sealed class InMemoryStorage : IStorage
 	                              bool overwrite = false,
 	                              bool recursive = false)
 	{
+		ThrowIfParentDoesNotExist(destination);
+
 		List<Rollback> rollbacks = new();
 		try
 		{
@@ -303,6 +307,8 @@ internal sealed class InMemoryStorage : IStorage
 	                                 IStorageLocation? backup,
 	                                 bool ignoreMetadataErrors = false)
 	{
+		ThrowIfParentDoesNotExist(destination);
+
 		if (!_containers.TryGetValue(source,
 			out IStorageContainer? sourceContainer))
 		{
@@ -594,6 +600,15 @@ internal sealed class InMemoryStorage : IStorage
 		return nextLocation;
 	}
 #endif
+
+	private void ThrowIfParentDoesNotExist(IStorageLocation location)
+	{
+		var parentLocation = location.GetParent();
+		if (parentLocation != null && !_containers.TryGetValue(parentLocation, out _))
+		{
+			throw ExceptionFactory.DirectoryNotFound(parentLocation.FullPath);
+		}
+	}
 
 	private static void ValidateExpression(string expression)
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.Move.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.Move.cs
@@ -9,6 +9,23 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
+	public void Move_DestinationDoesNotExist_ShouldThrowDirectoryNotFoundException(
+		string source)
+	{
+		FileSystem.InitializeIn(source)
+		   .WithAFile();
+		string destination = FileTestHelper.RootDrive("not-existing/path");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.Directory.Move(source, destination);
+		});
+
+		exception.Should().BeOfType<DirectoryNotFoundException>();
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void Move_ShouldMoveDirectoryWithContent(string source, string destination)
 	{
 		FileSystemInitializer.IFileSystemDirectoryInitializer<TFileSystem> initialized =

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Copy.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Copy.cs
@@ -7,6 +7,24 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
+	public void
+		Copy_DestinationDirectoryDoesNotExist_ShouldThrowDirectoryNotFoundException(
+			string source)
+	{
+		FileSystem.Initialize()
+		   .WithFile(source);
+		string destination = FileTestHelper.RootDrive("not-existing/path/foo.txt");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.Copy(source, destination);
+		});
+
+		exception.Should().BeOfType<DirectoryNotFoundException>();
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void Copy_DestinationExists_ShouldThrowIOExceptionAndNotCopyFile(
 		string sourceName,
 		string destinationName,

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Move.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Move.cs
@@ -28,6 +28,24 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void
+		Move_DestinationDirectoryDoesNotExist_ShouldThrowDirectoryNotFoundException(
+			string source)
+	{
+		FileSystem.Initialize()
+		   .WithFile(source);
+		string destination = FileTestHelper.RootDrive("not-existing/path");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.Move(source, destination);
+		});
+
+		exception.Should().BeOfType<DirectoryNotFoundException>();
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void Move_DestinationExists_ShouldThrowIOExceptionAndNotMoveFile(
 		string sourceName,
 		string destinationName,

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Replace.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Replace.cs
@@ -20,7 +20,14 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 			FileSystem.File.Replace(source, destination, null);
 		});
 
-		exception.Should().BeOfType<DirectoryNotFoundException>();
+		if (Test.RunsOnWindows)
+		{
+			exception.Should().BeOfType<DirectoryNotFoundException>();
+		}
+		else
+		{
+			exception.Should().BeOfType<FileNotFoundException>();
+		}
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Replace.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.Replace.cs
@@ -7,6 +7,24 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
+	public void
+		Replace_DestinationDirectoryDoesNotExist_ShouldThrowDirectoryNotFoundException(
+			string source)
+	{
+		FileSystem.Initialize()
+		   .WithFile(source);
+		string destination = FileTestHelper.RootDrive("not-existing/path/foo.txt");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.Replace(source, destination, null);
+		});
+
+		exception.Should().BeOfType<DirectoryNotFoundException>();
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void Replace_DestinationIsDirectory_ShouldThrowUnauthorizedAccessException(
 		string sourceName,
 		string destinationName,


### PR DESCRIPTION
This applies to `File.Move`, `File.Copy`, `File.Replace` and `Directory.Replace`:

In all instances, when the destination directory does not exist, the file system should throw a `DirectoryNotFoundException`.

*See also [\#551 MockDirectory.Move does not throw exception if (part of the) target's parent folder does not exist](https://github.com/TestableIO/System.IO.Abstractions/issues/551).*