### PR TITLE
fix: handle search pattern correctly in edge cases

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
@@ -85,9 +85,8 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.EnumerateDirectories(string, SearchOption)" />
 	public IEnumerable<IDirectoryInfo> EnumerateDirectories(
 		string searchPattern, SearchOption searchOption)
-		=> FileSystem.Storage.EnumerateLocations(
-				FileSystem.Storage.GetLocation(FullName),
-				FileSystemTypes.Directory,
+		=> EnumerateInternal(FileSystemTypes.Directory,
+				FullName,
 				searchPattern,
 				EnumerationOptionsHelper.FromSearchOption(searchOption))
 		   .Select(location => New(location, FileSystem));
@@ -97,9 +96,8 @@ internal sealed class DirectoryInfoMock
 	public IEnumerable<IDirectoryInfo> EnumerateDirectories(
 		string searchPattern,
 		EnumerationOptions enumerationOptions)
-		=> FileSystem.Storage.EnumerateLocations(
-				FileSystem.Storage.GetLocation(FullName),
-				FileSystemTypes.Directory,
+		=> EnumerateInternal(FileSystemTypes.Directory,
+				FullName,
 				searchPattern,
 				enumerationOptions)
 		   .Select(location => New(location, FileSystem));
@@ -118,9 +116,8 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.EnumerateFiles(string, SearchOption)" />
 	public IEnumerable<IFileInfo> EnumerateFiles(
 		string searchPattern, SearchOption searchOption)
-		=> FileSystem.Storage.EnumerateLocations(
-				FileSystem.Storage.GetLocation(FullName),
-				FileSystemTypes.File,
+		=> EnumerateInternal(FileSystemTypes.File,
+				FullName,
 				searchPattern,
 				EnumerationOptionsHelper.FromSearchOption(searchOption))
 		   .Select(location => FileInfoMock.New(location, FileSystem));
@@ -129,9 +126,8 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.EnumerateFiles(string, EnumerationOptions)" />
 	public IEnumerable<IFileInfo> EnumerateFiles(
 		string searchPattern, EnumerationOptions enumerationOptions)
-		=> FileSystem.Storage.EnumerateLocations(
-				FileSystem.Storage.GetLocation(FullName),
-				FileSystemTypes.File,
+		=> EnumerateInternal(FileSystemTypes.File,
+				FullName,
 				searchPattern,
 				enumerationOptions)
 		   .Select(location => FileInfoMock.New(location, FileSystem));
@@ -151,9 +147,8 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.EnumerateFileSystemInfos(string, SearchOption)" />
 	public IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos(
 		string searchPattern, SearchOption searchOption)
-		=> FileSystem.Storage.EnumerateLocations(
-				FileSystem.Storage.GetLocation(FullName),
-				FileSystemTypes.DirectoryOrFile,
+		=> EnumerateInternal(FileSystemTypes.DirectoryOrFile,
+				FullName,
 				searchPattern,
 				EnumerationOptionsHelper.FromSearchOption(searchOption))
 		   .Select(location => FileSystemInfoMock.New(location, FileSystem));
@@ -163,9 +158,8 @@ internal sealed class DirectoryInfoMock
 	public IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos(
 		string searchPattern,
 		EnumerationOptions enumerationOptions)
-		=> FileSystem.Storage.EnumerateLocations(
-				FileSystem.Storage.GetLocation(FullName),
-				FileSystemTypes.DirectoryOrFile,
+		=> EnumerateInternal(FileSystemTypes.DirectoryOrFile,
+				FullName,
 				searchPattern,
 				enumerationOptions)
 		   .Select(location => FileSystemInfoMock.New(location, FileSystem));
@@ -253,5 +247,21 @@ internal sealed class DirectoryInfoMock
 		}
 
 		return new DirectoryInfoMock(location, fileSystem);
+	}
+
+	private IEnumerable<IStorageLocation> EnumerateInternal(FileSystemTypes fileSystemTypes,
+	                                              string path,
+	                                              string searchPattern,
+	                                              EnumerationOptions enumerationOptions)
+	{
+		StorageExtensions.AdjustedLocation adjustedLocation = FileSystem.Storage
+		   .AdjustLocationFromSearchPattern(
+				path.EnsureValidFormat(FileSystem),
+				searchPattern);
+		return FileSystem.Storage.EnumerateLocations(
+				adjustedLocation.Location,
+				fileSystemTypes,
+				adjustedLocation.SearchPattern,
+				enumerationOptions);
 	}
 }

--- a/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
@@ -6,12 +6,22 @@ namespace Testably.Abstractions.Testing.Helpers;
 
 internal static class ExceptionFactory
 {
+	public static ArgumentException HandleIsInvalid(string? paramName = "handle")
+		=> new("Invalid handle.", paramName);
+
+	public static IOException MoveSourceMustBeDifferentThanDestination()
+		=> new("Source and destination path must be different.", -2146232800);
+
 	public static NotSupportedException NotSupportedFileStreamWrapping()
 		=> new("You cannot wrap an existing FileStream in the MockFileSystem instance!");
 
 	public static NotSupportedException NotSupportedSafeFileHandle()
 		=> new(
 			"You cannot mock a safe file handle in the mocked file system without registering it explicitly. Use `MockFileSystem.MapSafeFileHandle`!");
+
+	public static ArgumentException SearchPatternCannotContainTwoDots()
+		=> new(
+			"Search pattern cannot contain \"..\" to move up directories and can be contained only internally in file/directory names, as in \"a..b\".");
 
 	internal static UnauthorizedAccessException AccessToPathDenied(string path = "")
 		=> new(string.IsNullOrEmpty(path)
@@ -208,10 +218,4 @@ internal static class ExceptionFactory
 	internal static TimeoutException TimeoutExpired(int timeoutMilliseconds)
 		=> new(
 			$"The timeout of {timeoutMilliseconds}ms expired in the awaitable callback.");
-
-	public static ArgumentException HandleIsInvalid(string? paramName = "handle")
-		=> new("Invalid handle.", paramName);
-
-	public static IOException MoveSourceMustBeDifferentThanDestination()
-		=> new("Source and destination path must be different.", -2146232800);
 }

--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
@@ -58,24 +58,22 @@ internal static class FileSystemExtensions
 		}
 		else
 		{
-			List<string> parentDirectories = new();
 			string? parentName = currentDirectory;
 			while (parentName != null &&
 			       !fullFilePath.StartsWith(parentName + Path.DirectorySeparatorChar))
 			{
-				parentDirectories.Add(Path.GetFileName(parentName));
 				parentName = Path.GetDirectoryName(parentName);
+				var lastIndex = givenPath.LastIndexOf(Path.DirectorySeparatorChar);
+				if (lastIndex >= 0)
+				{
+					givenPath = givenPath.Substring(0, lastIndex);
+				}
 			}
 
 			if (parentName != null)
 			{
 				fullFilePath = fullFilePath.Substring(parentName.Length + 1);
 			}
-
-			fullFilePath = Path.Combine(
-				Path.Combine(parentDirectories.Select(_ => "..").ToArray()),
-				Path.Combine(parentDirectories.ToArray()),
-				fullFilePath);
 		}
 
 		if (!fullFilePath.StartsWith(givenPath + fileSystem.Path.DirectorySeparatorChar))

--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.Helpers;
@@ -49,9 +52,30 @@ internal static class FileSystemExtensions
 		{
 			fullFilePath = fullFilePath.Substring(currentDirectory.Length);
 		}
-		else
+		else if (fullFilePath.StartsWith(currentDirectory + Path.DirectorySeparatorChar))
 		{
 			fullFilePath = fullFilePath.Substring(currentDirectory.Length + 1);
+		}
+		else
+		{
+			List<string> parentDirectories = new();
+			string? parentName = currentDirectory;
+			while (parentName != null &&
+			       !fullFilePath.StartsWith(parentName + Path.DirectorySeparatorChar))
+			{
+				parentDirectories.Add(Path.GetFileName(parentName));
+				parentName = Path.GetDirectoryName(parentName);
+			}
+
+			if (parentName != null)
+			{
+				fullFilePath = fullFilePath.Substring(parentName.Length + 1);
+			}
+
+			fullFilePath = Path.Combine(
+				Path.Combine(parentDirectories.Select(_ => "..").ToArray()),
+				Path.Combine(parentDirectories.ToArray()),
+				fullFilePath);
 		}
 
 		if (!fullFilePath.StartsWith(givenPath + fileSystem.Path.DirectorySeparatorChar))

--- a/Source/Testably.Abstractions.Testing/Storage/IStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorage.cs
@@ -54,7 +54,7 @@ internal interface IStorage
 	/// </summary>
 	/// <param name="location">The parent location in which the files or directories are searched for.</param>
 	/// <param name="type">The type of the container (file, directory or both).</param>
-	/// <param name="expression">
+	/// <param name="searchPattern">
 	///     (optional) The expression to filter the name of the locations.
 	///     <para />
 	///     Defaults to <c>"*"</c> which matches any name.
@@ -67,13 +67,13 @@ internal interface IStorage
 	///     - Use Win32 expression MatchType
 	/// </param>
 	/// <returns>
-	///     The location of files or directories that match the <paramref name="type" />, <paramref name="expression" />
+	///     The location of files or directories that match the <paramref name="type" />, <paramref name="searchPattern" />
 	///     and <paramref name="enumerationOptions" />.
 	/// </returns>
 	IEnumerable<IStorageLocation> EnumerateLocations(
 		IStorageLocation location,
 		FileSystemTypes type,
-		string expression = EnumerationOptionsHelper.DefaultSearchPattern,
+		string searchPattern = EnumerationOptionsHelper.DefaultSearchPattern,
 		EnumerationOptions? enumerationOptions = null);
 
 	/// <summary>

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
@@ -95,7 +95,22 @@ internal sealed class InMemoryLocation : IStorageLocation
 
 		return New(Drive,
 			parentPath,
-			Path.GetDirectoryName(FriendlyName));
+			GetFriendlyNameParent(FriendlyName));
+	}
+
+	private static string? GetFriendlyNameParent(string friendlyName)
+	{
+		if (friendlyName == ".")
+		{
+			return "./..";
+		}
+
+		if (friendlyName.StartsWith("./"))
+		{
+			return "./../" + friendlyName.Substring(2);
+		}
+
+		return Path.GetDirectoryName(friendlyName);
 	}
 
 	#endregion

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -150,10 +150,10 @@ internal sealed class InMemoryStorage : IStorage
 	public IEnumerable<IStorageLocation> EnumerateLocations(
 		IStorageLocation location,
 		FileSystemTypes type,
-		string expression = EnumerationOptionsHelper.DefaultSearchPattern,
+		string searchPattern = EnumerationOptionsHelper.DefaultSearchPattern,
 		EnumerationOptions? enumerationOptions = null)
 	{
-		ValidateExpression(expression);
+		ValidateExpression(searchPattern);
 		if (!_containers.ContainsKey(location))
 		{
 			throw ExceptionFactory.DirectoryNotFound(location.FullPath);
@@ -188,7 +188,7 @@ internal sealed class InMemoryStorage : IStorage
 			}
 
 			if (!EnumerationOptionsHelper.MatchesPattern(enumerationOptions,
-				_fileSystem.Path.GetFileName(item.Key.FullPath), expression))
+				_fileSystem.Path.GetFileName(item.Key.FullPath), searchPattern))
 			{
 				continue;
 			}

