### PR TITLE
fix: set current directory correctly

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer.cs
@@ -24,12 +24,8 @@ public static partial class FileSystemInitializer
 		where TFileSystem : IFileSystem
 	{
 		fileSystem.Directory.CreateDirectory(basePath);
-		if (fileSystem is FileSystemMock)
-		{
-			//TODO: Check if this could be activated for all file systems
-			fileSystem.Directory.SetCurrentDirectory(basePath);
-		}
-		return new Initializer<TFileSystem>(fileSystem, basePath);
+		fileSystem.Directory.SetCurrentDirectory(basePath);
+		return new Initializer<TFileSystem>(fileSystem, ".");
 	}
 
 	/// <summary>

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer.cs
@@ -24,6 +24,11 @@ public static partial class FileSystemInitializer
 		where TFileSystem : IFileSystem
 	{
 		fileSystem.Directory.CreateDirectory(basePath);
+		if (fileSystem is FileSystemMock)
+		{
+			//TODO: Check if this could be activated for all file systems
+			fileSystem.Directory.SetCurrentDirectory(basePath);
+		}
 		return new Initializer<TFileSystem>(fileSystem, basePath);
 	}
 

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryMock.cs
@@ -77,8 +77,7 @@ public sealed partial class FileSystemMock
 					searchPattern,
 					EnumerationOptionsHelper.FromSearchOption(searchOption))
 			   .Select(x => _fileSystem
-				   .GetSubdirectoryPath(x.FullPath, path,
-						searchOption == SearchOption.AllDirectories));
+				   .GetSubdirectoryPath(x.FullPath, path));
 
 #if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS
 		/// <inheritdoc cref="IFileSystem.IDirectory.EnumerateDirectories(string, string, EnumerationOptions)" />
@@ -92,8 +91,7 @@ public sealed partial class FileSystemMock
 					searchPattern,
 					enumerationOptions)
 			   .Select(x => _fileSystem
-				   .GetSubdirectoryPath(x.FullPath, path,
-						enumerationOptions.RecurseSubdirectories));
+				   .GetSubdirectoryPath(x.FullPath, path));
 #endif
 
 		/// <inheritdoc cref="IFileSystem.IDirectory.EnumerateFiles(string)" />
@@ -116,8 +114,7 @@ public sealed partial class FileSystemMock
 					searchPattern,
 					EnumerationOptionsHelper.FromSearchOption(searchOption))
 			   .Select(x => _fileSystem
-				   .GetSubdirectoryPath(x.FullPath, path,
-						searchOption == SearchOption.AllDirectories));
+				   .GetSubdirectoryPath(x.FullPath, path));
 
 #if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS
 		/// <inheritdoc cref="IFileSystem.IDirectory.EnumerateFiles(string, string, EnumerationOptions)" />
@@ -130,8 +127,7 @@ public sealed partial class FileSystemMock
 					searchPattern,
 					enumerationOptions)
 			   .Select(x => _fileSystem
-				   .GetSubdirectoryPath(x.FullPath, path,
-						enumerationOptions.RecurseSubdirectories));
+				   .GetSubdirectoryPath(x.FullPath, path));
 #endif
 
 		/// <inheritdoc cref="IFileSystem.IDirectory.EnumerateFileSystemEntries(string)" />
@@ -157,8 +153,7 @@ public sealed partial class FileSystemMock
 					searchPattern,
 					EnumerationOptionsHelper.FromSearchOption(searchOption))
 			   .Select(x => _fileSystem
-				   .GetSubdirectoryPath(x.FullPath, path,
-						searchOption == SearchOption.AllDirectories));
+				   .GetSubdirectoryPath(x.FullPath, path));
 
 #if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS
 		/// <inheritdoc cref="IFileSystem.IDirectory.EnumerateFileSystemEntries(string, string, EnumerationOptions)" />
@@ -171,8 +166,7 @@ public sealed partial class FileSystemMock
 					searchPattern,
 					enumerationOptions)
 			   .Select(x => _fileSystem
-				   .GetSubdirectoryPath(x.FullPath, path,
-						enumerationOptions.RecurseSubdirectories));
+				   .GetSubdirectoryPath(x.FullPath, path));
 #endif
 
 		/// <inheritdoc cref="IFileSystem.IDirectory.Exists(string)" />
