### PR TITLE
refactor: move the `SupportedOSPlatformAttribute` to a distinct namespace

### DIFF
--- a/Source/Testably.Abstractions.AccessControl/DirectoryAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/DirectoryAclExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Runtime.Versioning;
 using System.Security.AccessControl;
 using Testably.Abstractions.FileSystem;
 

--- a/Source/Testably.Abstractions.AccessControl/DirectoryInfoAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/DirectoryInfoAclExtensions.cs
@@ -1,7 +1,11 @@
 ﻿using System.IO;
-using System.Runtime.Versioning;
 using System.Security.AccessControl;
 using Testably.Abstractions.FileSystem;
+#if NETSTANDARD2_0 || NETSTANDARD2_1
+using Testably.Abstractions.Polyfills;
+#else
+using System.Runtime.Versioning;
+#endif
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.AccessControl/DirectoryInfoAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/DirectoryInfoAclExtensions.cs
@@ -1,11 +1,6 @@
 ﻿using System.IO;
 using System.Security.AccessControl;
 using Testably.Abstractions.FileSystem;
-#if NETSTANDARD2_0 || NETSTANDARD2_1
-using Testably.Abstractions.Polyfills;
-#else
-using System.Runtime.Versioning;
-#endif
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.AccessControl/FileAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileAclExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Runtime.Versioning;
 using System.Security.AccessControl;
 using Testably.Abstractions.FileSystem;
 

--- a/Source/Testably.Abstractions.AccessControl/FileInfoAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileInfoAclExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Runtime.Versioning;
 using System.Security.AccessControl;
 using Testably.Abstractions.FileSystem;
 

--- a/Source/Testably.Abstractions.AccessControl/FileStreamAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileStreamAclExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Runtime.Versioning;
 using System.Security.AccessControl;
 using Testably.Abstractions.FileSystem;
 

--- a/Source/Testably.Abstractions.AccessControl/Usings.cs
+++ b/Source/Testably.Abstractions.AccessControl/Usings.cs
@@ -1,0 +1,5 @@
+﻿#if NETSTANDARD2_0 || NETSTANDARD2_1
+global using Testably.Abstractions.Polyfills;
+#else
+global using System.Runtime.Versioning;
+#endif

--- a/Source/Testably.Abstractions.Interface/FileSystem/IDriveInfo.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IDriveInfo.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Runtime.Versioning;
 
 namespace Testably.Abstractions.FileSystem;
 

--- a/Source/Testably.Abstractions.Interface/FileSystem/IFile.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IFile.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Runtime.Versioning;
 using System.Text;
 #if FEATURE_FILESYSTEM_ASYNC
 using System.Threading;

--- a/Source/Testably.Abstractions.Interface/FileSystem/IFileInfo.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IFileInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Runtime.Versioning;
 
 namespace Testably.Abstractions.FileSystem;
 

--- a/Source/Testably.Abstractions.Interface/Polyfills/SupportedOsPlatformAttribute.cs
+++ b/Source/Testably.Abstractions.Interface/Polyfills/SupportedOsPlatformAttribute.cs
@@ -1,6 +1,6 @@
-﻿#if NETSTANDARD2_0 || NETSTANDARD2_1
-// ReSharper disable once CheckNamespace
-namespace System.Runtime.Versioning;
+﻿using System;
+#if NETSTANDARD2_0 || NETSTANDARD2_1
+namespace Testably.Abstractions.Polyfills;
 
 /// <summary>
 ///     Records the operating system (and minimum version) that supports an API. Multiple attributes can be

--- a/Source/Testably.Abstractions.Interface/Polyfills/SupportedOsPlatformAttribute.cs
+++ b/Source/Testably.Abstractions.Interface/Polyfills/SupportedOsPlatformAttribute.cs
@@ -1,5 +1,6 @@
-﻿using System;
-#if NETSTANDARD2_0 || NETSTANDARD2_1
+﻿#if NETSTANDARD2_0 || NETSTANDARD2_1
+using System;
+
 namespace Testably.Abstractions.Polyfills;
 
 /// <summary>

--- a/Source/Testably.Abstractions.Interface/Usings.cs
+++ b/Source/Testably.Abstractions.Interface/Usings.cs
@@ -1,0 +1,5 @@
+﻿#if NETSTANDARD2_0 || NETSTANDARD2_1
+global using Testably.Abstractions.Polyfills;
+#else
+global using System.Runtime.Versioning;
+#endif

--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Runtime.Versioning;
 using Testably.Abstractions.FileSystem;
 using Testably.Abstractions.Testing.Internal;
 using Testably.Abstractions.Testing.Storage;

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Runtime.Versioning;
 using Testably.Abstractions.FileSystem;
 using Testably.Abstractions.Testing.Internal;
 using Testably.Abstractions.Testing.Storage;

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Runtime.Versioning;
 using System.Text;
 using Testably.Abstractions.FileSystem;
 using Testably.Abstractions.Testing.Internal;

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using Testably.Abstractions.FileSystem;
 using Testably.Abstractions.Testing.FileSystem;
 using Testably.Abstractions.Testing.Internal;
-using static Testably.Abstractions.Testing.MockFileSystem;
 
 namespace Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/Usings.cs
+++ b/Source/Testably.Abstractions.Testing/Usings.cs
@@ -1,0 +1,5 @@
+﻿#if NETSTANDARD2_0 || NETSTANDARD2_1
+global using Testably.Abstractions.Polyfills;
+#else
+global using System.Runtime.Versioning;
+#endif

--- a/Source/Testably.Abstractions/FileSystem/DriveInfoWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/DriveInfoWrapper.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Runtime.Versioning;
 
 namespace Testably.Abstractions.FileSystem;
 

--- a/Source/Testably.Abstractions/FileSystem/FileInfoWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileInfoWrapper.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Runtime.Versioning;
 
 namespace Testably.Abstractions.FileSystem;
 

--- a/Source/Testably.Abstractions/Usings.cs
+++ b/Source/Testably.Abstractions/Usings.cs
@@ -1,0 +1,5 @@
+﻿#if NETSTANDARD2_0 || NETSTANDARD2_1
+global using Testably.Abstractions.Polyfills;
+#else
+global using System.Runtime.Versioning;
+#endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/FileSystemFileInfoTests.EncryptDecrypt.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/FileSystemFileInfoTests.EncryptDecrypt.cs
@@ -1,5 +1,3 @@
-using System.Runtime.Versioning;
-
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 
 public abstract partial class FileSystemFileInfoTests<TFileSystem>

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/Usings.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/Usings.cs
@@ -4,3 +4,8 @@ global using System;
 global using Testably.Abstractions.Testing;
 global using Testably.Abstractions.Tests.TestHelpers;
 global using Xunit;
+#if NET472
+global using Testably.Abstractions.Polyfills;
+#else
+global using System.Runtime.Versioning;
+#endif


### PR DESCRIPTION
Otherwise this attribute could clash with the real attribute e.g. on .NET 5 in client projects
- #158 