### PR TITLE
refactor: improve test coverage

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DriveInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DriveInfoMock.cs
@@ -124,7 +124,13 @@ public sealed partial class FileSystemMock
 #if NET6_0_OR_GREATER
 			[SupportedOSPlatform("windows")]
 #endif
-			set => throw ExceptionFactory.VolumeLabelsCanOnlyBeSetForWritableVolumes();
+			set
+			{
+				_ = value;
+				Execute.OnWindows(
+					() => throw ExceptionFactory.VolumeLabelsCannotBeSet(),
+					() => throw ExceptionFactory.OperationNotSupportedOnThisPlatform());
+			}
 		}
 
 		/// <inheritdoc cref="IStorageDrive.ChangeUsedBytes(long)" />

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DriveInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DriveInfoMock.cs
@@ -120,12 +120,12 @@ public sealed partial class FileSystemMock
 		[AllowNull]
 		public string VolumeLabel
 		{
-			get;
+			get => nameof(FileSystemMock);
 #if NET6_0_OR_GREATER
 			[SupportedOSPlatform("windows")]
 #endif
-			set;
-		} = nameof(FileSystemMock);
+			set => throw ExceptionFactory.VolumeLabelsCanOnlyBeSetForWritableVolumes();
+		}
 
 		/// <inheritdoc cref="IStorageDrive.ChangeUsedBytes(long)" />
 		public IStorageDrive ChangeUsedBytes(long usedBytesDelta)

--- a/Source/Testably.Abstractions.Testing/FileSystemMock.DriveInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemMock.DriveInfoMock.cs
@@ -34,6 +34,7 @@ public sealed partial class FileSystemMock
 		private readonly FileSystemMock _fileSystem;
 
 		private long _usedBytes;
