### PR TITLE
fix: throw exception when trying to delete a file in a missing directory

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
@@ -87,7 +87,8 @@ internal class FileSystemInfoMock : IFileSystemInfo
 	/// <inheritdoc cref="IFileSystemInfo.Delete()" />
 	public void Delete()
 	{
-		if (!FileSystem.Storage.DeleteContainer(Location))
+		if (!FileSystem.Storage.DeleteContainer(Location) &&
+		    this is IDirectoryInfo)
 		{
 			throw ExceptionFactory.DirectoryNotFound(Location.FullPath);
 		}

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -101,6 +101,13 @@ internal sealed class InMemoryStorage : IStorage
 	{
 		if (!_containers.TryGetValue(location, out IStorageContainer? container))
 		{
+			IStorageLocation? parentLocation = location.GetParent();
+			if (parentLocation != null &&
+			    !_containers.TryGetValue(parentLocation, out _))
+			{
+				throw ExceptionFactory.DirectoryNotFound(parentLocation.FullPath);
+			}
+
 			return false;
 		}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/DeleteTests.cs
@@ -10,6 +10,35 @@ public abstract partial class DeleteTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
+	public void Delete_MissingDirectory_ShouldThrowDirectoryNotFoundException(
+		string missingDirectory, string fileName)
+	{
+		string filePath = FileSystem.Path.Combine(missingDirectory, fileName);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.Delete(filePath);
+		});
+
+		exception.Should().BeOfType<DirectoryNotFoundException>()
+		   .Which.HResult.Should().Be(-2147024893);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void Delete_MissingFile_ShouldDoNothing(
+		string fileName)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.Delete(fileName);
+		});
+
+		exception.Should().BeNull();
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void Delete_WithOpenFile_ShouldThrowIOException(string filename)
 	{
 		FileSystem.Initialize();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/DeleteTests.cs
@@ -10,6 +10,35 @@ public abstract partial class DeleteTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
+	public void Delete_MissingDirectory_ShouldThrowDirectoryNotFoundException(
+		string missingDirectory, string fileName)
+	{
+		string filePath = FileSystem.Path.Combine(missingDirectory, fileName);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.FileInfo.New(filePath).Delete();
+		});
+
+		exception.Should().BeOfType<DirectoryNotFoundException>()
+		   .Which.HResult.Should().Be(-2147024893);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void Delete_MissingFile_ShouldDoNothing(
+		string fileName)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.FileInfo.New(fileName).Delete();
+		});
+
+		exception.Should().BeNull();
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void Delete_WithOpenFile_ShouldThrowIOException(string filename)
 	{
 		FileSystem.Initialize();


### PR DESCRIPTION
In this case a `DirectoryNotFoundException` should be thrown.