### PR TITLE
doc: add Codacy badge to readme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,8 +267,8 @@ jobs:
             echo "Processing $f" # always double quote "$f" filename
             # do something on $f
             version="${GITHUB_REF#refs/heads/release/}"
-            # Remove the quality gate status badge
-            grep -v "Quality Gate Status" "./$f" > "./$f.backup" && mv "./$f.backup" "./$f"
+            # Remove the codacy badge as it is not aligned to the release
+            grep -v "Codacy Badge" "./$f" > "./$f.backup" && mv "./$f.backup" "./$f"
             # Change status badges to display explicit version
             sed -i -e "s/branch=main/branch=release%2F${version}/g" "./$f"
             sed -i -e "s/Testably.Abstractions%2Fmain/Testably.Abstractions%2Frelease%2F${version}/g" "./$f"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Testably.Abstractions](https://raw.githubusercontent.com/Testably/Testably.Abstractions/main/Docs/Images/social-preview.png)
 [![Nuget](https://img.shields.io/nuget/v/Testably.Abstractions)](https://www.nuget.org/packages/Testably.Abstractions)
 [![Build](https://github.com/Testably/Testably.Abstractions/actions/workflows/build.yml/badge.svg)](https://github.com/Testably/Testably.Abstractions/actions/workflows/build.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_Testably.Abstractions&branch=main&metric=alert_status)](https://sonarcloud.io/summary/overall?id=Testably_Testably.Abstractions&branch=main)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/5b9b2f79950447a69d69037b43acd590)](https://www.codacy.com/gh/Testably/Testably.Abstractions/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Testably/Testably.Abstractions&amp;utm_campaign=Badge_Grade)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Testably_Testably.Abstractions&branch=main&metric=coverage)](https://sonarcloud.io/summary/overall?id=Testably_Testably.Abstractions&branch=main)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FTestably.Abstractions%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/Testably.Abstractions/main)
 


### PR DESCRIPTION
Add a [Codacy](https://app.codacy.com/gh/Testably/Testably.Abstractions/dashboard?branch=main) badge to the readme.md