+		private string _volumeLabel = nameof(FileSystemMock);
 
 		private DriveInfoMock(string driveName, FileSystemMock fileSystem)
 		{
@@ -120,15 +121,14 @@ public sealed partial class FileSystemMock
 		[AllowNull]
 		public string VolumeLabel
 		{
-			get => nameof(FileSystemMock);
+			get => _volumeLabel;
 #if NET6_0_OR_GREATER
 			[SupportedOSPlatform("windows")]
 #endif
 			set
 			{
-				_ = value;
-				Execute.OnWindows(
-					() => throw ExceptionFactory.VolumeLabelsCannotBeSet(),
+				_volumeLabel = value ?? _volumeLabel;
+				Execute.NotOnWindows(
 					() => throw ExceptionFactory.OperationNotSupportedOnThisPlatform());
 			}
 		}

--- a/Source/Testably.Abstractions.Testing/Internal/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/ExceptionFactory.cs
@@ -67,6 +67,9 @@ internal static class ExceptionFactory
 	internal static IOException NotEnoughDiskSpace(string name)
 		=> new($"There is not enough space on the disk: '{name}'");
 
+	internal static PlatformNotSupportedException OperationNotSupportedOnThisPlatform()
+		=> new("Operation is not supported on this platform.");
+
 	internal static ArgumentException PathCannotBeEmpty(string paramName = "path")
 		=> Execute.OnNetFramework(
 			() => new ArgumentException(
@@ -110,7 +113,6 @@ internal static class ExceptionFactory
 		=> new(
 			$"The timeout of {timeoutMilliseconds}ms expired in the awaitable callback.");
 
-	internal static UnauthorizedAccessException
-		VolumeLabelsCanOnlyBeSetForWritableVolumes()
+	internal static UnauthorizedAccessException VolumeLabelsCannotBeSet()
 		=> new("Volume labels can only be set for writable local volumes.");
 }

--- a/Source/Testably.Abstractions.Testing/Internal/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Internal/ExceptionFactory.cs
@@ -109,4 +109,8 @@ internal static class ExceptionFactory
 	internal static TimeoutException TimeoutExpired(int timeoutMilliseconds)
 		=> new(
 			$"The timeout of {timeoutMilliseconds}ms expired in the awaitable callback.");
+
+	internal static UnauthorizedAccessException
+		VolumeLabelsCanOnlyBeSetForWritableVolumes()
+		=> new("Volume labels can only be set for writable local volumes.");
 }

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -78,7 +78,7 @@ internal sealed class NullContainer : IStorageContainer
 	/// <inheritdoc cref="IStorageContainer.RequestAccess(FileAccess, FileShare, bool)" />
 	public IStorageAccessHandle RequestAccess(FileAccess access, FileShare share,
 	                                          bool ignoreMetadataError = true)
-		=> new NullStorageAccessHandle();
+		=> new NullStorageAccessHandle(access, share);
 
 	/// <inheritdoc cref="IStorageContainer.WriteBytes(byte[])" />
 	public void WriteBytes(byte[] bytes)
@@ -93,13 +93,19 @@ internal sealed class NullContainer : IStorageContainer
 
 	private sealed class NullStorageAccessHandle : IStorageAccessHandle
 	{
+		public NullStorageAccessHandle(FileAccess access, FileShare share)
+		{
+			Access = access;
+			Share = share;
+		}
+
 		#region IStorageAccessHandle Members
 
 		/// <inheritdoc cref="IStorageAccessHandle.Access" />
-		public FileAccess Access => FileAccess.ReadWrite;
+		public FileAccess Access { get; }
 
 		/// <inheritdoc cref="IStorageAccessHandle.Share" />
-		public FileShare Share => FileShare.None;
+		public FileShare Share { get; }
 
 		/// <inheritdoc cref="IDisposable.Dispose()" />
 		public void Dispose()

--- a/Source/Testably.Abstractions/FileSystem.DriveInfoWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem.DriveInfoWrapper.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
 #if NET6_0_OR_GREATER
-using System;
 using System.Runtime.Versioning;
 #endif
 
@@ -65,19 +64,13 @@ public sealed partial class FileSystem
 			get => _instance.VolumeLabel;
 #if NET6_0_OR_GREATER
 			[SupportedOSPlatform("windows")]
-			set
-			{
-				if (OperatingSystem.IsWindows())
-				{
-					_instance.VolumeLabel = value;
-				}
-			}
-#else
-			set => _instance.VolumeLabel = value;
 #endif
+#pragma warning disable CA1416
+			set => _instance.VolumeLabel = value;
+#pragma warning restore CA1416
 		}
 
-		#endregion
+#endregion
 
 		[return: NotNullIfNotNull("instance")]
 		internal static DriveInfoWrapper? FromDriveInfo(DriveInfo? instance,

--- a/Tests/Testably.Abstractions.Testing.Tests/Storage/NullContainerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Storage/NullContainerTests.cs
@@ -1,9 +1,33 @@
-﻿using Testably.Abstractions.Testing.Storage;
+﻿using System.IO;
+using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.Tests.Storage;
 
 public class NullContainerTests
 {
+	[Theory]
+	[AutoData]
+	public void AppendBytes_ShouldReturnEmptyArray(byte[] bytes)
+	{
+		Testing.FileSystemMock fileSystem = new();
+		IStorageContainer sut = NullContainer.New(fileSystem);
+
+		sut.AppendBytes(bytes);
+
+		sut.GetBytes().Should().BeEmpty();
+	}
+
+	[Fact]
+	public void ClearBytes_ShouldReturnEmptyArray()
+	{
+		Testing.FileSystemMock fileSystem = new();
+		IStorageContainer sut = NullContainer.New(fileSystem);
+
+		sut.ClearBytes();
+
+		sut.GetBytes().Should().BeEmpty();
+	}
+
 	[Fact]
 	public void Constructor_ShouldSetFileAndTimeSystem()
 	{
@@ -13,5 +37,96 @@ public class NullContainerTests
 
 		sut.FileSystem.Should().Be(fileSystem);
 		sut.TimeSystem.Should().Be(fileSystem.TimeSystem);
+	}
+
+	[Theory]
+	[AutoData]
+	public void CreationTime_WithUnspecifiedKind_ShouldReturnNullTime(string path)
+	{
+		Testing.FileSystemMock fileSystem = new();
+		IStorageContainer sut = NullContainer.New(fileSystem);
+
+		DateTime result = sut.CreationTime.Get(DateTimeKind.Unspecified);
+
+		result.Should().Be(new DateTime(1601, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+	}
+
+	[Fact]
+	public void Decrypt_ShouldReturnEmptyArray()
+	{
+		Testing.FileSystemMock fileSystem = new();
+		IStorageContainer sut = NullContainer.New(fileSystem);
+
+		sut.Decrypt();
+
+		sut.GetBytes().Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Encrypt_ShouldReturnEmptyArray()
+	{
+		Testing.FileSystemMock fileSystem = new();
+		IStorageContainer sut = NullContainer.New(fileSystem);
+
+		sut.Encrypt();
+
+		sut.GetBytes().Should().BeEmpty();
+	}
+
+	[Fact]
+	public void GetBytes_ShouldReturnEmptyArray()
+	{
+		Testing.FileSystemMock fileSystem = new();
+		IStorageContainer sut = NullContainer.New(fileSystem);
+
+		sut.GetBytes().Should().BeEmpty();
+	}
+
+	[Theory]
+	[AutoData]
+	public void LinkTarget_ShouldAlwaysReturnNull(string linkTarget)
+	{
+		Testing.FileSystemMock fileSystem = new();
+		IStorageContainer sut = NullContainer.New(fileSystem);
+		sut.LinkTarget.Should().BeNull();
+
+		sut.LinkTarget = linkTarget;
+
+		sut.LinkTarget.Should().BeNull();
+	}
+
+	[Theory]
+	[AutoData]
+	public void RequestAccess_ShouldReturnEmptyArray(FileAccess access, FileShare share)
+	{
+		Testing.FileSystemMock fileSystem = new();
+		IStorageContainer sut = NullContainer.New(fileSystem);
+
+		IStorageAccessHandle result = sut.RequestAccess(access, share);
+
+		result.Access.Should().Be(access);
+		result.Share.Should().Be(share);
+	}
+
+	[Theory]
+	[AutoData]
+	public void Type_ShouldBeDirectoryOrFile(string linkTarget)
+	{
+		Testing.FileSystemMock fileSystem = new();
+		IStorageContainer sut = NullContainer.New(fileSystem);
+
+		sut.Type.Should().Be(FileSystemTypes.DirectoryOrFile);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WriteBytes_ShouldReturnEmptyArray(byte[] bytes)
+	{
+		Testing.FileSystemMock fileSystem = new();
+		IStorageContainer sut = NullContainer.New(fileSystem);
+
+		sut.WriteBytes(bytes);
+
+		sut.GetBytes().Should().BeEmpty();
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Storage/NullContainerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Storage/NullContainerTests.cs
@@ -39,9 +39,8 @@ public class NullContainerTests
 		sut.TimeSystem.Should().Be(fileSystem.TimeSystem);
 	}
 
-	[Theory]
-	[AutoData]
-	public void CreationTime_WithUnspecifiedKind_ShouldReturnNullTime(string path)
+	[Fact]
+	public void CreationTime_WithUnspecifiedKind_ShouldReturnNullTime()
 	{
 		Testing.FileSystemMock fileSystem = new();
 		IStorageContainer sut = NullContainer.New(fileSystem);
@@ -108,9 +107,8 @@ public class NullContainerTests
 		result.Share.Should().Be(share);
 	}
 
-	[Theory]
-	[AutoData]
-	public void Type_ShouldBeDirectoryOrFile(string linkTarget)
+	[Fact]
+	public void Type_ShouldBeDirectoryOrFile()
 	{
 		Testing.FileSystemMock fileSystem = new();
 		IStorageContainer sut = NullContainer.New(fileSystem);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/FileSystemDriveInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/FileSystemDriveInfoTests.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using System.Linq;
+
+namespace Testably.Abstractions.Tests.FileSystem.DriveInfo;
+
+public abstract class FileSystemDriveInfoTests<TFileSystem>
+	where TFileSystem : IFileSystem
+{
+	public abstract string BasePath { get; }
+	public TFileSystem FileSystem { get; }
+	public ITimeSystem TimeSystem { get; }
+
+	protected FileSystemDriveInfoTests(
+		TFileSystem fileSystem,
+		ITimeSystem timeSystem)
+	{
+		FileSystem = fileSystem;
+		TimeSystem = timeSystem;
+
+		Test.SkipIfTestsOnRealFileSystemShouldBeSkipped(FileSystem);
+	}
+
+	[SkippableFact]
+	public void VolumeLabel_ShouldNotBeWritable()
+	{
+		IFileSystem.IDriveInfo result =
+			FileSystem.DriveInfo.New(FileTestHelper.RootDrive());
+
+		Exception? exception = Record.Exception(() =>
+		{
+			result.VolumeLabel = "TEST";
+		});
+
+		exception.Should().BeOfType<UnauthorizedAccessException>();
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/FileSystemDriveInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/FileSystemDriveInfoTests.cs
@@ -30,6 +30,13 @@ public abstract class FileSystemDriveInfoTests<TFileSystem>
 #pragma warning restore CA1416
 		});
 
-		exception.Should().BeOfType<UnauthorizedAccessException>();
+		if (Test.RunsOnWindows)
+		{
+			exception.Should().BeOfType<UnauthorizedAccessException>();
+		}
+		else
+		{
+			exception.Should().BeOfType<PlatformNotSupportedException>();
+		}
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/FileSystemDriveInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/FileSystemDriveInfoTests.cs
@@ -1,6 +1,3 @@
-using System.IO;
-using System.Linq;
-
 namespace Testably.Abstractions.Tests.FileSystem.DriveInfo;
 
 public abstract class FileSystemDriveInfoTests<TFileSystem>
@@ -28,7 +25,9 @@ public abstract class FileSystemDriveInfoTests<TFileSystem>
 
 		Exception? exception = Record.Exception(() =>
 		{
+#pragma warning disable CA1416
 			result.VolumeLabel = "TEST";
+#pragma warning restore CA1416
 		});
 
 		exception.Should().BeOfType<UnauthorizedAccessException>();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/FileSystemDriveInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/FileSystemDriveInfoTests.cs
@@ -49,7 +49,9 @@ public abstract class FileSystemDriveInfoTests<TFileSystem>
 		{
 			if (Test.RunsOnWindows)
 			{
+#pragma warning disable CA1416
 				result.VolumeLabel = previousVolumeLabel;
+#pragma warning restore CA1416
 			}
 		}
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/MockFileSystemTests.cs
@@ -1,0 +1,33 @@
+using Testably.Abstractions.Tests.TestHelpers.Traits;
+
+namespace Testably.Abstractions.Tests.FileSystem.DriveInfo;
+
+[SystemTest(nameof(MockFileSystemTests))]
+public sealed class MockFileSystemTests
+	: FileSystemDriveInfoTests<FileSystemMock>, IDisposable
+{
+	/// <inheritdoc cref="FileSystemDriveInfoTests{TFileSystem}.BasePath" />
+	public override string BasePath => _directoryCleaner.BasePath;
+
+	private readonly FileSystemInitializer.IDirectoryCleaner _directoryCleaner;
+
+	public MockFileSystemTests() : this(new FileSystemMock())
+	{
+	}
+
+	private MockFileSystemTests(FileSystemMock fileSystemMock) : base(
+		fileSystemMock,
+		fileSystemMock.TimeSystem)
+	{
+		_directoryCleaner = FileSystem
+		   .SetCurrentDirectoryToEmptyTemporaryDirectory();
+	}
+
+	#region IDisposable Members
+
+	/// <inheritdoc cref="IDisposable.Dispose()" />
+	public void Dispose()
+		=> _directoryCleaner.Dispose();
+
+	#endregion
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/RealFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/RealFileSystemTests.cs
@@ -1,0 +1,33 @@
+#if !DEBUG || !DISABLE_TESTS_REALFILESYSTEM
+using Testably.Abstractions.Tests.TestHelpers.Traits;
+using Xunit.Abstractions;
+
+namespace Testably.Abstractions.Tests.FileSystem.DriveInfo;
+
+[Collection(nameof(RealFileSystemTests))]
+[SystemTest(nameof(RealFileSystemTests))]
+public sealed class RealFileSystemTests :
+	FileSystemDriveInfoTests<Abstractions.FileSystem>,
+	IDisposable
+{
+	/// <inheritdoc cref="FileSystemDriveInfoTests{TFileSystem}.BasePath" />
+	public override string BasePath => _directoryCleaner.BasePath;
+
+	private readonly FileSystemInitializer.IDirectoryCleaner _directoryCleaner;
+
+	public RealFileSystemTests(ITestOutputHelper testOutputHelper)
+		: base(new Abstractions.FileSystem(), new Abstractions.TimeSystem())
+	{
+		_directoryCleaner = FileSystem
+		   .SetCurrentDirectoryToEmptyTemporaryDirectory(testOutputHelper.WriteLine);
+	}
+
+	#region IDisposable Members
+
+	/// <inheritdoc cref="IDisposable.Dispose()" />
+	public void Dispose()
+		=> _directoryCleaner.Dispose();
+
+	#endregion
+}
+#endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/FileSystemDriveInfoFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/FileSystemDriveInfoFactoryTests.cs
@@ -84,6 +84,7 @@ public abstract class FileSystemDriveInfoFactoryTests<TFileSystem>
 		result.RootDirectory.FullName.Should().Be(FileTestHelper.RootDrive());
 		result.TotalFreeSpace.Should().BeGreaterThan(0);
 		result.TotalSize.Should().BeGreaterThan(0);
+		result.VolumeLabel.Should().NotBeEmpty();
 	}
 
 	[SkippableTheory]
@@ -153,7 +154,7 @@ public abstract class FileSystemDriveInfoFactoryTests<TFileSystem>
 	{
 		Skip.IfNot(Test.RunsOnWindows, "Linux does not support different drives.");
 
-		DriveInfo driveInfo = new("C");
+		System.IO.DriveInfo driveInfo = new("C");
 		IFileSystem.IDriveInfo result = FileSystem.DriveInfo.Wrap(driveInfo);
 
 		result.Name.Should().Be(driveInfo.Name);

--- a/Tests/stryker-config-testing.json
+++ b/Tests/stryker-config-testing.json
@@ -13,16 +13,24 @@
     "reporters": [ "html", "progress", "cleartext" ],
     "mutation-level": "Advanced",
     "mutate": [
-      "!Testably.Abstractions.Testing/Internal/EnumerationOptionsHelper.cs", // The enumeration options helper is a wrapper around Microsoft code
-      "!Testably.Abstractions.Testing/Internal/ExceptionFactory.cs", // The exception type is checked, but not the message, as this could be language dependent
-      "!Testably.Abstractions.Testing/Internal/Execute.cs" // Indicates operating system specific code
+      // The enumeration options helper is a wrapper around Microsoft code
+      "!Testably.Abstractions.Testing/Internal/EnumerationOptionsHelper.cs",
+      // The exception type is checked, but not the message, as this could be language dependent
+      "!Testably.Abstractions.Testing/Internal/ExceptionFactory.cs",
+      // Indicates operating system specific code
+      "!Testably.Abstractions.Testing/Internal/Execute.cs"
     ],
     "ignore-methods": [
-      "ExceptionFactory.*", // The exception type is checked, but not the message, as this could be language dependent
-      "Execute.*On*", // Indicates operating system specific code
-      "ValidateDriveLetter", // Drives are not used in Linux
-      "ThrowCommonExceptionsIfPathIsInvalid", // Triggered by invalid chars which don't exist in Linux
-      "System.Threading.Thread.Sleep" // Calls to Thread.Sleep cannot be detected by a test
+      // The exception type is checked, but not the message, as this could be language dependent
+      "ExceptionFactory.*",
+      // Indicates operating system specific code
+      "Execute.*On*",
+      // Drives are not used in Linux
+      "ValidateDriveLetter",
+      // Triggered by invalid chars which don't exist in Linux
+      "ThrowCommonExceptionsIfPathIsInvalid",
+      // Calls to Thread.Sleep cannot be detected by a test
+      "System.Threading.Thread.Sleep"
     ]
   }
 }

--- a/Tests/stryker-config-testing.json
+++ b/Tests/stryker-config-testing.json
@@ -12,12 +12,17 @@
     "target-framework": "net6.0",
     "reporters": [ "html", "progress", "cleartext" ],
     "mutation-level": "Advanced",
+    "mutate": [
+      "!Testably.Abstractions.Testing/Internal/EnumerationOptionsHelper.cs", // The enumeration options helper is a wrapper around Microsoft code
+      "!Testably.Abstractions.Testing/Internal/ExceptionFactory.cs", // The exception type is checked, but not the message, as this could be language dependent
+      "!Testably.Abstractions.Testing/Internal/Execute.cs" // Indicates operating system specific code
+    ],
     "ignore-methods": [
-      "ExceptionFactory.*",                    // The exception type is checked, but not the message, as this could be language dependent
-      "Execute.*On*",                          // Indicates operating system specific code
-      "ValidateDriveLetter",                   // Drives are not used in Linux
-      "ThrowCommonExceptionsIfPathIsInvalid",  // Triggered by invalid chars which don't exist in Linux
-      "System.Threading.Thread.Sleep"          // Calls to Thread.Sleep cannot be detected by a test
+      "ExceptionFactory.*", // The exception type is checked, but not the message, as this could be language dependent
+      "Execute.*On*", // Indicates operating system specific code
+      "ValidateDriveLetter", // Drives are not used in Linux
+      "ThrowCommonExceptionsIfPathIsInvalid", // Triggered by invalid chars which don't exist in Linux
+      "System.Threading.Thread.Sleep" // Calls to Thread.Sleep cannot be detected by a test
     ]
   }
 }


### PR DESCRIPTION
- Add tests for `NullContainer`
- Add tests for `VolumeLabel` on `DriveInfo`
- Exclude OS-Specific tests from Stryker