@@ -337,7 +331,6 @@ public sealed partial class FileSystemMock
 		/// <inheritdoc cref="IFileSystem.IDirectory.SetCurrentDirectory(string)" />
 		public void SetCurrentDirectory(string path)
 		{
-
 			IFileSystem.IDirectoryInfo directoryInfo =
 				_fileSystem.DirectoryInfo.New(path);
 			if (!directoryInfo.Exists)
@@ -345,6 +338,7 @@ public sealed partial class FileSystemMock
 				throw ExceptionFactory.DirectoryNotFound(
 					FileSystem.Path.GetFullPath(path));
 			}
+
 			_fileSystem.Storage.CurrentDirectory = directoryInfo.FullName;
 		}
 

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DirectoryMock.cs
@@ -336,7 +336,17 @@ public sealed partial class FileSystemMock
 
 		/// <inheritdoc cref="IFileSystem.IDirectory.SetCurrentDirectory(string)" />
 		public void SetCurrentDirectory(string path)
-			=> _fileSystem.Storage.CurrentDirectory = path;
+		{
+
+			IFileSystem.IDirectoryInfo directoryInfo =
+				_fileSystem.DirectoryInfo.New(path);
+			if (!directoryInfo.Exists)
+			{
+				throw ExceptionFactory.DirectoryNotFound(
+					FileSystem.Path.GetFullPath(path));
+			}
+			_fileSystem.Storage.CurrentDirectory = directoryInfo.FullName;
+		}
 
 		/// <inheritdoc cref="IFileSystem.IDirectory.SetLastAccessTime(string, DateTime)" />
 		public void SetLastAccessTime(string path, DateTime lastAccessTime)

--- a/Source/Testably.Abstractions.Testing/Internal/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/FileSystemExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.Internal;
@@ -35,14 +34,10 @@ internal static class FileSystemExtensions
 
 	/// <summary>
 	///     Returns the relative subdirectory path from <paramref name="fullFilePath" /> to the <paramref name="givenPath" />.
-	///     <br />
-	///     If <paramref name="recurseSubdirectories" /> is <see langword="false" /> and the <paramref name="givenPath" /> is
-	///     not rooted, the result is prefixed with the <paramref name="givenPath" />.
 	/// </summary>
 	internal static string GetSubdirectoryPath(this IFileSystem fileSystem,
 	                                           string fullFilePath,
-	                                           string givenPath,
-	                                           bool recurseSubdirectories)
+	                                           string givenPath)
 	{
 		if (fileSystem.Path.IsPathRooted(givenPath))
 		{
@@ -59,9 +54,9 @@ internal static class FileSystemExtensions
 			fullFilePath = fullFilePath.Substring(currentDirectory.Length + 1);
 		}
 
-		if (!recurseSubdirectories && !fullFilePath.StartsWith(givenPath))
+		if (!fullFilePath.StartsWith(givenPath + fileSystem.Path.DirectorySeparatorChar))
 		{
-			return Path.Combine(givenPath, fullFilePath);
+			return fileSystem.Path.Combine(givenPath, fullFilePath);
 		}
 
 		return fullFilePath;

--- a/Source/Testably.Abstractions.Testing/Internal/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/PathHelper.cs
@@ -30,22 +30,6 @@ internal static class PathHelper
 			() => false);
 	}
 
-	internal static string
-		NormalizeAndTrimPath(this string path, IFileSystem fileSystem)
-		=> fileSystem.Path
-		   .TrimEndingDirectorySeparator(path.NormalizePath())
-		   .TrimOnWindows();
-
-	internal static string RemoveLeadingDot(this string path)
-	{
-		while (path.StartsWith($".{Path.DirectorySeparatorChar}"))
-		{
-			path = path.Substring(2);
-		}
-
-		return path;
-	}
-
 	internal static bool IsUncPath(this string? path)
 	{
 		if (path == null)

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
@@ -25,7 +25,7 @@ internal sealed class InMemoryLocation : IStorageLocation
 		Execute.OnNetFramework(()
 			=> friendlyName = friendlyName.TrimOnWindows());
 
-		FriendlyName = friendlyName.RemoveLeadingDot();
+		FriendlyName = friendlyName;
 		Drive = drive;
 	}
 

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
@@ -103,9 +103,9 @@ public class FileSystemInitializerTests
 		   .EnumerateDirectories(".", "*", SearchOption.AllDirectories).ToList();
 
 		result.Count.Should().Be(3);
