### PR TITLE
refactor: remove `ExcludeFromCodeCoverage` attribute

### DIFF
--- a/Source/Testably.Abstractions.Testing/Internal/EncryptionHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/EncryptionHelper.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -14,7 +13,7 @@ internal static class EncryptionHelper
 	internal static byte[] Decrypt(byte[] cypherBytes)
 	{
 		using Aes algorithm = CreateAlgorithm();
-		using ICryptoTransform? decryptor = algorithm
+		using ICryptoTransform decryptor = algorithm
 		   .CreateDecryptor(algorithm.Key, algorithm.IV);
 
 		return PerformCryptography(decryptor, cypherBytes);
@@ -31,8 +30,7 @@ internal static class EncryptionHelper
 
 		return PerformCryptography(encryptor, plainBytes);
 	}
-
-	[ExcludeFromCodeCoverage]
+	
 	private static Aes CreateAlgorithm()
 	{
 		byte[] bytes = Encoding.UTF8.GetBytes(

--- a/Source/Testably.Abstractions.Testing/Internal/EnumerationOptionsHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/EnumerationOptionsHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Enumeration;
 
@@ -20,7 +19,6 @@ internal static class EnumerationOptionsHelper
 	///     <see
 	///         href="https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/IO/EnumerationOptions.cs#L24" />
 	/// </summary>
-	[ExcludeFromCodeCoverage]
 	internal static EnumerationOptions Compatible { get; } =
 		new()
 		{
@@ -33,7 +31,6 @@ internal static class EnumerationOptionsHelper
 	///     <see
 	///         href="https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/IO/EnumerationOptions.cs#L27" />
 	/// </summary>
-	[ExcludeFromCodeCoverage]
 	private static EnumerationOptions CompatibleRecursive { get; } =
 		new()
 		{
@@ -47,7 +44,6 @@ internal static class EnumerationOptionsHelper
 	///     <see
 	///         href="https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerableFactory.cs#L107" />
 	/// </summary>
-	[ExcludeFromCodeCoverage]
 	public static bool MatchesPattern(EnumerationOptions enumerationOptions, string name,
 	                                  string searchString)
 	{
@@ -70,7 +66,6 @@ internal static class EnumerationOptionsHelper
 	///     <see
 	///         href="https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/IO/EnumerationOptions.cs#L46" />
 	/// </summary>
-	[ExcludeFromCodeCoverage]
 	internal static EnumerationOptions FromSearchOption(SearchOption searchOption)
 	{
 		if (searchOption != SearchOption.TopDirectoryOnly &&
@@ -84,7 +79,6 @@ internal static class EnumerationOptionsHelper
 			: Compatible;
 	}
 
-	[ExcludeFromCodeCoverage]
 	private static bool MatchPattern(string expression,
 	                                 string name,
 	                                 bool ignoreCase,
@@ -116,7 +110,6 @@ internal static class EnumerationOptionsHelper
 	///     <seealso
 	///         href="https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerableFactory.cs#L37" />
 	/// </summary>
-	[ExcludeFromCodeCoverage]
 	private static string SimplifyExpression(string expression)
 	{
 		char[] unixEscapeChars = { '\\', '"', '<', '>' };

--- a/Source/Testably.Abstractions.Testing/Internal/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/ExceptionFactory.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Testing.Internal;
 
-[ExcludeFromCodeCoverage]
 internal static class ExceptionFactory
 {
 	public static NotSupportedException NotSupportedFileStreamWrapping()

--- a/Source/Testably.Abstractions.Testing/Internal/Execute.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/Execute.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace Testably.Abstractions.Testing.Internal;
 
-[ExcludeFromCodeCoverage]
 internal static class Execute
 {
 	private static bool? _isNetFramework;
@@ -27,7 +25,6 @@ internal static class Execute
 	/// <remarks>
 	///     <see href="https://stackoverflow.com/a/53675231" />
 	/// </remarks>
-	[ExcludeFromCodeCoverage]
 	public static bool IsNetFramework
 	{
 		get

--- a/Source/Testably.Abstractions.Testing/Internal/FilePlatformIndependenceExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/FilePlatformIndependenceExtensions.cs
@@ -7,7 +7,6 @@ namespace Testably.Abstractions.Testing.Internal;
 /// <summary>
 ///     Provides extension methods to simplify writing platform independent tests.
 /// </summary>
-[ExcludeFromCodeCoverage]
 internal static class FilePlatformIndependenceExtensions
 {
 	private static readonly Regex PathTransformRegex = new(@"^[a-zA-Z]:(?<path>.*)$");

--- a/Source/Testably.Abstractions.Testing/Internal/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/PathHelper.cs
@@ -15,7 +15,6 @@ internal static class PathHelper
 	/// <summary>
 	///     Determines whether the given path contains illegal characters.
 	/// </summary>
-	[ExcludeFromCodeCoverage]
 	internal static bool HasIllegalCharacters(this string path, IFileSystem fileSystem)
 	{
 		char[] invalidPathChars = fileSystem.Path.GetInvalidPathChars();
@@ -70,8 +69,7 @@ internal static class PathHelper
 				fileSystem.Path.GetFullPath(path));
 		}
 	}
-
-	[ExcludeFromCodeCoverage]
+	
 	internal static string TrimOnWindows(this string path)
 		=> Execute.OnWindows(
 			() => path.TrimEnd(' '),

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using Testably.Abstractions.Testing.Internal;
@@ -32,7 +31,6 @@ internal class InMemoryContainer : IStorageContainer
 	#region IStorageContainer Members
 
 	/// <inheritdoc cref="IStorageContainer.Attributes" />
-	[ExcludeFromCodeCoverage]
 	public FileAttributes Attributes
 	{
 		get

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Testably.Abstractions.Testing.Internal;
 
@@ -41,7 +40,6 @@ internal sealed class InMemoryLocation : IStorageLocation
 	public string FullPath { get; }
 
 	/// <inheritdoc cref="IEquatable{IStorageLocation}.Equals(IStorageLocation)" />
-	[ExcludeFromCodeCoverage]
 	public bool Equals(IStorageLocation? other)
 	{
 		if (ReferenceEquals(null, other))

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Testably.Abstractions.Testing.Internal;
 
@@ -35,7 +34,6 @@ internal sealed class NullContainer : IStorageContainer
 	public IStorageContainer.ITimeContainer LastWriteTime { get; } = new NullTime();
 
 	/// <inheritdoc cref="IStorageContainer.LinkTarget" />
-	[ExcludeFromCodeCoverage]
 	public string? LinkTarget
 	{
 		get => null;
@@ -43,7 +41,6 @@ internal sealed class NullContainer : IStorageContainer
 	}
 
 	/// <inheritdoc cref="ITimeSystem.ITimeSystemExtensionPoint.TimeSystem" />
-	[ExcludeFromCodeCoverage]
 	public ITimeSystem TimeSystem { get; }
 
 	/// <inheritdoc cref="IStorageContainer.Type" />
@@ -51,46 +48,39 @@ internal sealed class NullContainer : IStorageContainer
 		=> FileSystemTypes.DirectoryOrFile;
 
 	/// <inheritdoc cref="IStorageContainer.AppendBytes(byte[])" />
-	[ExcludeFromCodeCoverage]
 	public void AppendBytes(byte[] bytes)
 	{
 		// Do nothing in NullContainer
 	}
 
 	/// <inheritdoc cref="IStorageContainer.ClearBytes()" />
-	[ExcludeFromCodeCoverage]
 	public void ClearBytes()
 	{
 		// Do nothing in NullContainer
 	}
 
 	/// <inheritdoc cref="IStorageContainer.Decrypt()" />
-	[ExcludeFromCodeCoverage]
 	public void Decrypt()
 	{
 		// Do nothing in NullContainer
 	}
 
 	/// <inheritdoc cref="IStorageContainer.Encrypt()" />
-	[ExcludeFromCodeCoverage]
 	public void Encrypt()
 	{
 		// Do nothing in NullContainer
 	}
 
 	/// <inheritdoc cref="IStorageContainer.GetBytes()" />
-	[ExcludeFromCodeCoverage]
 	public byte[] GetBytes()
 		=> Array.Empty<byte>();
 
 	/// <inheritdoc cref="IStorageContainer.RequestAccess(FileAccess, FileShare, bool)" />
-	[ExcludeFromCodeCoverage]
 	public IStorageAccessHandle RequestAccess(FileAccess access, FileShare share,
 	                                          bool ignoreMetadataError = true)
 		=> new NullStorageAccessHandle();
 
 	/// <inheritdoc cref="IStorageContainer.WriteBytes(byte[])" />
-	[ExcludeFromCodeCoverage]
 	public void WriteBytes(byte[] bytes)
 	{
 		// Do nothing in NullContainer
@@ -101,7 +91,6 @@ internal sealed class NullContainer : IStorageContainer
 	internal static IStorageContainer New(FileSystemMock fileSystem)
 		=> new NullContainer(fileSystem, fileSystem.TimeSystem);
 
-	[ExcludeFromCodeCoverage]
 	private sealed class NullStorageAccessHandle : IStorageAccessHandle
 	{
 		#region IStorageAccessHandle Members

--- a/Source/Testably.Abstractions/FileSystem.DriveInfoWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem.DriveInfoWrapper.cs
@@ -59,7 +59,6 @@ public sealed partial class FileSystem
 			=> _instance.TotalSize;
 
 		/// <inheritdoc cref="IFileSystem.IDriveInfo.VolumeLabel" />
-		[ExcludeFromCodeCoverage]
 		[AllowNull]
 		public string VolumeLabel
 		{


### PR DESCRIPTION
Remove the `ExcludeFromCodeCoverage` attribute everywhere except for the "Polyfill" classes.