### PR TITLE
refactor: use relative base for output path

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -23,7 +23,7 @@
     <Nullable>enable</Nullable>
     <NoWarn>1701;1702</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <OutputPath>$(SolutionDir)Build\Binaries</OutputPath>
+    <OutputPath>..\..\Build\Binaries</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' != 'Debug' ">

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -15,7 +15,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <NoWarn>701;1702;CA1845</NoWarn>
-    <OutputPath>$(SolutionDir)Build\Tests\$(MSBuildProjectName)</OutputPath>
+    <OutputPath>..\..\Build\Tests\$(MSBuildProjectName)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
Some tools (Stryker) don't support using the `$(SolutionDir)` variable in the output path. Use a relative path instead...