--- a/Source/Testably.Abstractions.Testing/Storage/StorageExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/StorageExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.Storage;
@@ -24,7 +25,7 @@ internal static class StorageExtensions
 		if (searchPattern.StartsWith(".."))
 		{
 			Stack<string> parentDirectories = new();
-			string givenPathPrefix = "";
+			StringBuilder givenPathPrefix = new();
 
 			while (searchPattern.StartsWith(".." + Path.DirectorySeparatorChar) ||
 			       searchPattern.StartsWith(".." + Path.AltDirectorySeparatorChar))
@@ -33,15 +34,16 @@ internal static class StorageExtensions
 					() => throw ExceptionFactory.SearchPatternCannotContainTwoDots());
 				parentDirectories.Push(Path.GetFileName(location.FullPath));
 				location = location.GetParent() ?? throw new Exception("foo");
-				givenPathPrefix += searchPattern.Substring(0, 3);
+				givenPathPrefix.Append(searchPattern.Substring(0, 3));
 				searchPattern = searchPattern.Substring(3);
 			}
 
 			if (parentDirectories.Any())
 			{
+				givenPathPrefix.Length--;
 				givenPath = Path.Combine(
 					givenPath,
-					givenPathPrefix.Substring(0, givenPathPrefix.Length -1),
+					givenPathPrefix.ToString(),
 					Path.Combine(parentDirectories.ToArray()));
 			}
 		}

