### PR TITLE
doc: change order of badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ![Testably.Abstractions](https://raw.githubusercontent.com/Testably/Testably.Abstractions/main/Docs/Images/social-preview.png)
+[![Nuget](https://img.shields.io/nuget/v/Testably.Abstractions)](https://www.nuget.org/packages/Testably.Abstractions)
 [![CI](https://github.com/Testably/Testably.Abstractions/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Testably/Testably.Abstractions/actions/workflows/ci.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_Testably.Abstractions&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Testably_Testably.Abstractions)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Testably_Testably.Abstractions&metric=coverage)](https://sonarcloud.io/summary/new_code?id=Testably_Testably.Abstractions)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FTestably.Abstractions%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/Testably.Abstractions/main)
-[![Nuget](https://img.shields.io/nuget/v/Testably.Abstractions)](https://www.nuget.org/packages/Testably.Abstractions)
 
 At the core of this library are the abstraction interfaces, which allow replacing system dependencies:
 


### PR DESCRIPTION
Change the order of the badges, so that the current version on [Nuget.org](https://www.nuget.org/packages/Testably.Abstractions) is the first badge.