-		result.Should().Contain("foo");
-		result.Should().Contain(sut.Path.Combine("foo", "bar"));
-		result.Should().Contain(sut.Path.Combine("foo", "bar", "xyz"));
+		result.Should().Contain(sut.Path.Combine(".", "foo"));
+		result.Should().Contain(sut.Path.Combine(".", "foo", "bar"));
+		result.Should().Contain(sut.Path.Combine(".", "foo", "bar", "xyz"));
 	}
 
 	[Theory]

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
@@ -134,4 +134,16 @@ public class FileSystemInitializerTests
 
 		sut.Directory.EnumerateDirectories(".", directoryName).Should().ContainSingle();
 	}
+
+	[Theory]
+	[AutoData]
+	public void InitializeIn_ShouldSetCurrentDirectory(string path)
+	{
+		Testing.FileSystemMock sut = new();
+		string expectedPath = sut.Path.GetFullPath(path);
+
+		sut.InitializeIn(path);
+
+		sut.Directory.GetCurrentDirectory().Should().Be(expectedPath);
+	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Internal/PathHelperTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Internal/PathHelperTests.cs
@@ -56,16 +56,6 @@ public class PathHelperTests
 	}
 
 	[Fact]
-	public void RemoveLeadingDot_MultipleLocalDirectories_ShouldBeRemoved()
-	{
-		string path = Path.Combine(".", ".", ".", "foo");
-
-		string result = path.RemoveLeadingDot();
-
-		result.Should().Be("foo");
-	}
-
-	[Fact]
 	public void
 		ThrowCommonExceptionsIfPathIsInvalid_StartWithNull_ShouldThrowArgumentException()
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.EnumerateFileSystemInfos.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.EnumerateFileSystemInfos.cs
@@ -37,7 +37,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 
 		List<string> result = FileSystem.Directory
 		   .EnumerateFileSystemEntries(
-				FileSystem.Path.GetFullPath(path),
+				FileSystem.Directory.GetCurrentDirectory(),
 				"*",
 				SearchOption.AllDirectories)
 		   .ToList();
@@ -61,7 +61,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result = FileSystem.Directory
-		   .EnumerateFileSystemEntries(path, "*", SearchOption.AllDirectories)
+		   .EnumerateFileSystemEntries(".", "*", SearchOption.AllDirectories)
 		   .ToList();
 
 		result.Count.Should().Be(3);
