### PR TITLE
refactor: use file references on the build system for the Example build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,8 @@ jobs:
           dotnet-version: |
             6.0.x
       - name: Build solution
-        run: dotnet build Examples
-      - name: Run tests
+        run: dotnet build /p:NetCoreOnly=True
+      - name: Build example solution
+        run: dotnet build Examples /p:UseFileReferenceToTestablyLibraries=True
+      - name: Run example tests
         run: dotnet test Examples --no-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,8 +100,10 @@ jobs:
           dotnet-version: |
             6.0.x
       - name: Build solution
-        run: dotnet build Examples
-      - name: Run tests
+        run: dotnet build /p:NetCoreOnly=True
+      - name: Build example solution
+        run: dotnet build Examples /p:UseFileReferenceToTestablyLibraries=True
+      - name: Run example tests
         run: dotnet test Examples --no-build
 
   deploy:

--- a/Examples/Directory.Build.props
+++ b/Examples/Directory.Build.props
@@ -15,7 +15,22 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseFileReferenceToTestablyLibraries)' == 'True'">
+    <Reference Include="Testably.Abstractions">
+      <HintPath>..\..\..\Build\Binaries\net6.0\Testably.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Testably.Abstractions.Extensions">
+      <HintPath>..\..\..\Build\Binaries\net6.0\Testably.Abstractions.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Testably.Abstractions.Interface">
+      <HintPath>..\..\..\Build\Binaries\net6.0\Testably.Abstractions.Interface.dll</HintPath>
+    </Reference>
+    <Reference Include="Testably.Abstractions.Testing">
+      <HintPath>..\..\..\Build\Binaries\net6.0\Testably.Abstractions.Testing.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseFileReferenceToTestablyLibraries)' != 'True'">
     <PackageReference Include="Testably.Abstractions" Version="$(TestablyAbstractionsVersion)" />
     <PackageReference Include="Testably.Abstractions.Extensions" Version="$(TestablyAbstractionsVersion)" />
     <PackageReference Include="Testably.Abstractions.Testing" Version="$(TestablyAbstractionsVersion)" />


### PR DESCRIPTION
The example build should check the tests against the latest code in the `main` branch. Therefore instead of nuget packages, use the file references on the build system.