### PR TITLE
fix: exclude UNC servers from GetDrives()

### DIFF
--- a/Examples/Configuration/FileSystemConfiguration.Tests/InitializationTests.cs
+++ b/Examples/Configuration/FileSystemConfiguration.Tests/InitializationTests.cs
@@ -63,10 +63,10 @@ public class InitializationTests
 		MockFileSystem fileSystem = new();
 		fileSystem.DriveInfo.GetDrives().Should().HaveCount(1);
 
-		fileSystem.WithUncDrive(@"\\unc-server");
+		fileSystem.WithUncDrive(@"//unc-server");
 
 		fileSystem.DriveInfo.GetDrives().Should().HaveCount(1);
-		IDriveInfo drive = fileSystem.DriveInfo.New(@"\\unc-server");
+		IDriveInfo drive = fileSystem.DriveInfo.New(@"//unc-server");
 		drive.IsReady.Should().BeTrue();
 
 		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/Examples/Configuration/FileSystemConfiguration.Tests/InitializationTests.cs
+++ b/Examples/Configuration/FileSystemConfiguration.Tests/InitializationTests.cs
@@ -65,13 +65,15 @@ public class InitializationTests
 
 		fileSystem.WithUncDrive(@"\\unc-server");
 
-		fileSystem.DriveInfo.GetDrives().Should().HaveCount(2);
+		fileSystem.DriveInfo.GetDrives().Should().HaveCount(1);
+		IDriveInfo drive = fileSystem.DriveInfo.New(@"\\unc-server");
+		drive.IsReady.Should().BeTrue();
 
 		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 		{
 			fileSystem.WithDrive(@"D:");
 
-			fileSystem.DriveInfo.GetDrives().Should().HaveCount(3);
+			fileSystem.DriveInfo.GetDrives().Should().HaveCount(2);
 		}
 	}
 

--- a/Examples/Directory.Build.props
+++ b/Examples/Directory.Build.props
@@ -1,5 +1,8 @@
 <Project>
 
+  <Import Project="$(MSBuildThisFileDirectory)/../Directory.Build.props"
+          Condition="Exists('$(MSBuildThisFileDirectory)/../Directory.Build.props')" />
+
   <PropertyGroup>
     <TestablyAbstractionsVersion>0.12.*</TestablyAbstractionsVersion>
   </PropertyGroup>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,5 +1,7 @@
 <Project>
 
+  <Import Project="$(MSBuildThisFileDirectory)/../Directory.Build.props"
+          Condition="Exists('$(MSBuildThisFileDirectory)/../Directory.Build.props')" />
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Feature.Flags.props', '$(MSBuildThisFileDirectory)/../'))" />
 
   <PropertyGroup>

--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoFactoryMock.cs
@@ -25,6 +25,7 @@ internal sealed class DriveInfoFactoryMock : IDriveInfoFactory
 	/// <inheritdoc cref="IDriveInfoFactory.GetDrives()" />
 	public IDriveInfo[] GetDrives()
 		=> _fileSystem.Storage.GetDrives()
+		   .Where(x => !x.IsUncPath)
 		   .Cast<IDriveInfo>()
 		   .ToArray();
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
@@ -56,11 +56,6 @@ internal sealed class DriveInfoMock : IStorageDrive
 		IsReady = true;
 	}
 
-	/// <summary>
-	///     Flag indicating if the drive is a UNC drive
-	/// </summary>
-	public bool IsUncPath { get; }
-
 	#region IStorageDrive Members
 
 	/// <inheritdoc cref="IDriveInfo.AvailableFreeSpace" />
@@ -79,6 +74,11 @@ internal sealed class DriveInfoMock : IStorageDrive
 
 	/// <inheritdoc cref="IDriveInfo.IsReady" />
 	public bool IsReady { get; private set; }
+
+	/// <summary>
+	///     Flag indicating if the drive is a UNC drive
+	/// </summary>
+	public bool IsUncPath { get; }
 
 	/// <inheritdoc cref="IDriveInfo.Name" />
 	public string Name { get; }

--- a/Source/Testably.Abstractions.Testing/Storage/IStorageDrive.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageDrive.cs
@@ -10,6 +10,11 @@ namespace Testably.Abstractions.Testing.Storage;
 public interface IStorageDrive : IDriveInfo
 {
 	/// <summary>
+	///     Flag indicating if the drive is a UNC drive
+	/// </summary>
+	bool IsUncPath { get; }
+
+	/// <summary>
 	///     Changes the currently used bytes by <paramref name="usedBytesDelta" />.
 	///     <para />
 	///     Throws an <see cref="IOException" /> if the <see cref="IDriveInfo.AvailableFreeSpace" /> becomes

--- a/Source/Testably.Abstractions/FileSystem/DriveInfoWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/DriveInfoWrapper.cs
@@ -55,7 +55,8 @@ internal sealed class DriveInfoWrapper : IDriveInfo
 	/// <inheritdoc cref="IDriveInfo.VolumeLabel" />
 	[AllowNull]
 #if NET6_0_OR_GREATER
-	[ExcludeFromCodeCoverage(Justification = "Setting the VolumeLabel cannot be unit tested.")]
+	[ExcludeFromCodeCoverage(Justification =
+		"Setting the VolumeLabel cannot be unit tested.")]
 #endif
 	public string VolumeLabel
 	{
@@ -67,6 +68,10 @@ internal sealed class DriveInfoWrapper : IDriveInfo
 	}
 
 	#endregion
+
+	/// <inheritdoc cref="object.ToString()" />
+	public override string ToString()
+		=> _instance.ToString();
 
 	[return: NotNullIfNotNull("instance")]
 	internal static DriveInfoWrapper? FromDriveInfo(DriveInfo? instance,

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/Tests.cs
@@ -46,4 +46,15 @@ public abstract partial class Tests<TFileSystem>
 			}
 		}
 	}
+
+	[SkippableFact]
+	public void ToString_ShouldReturnDriveName()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		IDriveInfo result =
+			FileSystem.DriveInfo.New(FileTestHelper.RootDrive());
+
+		result.ToString().Should().Be("C:\\");
+	}
 }


### PR DESCRIPTION
`IDriveInfo.GetDrives()` and `IDirectory.GetLogicalDrives()` should not include UNC servers, but only local drives.