### PR TITLE
refactor: exclude markdown files from Codacy analysis

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -4,5 +4,5 @@ engines:
       - "Tests/**"
 exclude_paths:
   - ".github/**"
-  - "CODE_OF_CONDUCT.md"
+  - "**.md"
   - "Tests/Testably.Abstractions.Tests.SourceGenerator/**"


### PR DESCRIPTION
Markdown files just clutter the analysis page.