### PR TITLE
fix: missing tests for AccessControl

### DIFF
--- a/Source/Testably.Abstractions.AccessControl/DirectoryAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/DirectoryAclExtensions.cs
@@ -40,13 +40,10 @@ public static class DirectoryAclExtensions
 			directory.FileSystem.DirectoryInfo.New(path);
 		IFileSystem.IFileSystemExtensionContainer extensionContainer =
 			directoryInfo.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out DirectoryInfo? di))
-		{
-			return di.GetAccessControl();
-		}
-
-		return extensionContainer.RetrieveMetadata<DirectorySecurity>(
-			AccessControlConstants.AccessControl) ?? new DirectorySecurity();
+		return extensionContainer.HasWrappedInstance(out DirectoryInfo? di)
+			? di.GetAccessControl()
+			: extensionContainer.RetrieveMetadata<DirectorySecurity>(
+				AccessControlConstants.AccessControl) ?? new DirectorySecurity();
 	}
 
 	/// <inheritdoc cref="System.IO.FileSystemAclExtensions.GetAccessControl(DirectoryInfo, AccessControlSections)" />
@@ -60,13 +57,10 @@ public static class DirectoryAclExtensions
 			directory.FileSystem.DirectoryInfo.New(path);
 		IFileSystem.IFileSystemExtensionContainer extensionContainer =
 			directoryInfo.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out DirectoryInfo? di))
-		{
-			return di.GetAccessControl(includeSections);
-		}
-
-		return extensionContainer.RetrieveMetadata<DirectorySecurity>(
-			AccessControlConstants.AccessControl) ?? new DirectorySecurity();
+		return extensionContainer.HasWrappedInstance(out DirectoryInfo? di)
+			? di.GetAccessControl(includeSections)
+			: extensionContainer.RetrieveMetadata<DirectorySecurity>(
+				AccessControlConstants.AccessControl) ?? new DirectorySecurity();
 	}
 
 	/// <inheritdoc cref="System.IO.FileSystemAclExtensions.SetAccessControl(DirectoryInfo, DirectorySecurity)" />

--- a/Source/Testably.Abstractions.AccessControl/DirectoryInfoAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/DirectoryInfoAclExtensions.cs
@@ -35,13 +35,10 @@ public static class DirectoryInfoAclExtensions
 	{
 		IFileSystem.IFileSystemExtensionContainer extensionContainer =
 			directoryInfo.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out DirectoryInfo? di))
-		{
-			return di.GetAccessControl();
-		}
-
-		return extensionContainer.RetrieveMetadata<DirectorySecurity>(
-			AccessControlConstants.AccessControl) ?? new DirectorySecurity();
+		return extensionContainer.HasWrappedInstance(out DirectoryInfo? di)
+			? di.GetAccessControl()
+			: extensionContainer.RetrieveMetadata<DirectorySecurity>(
+				AccessControlConstants.AccessControl) ?? new DirectorySecurity();
 	}
 
 	/// <inheritdoc cref="System.IO.FileSystemAclExtensions.GetAccessControl(DirectoryInfo, AccessControlSections)" />
@@ -52,13 +49,10 @@ public static class DirectoryInfoAclExtensions
 	{
 		IFileSystem.IFileSystemExtensionContainer extensionContainer =
 			directoryInfo.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out DirectoryInfo? di))
-		{
-			return di.GetAccessControl(includeSections);
-		}
-
-		return extensionContainer.RetrieveMetadata<DirectorySecurity>(
-			AccessControlConstants.AccessControl) ?? new DirectorySecurity();
+		return extensionContainer.HasWrappedInstance(out DirectoryInfo? di)
+			? di.GetAccessControl(includeSections)
+			: extensionContainer.RetrieveMetadata<DirectorySecurity>(
+				AccessControlConstants.AccessControl) ?? new DirectorySecurity();
 	}
 
 	/// <inheritdoc cref="System.IO.FileSystemAclExtensions.SetAccessControl(DirectoryInfo, DirectorySecurity)" />

--- a/Source/Testably.Abstractions.AccessControl/FileAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileAclExtensions.cs
@@ -17,13 +17,10 @@ public static class FileAclExtensions
 		IFileSystem.IFileInfo fileInfo = file.FileSystem.FileInfo.New(path);
 		IFileSystem.IFileSystemExtensionContainer extensionContainer =
 			fileInfo.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out FileInfo? fi))
-		{
-			return fi.GetAccessControl();
-		}
-
-		return extensionContainer.RetrieveMetadata<FileSecurity>(
-			AccessControlConstants.AccessControl) ?? new FileSecurity();
+		return extensionContainer.HasWrappedInstance(out FileInfo? fi)
+			? fi.GetAccessControl()
+			: extensionContainer.RetrieveMetadata<FileSecurity>(
+				AccessControlConstants.AccessControl) ?? new FileSecurity();
 	}
 
 	/// <inheritdoc cref="System.IO.FileSystemAclExtensions.GetAccessControl(FileInfo, AccessControlSections)" />