--- a/Source/Testably.Abstractions.Testing/Storage/StorageExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/StorageExtensions.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Testably.Abstractions.Testing.Helpers;
+
+namespace Testably.Abstractions.Testing.Storage;
+
+internal static class StorageExtensions
+{
+	public static AdjustedLocation AdjustLocationFromSearchPattern(
+		this IStorage storage, string path, string searchPattern)
+	{
+		if (searchPattern == null)
+		{
+			throw new ArgumentNullException(nameof(searchPattern));
+		}
+
+		Execute.OnNetFrameworkIf(searchPattern.EndsWith(".."),
+			() => throw ExceptionFactory.SearchPatternCannotContainTwoDots());
+
+		IStorageLocation location = storage.GetLocation(path);
+		string givenPath = location.FriendlyName;
+		if (searchPattern.StartsWith(".."))
+		{
+			List<string> parentDirectories = new();
+
+			while (searchPattern.StartsWith(".." + Path.DirectorySeparatorChar) ||
+			       searchPattern.StartsWith(".." + Path.AltDirectorySeparatorChar))
+			{
+				Execute.OnNetFramework(
+					() => throw ExceptionFactory.SearchPatternCannotContainTwoDots());
+				parentDirectories.Add(Path.GetFileName(location.FullPath));
+				location = location.GetParent() ?? throw new Exception("foo");
+				searchPattern = searchPattern.Substring(3);
+			}
+
+			if (parentDirectories.Any())
+			{
+				givenPath = Path.Combine(
+					givenPath,
+					Path.Combine(parentDirectories.Select(_ => "..").ToArray()),
+					Path.Combine(parentDirectories.ToArray()));
+			}
+		}
+
+		return new AdjustedLocation(location, searchPattern, givenPath);
+	}
+
+	internal class AdjustedLocation
+	{
+		public string GivenPath { get; }
+
+		public IStorageLocation Location { get; }
+		public string SearchPattern { get; }
+
+		public AdjustedLocation(IStorageLocation location, string searchPattern,
+		                        string givenPath)
+		{
+			Location = location;
+			SearchPattern = searchPattern;
+			GivenPath = givenPath;
+		}
+	}
+}

