### PR TITLE
fix: notification execute while waiting callback blocks the timeout

### DIFF
--- a/Source/Testably.Abstractions.Testing/Notification.cs
+++ b/Source/Testably.Abstractions.Testing/Notification.cs
@@ -104,11 +104,13 @@ public static class Notification
 				_count = count;
 				_filter = filter;
 				_reset.Reset();
+				Task? task = null;
 				if (executeWhenWaiting != null)
 				{
-					Task.Factory.StartNew(executeWhenWaiting.Invoke);
+					task = Task.Factory.StartNew(executeWhenWaiting.Invoke);
 				}
-				if (!_reset.Wait(timeout))
+				if (!_reset.Wait(timeout) ||
+				    task?.Wait(timeout) == false)
 				{
 					throw ExceptionFactory.TimeoutExpired(timeout);
 				}

--- a/Source/Testably.Abstractions.Testing/Notification.cs
+++ b/Source/Testably.Abstractions.Testing/Notification.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Threading;
+using System.Threading.Tasks;
 using Testably.Abstractions.Testing.Internal;
 
 namespace Testably.Abstractions.Testing;
@@ -103,7 +104,10 @@ public static class Notification
 				_count = count;
 				_filter = filter;
 				_reset.Reset();
-				executeWhenWaiting?.Invoke();
+				if (executeWhenWaiting != null)
+				{
+					Task.Factory.StartNew(executeWhenWaiting.Invoke);
+				}
 				if (!_reset.Wait(timeout))
 				{
 					throw ExceptionFactory.TimeoutExpired(timeout);

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/InterceptionHandlerExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/InterceptionHandlerExtensionsTests.cs
@@ -89,13 +89,7 @@ public class InterceptionHandlerExtensionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Notify
-			   .OnEvent()
-			   .ExecuteWhileWaiting(() =>
-				{
-					FileSystem.File.AppendAllText(path, "foo");
-				})
-			   .Wait(timeout: 50);
+			FileSystem.File.AppendAllText(path, "foo");
 		});
 
 		if (expectedResult)
@@ -127,13 +121,7 @@ public class InterceptionHandlerExtensionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Notify
-			   .OnEvent()
-			   .ExecuteWhileWaiting(() =>
-				{
-					FileSystem.File.AppendAllText(path, "foo");
-				})
-			   .Wait(timeout: 50);
+			FileSystem.File.AppendAllText(path, "foo");
 		});
 
 		if (expectedResult)
@@ -222,13 +210,7 @@ public class InterceptionHandlerExtensionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Notify
-			   .OnEvent()
-			   .ExecuteWhileWaiting(() =>
-				{
-					FileSystem.Directory.CreateDirectory(path);
-				})
-			   .Wait(timeout: 50);
+			FileSystem.Directory.CreateDirectory(path);
 		});
 
 		if (expectedResult)
@@ -259,13 +241,7 @@ public class InterceptionHandlerExtensionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Notify
-			   .OnEvent()
-			   .ExecuteWhileWaiting(() =>
-				{
-					FileSystem.Directory.CreateDirectory(path);
-				})
-			   .Wait(timeout: 50);
+			FileSystem.Directory.CreateDirectory(path);
 		});
 
 		if (expectedResult)
@@ -354,13 +330,7 @@ public class InterceptionHandlerExtensionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Notify
-			   .OnEvent()
-			   .ExecuteWhileWaiting(() =>
-				{
-					FileSystem.File.WriteAllText(path, null);
-				})
-			   .Wait(timeout: 50);
+			FileSystem.File.WriteAllText(path, null);
 		});
 
 		if (expectedResult)
@@ -391,13 +361,7 @@ public class InterceptionHandlerExtensionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Notify
-			   .OnEvent()
-			   .ExecuteWhileWaiting(() =>
-				{
-					FileSystem.File.WriteAllText(path, null);
-				})
-			   .Wait(timeout: 50);
+			FileSystem.File.WriteAllText(path, null);
 		});
 
 		if (expectedResult)
@@ -487,13 +451,7 @@ public class InterceptionHandlerExtensionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Notify
-			   .OnEvent()
-			   .ExecuteWhileWaiting(() =>
-				{
-					FileSystem.Directory.Delete(path);
-				})
-			   .Wait(timeout: 50);
+			FileSystem.Directory.Delete(path);
 		});
 
 		if (expectedResult)
@@ -525,13 +483,7 @@ public class InterceptionHandlerExtensionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Notify
-			   .OnEvent()
-			   .ExecuteWhileWaiting(() =>
-				{
-					FileSystem.Directory.Delete(path);
-				})
-			   .Wait(timeout: 50);
+			FileSystem.Directory.Delete(path);
 		});
 
 		if (expectedResult)
@@ -621,13 +573,7 @@ public class InterceptionHandlerExtensionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Notify
-			   .OnEvent()
-			   .ExecuteWhileWaiting(() =>
-				{
-					FileSystem.File.Delete(path);
-				})
-			   .Wait(timeout: 50);
+			FileSystem.File.Delete(path);
 		});
 
 		if (expectedResult)
