### PR TITLE
fix: throw correct exception on CreateSymbolicLink with invalid parameters

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
@@ -41,6 +41,7 @@ internal sealed class DirectoryMock : IDirectory
 	public IFileSystemInfo CreateSymbolicLink(
 		string path, string pathToTarget)
 	{
+		path.ThrowCommonExceptionsIfPathIsInvalid(_fileSystem);
 		IDirectoryInfo fileSystemInfo =
 			_fileSystem.DirectoryInfo.New(path);
 		fileSystemInfo.CreateAsSymbolicLink(pathToTarget);

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -175,15 +175,11 @@ internal sealed class FileMock : IFile
 	public IFileSystemInfo CreateSymbolicLink(
 		string path, string pathToTarget)
 	{
-		IStorageLocation location = _fileSystem.Storage.GetLocation(path);
-		if (_fileSystem.Storage.TryAddContainer(location, InMemoryContainer.NewFile,
-			out IStorageContainer? container))
-		{
-			container.LinkTarget = pathToTarget;
-			return FileSystemInfoMock.New(location, _fileSystem);
-		}
-
-		throw ExceptionFactory.CannotCreateFileAsAlreadyExists(path);
+		path.ThrowCommonExceptionsIfPathIsInvalid(_fileSystem);
+		IFileInfo fileSystemInfo =
+			_fileSystem.FileInfo.New(path);
+		fileSystemInfo.CreateAsSymbolicLink(pathToTarget);
+		return fileSystemInfo;
 	}
 #endif
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
@@ -54,6 +54,7 @@ internal class FileSystemInfoMock : IFileSystemInfo
 	/// <inheritdoc cref="IFileSystemInfo.CreateAsSymbolicLink(string)" />
 	public void CreateAsSymbolicLink(string pathToTarget)
 	{
+		pathToTarget.ThrowCommonExceptionsIfPathToTargetIsInvalid(FileSystem);
 		if (FileSystem.Storage.TryAddContainer(Location, InMemoryContainer.NewFile,
 			out IStorageContainer? container))
 		{

--- a/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
@@ -143,24 +143,24 @@ internal static class ExceptionFactory
 			});
 
 	internal static ArgumentException PathHasIllegalCharacters(
-		string path, string paramName = "path")
+		string path, string paramName = "path", int? hResult = -2147024809)
 		=> new($"Illegal characters in path '{path}'", paramName)
 		{
 #if FEATURE_EXCEPTION_HRESULT
-			HResult = -2147024809
+			HResult = hResult ?? -2147024809
 #endif
 		};
 
-	internal static IOException PathHasIncorrectSyntax(string path)
+	internal static IOException PathHasIncorrectSyntax(string path, int? hResult = -2147024773)
 		=> new(
 			$"The filename, directory name, or volume label syntax is incorrect. : '{path}'",
-			-2147024773);
+			hResult ?? -2147024773);
 
-	internal static ArgumentException PathIsEmpty(string paramName)
+	internal static ArgumentException PathIsEmpty(string paramName, int hResult = -2147024809)
 		=> new("The path is empty.", paramName)
 		{
 #if FEATURE_EXCEPTION_HRESULT
-			HResult = -2147024809
+			HResult = hResult
 #endif
 		};
 