--- a/Source/Testably.Abstractions.Testing/Storage/StorageExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/StorageExtensions.cs
@@ -23,15 +23,17 @@ internal static class StorageExtensions
 		string givenPath = location.FriendlyName;
 		if (searchPattern.StartsWith(".."))
 		{
-			List<string> parentDirectories = new();
+			Stack<string> parentDirectories = new();
+			string givenPathPrefix = "";
 
 			while (searchPattern.StartsWith(".." + Path.DirectorySeparatorChar) ||
 			       searchPattern.StartsWith(".." + Path.AltDirectorySeparatorChar))
 			{
 				Execute.OnNetFramework(
 					() => throw ExceptionFactory.SearchPatternCannotContainTwoDots());
-				parentDirectories.Add(Path.GetFileName(location.FullPath));
+				parentDirectories.Push(Path.GetFileName(location.FullPath));
 				location = location.GetParent() ?? throw new Exception("foo");
+				givenPathPrefix += searchPattern.Substring(0, 3);
 				searchPattern = searchPattern.Substring(3);
 			}
 
@@ -39,7 +41,7 @@ internal static class StorageExtensions
 			{
 				givenPath = Path.Combine(
 					givenPath,
-					Path.Combine(parentDirectories.Select(_ => "..").ToArray()),
+					givenPathPrefix.Substring(0, givenPathPrefix.Length -1),
 					Path.Combine(parentDirectories.ToArray()));
 			}
 		}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/SearchFilterTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/SearchFilterTests.cs