@@ -659,13 +605,7 @@ public class InterceptionHandlerExtensionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Notify
-			   .OnEvent()
-			   .ExecuteWhileWaiting(() =>
-				{
-					FileSystem.File.Delete(path);
-				})
-			   .Wait(timeout: 50);
+			FileSystem.File.Delete(path);
 		});
 
 		if (expectedResult)

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/InterceptionHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/InterceptionHandlerTests.cs
@@ -21,13 +21,7 @@ public class InterceptionHandlerTests
 		});
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Notify
-			   .OnEvent()
-			   .ExecuteWhileWaiting(() =>
-				{
-					FileSystem.Directory.CreateDirectory(path);
-				})
-			   .Wait(timeout: 500);
+			FileSystem.Directory.CreateDirectory(path);
 		});
 
 		FileSystem.Directory.Exists(path).Should().BeFalse();
@@ -43,13 +37,7 @@ public class InterceptionHandlerTests
 		FileSystem.Intercept.Event(_ => throw exceptionToThrow);
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Notify
-			   .OnEvent(c => receivedPath = c.Path)
-			   .ExecuteWhileWaiting(() =>
-				{
-					FileSystem.Directory.CreateDirectory(path);
-				})
-			   .Wait(timeout: 500);
+			FileSystem.Directory.CreateDirectory(path);
 		});
 
 		exception.Should().Be(exceptionToThrow);

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/NotificationHandlerExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/NotificationHandlerExtensionsTests.cs
@@ -76,7 +76,7 @@ public class NotificationHandlerExtensionsTests
 				{
 					FileSystem.Directory.CreateDirectory(path);
 				})
-			   .Wait(timeout: 50);
+			   .Wait(timeout: expectedResult ? 3000 : 50);
 		});
 
 		if (expectedResult)
@@ -126,7 +126,7 @@ public class NotificationHandlerExtensionsTests
 				{
 					FileSystem.Directory.CreateDirectory(path);
 				})
-			   .Wait(timeout: 50);
+			   .Wait(timeout: expectedResult ? 3000 : 50);
 		});
 
 		if (expectedResult)
@@ -204,7 +204,7 @@ public class NotificationHandlerExtensionsTests
 				{
 					FileSystem.File.WriteAllText(path, null);
 				})
-			   .Wait(timeout: 50);
+			   .Wait(timeout: expectedResult ? 3000 : 50);
 		});
 
 		if (expectedResult)
@@ -254,7 +254,7 @@ public class NotificationHandlerExtensionsTests
 				{
 					FileSystem.File.WriteAllText(path, null);
 				})
-			   .Wait(timeout: 50);
+			   .Wait(timeout: expectedResult ? 3000 : 50);
 		});
 
 		if (expectedResult)
@@ -334,7 +334,7 @@ public class NotificationHandlerExtensionsTests
 				{
 					FileSystem.Directory.Delete(path);
 				})
-			   .Wait(timeout: 50);
+			   .Wait(timeout: expectedResult ? 3000 : 50);
 		});
 
 		if (expectedResult)
@@ -386,7 +386,7 @@ public class NotificationHandlerExtensionsTests
 				{
 					FileSystem.Directory.Delete(path);
 				})
-			   .Wait(timeout: 50);
+			   .Wait(timeout: expectedResult ? 3000 : 50);
 		});
 
 		if (expectedResult)
@@ -466,7 +466,7 @@ public class NotificationHandlerExtensionsTests
 				{
 					FileSystem.File.Delete(path);
 				})
-			   .Wait(timeout: 50);
+			   .Wait(timeout: expectedResult ? 3000 : 50);
 		});
 
 		if (expectedResult)
@@ -518,7 +518,7 @@ public class NotificationHandlerExtensionsTests
 				{
 					FileSystem.File.Delete(path);
 				})
-			   .Wait(timeout: 50);
+			   .Wait(timeout: expectedResult ? expectedResult ? 3000 : 50 : 50);
 		});
 
 		if (expectedResult)
@@ -598,7 +598,7 @@ public class NotificationHandlerExtensionsTests
 				{
 					FileSystem.File.AppendAllText(path, "foo");
 				})
-			   .Wait(timeout: 50);
+			   .Wait(timeout: expectedResult ? 3000 : 50);
 		});
 
 		if (expectedResult)
@@ -650,7 +650,7 @@ public class NotificationHandlerExtensionsTests
 				{
 					FileSystem.File.AppendAllText(path, "foo");
 				})
-			   .Wait(timeout: 50);
+			   .Wait(timeout: expectedResult ? 3000 : 50);
 		});
 
 		if (expectedResult)

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/NotificationHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemMock/NotificationHandlerTests.cs
@@ -51,6 +51,7 @@ public class NotificationHandlerTests
 		string path)
 	{
 		string? receivedPath = null;
+		FileSystem.Initialize();
 		initialization?.Invoke(FileSystem, path);
 
 		FileSystem.Notify


### PR DESCRIPTION
Execute the `executeWhanWaiting` callback in a separate thread, so that the timeout setting is respected when the execute while waiting callback is blocked.

The following code should throw a `TimeoutException` after 1s:
```csharp
FileSystemMock fileSystem = new();
fileSystem.Notify
    .OnCreated(FileSystemTypes.File, _ => { })
    .ExecuteWhileWaiting(() =>
    {
        Thread.Sleep(3000);
        fileSystem.File.Create("foo.txt");
    })
    // If a timeout is provided, this will throw a TimeoutException if no event was triggered within 1000ms
    .Wait(timeout: 1000);
```