### PR TITLE
refactor: run Stryker on windows for AccessControl project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,8 +184,8 @@ jobs:
       - name: Run example tests
         run: dotnet test Examples --no-build
 
-  stryker:
-    name: Analyze quality of unit test coverage with .NET Stryker
+  stryker-ubuntu:
+    name: Analyze quality of unit test coverage with .NET Stryker (Ubuntu)
     runs-on: ubuntu-latest
     timeout-minutes: 300
     steps:
@@ -193,11 +193,27 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Tag current commit
+      - name: Install .NET Stryker
         shell: bash
         run: |
-          version="${GITHUB_REF#refs/heads/release/}"
-          git tag "${version}"
+          dotnet tool install dotnet-stryker --global
+          dotnet tool restore
+      - name: Analyze Testably.Abstractions.Testing
+        env:
+          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+        shell: bash
+        run: |
+          dotnet stryker -f Tests/stryker-config-testing.json -v "${GITHUB_REF#refs/heads/}" -r "Dashboard" -r "cleartext"
+
+  stryker-windows:
+    name: Analyze quality of unit test coverage with .NET Stryker (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 300
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Install .NET Stryker
         shell: bash
         run: |
@@ -215,13 +231,6 @@ jobs:
         shell: bash
         run: |
           dotnet stryker -f Tests/stryker-config-accesscontrol.json -v "${GITHUB_REF#refs/heads/}" -r "Dashboard" -r "cleartext"
-      - name: Analyze Testably.Abstractions.Testing
-        env:
-          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
-        shell: bash
-        run: |
-          dotnet stryker -f Tests/stryker-config-testing.json -v "${GITHUB_REF#refs/heads/}" -r "Dashboard" -r "cleartext"
-
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
@@ -265,7 +274,7 @@ jobs:
   cleanup:
     name: Cleanup
     runs-on: ubuntu-latest
-    needs: [deploy, stryker]
+    needs: [deploy, stryker-windows, stryker-ubuntu]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/.github/workflows/stryker.yml
+++ b/.github/workflows/stryker.yml
@@ -6,9 +6,30 @@ on:
     branches: [main]
     
 jobs:
-  stryker:
-    name: Analyze quality of unit test coverage with .NET Stryker
+  stryker-ubuntu:
+    name: Analyze quality of unit test coverage with .NET Stryker (Ubuntu)
     runs-on: ubuntu-latest
+    timeout-minutes: 300
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install .NET Stryker
+        shell: bash
+        run: |
+          dotnet tool install dotnet-stryker --global
+          dotnet tool restore
+      - name: Analyze Testably.Abstractions.Testing
+        env:
+          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+        shell: bash
+        run: |
+          dotnet stryker -f Tests/stryker-config-testing.json -v "${GITHUB_REF#refs/heads/}" -r "Dashboard" -r "cleartext"
+
+  stryker-windows:
+    name: Analyze quality of unit test coverage with .NET Stryker (Windows)
+    runs-on: windows-latest
     timeout-minutes: 300
     steps:
       - name: Checkout sources
@@ -32,9 +53,3 @@ jobs:
         shell: bash
         run: |
           dotnet stryker -f Tests/stryker-config-accesscontrol.json -v "${GITHUB_REF#refs/heads/}" -r "Dashboard" -r "cleartext"
-      - name: Analyze Testably.Abstractions.Testing
-        env:
-          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
-        shell: bash
-        run: |
-          dotnet stryker -f Tests/stryker-config-testing.json -v "${GITHUB_REF#refs/heads/}" -r "Dashboard" -r "cleartext"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ public void StoreData_ShouldWriteValidFile()
 }
 ```
 
-**More examples can be found in our [examples section](Examples/README.md)!**
+**More examples can be found in the [examples section](Examples/README.md)!**
 
 # Getting Started
 - Install `Testably.Abstractions` as nuget package in your productive projects and `Testably.Abstractions.Testing` as nuget package in your test projects.

--- a/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryAclExtensionsTests.cs
@@ -76,7 +76,7 @@ public class DirectoryAclExtensionsTests
 			fileSystem.Directory.SetAccessControl("foo", originalAccessControl);
 
 			DirectorySecurity currentAccessControl =
-				fileSystem.Directory.GetAccessControl("foo");
+				fileSystem.Directory.GetAccessControl("foo", AccessControlSections.Access);
 #pragma warning restore CA1416
 
 			currentAccessControl.HasSameAccessRightsAs(originalAccessControl)

--- a/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryAclExtensionsTests.cs
@@ -6,6 +6,28 @@ namespace Testably.Abstractions.AccessControl.Tests;
 public class DirectoryAclExtensionsTests
 {
 	[SkippableFact]
+	public void Create_RealFileSystem_ShouldChangeAccessControl()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		FileSystem fileSystem = new();
+		using (fileSystem.SetCurrentDirectoryToEmptyTemporaryDirectory())
+		{
+			fileSystem.Directory.CreateDirectory("foo");
+#pragma warning disable CA1416
+			DirectorySecurity directorySecurity =
+				fileSystem.Directory.GetAccessControl("foo");
+
+			fileSystem.Directory.CreateDirectory("bar", directorySecurity);
+			DirectorySecurity result = fileSystem.Directory.GetAccessControl("bar");
+#pragma warning restore CA1416
+
+			result.HasSameAccessRightsAs(directorySecurity).Should().BeTrue();
+			result.Should().NotBe(directorySecurity);
+		}
+	}
+
+	[SkippableFact]
 	public void Create_ShouldChangeAccessControl()
 	{
 		Skip.IfNot(Test.RunsOnWindows);
@@ -20,6 +42,7 @@ public class DirectoryAclExtensionsTests
 #pragma warning restore CA1416
 
 		result.Should().Be(directorySecurity);
+		fileSystem.Directory.Exists("foo").Should().BeTrue();
 	}
 
 	[SkippableFact]
@@ -36,6 +59,30 @@ public class DirectoryAclExtensionsTests
 #pragma warning restore CA1416
 
 		result.Should().NotBeNull();
+	}
+
+	[SkippableFact]
+	public void SetAccessControl_RealFileSystem_ShouldChangeAccessControl()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		FileSystem fileSystem = new();
+		using (fileSystem.SetCurrentDirectoryToEmptyTemporaryDirectory())
+		{
+			fileSystem.Directory.CreateDirectory("foo");
+#pragma warning disable CA1416
+			DirectorySecurity originalAccessControl =
+				fileSystem.Directory.GetAccessControl("foo");
+			fileSystem.Directory.SetAccessControl("foo", originalAccessControl);
+
+			DirectorySecurity currentAccessControl =
+				fileSystem.Directory.GetAccessControl("foo");
+#pragma warning restore CA1416
+
+			currentAccessControl.HasSameAccessRightsAs(originalAccessControl)
+			   .Should().BeTrue();
+			currentAccessControl.Should().NotBe(originalAccessControl);
+		}
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryInfoAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryInfoAclExtensionsTests.cs
@@ -55,7 +55,7 @@ public class DirectoryInfoAclExtensionsTests
 
 #pragma warning disable CA1416
 		DirectorySecurity result =
-			directoryInfo.GetAccessControl(AccessControlSections.All);
+			directoryInfo.GetAccessControl(AccessControlSections.Access);
 #pragma warning restore CA1416
 
 		result.Should().NotBeNull();
@@ -76,7 +76,7 @@ public class DirectoryInfoAclExtensionsTests
 			fileSystem.DirectoryInfo.New("foo").SetAccessControl(originalAccessControl);
 
 			DirectorySecurity currentAccessControl =
-				fileSystem.DirectoryInfo.New("foo").GetAccessControl();
+				fileSystem.DirectoryInfo.New("foo").GetAccessControl(AccessControlSections.Access);
 #pragma warning restore CA1416
 
 			currentAccessControl.HasSameAccessRightsAs(originalAccessControl)

--- a/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryInfoAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryInfoAclExtensionsTests.cs
@@ -6,6 +6,29 @@ namespace Testably.Abstractions.AccessControl.Tests;
 public class DirectoryInfoAclExtensionsTests
 {
 	[SkippableFact]
+	public void Create_RealFileSystem_ShouldChangeAccessControl()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		FileSystem fileSystem = new();
+		using (fileSystem.SetCurrentDirectoryToEmptyTemporaryDirectory())
+		{
+			fileSystem.Directory.CreateDirectory("foo");
+#pragma warning disable CA1416
+			DirectorySecurity directorySecurity =
+				fileSystem.DirectoryInfo.New("foo").GetAccessControl();
+
+			fileSystem.DirectoryInfo.New("bar").Create(directorySecurity);
+			DirectorySecurity result =
+				fileSystem.DirectoryInfo.New("bar").GetAccessControl();
+#pragma warning restore CA1416
+
+			result.HasSameAccessRightsAs(directorySecurity).Should().BeTrue();
+			result.Should().NotBe(directorySecurity);
+		}
+	}
+
+	[SkippableFact]
 	public void Create_ShouldChangeAccessControl()
 	{
 		Skip.IfNot(Test.RunsOnWindows);
@@ -36,6 +59,30 @@ public class DirectoryInfoAclExtensionsTests
 #pragma warning restore CA1416
 
 		result.Should().NotBeNull();
+	}
+
+	[SkippableFact]
+	public void SetAccessControl_RealFileSystem_ShouldChangeAccessControl()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		FileSystem fileSystem = new();
+		using (fileSystem.SetCurrentDirectoryToEmptyTemporaryDirectory())
+		{
+			fileSystem.Directory.CreateDirectory("foo");
+#pragma warning disable CA1416
+			DirectorySecurity originalAccessControl =
+				fileSystem.DirectoryInfo.New("foo").GetAccessControl();
+			fileSystem.DirectoryInfo.New("foo").SetAccessControl(originalAccessControl);
+
+			DirectorySecurity currentAccessControl =
+				fileSystem.DirectoryInfo.New("foo").GetAccessControl();
+#pragma warning restore CA1416
+
+			currentAccessControl.HasSameAccessRightsAs(originalAccessControl)
+			   .Should().BeTrue();
+			currentAccessControl.Should().NotBe(originalAccessControl);
+		}
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileAclExtensionsTests.cs
@@ -22,6 +22,30 @@ public class FileAclExtensionsTests
 	}
 
 	[SkippableFact]
+	public void SetAccessControl_RealFileSystem_ShouldChangeAccessControl()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		FileSystem fileSystem = new();
+		using (fileSystem.SetCurrentDirectoryToEmptyTemporaryDirectory())
+		{
+			fileSystem.File.WriteAllText("foo", null);
+#pragma warning disable CA1416
+			FileSecurity originalAccessControl =
+				fileSystem.File.GetAccessControl("foo");
+			fileSystem.File.SetAccessControl("foo", originalAccessControl);
+
+			FileSecurity currentAccessControl =
+				fileSystem.File.GetAccessControl("foo");
+#pragma warning restore CA1416
+
+			currentAccessControl.HasSameAccessRightsAs(originalAccessControl)
+			   .Should().BeTrue();
+			currentAccessControl.Should().NotBe(originalAccessControl);
+		}
+	}
+
+	[SkippableFact]
 	public void SetAccessControl_ShouldChangeAccessControl()
 	{
 		Skip.IfNot(Test.RunsOnWindows);

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileAclExtensionsTests.cs
@@ -36,7 +36,7 @@ public class FileAclExtensionsTests
 			fileSystem.File.SetAccessControl("foo", originalAccessControl);
 
 			FileSecurity currentAccessControl =
-				fileSystem.File.GetAccessControl("foo");
+				fileSystem.File.GetAccessControl("foo", AccessControlSections.Access);
 #pragma warning restore CA1416
 
 			currentAccessControl.HasSameAccessRightsAs(originalAccessControl)

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileInfoAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileInfoAclExtensionsTests.cs
@@ -35,7 +35,7 @@ public class FileInfoAclExtensionsTests
 			fileSystem.FileInfo.New("foo").SetAccessControl(originalAccessControl);
 
 			FileSecurity currentAccessControl =
-				fileSystem.FileInfo.New("foo").GetAccessControl();
+				fileSystem.FileInfo.New("foo").GetAccessControl(AccessControlSections.Access);
 #pragma warning restore CA1416
 
 			currentAccessControl.HasSameAccessRightsAs(originalAccessControl)

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileInfoAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileInfoAclExtensionsTests.cs
@@ -21,6 +21,30 @@ public class FileInfoAclExtensionsTests
 	}
 
 	[SkippableFact]
+	public void SetAccessControl_RealFileSystem_ShouldChangeAccessControl()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		FileSystem fileSystem = new();
+		using (fileSystem.SetCurrentDirectoryToEmptyTemporaryDirectory())
+		{
+			fileSystem.File.WriteAllText("foo", null);
+#pragma warning disable CA1416
+			FileSecurity originalAccessControl =
+				fileSystem.FileInfo.New("foo").GetAccessControl();
+			fileSystem.FileInfo.New("foo").SetAccessControl(originalAccessControl);
+
+			FileSecurity currentAccessControl =
+				fileSystem.FileInfo.New("foo").GetAccessControl();
+#pragma warning restore CA1416
+
+			currentAccessControl.HasSameAccessRightsAs(originalAccessControl)
+			   .Should().BeTrue();
+			currentAccessControl.Should().NotBe(originalAccessControl);
+		}
+	}
+
+	[SkippableFact]
 	public void SetAccessControl_ShouldChangeAccessControl()
 	{
 		Skip.IfNot(Test.RunsOnWindows);

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileStreamAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileStreamAclExtensionsTests.cs
@@ -21,6 +21,28 @@ public class FileStreamAclExtensionsTests
 	}
 
 	[SkippableFact]
+	public void SetAccessControl_RealFileSystem_ShouldChangeAccessControl()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		FileSystem fileSystem = new();
+		using (fileSystem.SetCurrentDirectoryToEmptyTemporaryDirectory())
+		{
+			FileSystemStream fileStream = fileSystem.File.Create("foo");
+#pragma warning disable CA1416
+			FileSecurity originalAccessControl = fileStream.GetAccessControl();
+			fileStream.SetAccessControl(originalAccessControl);
+
+			FileSecurity currentAccessControl = fileStream.GetAccessControl();
+#pragma warning restore CA1416
+
+			currentAccessControl.HasSameAccessRightsAs(originalAccessControl)
+			   .Should().BeTrue();
+			currentAccessControl.Should().NotBe(originalAccessControl);
+		}
+	}
+
+	[SkippableFact]
 	public void SetAccessControl_ShouldChangeAccessControl()
 	{
 		Skip.IfNot(Test.RunsOnWindows);

--- a/Tests/Testably.Abstractions.AccessControl.Tests/TestHelpers/FileSystemSecurityExtensions.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/TestHelpers/FileSystemSecurityExtensions.cs
@@ -10,6 +10,7 @@ internal static class FileSystemSecurityExtensions
 	///     Compares to <see cref="FileSystemSecurity" /> objects.
 	///     https://stackoverflow.com/a/17047098
 	/// </summary>
+#pragma warning disable CA1416
 	public static bool HasSameAccessRightsAs(this FileSystemSecurity sourceAccessControl,
 	                             FileSystemSecurity destinationAccessControl)
 	{
@@ -187,4 +188,5 @@ internal static class FileSystemSecurityExtensions
 
 		return true;
 	}
+#pragma warning restore CA1416
 }

--- a/Tests/Testably.Abstractions.AccessControl.Tests/TestHelpers/FileSystemSecurityExtensions.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/TestHelpers/FileSystemSecurityExtensions.cs
@@ -1,0 +1,190 @@
+﻿using System.Collections.Generic;
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+namespace Testably.Abstractions.AccessControl.Tests.TestHelpers;
+
+internal static class FileSystemSecurityExtensions
+{
+	/// <summary>
+	///     Compares to <see cref="FileSystemSecurity" /> objects.
+	///     https://stackoverflow.com/a/17047098
+	/// </summary>
+	public static bool HasSameAccessRightsAs(this FileSystemSecurity sourceAccessControl,
+	                             FileSystemSecurity destinationAccessControl)
+	{
+		// combine parent access rules
+		Dictionary<IdentityReference, FileSystemRights> combinedParentAccessAllowRules =
+			new();
+		Dictionary<IdentityReference, FileSystemRights> combinedParentAccessDenyRules =
+			new();
+		foreach (FileSystemAccessRule parentAccessRule in sourceAccessControl
+		   .GetAccessRules(true, true, typeof(NTAccount)))
+		{
+			if (parentAccessRule.AccessControlType == AccessControlType.Allow)
+			{
+				if (combinedParentAccessAllowRules.ContainsKey(parentAccessRule
+				   .IdentityReference))
+				{
+					combinedParentAccessAllowRules[parentAccessRule.IdentityReference] |= parentAccessRule.FileSystemRights;
+				}
+				else
+				{
+					combinedParentAccessAllowRules.Add(parentAccessRule.IdentityReference,
+						parentAccessRule.FileSystemRights);
+				}
+			}
+			else if (combinedParentAccessDenyRules.ContainsKey(parentAccessRule
+			   .IdentityReference))
+			{
+				combinedParentAccessDenyRules[parentAccessRule.IdentityReference] |= parentAccessRule.FileSystemRights;
+			}
+			else
+			{
+				combinedParentAccessDenyRules.Add(parentAccessRule.IdentityReference,
+					parentAccessRule.FileSystemRights);
+			}
+		}
+
+		// combine child access rules
+
+		Dictionary<IdentityReference, FileSystemRights> combinedChildAccessAllowRules =
+			new();
+		Dictionary<IdentityReference, FileSystemRights> combinedChildAccessDenyRules =
+			new();
+		foreach (FileSystemAccessRule childAccessRule in destinationAccessControl
+		   .GetAccessRules(true, true, typeof(NTAccount)))
+		{
+			if (childAccessRule.AccessControlType == AccessControlType.Allow)
+			{
+				if (combinedChildAccessAllowRules.ContainsKey(childAccessRule
+				   .IdentityReference))
+				{
+					combinedChildAccessAllowRules[childAccessRule.IdentityReference] |= childAccessRule.FileSystemRights;
+				}
+				else
+				{
+					combinedChildAccessAllowRules.Add(childAccessRule.IdentityReference,
+						childAccessRule.FileSystemRights);
+				}
+			}
+			else if (combinedChildAccessDenyRules.ContainsKey(childAccessRule
+			   .IdentityReference))
+			{
+				combinedChildAccessDenyRules[childAccessRule.IdentityReference] |= childAccessRule.FileSystemRights;
+			}
+			else
+			{
+				combinedChildAccessDenyRules.Add(childAccessRule.IdentityReference,
+					childAccessRule.FileSystemRights);
+			}
+		}
+
+		// compare combined rules
+		Dictionary<IdentityReference, FileSystemRights> accessAllowRulesGainedByChild = new();
+		foreach (
+			KeyValuePair<IdentityReference, FileSystemRights> combinedChildAccessAllowRule
+			in combinedChildAccessAllowRules)
+		{
+			if (combinedParentAccessAllowRules.ContainsKey(combinedChildAccessAllowRule
+			   .Key))
+			{
+				FileSystemRights accessAllowRuleGainedByChild =
+					combinedChildAccessAllowRule.Value &
+					~combinedParentAccessAllowRules[combinedChildAccessAllowRule.Key];
+				if (accessAllowRuleGainedByChild != default)
+				{
+					accessAllowRulesGainedByChild.Add(combinedChildAccessAllowRule.Key,
+						accessAllowRuleGainedByChild);
+				}
+			}
+			else
+			{
+				accessAllowRulesGainedByChild.Add(combinedChildAccessAllowRule.Key,
+					combinedChildAccessAllowRule.Value);
+			}
+		}
+
+		Dictionary<IdentityReference, FileSystemRights> accessDenyRulesGainedByChild = new();
+		foreach (
+			KeyValuePair<IdentityReference, FileSystemRights> combinedChildAccessDenyRule
+			in combinedChildAccessDenyRules)
+		{
+			if (combinedParentAccessDenyRules.ContainsKey(combinedChildAccessDenyRule
+			   .Key))
+			{
+				FileSystemRights accessDenyRuleGainedByChild =
+					combinedChildAccessDenyRule.Value &
+					~combinedParentAccessDenyRules[combinedChildAccessDenyRule.Key];
+				if (accessDenyRuleGainedByChild != default)
+				{
+					accessDenyRulesGainedByChild.Add(combinedChildAccessDenyRule.Key,
+						accessDenyRuleGainedByChild);
+				}
+			}
+			else
+			{
+				accessDenyRulesGainedByChild.Add(combinedChildAccessDenyRule.Key,
+					combinedChildAccessDenyRule.Value);
+			}
+		}
+
+		Dictionary<IdentityReference, FileSystemRights> accessAllowRulesGainedByParent = new();
+		foreach (
+			KeyValuePair<IdentityReference, FileSystemRights>
+				combinedParentAccessAllowRule in combinedParentAccessAllowRules)
+		{
+			if (combinedChildAccessAllowRules.ContainsKey(combinedParentAccessAllowRule
+			   .Key))
+			{
+				FileSystemRights accessAllowRuleGainedByParent =
+					combinedParentAccessAllowRule.Value &
+					~combinedChildAccessAllowRules[combinedParentAccessAllowRule.Key];
+				if (accessAllowRuleGainedByParent != default)
+				{
+					accessAllowRulesGainedByParent.Add(combinedParentAccessAllowRule.Key,
+						accessAllowRuleGainedByParent);
+				}
+			}
+			else
+			{
+				accessAllowRulesGainedByParent.Add(combinedParentAccessAllowRule.Key,
+					combinedParentAccessAllowRule.Value);
+			}
+		}
+
+		Dictionary<IdentityReference, FileSystemRights> accessDenyRulesGainedByParent = new();
+		foreach (
+			KeyValuePair<IdentityReference, FileSystemRights> combinedParentAccessDenyRule
+			in combinedParentAccessDenyRules)
+		{
+			if (combinedChildAccessDenyRules.ContainsKey(combinedParentAccessDenyRule
+			   .Key))
+			{
+				FileSystemRights accessDenyRuleGainedByParent =
+					combinedParentAccessDenyRule.Value &
+					~combinedChildAccessDenyRules[combinedParentAccessDenyRule.Key];
+				if (accessDenyRuleGainedByParent != default)
+				{
+					accessDenyRulesGainedByParent.Add(combinedParentAccessDenyRule.Key,
+						accessDenyRuleGainedByParent);
+				}
+			}
+			else
+			{
+				accessDenyRulesGainedByParent.Add(combinedParentAccessDenyRule.Key,
+					combinedParentAccessDenyRule.Value);
+			}
+		}
+
+		if (accessAllowRulesGainedByChild.Count > 0 ||
+		    accessDenyRulesGainedByChild.Count > 0 ||
+		    accessAllowRulesGainedByParent.Count > 0 ||
+		    accessDenyRulesGainedByParent.Count > 0)
+		{
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/Tests/Testably.Abstractions.AccessControl.Tests/Testably.Abstractions.AccessControl.Tests.csproj
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/Testably.Abstractions.AccessControl.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Source\Testably.Abstractions.AccessControl\Testably.Abstractions.AccessControl.csproj" />
     <ProjectReference Include="..\..\Source\Testably.Abstractions.Testing\Testably.Abstractions.Testing.csproj" />
+    <ProjectReference Include="..\..\Source\Testably.Abstractions\Testably.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/FileSystemFileStreamTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/FileSystemFileStreamTests.cs
@@ -309,6 +309,27 @@ public abstract partial class FileSystemFileStreamTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void ExtensionContainer_ShouldWrapFileStreamOnRealFileSystem(
+		string path)
+	{
+		FileSystem.File.WriteAllText(path, null);
+		using FileSystemStream readStream = FileSystem.File.OpenRead(path);
+		bool result = readStream.ExtensionContainer
+		   .HasWrappedInstance(out System.IO.FileStream? fileStream);
+
+		if (FileSystem is Abstractions.FileSystem)
+		{
+			result.Should().BeTrue();
+			fileStream!.Name.Should().Be(readStream.Name);
+		}
+		else
+		{
+			result.Should().BeFalse();
+		}
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void Flush_ShouldNotChangePosition(
 		string path, byte[] bytes)
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/FileSystemFileSystemInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/FileSystemFileSystemInfoTests.cs
@@ -22,6 +22,27 @@ public abstract partial class FileSystemFileSystemInfoTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void ExtensionContainer_ShouldWrapFileSystemInfoOnRealFileSystem(
+		string path)
+	{
+		FileSystem.File.WriteAllText(path, null);
+		IFileSystem.IFileInfo fileInfo = FileSystem.FileInfo.New(path);
+		bool result = fileInfo.ExtensionContainer
+		   .HasWrappedInstance(out System.IO.FileSystemInfo? fileSystemInfo);
+
+		if (FileSystem is Abstractions.FileSystem)
+		{
+			result.Should().BeTrue();
+			fileSystemInfo!.Name.Should().Be(fileInfo.Name);
+		}
+		else
+		{
+			result.Should().BeFalse();
+		}
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void SetAttributes_Hidden_OnFileStartingWithDot_ShouldBeSet(string path)
 	{
 		Skip.IfNot(Test.RunsOnLinux);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.ExtensionContainer.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.ExtensionContainer.cs
@@ -1,0 +1,92 @@
+namespace Testably.Abstractions.Tests.FileSystem;
+
+public abstract partial class FileSystemTests<TFileSystem>
+	where TFileSystem : IFileSystem
+{
+	[SkippableTheory]
+	[AutoData]
+	public void
+		ExtensionContainer_HasWrappedInstance_WithCorrectType_ShouldReturnTrueOnRealFileSystem(
+			string name)
+	{
+		bool result = FileSystem.FileInfo.New(name).ExtensionContainer
+		   .HasWrappedInstance(out System.IO.FileInfo? fileInfo);
+
+		if (FileSystem is Abstractions.FileSystem)
+		{
+			result.Should().BeTrue();
+			fileInfo!.Name.Should().Be(name);
+		}
+		else
+		{
+			result.Should().BeFalse();
+		}
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void
+		ExtensionContainer_HasWrappedInstance_WithIncorrectType_ShouldReturnAlwaysFalse(
+			string name)
+	{
+		bool result = FileSystem.FileInfo.New(name).ExtensionContainer
+		   .HasWrappedInstance(out System.IO.DirectoryInfo? directoryInfo);
+
+		result.Should().BeFalse();
+		directoryInfo.Should().BeNull();
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void
+		ExtensionContainer_RetrieveMetadata_CorrectKeyAndType_ShouldReturnStoredValue(
+			string name, DateTime time)
+	{
+		IFileSystem.IFileSystemExtensionContainer sut = FileSystem.FileInfo.New(name)
+		   .ExtensionContainer;
+
+		sut.StoreMetadata("foo", time);
+		DateTime? result = sut.RetrieveMetadata<DateTime?>("foo");
+
+		result.Should().Be(time);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void ExtensionContainer_RetrieveMetadata_DifferentKey_ShouldReturnNull(
+		string name)
+	{
+		IFileSystem.IFileSystemExtensionContainer sut = FileSystem.FileInfo.New(name)
+		   .ExtensionContainer;
+
+		sut.StoreMetadata("foo", DateTime.Now);
+		DateTime? result = sut.RetrieveMetadata<DateTime?>("bar");
+
+		result.Should().BeNull();
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void ExtensionContainer_RetrieveMetadata_DifferentType_ShouldReturnNull(
+		string name)
+	{
+		IFileSystem.IFileSystemExtensionContainer sut = FileSystem.FileInfo.New(name)
+		   .ExtensionContainer;
+
+		sut.StoreMetadata("foo", DateTime.Now);
+		TimeSpan? result = sut.RetrieveMetadata<TimeSpan?>("foo");
+
+		result.Should().BeNull();
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void ExtensionContainer_RetrieveMetadata_NotRegisteredKey_ShouldReturnNull(
+		string name)
+	{
+		object? result = FileSystem.FileInfo.New(name).ExtensionContainer
+		   .RetrieveMetadata<object?>("foo");
+
+		result.Should().BeNull();
+	}
+}

--- a/Tests/stryker-config-testing.json
+++ b/Tests/stryker-config-testing.json
@@ -38,7 +38,7 @@
       // Calls to Thread.Sleep cannot be detected by a test
       "System.Threading.Thread.Sleep",
       // Ensures that an expectation from developers is met
-      "Debug.Assert",
+      "Debug.Assert"
     ]
   }
 }

--- a/Tests/stryker-config-testing.json
+++ b/Tests/stryker-config-testing.json
@@ -37,8 +37,8 @@
       "ThrowCommonExceptionsIfPathIsInvalid",
       // Calls to Thread.Sleep cannot be detected by a test
       "System.Threading.Thread.Sleep",
-      // Only framework dependent changes
-      "Testably.Abstractions.Testing.FileMock.Copy"
+      // Ensures that an expectation from developers is met
+      "Debug.Assert",
     ]
   }
 }


### PR DESCRIPTION
As "AccessControl" is only supported, Stryker should run on Windows for this project.

- Improve tests to also run on the real file system
- Add tests for `ExtensionContainer`