@@ -36,13 +33,10 @@ public static class FileAclExtensions
 		IFileSystem.IFileInfo fileInfo = file.FileSystem.FileInfo.New(path);
 		IFileSystem.IFileSystemExtensionContainer extensionContainer =
 			fileInfo.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out FileInfo? fi))
-		{
-			return fi.GetAccessControl(includeSections);
-		}
-
-		return extensionContainer.RetrieveMetadata<FileSecurity>(
-			AccessControlConstants.AccessControl) ?? new FileSecurity();
+		return extensionContainer.HasWrappedInstance(out FileInfo? fi)
+			? fi.GetAccessControl(includeSections)
+			: extensionContainer.RetrieveMetadata<FileSecurity>(
+				AccessControlConstants.AccessControl) ?? new FileSecurity();
 	}
 
 	/// <inheritdoc cref="System.IO.FileSystemAclExtensions.SetAccessControl(FileInfo, FileSecurity)" />

--- a/Source/Testably.Abstractions.AccessControl/FileInfoAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileInfoAclExtensions.cs
@@ -16,13 +16,10 @@ public static class FileInfoAclExtensions
 	{
 		IFileSystem.IFileSystemExtensionContainer extensionContainer =
 			fileInfo.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out FileInfo? fi))
-		{
-			return fi.GetAccessControl();
-		}
-
-		return extensionContainer.RetrieveMetadata<FileSecurity>(
-			AccessControlConstants.AccessControl) ?? new FileSecurity();
+		return extensionContainer.HasWrappedInstance(out FileInfo? fi)
+			? fi.GetAccessControl()
+			: extensionContainer.RetrieveMetadata<FileSecurity>(
+				AccessControlConstants.AccessControl) ?? new FileSecurity();
 	}
 
 	/// <inheritdoc cref="System.IO.FileSystemAclExtensions.GetAccessControl(FileInfo, AccessControlSections)" />
@@ -33,13 +30,10 @@ public static class FileInfoAclExtensions
 	{
 		IFileSystem.IFileSystemExtensionContainer extensionContainer =
 			fileInfo.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out FileInfo? fi))
-		{
-			return fi.GetAccessControl(includeSections);
-		}
-
-		return extensionContainer.RetrieveMetadata<FileSecurity>(
-			AccessControlConstants.AccessControl) ?? new FileSecurity();
+		return extensionContainer.HasWrappedInstance(out FileInfo? fi)
+			? fi.GetAccessControl(includeSections)
+			: extensionContainer.RetrieveMetadata<FileSecurity>(
+				AccessControlConstants.AccessControl) ?? new FileSecurity();
 	}
 
 	/// <inheritdoc cref="System.IO.FileSystemAclExtensions.SetAccessControl(FileInfo, FileSecurity)" />

--- a/Source/Testably.Abstractions.AccessControl/FileStreamAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileStreamAclExtensions.cs
@@ -15,13 +15,10 @@ public static class FileStreamAclExtensions
 	{
 		IFileSystem.IFileSystemExtensionContainer extensionContainer =
 			fileStream.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out FileStream? fs))
-		{
-			return fs.GetAccessControl();
-		}
-
-		return extensionContainer.RetrieveMetadata<FileSecurity>(
-			AccessControlConstants.AccessControl) ?? new FileSecurity();
+		return extensionContainer.HasWrappedInstance(out FileStream? fs)
+			? fs.GetAccessControl()
+			: extensionContainer.RetrieveMetadata<FileSecurity>(
+				AccessControlConstants.AccessControl) ?? new FileSecurity();
 	}
 
 	/// <inheritdoc cref="FileSystemAclExtensions.SetAccessControl(FileStream, FileSecurity)" />

--- a/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryAclExtensionsTests.cs
@@ -26,6 +26,7 @@ public class DirectoryAclExtensionsTests
 
 			result.HasSameAccessRightsAs(directorySecurity).Should().BeTrue();
 			result.Should().NotBe(directorySecurity);
+			fileSystem.Directory.Exists("bar").Should().BeTrue();
 		}
 	}
 

--- a/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryInfoAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryInfoAclExtensionsTests.cs
@@ -27,6 +27,7 @@ public class DirectoryInfoAclExtensionsTests
 
 			result.HasSameAccessRightsAs(directorySecurity).Should().BeTrue();
 			result.Should().NotBe(directorySecurity);
+			fileSystem.Directory.Exists("bar").Should().BeTrue();
 		}
 	}
 


### PR DESCRIPTION
The tests for AccessControl are missing some checks.
Also simplify the implementation when returning values.