### PR TITLE
coverage: add missing tests for TimeSystem

### DIFF
--- a/Tests/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/TimeSystemClassGenerator.cs
+++ b/Tests/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/TimeSystemClassGenerator.cs
@@ -31,7 +31,7 @@ namespace {@class.Namespace}.{@class.Name}
 	// ReSharper disable once UnusedMember.Global
 	public sealed class MockTimeSystemTests : {@class.Name}<MockTimeSystem>
 	{{
-		public MockTimeSystemTests() : base(new MockTimeSystem())
+		public MockTimeSystemTests() : base(new MockTimeSystem(TimeProvider.Now()))
 		{{
 		}}
 	}}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ExceptionTests.cs
@@ -13,7 +13,7 @@ public abstract partial class ExceptionTests<TFileSystem>
 {
 	[Theory]
 	[MemberData(nameof(GetDirectoryCallbacks), parameters: "")]
-	public void Operations_ShouldThrowArgumentExceptionIfPathIsEmpty(
+	public void Operations_ShouldThrowArgumentExceptionIfValueIsEmpty(
 		Expression<Action<IDirectory>> callback, string paramName, bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
@@ -23,17 +23,21 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (!Test.IsNetFramework && !ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 
-		exception.Should().BeOfType<ArgumentException>()
-		   .Which.HResult.Should().Be(-2147024809);
+		exception.Should().BeOfType<ArgumentException>(
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+		   .Which.HResult.Should().Be(-2147024809,
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 	}
 
 	[SkippableTheory]
 	[MemberData(nameof(GetDirectoryCallbacks), parameters: "  ")]
-	public void Operations_ShouldThrowArgumentExceptionIfPathIsWhitespace(
+	public void Operations_ShouldThrowArgumentExceptionIfValueIsWhitespace(
 		Expression<Action<IDirectory>> callback, string paramName, bool ignoreParamCheck)
 	{
 		Skip.IfNot(Test.RunsOnWindows);
@@ -45,17 +49,21 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (!Test.IsNetFramework && !ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 
-		exception.Should().BeOfType<ArgumentException>()
-		   .Which.HResult.Should().Be(-2147024809);
+		exception.Should().BeOfType<ArgumentException>(
+				$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+		   .Which.HResult.Should().Be(-2147024809,
+				$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 	}
 
 	[Theory]
 	[MemberData(nameof(GetDirectoryCallbacks), parameters: (string?)null)]
-	public void Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(
+	public void Operations_ShouldThrowArgumentNullExceptionIfValueIsNull(
 		Expression<Action<IDirectory>> callback, string paramName, bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
@@ -65,20 +73,24 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentNullException>();
+			exception.Should().BeOfType<ArgumentNullException>(
+				$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 		else
 		{
-			exception.Should().BeOfType<ArgumentNullException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentNullException>(
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 	}
 
 	[SkippableTheory]
 	[MemberData(nameof(GetDirectoryCallbacks), parameters: "Illegal\tCharacter?InPath")]
 	public void
-		Operations_ShouldThrowCorrectExceptionIfPathContainsIllegalCharactersOnWindows(
-			Expression<Action<IDirectory>> callback, string paramName, bool ignoreParamCheck)
+		Operations_ShouldThrowCorrectExceptionIfValueContainsIllegalPathCharactersOnWindows(
+			Expression<Action<IDirectory>> callback, string paramName,
+			bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -89,20 +101,25 @@ public abstract partial class ExceptionTests<TFileSystem>
 		{
 			if (exception is IOException ioException)
 			{
-				ioException.HResult.Should().NotBe(-2147024809);
+				ioException.HResult.Should().NotBe(-2147024809,
+					$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 			}
 		}
 		else
 		{
 			if (Test.IsNetFramework)
 			{
-				exception.Should().BeOfType<ArgumentException>()
-				   .Which.HResult.Should().Be(-2147024809);
+				exception.Should().BeOfType<ArgumentException>(
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})")
+				   .Which.HResult.Should().Be(-2147024809,
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 			}
 			else
 			{
-				exception.Should().BeOfType<IOException>()
-				   .Which.HResult.Should().Be(-2147024773);
+				exception.Should().BeOfType<IOException>(
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})")
+				   .Which.HResult.Should().Be(-2147024773,
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 			}
 		}
 	}
@@ -114,9 +131,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 		   .Where(item => item.TestType.HasFlag(path.ToTestType()))
 		   .Select(item => new object?[]
 			{
-				item.Callback,
-				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck)
+				item.Callback, item.ParamName,
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
+				   .IgnoreParamNameCheck)
 			});
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string ParamName,
@@ -220,8 +237,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 			directory
 				=> directory.Move("foo", value));
 #if FEATURE_FILESYSTEM_LINK
-		yield return (ExceptionTestHelper.TestTypes.AllExceptWhitespace, "linkPath", directory
-			=> directory.ResolveLinkTarget(value, false));
+		yield return (ExceptionTestHelper.TestTypes.AllExceptWhitespace, "linkPath",
+			directory
+				=> directory.ResolveLinkTarget(value, false));
 #endif
 		yield return (ExceptionTestHelper.TestTypes.All, "path", directory
 			=> directory.SetCreationTime(value, DateTime.Now));

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExceptionTests.cs
@@ -13,8 +13,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 {
 	[Theory]
 	[MemberData(nameof(GetDirectoryInfoCallbacks), parameters: "")]
-	public void Operations_ShouldThrowArgumentExceptionIfPathIsEmpty(
-		Expression<Action<IDirectoryInfo>> callback, string paramName, bool ignoreParamCheck)
+	public void Operations_ShouldThrowArgumentExceptionIfValueIsEmpty(
+		Expression<Action<IDirectoryInfo>> callback, string paramName,
+		bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -23,18 +24,23 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (!Test.IsNetFramework && !ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 
-		exception.Should().BeOfType<ArgumentException>()
-		   .Which.HResult.Should().Be(-2147024809);
+		exception.Should().BeOfType<ArgumentException>(
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+		   .Which.HResult.Should().Be(-2147024809,
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 	}
 
 	[SkippableTheory]
 	[MemberData(nameof(GetDirectoryInfoCallbacks), parameters: "  ")]
-	public void Operations_ShouldThrowArgumentExceptionIfPathIsWhitespace(
-		Expression<Action<IDirectoryInfo>> callback, string paramName, bool ignoreParamCheck)
+	public void Operations_ShouldThrowArgumentExceptionIfValueIsWhitespace(
+		Expression<Action<IDirectoryInfo>> callback, string paramName,
+		bool ignoreParamCheck)
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
@@ -45,21 +51,28 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (Test.IsNetFramework)
 		{
-			exception.Should().BeNull();
+			exception.Should()
+			   .BeNull(
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 		else
 		{
-			exception.Should().BeOfType<ArgumentException>()
-			   .Which.ParamName.Should().Be(paramName);
-			exception.Should().BeOfType<ArgumentException>()
-			   .Which.HResult.Should().Be(-2147024809);
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.HResult.Should().Be(-2147024809,
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 	}
 
 	[Theory]
 	[MemberData(nameof(GetDirectoryInfoCallbacks), parameters: (string?)null)]
-	public void Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(
-		Expression<Action<IDirectoryInfo>> callback, string paramName, bool ignoreParamCheck)
+	public void Operations_ShouldThrowArgumentNullExceptionIfValueIsNull(
+		Expression<Action<IDirectoryInfo>> callback, string paramName,
+		bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -68,12 +81,15 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentNullException>();
+			exception.Should().BeOfType<ArgumentNullException>(
+				$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 		else
 		{
-			exception.Should().BeOfType<ArgumentNullException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentNullException>(
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 	}
 
@@ -81,8 +97,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 	[MemberData(nameof(GetDirectoryInfoCallbacks),
 		parameters: "Illegal\tCharacter?InPath")]
 	public void
-		Operations_ShouldThrowCorrectExceptionIfPathContainsIllegalCharactersOnWindows(
-			Expression<Action<IDirectoryInfo>> callback, string paramName, bool ignoreParamCheck)
+		Operations_ShouldThrowCorrectExceptionIfValueContainsIllegalPathCharactersOnWindows(
+			Expression<Action<IDirectoryInfo>> callback, string paramName,
+			bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -93,20 +110,25 @@ public abstract partial class ExceptionTests<TFileSystem>
 		{
 			if (exception is IOException ioException)
 			{
-				ioException.HResult.Should().NotBe(-2147024809);
+				ioException.HResult.Should().NotBe(-2147024809,
+					$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 			}
 		}
 		else
 		{
 			if (Test.IsNetFramework)
 			{
-				exception.Should().BeOfType<ArgumentException>()
-				   .Which.HResult.Should().Be(-2147024809);
+				exception.Should().BeOfType<ArgumentException>(
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})")
+				   .Which.HResult.Should().Be(-2147024809,
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 			}
 			else
 			{
-				exception.Should().BeOfType<IOException>()
-				   .Which.HResult.Should().Be(-2147024773);
+				exception.Should().BeOfType<IOException>(
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})")
+				   .Which.HResult.Should().Be(-2147024773,
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 			}
 		}
 	}
@@ -118,16 +140,18 @@ public abstract partial class ExceptionTests<TFileSystem>
 		   .Where(item => item.TestType.HasFlag(path.ToTestType()))
 		   .Select(item => new object?[]
 			{
-				item.Callback,
-				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck)
+				item.Callback, item.ParamName, item.TestType.HasFlag(ExceptionTestHelper
+				   .TestTypes
+				   .IgnoreParamNameCheck)
 			});
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,
 			Expression<Action<IDirectoryInfo>> Callback)>
 		GetDirectoryInfoCallbackTestParameters(string value)
 	{
-		yield return (ExceptionTestHelper.TestTypes.Whitespace |  ExceptionTestHelper.TestTypes.InvalidPath, "path",
+		yield return (
+			ExceptionTestHelper.TestTypes.Whitespace |
+			ExceptionTestHelper.TestTypes.InvalidPath, "path",
 			directoryInfo
 				=> directoryInfo.CreateSubdirectory(value));
 		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "destDirName",

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/ExceptionTests.cs
@@ -12,8 +12,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 {
 	[Theory]
 	[MemberData(nameof(GetDirectoryInfoFactoryCallbacks), parameters: "")]
-	public void Operations_ShouldThrowArgumentExceptionIfPathIsEmpty(
-		Expression<Action<IDirectoryInfoFactory>> callback, string paramName, bool ignoreParamCheck)
+	public void Operations_ShouldThrowArgumentExceptionIfValueIsEmpty(
+		Expression<Action<IDirectoryInfoFactory>> callback, string paramName,
+		bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -22,18 +23,23 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (!Test.IsNetFramework && !ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 
-		exception.Should().BeOfType<ArgumentException>()
-		   .Which.HResult.Should().Be(-2147024809);
+		exception.Should().BeOfType<ArgumentException>(
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+		   .Which.HResult.Should().Be(-2147024809,
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 	}
 
 	[SkippableTheory]
 	[MemberData(nameof(GetDirectoryInfoFactoryCallbacks), parameters: "  ")]
-	public void Operations_ShouldThrowArgumentExceptionIfPathIsWhitespace(
-		Expression<Action<IDirectoryInfoFactory>> callback, string paramName, bool ignoreParamCheck)
+	public void Operations_ShouldThrowArgumentExceptionIfValueIsWhitespace(
+		Expression<Action<IDirectoryInfoFactory>> callback, string paramName,
+		bool ignoreParamCheck)
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
@@ -44,18 +50,23 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (!Test.IsNetFramework && !ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 
-		exception.Should().BeOfType<ArgumentException>()
-		   .Which.HResult.Should().Be(-2147024809);
+		exception.Should().BeOfType<ArgumentException>(
+				$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+		   .Which.HResult.Should().Be(-2147024809,
+				$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 	}
 
 	[Theory]
 	[MemberData(nameof(GetDirectoryInfoFactoryCallbacks), parameters: (string?)null)]
-	public void Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(
-		Expression<Action<IDirectoryInfoFactory>> callback, string paramName, bool ignoreParamCheck)
+	public void Operations_ShouldThrowArgumentNullExceptionIfValueIsNull(
+		Expression<Action<IDirectoryInfoFactory>> callback, string paramName,
+		bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -64,12 +75,15 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentNullException>();
+			exception.Should().BeOfType<ArgumentNullException>(
+				$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 		else
 		{
-			exception.Should().BeOfType<ArgumentNullException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentNullException>(
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 	}
 
@@ -77,8 +91,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 	[MemberData(nameof(GetDirectoryInfoFactoryCallbacks),
 		parameters: "Illegal\tCharacter?InPath")]
 	public void
-		Operations_ShouldThrowCorrectExceptionIfPathContainsIllegalCharactersOnWindows(
-			Expression<Action<IDirectoryInfoFactory>> callback, string paramName, bool ignoreParamCheck)
+		Operations_ShouldThrowCorrectExceptionIfValueContainsIllegalPathCharactersOnWindows(
+			Expression<Action<IDirectoryInfoFactory>> callback, string paramName,
+			bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -88,11 +103,14 @@ public abstract partial class ExceptionTests<TFileSystem>
 		if (Test.IsNetFramework)
 		{
 			exception.Should().BeOfType<ArgumentException>()
-			   .Which.HResult.Should().Be(-2147024809);
+			   .Which.HResult.Should().Be(-2147024809,
+					$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 		else
 		{
-			exception.Should().BeNull();
+			exception.Should()
+			   .BeNull(
+					$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 	}
 
@@ -103,9 +121,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 		   .Where(item => item.TestType.HasFlag(path.ToTestType()))
 		   .Select(item => new object?[]
 			{
-				item.Callback,
-				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck)
+				item.Callback, item.ParamName,
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
+				   .IgnoreParamNameCheck)
 			});
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/ExceptionTests.cs
@@ -30,8 +30,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	[Theory]
 	[MemberData(nameof(GetDriveInfoFactoryCallbacks), parameters: "")]
-	public void Operations_ShouldThrowArgumentExceptionIfPathIsEmpty(
-		Expression<Action<IDriveInfoFactory>> callback, string paramName, bool ignoreParamCheck)
+	public void Operations_ShouldThrowArgumentExceptionIfValueIsEmpty(
+		Expression<Action<IDriveInfoFactory>> callback, string paramName,
+		bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -40,18 +41,23 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (!Test.IsNetFramework && !ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 
-		exception.Should().BeOfType<ArgumentException>()
-		   .Which.HResult.Should().Be(-2147024809);
+		exception.Should().BeOfType<ArgumentException>(
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+		   .Which.HResult.Should().Be(-2147024809,
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 	}
 
 	[Theory]
 	[MemberData(nameof(GetDriveInfoFactoryCallbacks), parameters: (string?)null)]
-	public void Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(
-		Expression<Action<IDriveInfoFactory>> callback, string paramName, bool ignoreParamCheck)
+	public void Operations_ShouldThrowArgumentNullExceptionIfValueIsNull(
+		Expression<Action<IDriveInfoFactory>> callback, string paramName,
+		bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -60,12 +66,15 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentNullException>();
+			exception.Should().BeOfType<ArgumentNullException>(
+				$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 		else
 		{
-			exception.Should().BeOfType<ArgumentNullException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentNullException>(
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 	}
 
@@ -76,9 +85,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 		   .Where(item => item.TestType.HasFlag(path.ToTestType()))
 		   .Select(item => new object?[]
 			{
-				item.Callback,
-				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck)
+				item.Callback, item.ParamName,
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
+				   .IgnoreParamNameCheck)
 			});
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string ParamName,

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionTests.cs
@@ -15,7 +15,7 @@ public abstract partial class ExceptionTests<TFileSystem>
 {
 	[Theory]
 	[MemberData(nameof(GetFileCallbacks), parameters: "")]
-	public void Operations_ShouldThrowArgumentExceptionIfPathIsEmpty(
+	public void Operations_ShouldThrowArgumentExceptionIfValueIsEmpty(
 		Expression<Action<IFile>> callback, string paramName, bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
@@ -25,50 +25,21 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (!Test.IsNetFramework && !ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentException>($"\n{callback}\n has invalid parameter for '{paramName}'")
-			   .Which.ParamName.Should().Be(paramName, $"\n{callback}\n has invalid parameter for '{paramName}'");
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 
-		exception.Should().BeOfType<ArgumentException>($"\n{callback}\n has invalid parameter for '{paramName}'")
-		   .Which.HResult.Should().Be(-2147024809, $"\n{callback}\n has invalid parameter for HResult");
-	}
-
-	[SkippableTheory]
-	[MemberData(nameof(GetFileCallbacks), parameters: "Illegal\tCharacter?InPath")]
-	public void
-		Operations_ShouldThrowCorrectExceptionIfPathContainsIllegalCharactersOnWindows(
-			Expression<Action<IFile>> callback, string paramName, bool ignoreParamCheck)
-	{
-		Exception? exception = Record.Exception(() =>
-		{
-			callback.Compile().Invoke(FileSystem.File);
-		});
-
-		if (!Test.RunsOnWindows)
-		{
-			if (exception is IOException ioException)
-			{
-				ioException.HResult.Should().NotBe(-2147024809);
-			}
-		}
-		else
-		{
-			if (Test.IsNetFramework)
-			{
-				exception.Should().BeOfType<ArgumentException>($"\n{callback}\n has invalid parameter for '{paramName}'")
-				   .Which.HResult.Should().Be(-2147024809, $"\n{callback}\n has invalid parameter for HResult");
-			}
-			else
-			{
-				exception.Should().BeOfType<IOException>($"\n{callback}\n has invalid parameter for '{paramName}'")
-				   .Which.HResult.Should().Be(-2147024773, $"\n{callback}\n has invalid parameter for HResult");
-			}
-		}
+		exception.Should().BeOfType<ArgumentException>(
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+		   .Which.HResult.Should().Be(-2147024809,
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 	}
 
 	[SkippableTheory]
 	[MemberData(nameof(GetFileCallbacks), parameters: "  ")]
-	public void Operations_ShouldThrowArgumentExceptionIfPathIsWhitespace(
+	public void Operations_ShouldThrowArgumentExceptionIfValueIsWhitespace(
 		Expression<Action<IFile>> callback, string paramName, bool ignoreParamCheck)
 	{
 		Skip.IfNot(Test.RunsOnWindows);
@@ -80,17 +51,21 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (!Test.IsNetFramework && !ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentException>($"\n{callback}\n has invalid parameter for '{paramName}'")
-			   .Which.ParamName.Should().Be(paramName, $"\n{callback}\n has invalid parameter for '{paramName}'");
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 
-		exception.Should().BeOfType<ArgumentException>($"\n{callback}\n has invalid parameter for '{paramName}'")
-		   .Which.HResult.Should().Be(-2147024809, $"\n{callback}\n has invalid parameter for HResult");
+		exception.Should().BeOfType<ArgumentException>(
+				$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+		   .Which.HResult.Should().Be(-2147024809,
+				$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 	}
 
 	[Theory]
 	[MemberData(nameof(GetFileCallbacks), parameters: (string?)null)]
-	public void Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(
+	public void Operations_ShouldThrowArgumentNullExceptionIfValueIsNull(
 		Expression<Action<IFile>> callback, string paramName, bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
@@ -100,12 +75,53 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentNullException>($"\n{callback}\n has invalid parameter for '{paramName}'");
+			exception.Should().BeOfType<ArgumentNullException>(
+				$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 		else
 		{
-			exception.Should().BeOfType<ArgumentNullException>($"\n{callback}\n has invalid parameter for '{paramName}'")
-			   .Which.ParamName.Should().Be(paramName, $"\n{callback}\n has invalid parameter for '{paramName}'");
+			exception.Should().BeOfType<ArgumentNullException>(
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
+		}
+	}
+
+	[SkippableTheory]
+	[MemberData(nameof(GetFileCallbacks), parameters: "Illegal\tCharacter?InPath")]
+	public void
+		Operations_ShouldThrowCorrectExceptionIfValueContainsIllegalPathCharactersOnWindows(
+			Expression<Action<IFile>> callback, string paramName, bool ignoreParamCheck)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			callback.Compile().Invoke(FileSystem.File);
+		});
+
+		if (!Test.RunsOnWindows)
+		{
+			if (exception is IOException ioException)
+			{
+				ioException.HResult.Should().NotBe(-2147024809,
+					$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
+			}
+		}
+		else
+		{
+			if (Test.IsNetFramework)
+			{
+				exception.Should().BeOfType<ArgumentException>(
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})")
+				   .Which.HResult.Should().Be(-2147024809,
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
+			}
+			else
+			{
+				exception.Should().BeOfType<IOException>(
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})")
+				   .Which.HResult.Should().Be(-2147024773,
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
+			}
 		}
 	}
 
@@ -116,9 +132,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 		   .Where(item => item.TestType.HasFlag(path.ToTestType()))
 		   .Select(item => new object?[]
 			{
-				item.Callback,
-				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck)
+				item.Callback, item.ParamName,
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
+				   .IgnoreParamNameCheck)
 			});
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,
@@ -131,7 +147,8 @@ public abstract partial class ExceptionTests<TFileSystem>
 			=> file.AppendAllLines(value, new[] { "foo" }, Encoding.UTF8));
 #if FEATURE_FILESYSTEM_ASYNC
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.AppendAllLinesAsync(value, new[] { "foo" }, CancellationToken.None).GetAwaiter().GetResult());
+			=> file.AppendAllLinesAsync(value, new[] { "foo" }, CancellationToken.None)
+			   .GetAwaiter().GetResult());
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
 			=> file.AppendAllLinesAsync(value, new[] { "foo" }, Encoding.UTF8,
 				CancellationToken.None).GetAwaiter().GetResult());
@@ -142,29 +159,40 @@ public abstract partial class ExceptionTests<TFileSystem>
 			=> file.AppendAllText(value, "foo", Encoding.UTF8));
 #if FEATURE_FILESYSTEM_ASYNC
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.AppendAllTextAsync(value, "foo", CancellationToken.None).GetAwaiter().GetResult());
+			=> file.AppendAllTextAsync(value, "foo", CancellationToken.None).GetAwaiter()
+			   .GetResult());
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
 			=> file.AppendAllTextAsync(value, "foo", Encoding.UTF8,
 				CancellationToken.None).GetAwaiter().GetResult());
 #endif
 		yield return (ExceptionTestHelper.TestTypes.NullOrInvalidPath, "path", file
 			=> file.AppendText(value));
-		yield return (ExceptionTestHelper.TestTypes.AllExceptWhitespace, "sourceFileName", file
-			=> file.Copy(value, "foo"));
+		yield return (ExceptionTestHelper.TestTypes.AllExceptWhitespace, "sourceFileName",
+			file
+				=> file.Copy(value, "foo"));
 		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "destFileName", file
 			=> file.Copy("foo", value));
-		yield return (ExceptionTestHelper.TestTypes.AllExceptWhitespace, "sourceFileName", file
-			=> file.Copy(value, "foo", false));
+		yield return (ExceptionTestHelper.TestTypes.AllExceptWhitespace, "sourceFileName",
+			file
+				=> file.Copy(value, "foo", false));
 		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "destFileName", file
 			=> file.Copy("foo", value, false));
-		yield return (ExceptionTestHelper.TestTypes.Whitespace | ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName", file
-			=> file.Copy(value, "foo"));
-		yield return (ExceptionTestHelper.TestTypes.Whitespace | ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName", file
-			=> file.Copy("foo", value));
-		yield return (ExceptionTestHelper.TestTypes.Whitespace | ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName", file
-			=> file.Copy(value, "foo", false));
-		yield return (ExceptionTestHelper.TestTypes.Whitespace | ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName", file
-			=> file.Copy("foo", value, false));
+		yield return (
+			ExceptionTestHelper.TestTypes.Whitespace |
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName", file
+				=> file.Copy(value, "foo"));
+		yield return (
+			ExceptionTestHelper.TestTypes.Whitespace |
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName", file
+				=> file.Copy("foo", value));
+		yield return (
+			ExceptionTestHelper.TestTypes.Whitespace |
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName", file
+				=> file.Copy(value, "foo", false));
+		yield return (
+			ExceptionTestHelper.TestTypes.Whitespace |
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName", file
+				=> file.Copy("foo", value, false));
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
 			=> file.Create(value));
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
@@ -215,19 +243,27 @@ public abstract partial class ExceptionTests<TFileSystem>
 			=> file.Move(value, "foo"));
 		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "destFileName", file
 			=> file.Move("foo", value));
-		yield return (ExceptionTestHelper.TestTypes.Whitespace | ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName", file
-			=> file.Move(value, "foo"));
-		yield return (ExceptionTestHelper.TestTypes.Whitespace | ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName", file
-			=> file.Move("foo", value));
+		yield return (
+			ExceptionTestHelper.TestTypes.Whitespace |
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName", file
+				=> file.Move(value, "foo"));
+		yield return (
+			ExceptionTestHelper.TestTypes.Whitespace |
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName", file
+				=> file.Move("foo", value));
 #if FEATURE_FILE_MOVETO_OVERWRITE
 		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "sourceFileName", file
 			=> file.Move(value, "foo", false));
 		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "destFileName", file
 			=> file.Move("foo", value, false));
-		yield return (ExceptionTestHelper.TestTypes.Whitespace | ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName", file
-			=> file.Move(value, "foo", false));
-		yield return (ExceptionTestHelper.TestTypes.Whitespace | ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName", file
-			=> file.Move("foo", value, false));
+		yield return (
+			ExceptionTestHelper.TestTypes.Whitespace |
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName", file
+				=> file.Move(value, "foo", false));
+		yield return (
+			ExceptionTestHelper.TestTypes.Whitespace |
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName", file
+				=> file.Move("foo", value, false));
 #endif
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
 			=> file.Open(value, FileMode.Open));
@@ -249,7 +285,8 @@ public abstract partial class ExceptionTests<TFileSystem>
 			=> file.ReadAllBytes(value));
 #if FEATURE_FILESYSTEM_ASYNC
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllBytesAsync(value, CancellationToken.None).GetAwaiter().GetResult());
+			=> file.ReadAllBytesAsync(value, CancellationToken.None).GetAwaiter()
+			   .GetResult());
 #endif
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
 			=> file.ReadAllLines(value));
@@ -257,9 +294,11 @@ public abstract partial class ExceptionTests<TFileSystem>
 			=> file.ReadAllLines(value, Encoding.UTF8));
 #if FEATURE_FILESYSTEM_ASYNC
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllLinesAsync(value, CancellationToken.None).GetAwaiter().GetResult());
+			=> file.ReadAllLinesAsync(value, CancellationToken.None).GetAwaiter()
+			   .GetResult());
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllLinesAsync(value, Encoding.UTF8, CancellationToken.None).GetAwaiter().GetResult());
+			=> file.ReadAllLinesAsync(value, Encoding.UTF8, CancellationToken.None)
+			   .GetAwaiter().GetResult());
 #endif
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
 			=> file.ReadAllText(value));
@@ -267,9 +306,11 @@ public abstract partial class ExceptionTests<TFileSystem>
 			=> file.ReadAllText(value, Encoding.UTF8));
 #if FEATURE_FILESYSTEM_ASYNC
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllTextAsync(value, CancellationToken.None).GetAwaiter().GetResult());
+			=> file.ReadAllTextAsync(value, CancellationToken.None).GetAwaiter()
+			   .GetResult());
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllTextAsync(value, Encoding.UTF8, CancellationToken.None).GetAwaiter().GetResult());
+			=> file.ReadAllTextAsync(value, Encoding.UTF8, CancellationToken.None)
+			   .GetAwaiter().GetResult());
 #endif
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
 			=> file.ReadLines(value));
@@ -324,7 +365,8 @@ public abstract partial class ExceptionTests<TFileSystem>
 			=> file.WriteAllLines(value, new[] { "foo" }, Encoding.UTF8));
 #if FEATURE_FILESYSTEM_ASYNC
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.WriteAllLinesAsync(value, new[] { "foo" }, CancellationToken.None).GetAwaiter().GetResult());
+			=> file.WriteAllLinesAsync(value, new[] { "foo" }, CancellationToken.None)
+			   .GetAwaiter().GetResult());
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
 			=> file.WriteAllLinesAsync(value, new[] { "foo" }, Encoding.UTF8,
 				CancellationToken.None).GetAwaiter().GetResult());
@@ -335,7 +377,8 @@ public abstract partial class ExceptionTests<TFileSystem>
 			=> file.WriteAllText(value, "foo", Encoding.UTF8));
 #if FEATURE_FILESYSTEM_ASYNC
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.WriteAllTextAsync(value, "foo", CancellationToken.None).GetAwaiter().GetResult());
+			=> file.WriteAllTextAsync(value, "foo", CancellationToken.None).GetAwaiter()
+			   .GetResult());
 		yield return (ExceptionTestHelper.TestTypes.All, "path", file
 			=> file.WriteAllTextAsync(value, "foo", Encoding.UTF8,
 				CancellationToken.None).GetAwaiter().GetResult());

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/ExceptionTests.cs
@@ -12,7 +12,7 @@ public abstract partial class ExceptionTests<TFileSystem>
 {
 	[Theory]
 	[MemberData(nameof(GetFileInfoFactoryCallbacks), parameters: "")]
-	public void Operations_ShouldThrowArgumentExceptionIfPathIsEmpty(
+	public void Operations_ShouldThrowArgumentExceptionIfValueIsEmpty(
 		Expression<Action<IFileInfoFactory>> callback, string paramName,
 		bool ignoreParamCheck)
 	{
@@ -23,17 +23,21 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (!Test.IsNetFramework && !ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 
-		exception.Should().BeOfType<ArgumentException>()
-		   .Which.HResult.Should().Be(-2147024809);
+		exception.Should().BeOfType<ArgumentException>(
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+		   .Which.HResult.Should().Be(-2147024809,
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 	}
 
 	[SkippableTheory]
 	[MemberData(nameof(GetFileInfoFactoryCallbacks), parameters: "  ")]
-	public void Operations_ShouldThrowArgumentExceptionIfPathIsWhitespace(
+	public void Operations_ShouldThrowArgumentExceptionIfValueIsWhitespace(
 		Expression<Action<IFileInfoFactory>> callback, string paramName,
 		bool ignoreParamCheck)
 	{
@@ -46,17 +50,21 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (!Test.IsNetFramework && !ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 
-		exception.Should().BeOfType<ArgumentException>()
-		   .Which.HResult.Should().Be(-2147024809);
+		exception.Should().BeOfType<ArgumentException>(
+				$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+		   .Which.HResult.Should().Be(-2147024809,
+				$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 	}
 
 	[Theory]
 	[MemberData(nameof(GetFileInfoFactoryCallbacks), parameters: (string?)null)]
-	public void Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(
+	public void Operations_ShouldThrowArgumentNullExceptionIfValueIsNull(
 		Expression<Action<IFileInfoFactory>> callback, string paramName,
 		bool ignoreParamCheck)
 	{
@@ -67,12 +75,15 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentNullException>();
+			exception.Should().BeOfType<ArgumentNullException>(
+				$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 		else
 		{
-			exception.Should().BeOfType<ArgumentNullException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentNullException>(
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 	}
 
@@ -80,7 +91,7 @@ public abstract partial class ExceptionTests<TFileSystem>
 	[MemberData(nameof(GetFileInfoFactoryCallbacks),
 		parameters: "Illegal\tCharacter?InPath")]
 	public void
-		Operations_ShouldThrowCorrectExceptionIfPathContainsIllegalCharactersOnWindows(
+		Operations_ShouldThrowCorrectExceptionIfValueContainsIllegalPathCharactersOnWindows(
 			Expression<Action<IFileInfoFactory>> callback, string paramName,
 			bool ignoreParamCheck)
 	{
@@ -91,12 +102,16 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (Test.IsNetFramework)
 		{
-			exception.Should().BeOfType<ArgumentException>()
-			   .Which.HResult.Should().Be(-2147024809);
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.HResult.Should().Be(-2147024809,
+					$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 		else
 		{
-			exception.Should().BeNull();
+			exception.Should()
+			   .BeNull(
+					$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 	}
 
@@ -107,8 +122,8 @@ public abstract partial class ExceptionTests<TFileSystem>
 		   .Where(item => item.TestType.HasFlag(path.ToTestType()))
 		   .Select(item => new object?[]
 			{
-				item.Callback, item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
+				item.Callback, item.ParamName, item.TestType.HasFlag(ExceptionTestHelper
+				   .TestTypes
 				   .IgnoreParamNameCheck)
 			});
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/ExceptionTests.cs
@@ -13,8 +13,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 {
 	[Theory]
 	[MemberData(nameof(GetFileStreamFactoryCallbacks), parameters: "")]
-	public void Operations_ShouldThrowArgumentExceptionIfPathIsEmpty(
-		Expression<Action<IFileStreamFactory>> callback, string paramName, bool ignoreParamCheck)
+	public void Operations_ShouldThrowArgumentExceptionIfValueIsEmpty(
+		Expression<Action<IFileStreamFactory>> callback, string paramName,
+		bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -23,18 +24,23 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (!Test.IsNetFramework && !ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 
-		exception.Should().BeOfType<ArgumentException>()
-		   .Which.HResult.Should().Be(-2147024809);
+		exception.Should().BeOfType<ArgumentException>(
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+		   .Which.HResult.Should().Be(-2147024809,
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 	}
 
 	[SkippableTheory]
 	[MemberData(nameof(GetFileStreamFactoryCallbacks), parameters: "  ")]
-	public void Operations_ShouldThrowArgumentExceptionIfPathIsWhitespace(
-		Expression<Action<IFileStreamFactory>> callback, string paramName, bool ignoreParamCheck)
+	public void Operations_ShouldThrowArgumentExceptionIfValueIsWhitespace(
+		Expression<Action<IFileStreamFactory>> callback, string paramName,
+		bool ignoreParamCheck)
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
@@ -45,18 +51,23 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (!Test.IsNetFramework)
 		{
-			exception.Should().BeOfType<ArgumentException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 
-		exception.Should().BeOfType<ArgumentException>()
-		   .Which.HResult.Should().Be(-2147024809);
+		exception.Should().BeOfType<ArgumentException>(
+				$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+		   .Which.HResult.Should().Be(-2147024809,
+				$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 	}
 
 	[Theory]
 	[MemberData(nameof(GetFileStreamFactoryCallbacks), parameters: (string?)null)]
-	public void Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(
-		Expression<Action<IFileStreamFactory>> callback, string paramName, bool ignoreParamCheck)
+	public void Operations_ShouldThrowArgumentNullExceptionIfValueIsNull(
+		Expression<Action<IFileStreamFactory>> callback, string paramName,
+		bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -65,12 +76,15 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentNullException>();
+			exception.Should().BeOfType<ArgumentNullException>(
+				$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 		else
 		{
-			exception.Should().BeOfType<ArgumentNullException>()
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentNullException>(
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 	}
 
@@ -78,8 +92,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 	[MemberData(nameof(GetFileStreamFactoryCallbacks),
 		parameters: "Illegal\tCharacter?InPath")]
 	public void
-		Operations_ShouldThrowCorrectExceptionIfPathContainsIllegalCharactersOnWindows(
-			Expression<Action<IFileStreamFactory>> callback, string paramName, bool ignoreParamCheck)
+		Operations_ShouldThrowCorrectExceptionIfValueContainsIllegalPathCharactersOnWindows(
+			Expression<Action<IFileStreamFactory>> callback, string paramName,
+			bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -90,20 +105,25 @@ public abstract partial class ExceptionTests<TFileSystem>
 		{
 			if (exception is IOException ioException)
 			{
-				ioException.HResult.Should().NotBe(-2147024809);
+				ioException.HResult.Should().NotBe(-2147024809,
+					$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 			}
 		}
 		else
 		{
 			if (Test.IsNetFramework)
 			{
-				exception.Should().BeOfType<ArgumentException>()
-				   .Which.HResult.Should().Be(-2147024809);
+				exception.Should().BeOfType<ArgumentException>(
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})")
+				   .Which.HResult.Should().Be(-2147024809,
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 			}
 			else
 			{
-				exception.Should().BeOfType<IOException>()
-				   .Which.HResult.Should().Be(-2147024773);
+				exception.Should().BeOfType<IOException>(
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})")
+				   .Which.HResult.Should().Be(-2147024773,
+						$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 			}
 		}
 	}
@@ -115,9 +135,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 		   .Where(item => item.TestType.HasFlag(path.ToTestType()))
 		   .Select(item => new object?[]
 			{
-				item.Callback,
-				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck)
+				item.Callback, item.ParamName,
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
+				   .IgnoreParamNameCheck)
 			});
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,
@@ -129,11 +149,14 @@ public abstract partial class ExceptionTests<TFileSystem>
 		yield return (ExceptionTestHelper.TestTypes.All, "path", fileStreamFactory
 			=> fileStreamFactory.New(value, FileMode.Open, FileAccess.ReadWrite));
 		yield return (ExceptionTestHelper.TestTypes.All, "path", fileStreamFactory
-			=> fileStreamFactory.New(value, FileMode.Open, FileAccess.ReadWrite, FileShare.None));
+			=> fileStreamFactory.New(value, FileMode.Open, FileAccess.ReadWrite,
+				FileShare.None));
 		yield return (ExceptionTestHelper.TestTypes.All, "path", fileStreamFactory
-			=> fileStreamFactory.New(value, FileMode.Open, FileAccess.ReadWrite, FileShare.None, 1024));
+			=> fileStreamFactory.New(value, FileMode.Open, FileAccess.ReadWrite,
+				FileShare.None, 1024));
 		yield return (ExceptionTestHelper.TestTypes.All, "path", fileStreamFactory
-			=> fileStreamFactory.New(value, FileMode.Open, FileAccess.ReadWrite, FileShare.None, 1024, FileOptions.None));
+			=> fileStreamFactory.New(value, FileMode.Open, FileAccess.ReadWrite,
+				FileShare.None, 1024, FileOptions.None));
 #if FEATURE_FILESYSTEM_STREAM_OPTIONS
 		yield return (ExceptionTestHelper.TestTypes.All, "path", fileStreamFactory
 			=> fileStreamFactory.New(value, new FileStreamOptions()));

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ExceptionTests.cs
@@ -13,8 +13,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 {
 	[Theory]
 	[MemberData(nameof(GetFileSystemInfoCallbacks), parameters: "")]
-	public void Operations_ShouldThrowArgumentExceptionIfPathIsEmpty(
-		Expression<Action<IFileSystemInfo>> callback, string paramName, bool ignoreParamCheck)
+	public void Operations_ShouldThrowArgumentExceptionIfValueIsEmpty(
+		Expression<Action<IFileSystemInfo>> callback, string paramName,
+		bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -23,18 +24,23 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (!Test.IsNetFramework && !ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentException>($"{callback}\n has invalid parameter for '{paramName}'")
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentException>(
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 
-		exception.Should().BeOfType<ArgumentException>($"{callback}\n has invalid parameter for '{paramName}'")
-		   .Which.HResult.Should().Be(-2147024809);
+		exception.Should().BeOfType<ArgumentException>(
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+		   .Which.HResult.Should().Be(-2147024809,
+				$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 	}
 
 	[Theory]
 	[MemberData(nameof(GetFileSystemInfoCallbacks), parameters: (string?)null)]
-	public void Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(
-		Expression<Action<IFileSystemInfo>> callback, string paramName, bool ignoreParamCheck)
+	public void Operations_ShouldThrowArgumentNullExceptionIfValueIsNull(
+		Expression<Action<IFileSystemInfo>> callback, string paramName,
+		bool ignoreParamCheck)
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -43,12 +49,15 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 		if (ignoreParamCheck)
 		{
-			exception.Should().BeOfType<ArgumentNullException>($"{callback}\n has invalid parameter for '{paramName}'");
+			exception.Should().BeOfType<ArgumentNullException>(
+				$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 		else
 		{
-			exception.Should().BeOfType<ArgumentNullException>($"{callback}\n has invalid parameter for '{paramName}'")
-			   .Which.ParamName.Should().Be(paramName);
+			exception.Should().BeOfType<ArgumentNullException>(
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})")
+			   .Which.ParamName.Should().Be(paramName,
+					$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 	}
 
@@ -59,9 +68,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 		   .Where(item => item.TestType.HasFlag(path.ToTestType()))
 		   .Select(item => new object?[]
 			{
-				item.Callback,
-				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck)
+				item.Callback, item.ParamName,
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
+				   .IgnoreParamNameCheck)
 			});
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,
@@ -69,8 +78,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 		GetFileSystemInfoCallbackTestParameters(string value)
 	{
 #if FEATURE_FILESYSTEM_LINK
-		yield return (ExceptionTestHelper.TestTypes.AllExceptInvalidPath, "pathToTarget", fileSystemInfo
-			=> fileSystemInfo.CreateAsSymbolicLink(value));
+		yield return (ExceptionTestHelper.TestTypes.AllExceptInvalidPath, "pathToTarget",
+			fileSystemInfo
+				=> fileSystemInfo.CreateAsSymbolicLink(value));
 #endif
 	}
 

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/DateTimeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/DateTimeTests.cs
@@ -26,6 +26,32 @@ public abstract partial class DateTimeTests<TTimeSystem>
 	}
 
 	[Fact]
+	public void Now_ShouldBeSetToNow()
+	{
+		DateTime before = DateTime.Now;
+		DateTime result = TimeSystem.DateTime.Now;
+		DateTime after = DateTime.Now;
+
+		result.Kind.Should().Be(DateTimeKind.Local);
+		result.Should().BeOnOrAfter(before.ApplySystemClockTolerance());
+		result.ApplySystemClockTolerance().Should().BeOnOrBefore(after);
+	}
+
+	[Fact]
+	public void Today_ShouldBeSetToToday()
+	{
+		DateTime before = DateTime.Today;
+		DateTime result = TimeSystem.DateTime.Today;
+		DateTime after = DateTime.Today;
+
+		result.Hour.Should().Be(0);
+		result.Minute.Should().Be(0);
+		result.Second.Should().Be(0);
+		result.Should().BeOnOrAfter(before.ApplySystemClockTolerance());
+		result.ApplySystemClockTolerance().Should().BeOnOrBefore(after);
+	}
+
+	[Fact]
 	public void UnixEpoch_ShouldReturnDefaultValue()
 	{
 		DateTime expectedResult = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -33,5 +59,17 @@ public abstract partial class DateTimeTests<TTimeSystem>
 		DateTime result = TimeSystem.DateTime.UnixEpoch;
 
 		result.Should().Be(expectedResult);
+	}
+
+	[Fact]
+	public void UtcNow_ShouldBeSetToUtcNow()
+	{
+		DateTime before = DateTime.UtcNow;
+		DateTime result = TimeSystem.DateTime.UtcNow;
+		DateTime after = DateTime.UtcNow;
+
+		result.Kind.Should().Be(DateTimeKind.Utc);
+		result.Should().BeOnOrAfter(before.ApplySystemClockTolerance());
+		result.ApplySystemClockTolerance().Should().BeOnOrBefore(after);
 	}
 }


### PR DESCRIPTION
Add missing tests for the `TimeSystem`.

Also refactor exception tests to include a "because" information