@@ -141,15 +141,9 @@ public abstract partial class SearchFilterTests<TFileSystem>
 
 	[SkippableTheory]
 	[InlineAutoData("../", 4)]
-	[InlineAutoData("../../", 5)]
-	[InlineAutoData("../../../", 6)]
 	[InlineAutoData("../*", 4)]
-	[InlineAutoData("../../*", 5)]
-	[InlineAutoData("../../../*", 6)]
 	[InlineAutoData("../a*", 2)]
-	[InlineAutoData("../../a*", 2)]
-	[InlineAutoData("../../../a*", 2)]
-	public void SearchPattern_ContainingMultipleTwoDotsAndDirectorySeparator_ShouldMatchExpectedFiles(string searchPattern, int expectedMatchingFiles)
+	public void SearchPattern_Containing1InstanceOfTwoDotsAndDirectorySeparator_ShouldMatchExpectedFiles(string searchPattern, int expectedMatchingFiles)
 	{
 		Skip.If(Test.IsNetFramework);
 		string path = FileSystem.Path.Combine("foo", "bar", "xyz");
@@ -163,7 +157,60 @@ public abstract partial class SearchFilterTests<TFileSystem>
 		   .GetFileSystemEntries(".", searchPattern, SearchOption.AllDirectories);
 
 		result.Length.Should().Be(expectedMatchingFiles);
-		result.Should().Contain(System.IO.Path.Combine(".", "..", path, "a.test"));
+		result.Should().Contain(System.IO.Path.Combine(".", "..", "xyz", "a.test"));
+	}
+
+	[SkippableTheory]
+	[InlineAutoData("../../", 5)]
+	[InlineAutoData("../../*", 5)]
+	[InlineAutoData("../../a*", 2)]
+	public void SearchPattern_Containing2InstancesOfMultipleTwoDotsAndDirectorySeparator_ShouldMatchExpectedFiles(string searchPattern, int expectedMatchingFiles)
+	{
+		Skip.If(Test.IsNetFramework);
+		string path = FileSystem.Path.Combine("foo", "bar", "xyz");
+
+		FileSystem.InitializeIn(path)
+		   .WithFile("test..test")
+		   .WithFile("a.test")
+		   .WithFile("a.test.again");
+
+		string[] result = FileSystem.Directory
+		   .GetFileSystemEntries(".", searchPattern, SearchOption.AllDirectories);
+
+		result.Length.Should().Be(expectedMatchingFiles);
+		if (!searchPattern.EndsWith("a*"))
+		{
+			result.Should().Contain(System.IO.Path.Combine(".", "../..", "bar"));
+			result.Should().Contain(System.IO.Path.Combine(".", "../..", "bar", "xyz"));
+		}
+		result.Should().Contain(System.IO.Path.Combine(".", "../..", "bar", "xyz", "a.test"));
+	}
+
+	[SkippableTheory]
+	[InlineAutoData("../../../", 6)]
+	[InlineAutoData("../../../*", 6)]
+	[InlineAutoData("../../../a*", 2)]
+	public void SearchPattern_Containing3InstancesOfMultipleTwoDotsAndDirectorySeparator_ShouldMatchExpectedFiles(string searchPattern, int expectedMatchingFiles)
+	{
+		Skip.If(Test.IsNetFramework);
+		string path = FileSystem.Path.Combine("foo", "bar", "xyz");
+
+		FileSystem.InitializeIn(path)
+		   .WithFile("test..test")
+		   .WithFile("a.test")
+		   .WithFile("a.test.again");
+
+		string[] result = FileSystem.Directory
+		   .GetFileSystemEntries(".", searchPattern, SearchOption.AllDirectories);
+
+		result.Length.Should().Be(expectedMatchingFiles);
+		if (!searchPattern.EndsWith("a*"))
+		{
+			result.Should().Contain(System.IO.Path.Combine(".", "../../..", "foo"));
+			result.Should().Contain(System.IO.Path.Combine(".", "../../..", "foo", "bar"));
+			result.Should().Contain(System.IO.Path.Combine(".", "../../..", "foo", "bar", "xyz"));
+		}
+		result.Should().Contain(System.IO.Path.Combine(".", "../../..", "foo", "bar", "xyz", "a.test"));
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/SearchFilterTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/SearchFilterTests.cs
@@ -1,0 +1,234 @@
+using System.IO;
+
+namespace Testably.Abstractions.Tests.FileSystem.Directory;
+
+// ReSharper disable once PartialTypeWithSinglePart
+public abstract partial class SearchFilterTests<TFileSystem>
+	: FileSystemTestBase<TFileSystem>
+	where TFileSystem : IFileSystem
+{
+	[SkippableFact]
+	public void SearchPattern_ContainingAsterisk_ShouldReturnMatchingFiles()
+	{
+		FileSystem.Initialize()
+		   .WithFile("a.test")
+		   .WithFile("a.unmatchingtest")
+		   .WithFile("another.test")
+		   .WithFile("a.un-matching-test");
+
+		string[] result = FileSystem.Directory
+		   .GetFileSystemEntries(".", "a*.t*.", SearchOption.AllDirectories);
+
+		result.Length.Should().Be(2);
+		result.Should().Contain(System.IO.Path.Combine(".", "a.test"));
+		result.Should().Contain(System.IO.Path.Combine(".", "another.test"));
+	}
+
+	[SkippableFact]
+	public void SearchPattern_ContainingQuestionmark_ShouldReturnMatchingFiles()
+	{
+		FileSystem.Initialize()
+		   .WithFile("a-test")
+		   .WithFile("a-unmatchingtest")
+		   .WithFile("another-test")
+		   .WithFile("a-un-matching-test");
+
+		string[] result = FileSystem.Directory
+		   .GetFileSystemEntries(".", "a-??s*", SearchOption.AllDirectories);
+
+		result.Length.Should().Be(1);
+		result[0].Should().Be(System.IO.Path.Combine(".", "a-test"));
+	}
+
+	[SkippableFact]
+	public void SearchPattern_Extension_ShouldReturnAllFilesWithTheExtension()
+	{
+		FileSystem.Initialize()
+		   .WithAFile(".gif")
+		   .WithAFile(".jpg")
+		   .WithASubdirectory().Initialized(s => s
+			   .WithAFile(".gif")
+			   .WithASubdirectory().Initialized(t => t
+				   .WithAFile(".gif")
+				   .WithFile("a.gif.txt")));
+
+		string[] result = FileSystem.Directory
+		   .GetFileSystemEntries(".", "*.gif", SearchOption.AllDirectories);
+
+		result.Length.Should().Be(3);
+	}
+
+	[SkippableFact]
+	public void SearchPattern_StarDot_ShouldReturnFilesWithoutExtension()
+	{
+		FileSystem.Initialize()
+		   .WithFile("test.")
+		   .WithFile("a.test.")
+		   .WithFile("a.test.again.");
+
+		string[] result = FileSystem.Directory
+		   .GetFileSystemEntries(".", "*.", SearchOption.AllDirectories);
+
+		if (Test.RunsOnWindows)
+		{
+			result.Length.Should().Be(1);
+			result.Should().Contain(System.IO.Path.Combine(".", "test"));
+		}
+		else
+		{
+			result.Length.Should().Be(3);
+			result.Should().Contain(System.IO.Path.Combine(".", "test."));
+		}
+	}
+
+	[SkippableFact]
+	public void SearchPattern_EndingWithTwoDots_ShouldNotMatchAnyFile()
+	{
+		Skip.If(Test.IsNetFramework);
+
+		FileSystem.Initialize()
+		   .WithFile("test..")
+		   .WithFile("a.test...")
+		   .WithFile("a.test.again..");
+
+		string[] result = FileSystem.Directory
+		   .GetFileSystemEntries(".", "*t..", SearchOption.AllDirectories);
+
+		if (Test.RunsOnWindows)
+		{
+			result.Should().BeEmpty();
+		}
+		else
+		{
+			result.Length.Should().Be(1);
+			result.Should().Contain(System.IO.Path.Combine(".", "test.."));
+		}
+	}
+
+	[SkippableFact]
+	public void SearchPattern_ContainingWithTwoDots_ShouldContainMatchingFiles()
+	{
+		FileSystem.Initialize()
+		   .WithFile("test..x")
+		   .WithFile("a.test...x")
+		   .WithFile("a.test.again..x");
+
+		string[] result = FileSystem.Directory
+		   .GetFileSystemEntries(".", "*t..x", SearchOption.AllDirectories);
+
+		result.Length.Should().Be(1);
+	}
+
+	[SkippableTheory]
+	[InlineAutoData("../", 4)]
+	[InlineAutoData("../*", 4)]
+	[InlineAutoData("../a*", 2)]
+	public void SearchPattern_ContainingTwoDotsAndDirectorySeparator_ShouldMatchExpectedFiles(string searchPattern, int expectedMatchingFiles, string path)
+	{
+		Skip.If(Test.IsNetFramework);
+
+		FileSystem.InitializeIn(path)
+		   .WithFile("test..test")
+		   .WithFile("a.test")
+		   .WithFile("a.test.again");
+
+		string[] result = FileSystem.Directory
+		   .GetFileSystemEntries(".", searchPattern, SearchOption.AllDirectories);
+
+		result.Length.Should().Be(expectedMatchingFiles);
+		result.Should().Contain(System.IO.Path.Combine(".", "..", path, "a.test"));
+	}
+
+	[SkippableTheory]
+	[InlineAutoData("../", 4)]
+	[InlineAutoData("../../", 5)]
+	[InlineAutoData("../../../", 6)]
+	[InlineAutoData("../*", 4)]
+	[InlineAutoData("../../*", 5)]
+	[InlineAutoData("../../../*", 6)]
+	[InlineAutoData("../a*", 2)]
+	[InlineAutoData("../../a*", 2)]
+	[InlineAutoData("../../../a*", 2)]
+	public void SearchPattern_ContainingMultipleTwoDotsAndDirectorySeparator_ShouldMatchExpectedFiles(string searchPattern, int expectedMatchingFiles)
+	{
+		Skip.If(Test.IsNetFramework);
+		string path = FileSystem.Path.Combine("foo", "bar", "xyz");
+
+		FileSystem.InitializeIn(path)
+		   .WithFile("test..test")
+		   .WithFile("a.test")
+		   .WithFile("a.test.again");
+
+		string[] result = FileSystem.Directory
+		   .GetFileSystemEntries(".", searchPattern, SearchOption.AllDirectories);
+
+		result.Length.Should().Be(expectedMatchingFiles);
+		result.Should().Contain(System.IO.Path.Combine(".", "..", path, "a.test"));
+	}
+
+	[SkippableTheory]
+	[InlineAutoData("../")]
+	[InlineAutoData("../*")]
+	[InlineAutoData("../a*")]
+	[InlineAutoData("*t..")]
+	public void SearchPattern_ContainingTwoDotsAndDirectorySeparator_ShouldThrowArgumentExceptionOnNetFramework(string searchPattern, string path)
+	{
+		Skip.IfNot(Test.IsNetFramework);
+
+		FileSystem.InitializeIn(path);
+
+		var exception = Record.Exception(() =>
+		{
+			FileSystem.Directory
+			   .GetFileSystemEntries(".", searchPattern, SearchOption.AllDirectories);
+		});
+		
+		exception.Should().BeOfType<ArgumentException>()
+		   .Which.HResult.Should().Be(-2147024809);
+	}
+
+	[SkippableFact]
+	public void SearchPattern_Null_ShouldThrowArgumentNullException()
+	{
+		FileSystem.Initialize();
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.Directory
+			   .GetFileSystemEntries(".", null!, SearchOption.AllDirectories);
+		});
+
+		exception.Should().BeOfType<ArgumentNullException>()
+		   .Which.ParamName.Should().Be("searchPattern");
+	}
+
+	[SkippableTheory]
+#if NETFRAMEWORK
+	[InlineAutoData(false, "")]
+#else
+	[InlineAutoData(true, "")]
+#endif
+	[InlineAutoData(true, "*")]
+	[InlineAutoData(true, ".")]
+	[InlineAutoData(true, "*.*")]
+	public void SearchPattern_WildCard_ShouldReturnFile(
+		bool expectToBeFound, string searchPattern, string path)
+	{
+		FileSystem.Initialize().WithFile(path);
+
+		string[] result = FileSystem.Directory
+		   .GetFileSystemEntries(".", searchPattern);
+
+		if (expectToBeFound)
+		{
+			result.Should().ContainSingle(
+				path,
+				$"{searchPattern} should match any path.");
+		}
+		else
+		{
+			result.Should()
+			   .BeEmpty($"{searchPattern} should not match {path}");
+		}
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExistsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExistsTests.cs
@@ -1,0 +1,32 @@
+using Testably.Abstractions.FileSystem;
+
+namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
+
+// ReSharper disable once PartialTypeWithSinglePart
+public abstract partial class ExistsTests<TFileSystem>
+	: FileSystemTestBase<TFileSystem>
+	where TFileSystem : IFileSystem
+{
+	[SkippableTheory]
+	[AutoData]
+	public void Exists_Directory_ShouldReturnFalse(string path)
+	{
+		FileSystem.Directory.CreateDirectory(path);
+		IFileInfo sut = FileSystem.FileInfo.New(path);
+
+		sut.Exists.Should().BeFalse();
+	}
+
+	[SkippableTheory]
+	[InlineData("foo", "foo")]
+	[InlineData("foo", "foo.")]
+	[InlineData("foo.", "foo")]
+	[InlineData("foo.", "foo.")]
+	public void Exists_ShouldIgnoreTrailingDot(string path1, string path2)
+	{
+		FileSystem.File.WriteAllText(path1, "some text");
+		IFileInfo sut = FileSystem.FileInfo.New(path2);
+
+		sut.Exists.Should().BeTrue();
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExistsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExistsTests.cs
@@ -18,15 +18,13 @@ public abstract partial class ExistsTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[InlineData("foo", "foo")]
 	[InlineData("foo", "foo.")]
 	[InlineData("foo.", "foo")]
-	[InlineData("foo.", "foo.")]
-	public void Exists_ShouldIgnoreTrailingDot(string path1, string path2)
+	public void Exists_ShouldIgnoreTrailingDotOnWindows(string path1, string path2)
 	{
 		FileSystem.File.WriteAllText(path1, "some text");
 		IFileInfo sut = FileSystem.FileInfo.New(path2);
 
-		sut.Exists.Should().BeTrue();
+		sut.Exists.Should().Be(Test.RunsOnWindows);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
@@ -37,16 +37,6 @@ public abstract partial class Tests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void Exists_Directory_ShouldReturnFalse(string path)
-	{
-		FileSystem.Directory.CreateDirectory(path);
-		IFileInfo sut = FileSystem.FileInfo.New(path);
-
-		sut.Exists.Should().BeFalse();
-	}
-
-	[SkippableTheory]
-	[AutoData]
 	public void IsReadOnly_SetToFalse_ShouldRemoveReadOnlyAttribute(string path)
 	{
 		FileSystem.File.WriteAllText(path, null);


### PR DESCRIPTION
Handle search patterns which start with "../" correctly:
- Throw an ArgumentException on .NET Framework
- Search a directory further up on .NET Core

Also add more test cases to verify the correct behavior of `searchPattern` usage.