@@ -119,7 +119,8 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result = FileSystem.Directory
-		   .EnumerateFileSystemEntries(path, initialized[2].Name.ToUpper(),
+		   .EnumerateFileSystemEntries(".",
+				initialized[2].Name.ToUpper(),
 				new EnumerationOptions
 				{
 					MatchCasing = MatchCasing.CaseInsensitive,
@@ -170,7 +171,9 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result =
-			FileSystem.Directory.EnumerateFileSystemEntries(path).ToList();
+			FileSystem.Directory
+			   .EnumerateFileSystemEntries(".")
+			   .ToList();
 
 		result.Count.Should().Be(3);
 		result.Should().Contain(initialized[0].ToString());
@@ -193,7 +196,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result = FileSystem.Directory
-		   .EnumerateFileSystemEntries(path, initialized[0].Name)
+		   .EnumerateFileSystemEntries(".", initialized[0].Name)
 		   .ToList();
 
 		result.Count.Should().Be(1);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.EnumerateFiles.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.EnumerateFiles.cs
@@ -51,8 +51,8 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result = FileSystem.Directory
-		   .EnumerateFiles(FileSystem.Path.GetFullPath(path), "*",
-				SearchOption.AllDirectories)
+		   .EnumerateFiles(FileSystem.Directory.GetCurrentDirectory(),
+				"*", SearchOption.AllDirectories)
 		   .ToList();
 
 		result.Count.Should().Be(2);
@@ -72,7 +72,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result = FileSystem.Directory
-		   .EnumerateFiles(path, "*", SearchOption.AllDirectories)
+		   .EnumerateFiles(".", "*", SearchOption.AllDirectories)
 		   .ToList();
 
 		result.Count.Should().Be(2);
@@ -153,7 +153,8 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result = FileSystem.Directory
-		   .EnumerateFiles(path, initialized[2].Name.ToUpper(),
+		   .EnumerateFiles(".",
+				initialized[2].Name.ToUpper(),
 				new EnumerationOptions
 				{
 					MatchCasing = MatchCasing.CaseInsensitive,
@@ -203,7 +204,9 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 			   .WithASubdirectory().Initialized(s => s
 				   .WithAFile());
 
-		List<string> result = FileSystem.Directory.EnumerateFiles(path).ToList();
+		List<string> result = FileSystem.Directory
+		   .EnumerateFiles(".")
+		   .ToList();
 
 		result.Count.Should().Be(2);
 		result.Should().Contain(initialized[0].ToString());
@@ -224,7 +227,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result = FileSystem.Directory
-		   .EnumerateFiles(path, initialized[0].Name)
+		   .EnumerateFiles(".", initialized[0].Name)
 		   .ToList();
 
 		result.Count.Should().Be(1);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.GetFileSystemInfos.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.GetFileSystemInfos.cs
@@ -37,7 +37,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 
 		List<string> result = FileSystem.Directory
 		   .GetFileSystemEntries(
-				FileSystem.Path.GetFullPath(path),
+				FileSystem.Directory.GetCurrentDirectory(),
 				"*",
 				SearchOption.AllDirectories)
 		   .ToList();
@@ -61,7 +61,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result = FileSystem.Directory
-		   .GetFileSystemEntries(path, "*", SearchOption.AllDirectories)
+		   .GetFileSystemEntries(".", "*", SearchOption.AllDirectories)
 		   .ToList();
 
 		result.Count.Should().Be(3);
@@ -119,7 +119,8 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result = FileSystem.Directory
-		   .GetFileSystemEntries(path, initialized[2].Name.ToUpper(),
+		   .GetFileSystemEntries(".",
+				initialized[2].Name.ToUpper(),
 				new EnumerationOptions
 				{
 					MatchCasing = MatchCasing.CaseInsensitive,
@@ -170,7 +171,9 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result =
-			FileSystem.Directory.GetFileSystemEntries(path).ToList();
+			FileSystem.Directory
+			   .GetFileSystemEntries(".")
+			   .ToList();
 
 		result.Count.Should().Be(3);
 		result.Should().Contain(initialized[0].ToString());
@@ -193,7 +196,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result = FileSystem.Directory
-		   .GetFileSystemEntries(path, initialized[0].Name)
+		   .GetFileSystemEntries(".", initialized[0].Name)
 		   .ToList();
 
 		result.Count.Should().Be(1);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.GetFiles.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.GetFiles.cs
@@ -36,8 +36,8 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result = FileSystem.Directory
-		   .GetFiles(FileSystem.Path.GetFullPath(path), "*",
-				SearchOption.AllDirectories)
+		   .GetFiles(FileSystem.Directory.GetCurrentDirectory(),
+				"*", SearchOption.AllDirectories)
 		   .ToList();
 
 		result.Count.Should().Be(2);
@@ -57,7 +57,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result = FileSystem.Directory
-		   .GetFiles(path, "*", SearchOption.AllDirectories)
+		   .GetFiles(".", "*", SearchOption.AllDirectories)
 		   .ToList();
 
 		result.Count.Should().Be(2);
@@ -114,7 +114,8 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result = FileSystem.Directory
-		   .GetFiles(path, initialized[2].Name.ToUpper(),
+		   .GetFiles(".",
+				initialized[2].Name.ToUpper(),
 				new EnumerationOptions
 				{
 					MatchCasing = MatchCasing.CaseInsensitive,
@@ -164,7 +165,9 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 			   .WithASubdirectory().Initialized(s => s
 				   .WithAFile());
 
-		List<string> result = FileSystem.Directory.GetFiles(path).ToList();
+		List<string> result = FileSystem.Directory
+		   .GetFiles(".")
+		   .ToList();
 
 		result.Count.Should().Be(2);
 		result.Should().Contain(initialized[0].ToString());
@@ -185,7 +188,7 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 				   .WithAFile());
 
 		List<string> result = FileSystem.Directory
-		   .GetFiles(path, initialized[0].Name)
+		   .GetFiles(".", initialized[0].Name)
 		   .ToList();
 
 		result.Count.Should().Be(1);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.Move.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.Move.cs
@@ -29,24 +29,25 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 	public void Move_ShouldMoveDirectoryWithContent(string source, string destination)
 	{
 		FileSystemInitializer.IFileSystemDirectoryInitializer<TFileSystem> initialized =
-			FileSystem.InitializeIn(source)
-			   .WithAFile()
-			   .WithASubdirectory().Initialized(s => s
+			FileSystem.Initialize()
+			   .WithSubdirectory(source).Initialized(s => s
 				   .WithAFile()
-				   .WithASubdirectory());
+				   .WithASubdirectory().Initialized(t => t
+					   .WithAFile()
+					   .WithASubdirectory()));
 
 		FileSystem.Directory.Move(source, destination);
 
 		FileSystem.Directory.Exists(source).Should().BeFalse();
 		FileSystem.Directory.Exists(destination).Should().BeTrue();
-		FileSystem.Directory.GetFiles(destination, initialized[0].Name)
+		FileSystem.Directory.GetFiles(destination, initialized[1].Name)
 		   .Should().ContainSingle();
-		FileSystem.Directory.GetDirectories(destination, initialized[1].Name)
+		FileSystem.Directory.GetDirectories(destination, initialized[2].Name)
 		   .Should().ContainSingle();
-		FileSystem.Directory.GetFiles(destination, initialized[2].Name,
+		FileSystem.Directory.GetFiles(destination, initialized[3].Name,
 				SearchOption.AllDirectories)
 		   .Should().ContainSingle();
-		FileSystem.Directory.GetDirectories(destination, initialized[3].Name,
+		FileSystem.Directory.GetDirectories(destination, initialized[4].Name,
 				SearchOption.AllDirectories)
 		   .Should().ContainSingle();
 	}
@@ -93,12 +94,13 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		string source, string destination)
 	{
 		FileSystemInitializer.IFileSystemDirectoryInitializer<TFileSystem> initialized =
-			FileSystem.InitializeIn(source)
-			   .WithAFile()
-			   .WithASubdirectory().Initialized(s => s
+			FileSystem.Initialize()
+			   .WithSubdirectory(source).Initialized(s => s
 				   .WithAFile()
-				   .WithASubdirectory());
-		using FileSystemStream stream = FileSystem.File.Open(initialized[2].FullName,
+				   .WithASubdirectory().Initialized(t => t
+					   .WithAFile()
+					   .WithASubdirectory()));
+		using FileSystemStream stream = FileSystem.File.Open(initialized[3].FullName,
 			FileMode.Open,
 			FileAccess.Read,
 			FileShare.Read);
@@ -115,14 +117,14 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 			FileSystem.Directory.Exists(destination).Should().BeFalse();
 			IFileSystem.IDirectoryInfo sourceDirectory =
 				FileSystem.DirectoryInfo.New(source);
-			sourceDirectory.GetFiles(initialized[0].Name)
+			sourceDirectory.GetFiles(initialized[1].Name)
 			   .Should().ContainSingle();
-			sourceDirectory.GetDirectories(initialized[1].Name)
+			sourceDirectory.GetDirectories(initialized[2].Name)
 			   .Should().ContainSingle();
-			sourceDirectory.GetFiles(initialized[2].Name, SearchOption.AllDirectories)
+			sourceDirectory.GetFiles(initialized[3].Name, SearchOption.AllDirectories)
 			   .Should().ContainSingle();
 			sourceDirectory
-			   .GetDirectories(initialized[3].Name, SearchOption.AllDirectories)
+			   .GetDirectories(initialized[4].Name, SearchOption.AllDirectories)
 			   .Should().ContainSingle();
 		}
 		else
@@ -132,15 +134,15 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 			FileSystem.Directory.Exists(destination).Should().BeTrue();
 			IFileSystem.IDirectoryInfo destinationDirectory =
 				FileSystem.DirectoryInfo.New(destination);
-			destinationDirectory.GetFiles(initialized[0].Name)
+			destinationDirectory.GetFiles(initialized[1].Name)
 			   .Should().ContainSingle();
-			destinationDirectory.GetDirectories(initialized[1].Name)
-			   .Should().ContainSingle();
-			destinationDirectory
-			   .GetFiles(initialized[2].Name, SearchOption.AllDirectories)
+			destinationDirectory.GetDirectories(initialized[2].Name)
 			   .Should().ContainSingle();
 			destinationDirectory
-			   .GetDirectories(initialized[3].Name, SearchOption.AllDirectories)
+			   .GetFiles(initialized[3].Name, SearchOption.AllDirectories)
+			   .Should().ContainSingle();
+			destinationDirectory
+			   .GetDirectories(initialized[4].Name, SearchOption.AllDirectories)
 			   .Should().ContainSingle();
 		}
 	}
@@ -151,12 +153,13 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		string source, string destination)
 	{
 		FileSystemInitializer.IFileSystemDirectoryInitializer<TFileSystem> initialized =
-			FileSystem.InitializeIn(source)
-			   .WithAFile()
-			   .WithASubdirectory().Initialized(s => s
+			FileSystem.Initialize()
+			   .WithSubdirectory(source).Initialized(s => s
 				   .WithAFile()
-				   .WithASubdirectory());
-		initialized[2].Attributes = FileAttributes.ReadOnly;
+				   .WithASubdirectory().Initialized(t => t
+					   .WithAFile()
+					   .WithASubdirectory()));
+		initialized[3].Attributes = FileAttributes.ReadOnly;
 
 		FileSystem.Directory.Move(source, destination);
 
@@ -164,15 +167,15 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		FileSystem.Directory.Exists(destination).Should().BeTrue();
 		IFileSystem.IDirectoryInfo destinationDirectory =
 			FileSystem.DirectoryInfo.New(destination);
-		destinationDirectory.GetFiles(initialized[0].Name)
+		destinationDirectory.GetFiles(initialized[1].Name)
 		   .Should().ContainSingle();
-		destinationDirectory.GetDirectories(initialized[1].Name)
+		destinationDirectory.GetDirectories(initialized[2].Name)
 		   .Should().ContainSingle();
-		destinationDirectory.GetFiles(initialized[2].Name, SearchOption.AllDirectories)
+		destinationDirectory.GetFiles(initialized[3].Name, SearchOption.AllDirectories)
 		   .Should().ContainSingle().Which.Attributes.Should()
 		   .HaveFlag(FileAttributes.ReadOnly);
 		destinationDirectory
-		   .GetDirectories(initialized[3].Name, SearchOption.AllDirectories)
+		   .GetDirectories(initialized[4].Name, SearchOption.AllDirectories)
 		   .Should().ContainSingle();
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.Move.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.Move.cs
@@ -59,11 +59,12 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 		Test.SkipIfLongRunningTestsShouldBeSkipped(FileSystem);
 
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
-		FileSystem.InitializeIn(source)
-		   .WithAFile()
-		   .WithASubdirectory().Initialized(s => s
+		FileSystem.Initialize()
+		   .WithSubdirectory(source).Initialized(s => s
 			   .WithAFile()
-			   .WithASubdirectory());
+			   .WithASubdirectory().Initialized(t => t
+				   .WithAFile()
+				   .WithASubdirectory()));
 		DateTime creationTimeEnd = TimeSystem.DateTime.UtcNow;
 		TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/FileSystemDirectoryTests.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 
 public abstract partial class FileSystemDirectoryTests<TFileSystem>
@@ -48,5 +50,49 @@ public abstract partial class FileSystemDirectoryTests<TFileSystem>
 
 		result.Should().NotBeNull();
 		result!.FullName.Should().Be(expectedParent.FullName);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void
+		SetCurrentDirectory_MissingDirectory_ShouldThrowDirectoryNotFoundException(
+			string path)
+	{
+		string previousCurrentDirectory = FileSystem.Directory.GetCurrentDirectory();
+		try
+		{
+			Exception? exception = Record.Exception(() =>
+			{
+				FileSystem.Directory.SetCurrentDirectory(path);
+			});
+
+			exception.Should().BeOfType<DirectoryNotFoundException>();
+			FileSystem.Directory.GetCurrentDirectory().Should()
+			   .Be(previousCurrentDirectory);
+		}
+		finally
+		{
+			FileSystem.Directory.SetCurrentDirectory(previousCurrentDirectory);
+		}
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void SetCurrentDirectory_RelativePath_ShouldBeFullyQualified(string path)
+	{
+		string previousCurrentDirectory = FileSystem.Directory.GetCurrentDirectory();
+		try
+		{
+			string expectedPath = FileSystem.Path.GetFullPath(path);
+			FileSystem.Directory.CreateDirectory(path);
+			FileSystem.Directory.SetCurrentDirectory(path);
+			string result = FileSystem.Directory.GetCurrentDirectory();
+
+			result.Should().Be(expectedPath);
+		}
+		finally
+		{
+			FileSystem.Directory.SetCurrentDirectory(previousCurrentDirectory);
+		}
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/FileSystemDirectoryInfoTests.MoveTo.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/FileSystemDirectoryInfoTests.MoveTo.cs
@@ -12,25 +12,26 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
 	public void MoveTo_ShouldMoveDirectoryWithContent(string source, string destination)
 	{
 		FileSystemInitializer.IFileSystemDirectoryInitializer<TFileSystem> initialized =
-			FileSystem.InitializeIn(source)
-			   .WithAFile()
-			   .WithASubdirectory().Initialized(s => s
+			FileSystem.Initialize()
+			   .WithSubdirectory(source).Initialized(s => s
 				   .WithAFile()
-				   .WithASubdirectory());
+				   .WithASubdirectory().Initialized(t => t
+					   .WithAFile()
+					   .WithASubdirectory()));
 		IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New(source);
 
 		sut.MoveTo(destination);
 
 		FileSystem.Directory.Exists(source).Should().BeFalse();
 		FileSystem.Directory.Exists(destination).Should().BeTrue();
-		FileSystem.Directory.GetFiles(destination, initialized[0].Name)
+		FileSystem.Directory.GetFiles(destination, initialized[1].Name)
 		   .Should().ContainSingle();
-		FileSystem.Directory.GetDirectories(destination, initialized[1].Name)
+		FileSystem.Directory.GetDirectories(destination, initialized[2].Name)
 		   .Should().ContainSingle();
-		FileSystem.Directory.GetFiles(destination, initialized[2].Name,
+		FileSystem.Directory.GetFiles(destination, initialized[3].Name,
 				SearchOption.AllDirectories)
 		   .Should().ContainSingle();
-		FileSystem.Directory.GetDirectories(destination, initialized[3].Name,
+		FileSystem.Directory.GetDirectories(destination, initialized[4].Name,
 				SearchOption.AllDirectories)
 		   .Should().ContainSingle();
 	}
@@ -40,11 +41,12 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
 	public void MoveTo_ShouldUpdatePropertiesOfDirectoryInfo(
 		string source, string destination)
 	{
-		FileSystem.InitializeIn(source)
-		   .WithAFile()
-		   .WithASubdirectory().Initialized(s => s
+		FileSystem.Initialize()
+		   .WithSubdirectory(source).Initialized(s => s
 			   .WithAFile()
-			   .WithASubdirectory());
+			   .WithASubdirectory().Initialized(t => t
+				   .WithAFile()
+				   .WithASubdirectory()));
 		IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New(source);
 
 		sut.MoveTo(destination);
@@ -59,13 +61,14 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
 		string source, string destination)
 	{
 		FileSystemInitializer.IFileSystemDirectoryInitializer<TFileSystem> initialized =
-			FileSystem.InitializeIn(source)
-			   .WithAFile()
-			   .WithASubdirectory().Initialized(s => s
+			FileSystem.Initialize()
+			   .WithSubdirectory(source).Initialized(s => s
 				   .WithAFile()
-				   .WithASubdirectory());
+				   .WithASubdirectory().Initialized(t => t
+					   .WithAFile()
+					   .WithASubdirectory()));
 		IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New(source);
-		using FileSystemStream stream = FileSystem.File.Open(initialized[2].FullName,
+		using FileSystemStream stream = FileSystem.File.Open(initialized[3].FullName,
 			FileMode.Open,
 			FileAccess.Read,
 			FileShare.Read);
@@ -82,14 +85,14 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
 			FileSystem.Directory.Exists(destination).Should().BeFalse();
 			IFileSystem.IDirectoryInfo sourceDirectory =
 				FileSystem.DirectoryInfo.New(source);
-			sourceDirectory.GetFiles(initialized[0].Name)
+			sourceDirectory.GetFiles(initialized[1].Name)
 			   .Should().ContainSingle();
-			sourceDirectory.GetDirectories(initialized[1].Name)
+			sourceDirectory.GetDirectories(initialized[2].Name)
 			   .Should().ContainSingle();
-			sourceDirectory.GetFiles(initialized[2].Name, SearchOption.AllDirectories)
+			sourceDirectory.GetFiles(initialized[3].Name, SearchOption.AllDirectories)
 			   .Should().ContainSingle();
 			sourceDirectory
-			   .GetDirectories(initialized[3].Name, SearchOption.AllDirectories)
+			   .GetDirectories(initialized[4].Name, SearchOption.AllDirectories)
 			   .Should().ContainSingle();
 		}
 		else
@@ -99,15 +102,15 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
 			FileSystem.Directory.Exists(destination).Should().BeTrue();
 			IFileSystem.IDirectoryInfo destinationDirectory =
 				FileSystem.DirectoryInfo.New(destination);
-			destinationDirectory.GetFiles(initialized[0].Name)
+			destinationDirectory.GetFiles(initialized[1].Name)
 			   .Should().ContainSingle();
-			destinationDirectory.GetDirectories(initialized[1].Name)
-			   .Should().ContainSingle();
-			destinationDirectory
-			   .GetFiles(initialized[2].Name, SearchOption.AllDirectories)
+			destinationDirectory.GetDirectories(initialized[2].Name)
 			   .Should().ContainSingle();
 			destinationDirectory
-			   .GetDirectories(initialized[3].Name, SearchOption.AllDirectories)
+			   .GetFiles(initialized[3].Name, SearchOption.AllDirectories)
+			   .Should().ContainSingle();
+			destinationDirectory
+			   .GetDirectories(initialized[4].Name, SearchOption.AllDirectories)
 			   .Should().ContainSingle();
 		}
 	}
@@ -118,12 +121,13 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
 		string source, string destination)
 	{
 		FileSystemInitializer.IFileSystemDirectoryInitializer<TFileSystem> initialized =
-			FileSystem.InitializeIn(source)
-			   .WithAFile()
-			   .WithASubdirectory().Initialized(s => s
+			FileSystem.Initialize()
+			   .WithSubdirectory(source).Initialized(s => s
 				   .WithAFile()
-				   .WithASubdirectory());
-		initialized[2].Attributes = FileAttributes.ReadOnly;
+				   .WithASubdirectory().Initialized(t => t
+					   .WithAFile()
+					   .WithASubdirectory()));
+		initialized[3].Attributes = FileAttributes.ReadOnly;
 		IFileSystem.IDirectoryInfo sut = FileSystem.DirectoryInfo.New(source);
 
 		sut.MoveTo(destination);
@@ -132,15 +136,15 @@ public abstract partial class FileSystemDirectoryInfoTests<TFileSystem>
 		FileSystem.Directory.Exists(destination).Should().BeTrue();
 		IFileSystem.IDirectoryInfo destinationDirectory =
 			FileSystem.DirectoryInfo.New(destination);
-		destinationDirectory.GetFiles(initialized[0].Name)
+		destinationDirectory.GetFiles(initialized[1].Name)
 		   .Should().ContainSingle();
-		destinationDirectory.GetDirectories(initialized[1].Name)
+		destinationDirectory.GetDirectories(initialized[2].Name)
 		   .Should().ContainSingle();
-		destinationDirectory.GetFiles(initialized[2].Name, SearchOption.AllDirectories)
+		destinationDirectory.GetFiles(initialized[3].Name, SearchOption.AllDirectories)
 		   .Should().ContainSingle().Which.Attributes.Should()
 		   .HaveFlag(FileAttributes.ReadOnly);
 		destinationDirectory
-		   .GetDirectories(initialized[3].Name, SearchOption.AllDirectories)
+		   .GetDirectories(initialized[4].Name, SearchOption.AllDirectories)
 		   .Should().ContainSingle();
 	}
 }


### PR DESCRIPTION
Correctly set the current directory to a fully qualified path.
When initializing the file system via the `InitializeIn` method, set the current directory (see `Directory.GetCurrentDirectory()`) to the used base path.