--- a/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
@@ -44,7 +44,7 @@ internal static class PathHelper
 	internal static void ThrowCommonExceptionsIfPathIsInvalid(
 		[NotNull] this string? path, IFileSystem fileSystem)
 	{
-		CheckPathArgument(path, nameof(path), true);
+		CheckPathArgument(path, nameof(path), Execute.IsWindows);
 		CheckPathCharacters(path, fileSystem, nameof(path), null);
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateSymbolicLinkTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateSymbolicLinkTests.cs
@@ -133,7 +133,7 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void CreateSymbolicLink_WithIllegalPath_ShouldThrowArgumentException(
+	public void CreateSymbolicLink_WithIllegalPath_ShouldThrowArgumentExceptioncOnWindows(
 		string pathToTarget)
 	{
 		FileSystem.Directory.CreateDirectory(pathToTarget);
@@ -142,9 +142,16 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 		{
 			FileSystem.Directory.CreateSymbolicLink(" ", pathToTarget);
 		});
-
-		exception.Should().BeOfType<ArgumentException>()
-		   .Which.ParamName.Should().Be("path");
+		
+		if (Test.RunsOnWindows)
+		{
+			exception.Should().BeOfType<ArgumentException>()
+			   .Which.ParamName.Should().Be("path");
+		}
+		else
+		{
+			exception.Should().BeNull();
+		}
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateAsSymbolicLinkTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateAsSymbolicLinkTests.cs
@@ -133,7 +133,7 @@ public abstract partial class CreateAsSymbolicLinkTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void CreateSymbolicLink_WithIllegalPath_ShouldThrowArgumentException(
+	public void CreateSymbolicLink_WithIllegalPath_ShouldThrowArgumentExceptionOnWindows(
 		string pathToTarget)
 	{
 		FileSystem.Directory.CreateDirectory(pathToTarget);
@@ -143,8 +143,15 @@ public abstract partial class CreateAsSymbolicLinkTests<TFileSystem>
 			FileSystem.Directory.CreateSymbolicLink(" ", pathToTarget);
 		});
 
-		exception.Should().BeOfType<ArgumentException>()
-		   .Which.ParamName.Should().Be("path");
+		if (Test.RunsOnWindows)
+		{
+			exception.Should().BeOfType<ArgumentException>()
+			   .Which.ParamName.Should().Be("path");
+		}
+		else
+		{
+			exception.Should().BeNull();
+		}
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateAsSymbolicLinkTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateAsSymbolicLinkTests.cs
@@ -1,10 +1,10 @@
 #if FEATURE_FILESYSTEM_LINK
 using System.IO;
 
-namespace Testably.Abstractions.Tests.FileSystem.Directory;
+namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 
 // ReSharper disable once PartialTypeWithSinglePart
-public abstract partial class CreateSymbolicLinkTests<TFileSystem>
+public abstract partial class CreateAsSymbolicLinkTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
@@ -15,7 +15,7 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 	{
 		FileSystem.Directory.CreateDirectory(pathToTarget);
 
-		FileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
+		FileSystem.DirectoryInfo.New(path).CreateAsSymbolicLink(pathToTarget);
 
 		FileSystem.DirectoryInfo.New(path).Attributes
 		   .HasFlag(FileAttributes.ReparsePoint)
@@ -32,7 +32,7 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
+			FileSystem.DirectoryInfo.New(path).CreateAsSymbolicLink(pathToTarget);
 		});
 
 		if (Test.RunsOnWindows)
@@ -57,7 +57,7 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 	{
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
+			FileSystem.DirectoryInfo.New(path).CreateAsSymbolicLink(pathToTarget);
 		});
 
 		exception.Should().BeNull();
@@ -88,7 +88,7 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(path, string.Empty);
+			FileSystem.DirectoryInfo.New(path).CreateAsSymbolicLink(string.Empty);
 		});
 
 		exception.Should().BeOfType<ArgumentException>()
@@ -124,7 +124,7 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(path, "bar_?_");
+			FileSystem.DirectoryInfo.New(path).CreateAsSymbolicLink("bar_?_");
 		});
 
 		exception.Should().BeOfType<IOException>()
@@ -153,7 +153,7 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 	{
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(path, " ");
+			FileSystem.DirectoryInfo.New(path).CreateAsSymbolicLink(" ");
 		});
 
 		exception.Should().BeNull();
@@ -184,7 +184,7 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(path, null!);
+			FileSystem.DirectoryInfo.New(path).CreateAsSymbolicLink(null!);
 		});
 
 		exception.Should().BeOfType<ArgumentNullException>()

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateSymbolicLinkTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateSymbolicLinkTests.cs
@@ -133,7 +133,7 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void CreateSymbolicLink_WithIllegalPath_ShouldThrowArgumentException(
+	public void CreateSymbolicLink_WithIllegalPath_ShouldThrowArgumentExceptionOnWindows(
 		string pathToTarget)
 	{
 		FileSystem.File.WriteAllText(pathToTarget, "some content");
@@ -143,8 +143,15 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 			FileSystem.File.CreateSymbolicLink(" ", pathToTarget);
 		});
 
