### PR TITLE
fix: include byte order mark when creating text files.

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -82,6 +82,10 @@ internal sealed class FileMock : IFile
 				FileAccess.ReadWrite,
 				FileStreamFactoryMock.DefaultShare))
 			{
+				if (fileInfo.GetBytes().Length == 0)
+				{
+					fileInfo.WriteBytes(encoding.GetPreamble());
+				}
 				fileInfo.AppendBytes(encoding.GetBytes(contents));
 			}
 		}
@@ -755,7 +759,8 @@ internal sealed class FileMock : IFile
 				FileAccess.Write,
 				FileStreamFactoryMock.DefaultShare))
 			{
-				fileInfo.WriteBytes(encoding.GetBytes(contents));
+				fileInfo.WriteBytes(encoding.GetPreamble());
+				fileInfo.AppendBytes(encoding.GetBytes(contents));
 			}
 		}
 	}

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -86,6 +86,7 @@ internal sealed class FileMock : IFile
 				{
 					fileInfo.WriteBytes(encoding.GetPreamble());
 				}
+
 				fileInfo.AppendBytes(encoding.GetBytes(contents));
 			}
 		}
@@ -471,7 +472,11 @@ internal sealed class FileMock : IFile
 				FileStreamFactoryMock.DefaultShare))
 			{
 				fileInfo.AdjustTimes(TimeAdjustments.LastAccessTime);
-				return encoding.GetString(fileInfo.GetBytes());
+				using (MemoryStream ms = new(fileInfo.GetBytes()))
+				using (StreamReader sr = new(ms, encoding))
+				{
+					return sr.ReadToEnd();
+				}
 			}
 		}
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -38,10 +38,14 @@ internal sealed class FileMock : IFile
 		string path,
 		IEnumerable<string> contents,
 		Encoding encoding)
-		=> AppendAllText(
+	{
+		_ = contents ?? throw new ArgumentNullException(nameof(contents));
+		_ = encoding ?? throw new ArgumentNullException(nameof(encoding));
+		AppendAllText(
 			path,
 			contents.Aggregate(string.Empty, (a, b) => a + b + Environment.NewLine),
 			encoding);
+	}
 
 #if FEATURE_FILESYSTEM_ASYNC
 	/// <inheritdoc cref="IFile.AppendAllLinesAsync(string, IEnumerable{string}, CancellationToken)" />

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DriveInfoMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DriveInfoMockTests.cs
@@ -53,7 +53,7 @@ public class DriveInfoMockTests
 		string fileContent1, string fileContent2, int expectedRemainingBytes,
 		string path, Encoding encoding)
 	{
-		int fileSize1 = encoding.GetBytes(fileContent1).Length;
+		int fileSize1 = encoding.GetPreamble().Length + encoding.GetBytes(fileContent1).Length;
 		int fileSize2 = encoding.GetBytes(fileContent2).Length;
 		FileSystem.WithDrive(d
 			=> d.SetTotalSize(fileSize1 + fileSize2 + expectedRemainingBytes));

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
@@ -74,6 +74,38 @@ public abstract partial class AppendAllLinesAsyncTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public async Task AppendAllLinesAsync_NullContent_ShouldThrowArgumentNullException(
+		string path)
+	{
+		Exception? exception = await Record.ExceptionAsync(async () =>
+		{
+			await FileSystem.File.AppendAllLinesAsync(path, null!);
+		});
+
+		exception.Should().BeOfType<ArgumentNullException>()
+		   .Which.HResult.Should().Be(-2147467261);
+		exception.Should().BeOfType<ArgumentNullException>()
+		   .Which.ParamName.Should().Be("contents");
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public async Task AppendAllLinesAsync_NullEncoding_ShouldThrowArgumentNullException(
+		string path)
+	{
+		Exception? exception = await Record.ExceptionAsync(async () =>
+		{
+			await FileSystem.File.AppendAllLinesAsync(path, new List<string>(), null!);
+		});
+
+		exception.Should().BeOfType<ArgumentNullException>()
+		   .Which.HResult.Should().Be(-2147467261);
+		exception.Should().BeOfType<ArgumentNullException>()
+		   .Which.ParamName.Should().Be("encoding");
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public async Task AppendAllLinesAsync_ShouldEndWithNewline(string path)
 	{
 		string[] contents = { "foo", "bar" };

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
@@ -39,6 +39,38 @@ public abstract partial class AppendAllLinesTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void AppendAllLines_NullContent_ShouldThrowArgumentNullException(
+		string path)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.AppendAllLines(path, null!);
+		});
+
+		exception.Should().BeOfType<ArgumentNullException>()
+		   .Which.HResult.Should().Be(-2147467261);
+		exception.Should().BeOfType<ArgumentNullException>()
+		   .Which.ParamName.Should().Be("contents");
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void AppendAllLines_NullEncoding_ShouldThrowArgumentNullException(
+		string path)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.AppendAllLines(path, new List<string>(), null!);
+		});
+
+		exception.Should().BeOfType<ArgumentNullException>()
+		   .Which.HResult.Should().Be(-2147467261);
+		exception.Should().BeOfType<ArgumentNullException>()
+		   .Which.ParamName.Should().Be("encoding");
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void AppendAllLines_ShouldEndWithNewline(string path)
 	{
 		string[] contents = { "foo", "bar" };

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
@@ -30,7 +30,20 @@ public abstract partial class AppendAllTextTests<TFileSystem>
 		FileSystem.File.AppendAllText(path, contents);
 
 		FileSystem.File.Exists(path).Should().BeTrue();
-		FileSystem.File.ReadAllLines(path).Should().BeEquivalentTo(contents);
+		FileSystem.File.ReadAllText(path).Should().Be(contents);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void AppendAllText_MissingFile_ShouldCreateFileWithBOM(
+		string path)
+	{
+		byte[] expectedBytes = { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0 };
+
+		FileSystem.File.AppendAllText(path, "AA", Encoding.UTF32);
+
+		FileSystem.File.ReadAllBytes(path)
+		   .Should().BeEquivalentTo(expectedBytes);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Text;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 
@@ -72,6 +73,19 @@ public abstract partial class WriteAllTextTests<TFileSystem>
 
 		lastWriteTime.Should()
 		   .BeOnOrAfter(updateTime.ApplySystemClockTolerance());
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void WriteAllText_ShouldCreateFileWithBOM(
+		string path)
+	{
+		byte[] expectedBytes = { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0 };
+
+		FileSystem.File.WriteAllText(path, "AA", Encoding.UTF32);
+
+		FileSystem.File.ReadAllBytes(path)
+		   .Should().BeEquivalentTo(expectedBytes);
 	}
 
 	[SkippableTheory]


### PR DESCRIPTION
Include the encoding preamble in newly created text files.

Ensure correct exception when providing `null` to AppendLines