### PR TITLE
doc: use absolute link path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_Testably.Abstractions&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Testably_Testably.Abstractions)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Testably_Testably.Abstractions&metric=coverage)](https://sonarcloud.io/summary/new_code?id=Testably_Testably.Abstractions)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FTestably.Abstractions%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/Testably.Abstractions/main)
+[![Nuget](https://img.shields.io/nuget/v/Testably.Abstractions)](https://www.nuget.org/packages/Testably.Abstractions)
 
 At the core of this library are the abstraction interfaces, which allow replacing system dependencies:
 
@@ -56,7 +57,7 @@ public void StoreData_ShouldWriteValidFile()
 **More examples can be found in our [examples section](https://github.com/Testably/Testably.Abstractions/blob/main/Examples/README.md)!**
 
 # Getting Started
-- Install `Testably.Abstractions` [![Nuget](https://img.shields.io/nuget/v/Testably.Abstractions)](https://www.nuget.org/packages/Testably.Abstractions) as nuget package in your productive projects and `Testably.Abstractions.Testing` [![Nuget](https://img.shields.io/nuget/v/Testably.Abstractions.Testing)](https://www.nuget.org/packages/Testably.Abstractions.Testing) as nuget package in your test projects.
+- Install `Testably.Abstractions` as nuget package in your productive projects and `Testably.Abstractions.Testing` as nuget package in your test projects.
   ```ps
   dotnet add package Testably.Abstractions
   dotnet add package Testably.Abstractions.Testing

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ public void StoreData_ShouldWriteValidFile()
 }
 ```
 
-**More examples can be found in our [examples section](Examples/README.md)!**
+**More examples can be found in our [examples section](https://github.com/Testably/Testably.Abstractions/blob/main/Examples/README.md)!**
 
 # Getting Started
 - Install `Testably.Abstractions` [![Nuget](https://img.shields.io/nuget/v/Testably.Abstractions)](https://www.nuget.org/packages/Testably.Abstractions) as nuget package in your productive projects and `Testably.Abstractions.Testing` [![Nuget](https://img.shields.io/nuget/v/Testably.Abstractions.Testing)](https://www.nuget.org/packages/Testably.Abstractions.Testing) as nuget package in your test projects.


### PR DESCRIPTION
Use an absolute path to the examples section in the readme, so that it is also rendered correctly on [Nuget.org](https://www.nuget.org/packages/Testably.Abstractions)