-		exception.Should().BeOfType<ArgumentException>()
-		   .Which.ParamName.Should().Be("path");
+		if (Test.RunsOnWindows)
+		{
+			exception.Should().BeOfType<ArgumentException>()
+			   .Which.ParamName.Should().Be("path");
+		}
+		else
+		{
+			exception.Should().BeNull();
+		}
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateSymbolicLinkTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateSymbolicLinkTests.cs
@@ -49,5 +49,146 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 		exception.Should().BeOfType<IOException>()
 		   .Which.Message.Should().Contain($"'{path}'");
 	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateSymbolicLink_TargetFileMissing_ShouldNotThrowException(
+		string path, string pathToTarget)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.CreateSymbolicLink(path, pathToTarget);
+		});
+
+		exception.Should().BeNull();
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateSymbolicLink_WithEmptyPath_ShouldThrowArgumentException(
+		string pathToTarget)
+	{
+		FileSystem.File.WriteAllText(pathToTarget, "some content");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.CreateSymbolicLink(string.Empty, pathToTarget);
+		});
+
+		exception.Should().BeOfType<ArgumentException>()
+		   .Which.ParamName.Should().Be("path");
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateSymbolicLink_WithEmptyTarget_ShouldThrowArgumentException(
+		string path)
+	{
+		FileSystem.File.WriteAllText(path, "some content");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.CreateSymbolicLink(path, string.Empty);
+		});
+
+		exception.Should().BeOfType<ArgumentException>()
+		   .Which.ParamName.Should().Be("pathToTarget");
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateSymbolicLink_WithIllegalCharactersInPath_ShouldThrowIOException(
+		string pathToTarget)
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		FileSystem.File.WriteAllText(pathToTarget, "some content");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.CreateSymbolicLink("bar_?_", pathToTarget);
+		});
+
+		exception.Should().BeOfType<IOException>()
+		   .Which.HResult.Should().Be(-2147024773);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateSymbolicLink_WithIllegalCharactersInTarget_ShouldThrowIOException(
+		string path)
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		FileSystem.File.WriteAllText(path, "some content");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.CreateSymbolicLink(path, "bar_?_");
+		});
+
+		exception.Should().BeOfType<IOException>()
+		   .Which.HResult.Should().Be(-2147024713);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateSymbolicLink_WithIllegalPath_ShouldThrowArgumentException(
+		string pathToTarget)
+	{
+		FileSystem.File.WriteAllText(pathToTarget, "some content");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.CreateSymbolicLink(" ", pathToTarget);
+		});
+
+		exception.Should().BeOfType<ArgumentException>()
+		   .Which.ParamName.Should().Be("path");
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateSymbolicLink_WithIllegalTarget_ShouldNotThrowException(string path)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.CreateSymbolicLink(path, " ");
+		});
+
+		exception.Should().BeNull();
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateSymbolicLink_WithNullPath_ShouldThrowArgumentNullException(
+		string pathToTarget)
+	{
+		FileSystem.File.WriteAllText(pathToTarget, "some content");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.CreateSymbolicLink(null!, pathToTarget);
+		});
+
+		exception.Should().BeOfType<ArgumentNullException>()
+		   .Which.ParamName.Should().Be("path");
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateSymbolicLink_WithNullTarget_ShouldThrowArgumentNullException(
+		string path)
+	{
+		FileSystem.File.WriteAllText(path, "some content");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.CreateSymbolicLink(path, null!);
+		});
+
+		exception.Should().BeOfType<ArgumentNullException>()
+		   .Which.ParamName.Should().Be("pathToTarget");
+	}
 }
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateAsSymbolicLinkTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateAsSymbolicLinkTests.cs
@@ -1,10 +1,10 @@
 #if FEATURE_FILESYSTEM_LINK
 using System.IO;
 
-namespace Testably.Abstractions.Tests.FileSystem.Directory;
+namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 
 // ReSharper disable once PartialTypeWithSinglePart
-public abstract partial class CreateSymbolicLinkTests<TFileSystem>
+public abstract partial class CreateAsSymbolicLinkTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
@@ -13,26 +13,26 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 	public void CreateSymbolicLink_ShouldCreateSymbolicLink(
 		string path, string pathToTarget)
 	{
-		FileSystem.Directory.CreateDirectory(pathToTarget);
+		FileSystem.File.WriteAllText(pathToTarget, null);
 
-		FileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
+		FileSystem.File.CreateSymbolicLink(path, pathToTarget);
 
-		FileSystem.DirectoryInfo.New(path).Attributes
+		FileSystem.File.GetAttributes(path)
 		   .HasFlag(FileAttributes.ReparsePoint)
 		   .Should().BeTrue();
 	}
 
 	[SkippableTheory]
 	[AutoData]
-	public void CreateSymbolicLink_SourceDirectoryAlreadyExists_ShouldThrowIOException(
+	public void CreateSymbolicLink_SourceFileAlreadyExists_ShouldCreateSymbolicLink(
 		string path, string pathToTarget)
 	{
-		FileSystem.Directory.CreateDirectory(pathToTarget);
-		FileSystem.Directory.CreateDirectory(path);
+		FileSystem.File.WriteAllText(pathToTarget, null);
+		FileSystem.File.WriteAllText(path, "foo");
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
+			FileSystem.File.CreateSymbolicLink(path, pathToTarget);
 		});
 
 		if (Test.RunsOnWindows)
@@ -52,12 +52,12 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void CreateSymbolicLink_TargetDirectoryMissing_ShouldNotThrowException(
+	public void CreateSymbolicLink_TargetFileMissing_ShouldNotThrowException(
 		string path, string pathToTarget)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
+			FileSystem.File.CreateSymbolicLink(path, pathToTarget);
 		});
 
 		exception.Should().BeNull();
