### PR TITLE
fix: throw exception when a file is written to a missing directory

### DIFF
--- a/Source/Testably.Abstractions.Testing/Storage/IStorageLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageLocation.cs
@@ -23,6 +23,11 @@ internal interface IStorageLocation : IEquatable<IStorageLocation>
 	string FullPath { get; }
 
 	/// <summary>
+	///     Flag indicating if the location corresponds to a root directory.
+	/// </summary>
+	bool IsRooted { get; }
+
+	/// <summary>
 	///     Get the parent location.
 	/// </summary>
 	/// <returns>

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
@@ -25,6 +25,7 @@ internal sealed class InMemoryLocation : IStorageLocation
 		Execute.OnNetFramework(()
 			=> friendlyName = friendlyName.TrimOnWindows());
 
+		IsRooted = drive?.Name == fullPath || drive?.Name.Substring(1) == fullPath;
 		FriendlyName = friendlyName;
 		Drive = drive;
 	}
@@ -39,6 +40,9 @@ internal sealed class InMemoryLocation : IStorageLocation
 
 	/// <inheritdoc cref="IStorageLocation.FullPath" />
 	public string FullPath { get; }
+
+	/// <inheritdoc cref="IStorageLocation.IsRooted" />
+	public bool IsRooted { get; private set; }
 
 	/// <inheritdoc cref="IEquatable{IStorageLocation}.Equals(IStorageLocation)" />
 	public bool Equals(IStorageLocation? other)

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -267,6 +267,16 @@ internal sealed class InMemoryStorage : IStorage
 				{
 					CreateParents(_fileSystem, loc);
 				}
+				else
+				{
+					IStorageLocation? parentLocation = loc.GetParent();
+					if (parentLocation != null &&
+						parentLocation.Drive?.Name != parentLocation.FullPath &&
+					    !_containers.ContainsKey(parentLocation))
+					{
+						throw ExceptionFactory.DirectoryNotFound(loc.FullPath);
+					}
+				}
 
 				AdjustParentDirectoryTimes(loc);
 

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -271,7 +271,7 @@ internal sealed class InMemoryStorage : IStorage
 				{
 					IStorageLocation? parentLocation = loc.GetParent();
 					if (parentLocation != null &&
-						parentLocation.Drive?.Name != parentLocation.FullPath &&
+						!parentLocation.IsRooted &&
 					    !_containers.ContainsKey(parentLocation))
 					{
 						throw ExceptionFactory.DirectoryNotFound(loc.FullPath);

--- a/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryLocationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryLocationTests.cs
@@ -138,6 +138,10 @@ public class InMemoryLocationTests
 		/// <inheritdoc cref="IStorageLocation.FullPath" />
 		public string FullPath { get; }
 
+		/// <inheritdoc cref="IStorageLocation.IsRooted" />
+		public bool IsRooted
+			=> false;
+
 		/// <inheritdoc cref="IEquatable{IStorageLocation}.Equals(IStorageLocation)" />
 		public bool Equals(IStorageLocation? other)
 			=> throw new NotSupportedException();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.WriteAllText.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.WriteAllText.cs
@@ -1,8 +1,25 @@
+using System.IO;
+
 namespace Testably.Abstractions.Tests.FileSystem.File;
 
 public abstract partial class FileSystemFileTests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
+	[SkippableTheory]
+	[AutoData]
+	public void WriteAllText_MissingDirectory_PreviousFile_ShouldOverwriteFileWithText(
+		string directory, string path, string contents)
+	{
+		string fullPath = FileSystem.Path.Combine(directory, path);
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.WriteAllText(fullPath, "foo");
+		});
+
+		exception.Should().BeOfType<DirectoryNotFoundException>()
+		   .Which.Message.Should().Contain($"'{FileSystem.Path.GetFullPath(fullPath)}'");
+	}
+
 	[SkippableTheory]
 	[AutoData]
 	public void WriteAllText_PreviousFile_ShouldOverwriteFileWithText(

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.WriteAllText.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/FileSystemFileTests.WriteAllText.cs
@@ -7,8 +7,8 @@ public abstract partial class FileSystemFileTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
-	public void WriteAllText_MissingDirectory_PreviousFile_ShouldOverwriteFileWithText(
-		string directory, string path, string contents)
+	public void WriteAllText_MissingDirectory_ShouldThrowDirectoryNotFoundException(
+		string directory, string path)
 	{
 		string fullPath = FileSystem.Path.Combine(directory, path);
 		Exception? exception = Record.Exception(() =>


### PR DESCRIPTION
When writing a file to a directory that doesn't exist, the file system should throw a `DirectoryNotFoundException`.