@@ -68,11 +68,11 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 	public void CreateSymbolicLink_WithEmptyPath_ShouldThrowArgumentException(
 		string pathToTarget)
 	{
-		FileSystem.Directory.CreateDirectory(pathToTarget);
+		FileSystem.File.WriteAllText(pathToTarget, "some content");
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(string.Empty, pathToTarget);
+			FileSystem.File.CreateSymbolicLink(string.Empty, pathToTarget);
 		});
 
 		exception.Should().BeOfType<ArgumentException>()
@@ -84,11 +84,11 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 	public void CreateSymbolicLink_WithEmptyTarget_ShouldThrowArgumentException(
 		string path)
 	{
-		FileSystem.Directory.CreateDirectory(path);
+		FileSystem.File.WriteAllText(path, "some content");
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(path, string.Empty);
+			FileSystem.File.CreateSymbolicLink(path, string.Empty);
 		});
 
 		exception.Should().BeOfType<ArgumentException>()
@@ -102,11 +102,11 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		FileSystem.Directory.CreateDirectory(pathToTarget);
+		FileSystem.File.WriteAllText(pathToTarget, "some content");
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink("bar_?_", pathToTarget);
+			FileSystem.File.CreateSymbolicLink("bar_?_", pathToTarget);
 		});
 
 		exception.Should().BeOfType<IOException>()
@@ -120,11 +120,11 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		FileSystem.Directory.CreateDirectory(path);
+		FileSystem.File.WriteAllText(path, "some content");
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(path, "bar_?_");
+			FileSystem.File.CreateSymbolicLink(path, "bar_?_");
 		});
 
 		exception.Should().BeOfType<IOException>()
@@ -136,11 +136,11 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 	public void CreateSymbolicLink_WithIllegalPath_ShouldThrowArgumentException(
 		string pathToTarget)
 	{
-		FileSystem.Directory.CreateDirectory(pathToTarget);
+		FileSystem.File.WriteAllText(pathToTarget, "some content");
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(" ", pathToTarget);
+			FileSystem.File.CreateSymbolicLink(" ", pathToTarget);
 		});
 
 		exception.Should().BeOfType<ArgumentException>()
@@ -153,7 +153,7 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 	{
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(path, " ");
+			FileSystem.File.CreateSymbolicLink(path, " ");
 		});
 
 		exception.Should().BeNull();
@@ -164,11 +164,11 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 	public void CreateSymbolicLink_WithNullPath_ShouldThrowArgumentNullException(
 		string pathToTarget)
 	{
-		FileSystem.Directory.CreateDirectory(pathToTarget);
+		FileSystem.File.WriteAllText(pathToTarget, "some content");
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(null!, pathToTarget);
+			FileSystem.File.CreateSymbolicLink(null!, pathToTarget);
 		});
 
 		exception.Should().BeOfType<ArgumentNullException>()
@@ -180,11 +180,11 @@ public abstract partial class CreateSymbolicLinkTests<TFileSystem>
 	public void CreateSymbolicLink_WithNullTarget_ShouldThrowArgumentNullException(
 		string path)
 	{
-		FileSystem.Directory.CreateDirectory(path);
+		FileSystem.File.WriteAllText(path, "some content");
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.Directory.CreateSymbolicLink(path, null!);
+			FileSystem.File.CreateSymbolicLink(path, null!);
 		});
 
 		exception.Should().BeOfType<ArgumentNullException>()

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateAsSymbolicLinkTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateAsSymbolicLinkTests.cs
@@ -133,7 +133,7 @@ public abstract partial class CreateAsSymbolicLinkTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void CreateSymbolicLink_WithIllegalPath_ShouldThrowArgumentException(
+	public void CreateSymbolicLink_WithIllegalPath_ShouldThrowArgumentExceptionOnWindows(
 		string pathToTarget)
 	{
 		FileSystem.File.WriteAllText(pathToTarget, "some content");
@@ -143,8 +143,15 @@ public abstract partial class CreateAsSymbolicLinkTests<TFileSystem>
 			FileSystem.File.CreateSymbolicLink(" ", pathToTarget);
 		});
 
-		exception.Should().BeOfType<ArgumentException>()
-		   .Which.ParamName.Should().Be("path");
+		if (Test.RunsOnWindows)
+		{
+			exception.Should().BeOfType<ArgumentException>()
+			   .Which.ParamName.Should().Be("path");
+		}
+		else
+		{
+			exception.Should().BeNull();
+		}
 	}
 
 	[SkippableTheory]


### PR DESCRIPTION
Ensure that correct exceptions are thrown when calling `CreateSymbolicLink` or `CreateAsSymbolicLink` in the following cases:
- a `null` path or target is provided
- an empty path or target is provided
- an invalid path or target is provided
- a path or target containing invalid characters is provided