### PR TITLE
fix: consider the ReadOnly-Attribute when opening a FileSystemStream

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -102,6 +102,12 @@ internal sealed class FileStreamMock : FileSystemStream
 				Execute.IsWindows ? -2147024816 : 17);
 		}
 
+		if (file.Attributes.HasFlag(FileAttributes.ReadOnly) &&
+		    access.HasFlag(FileAccess.Write))
+		{
+			throw ExceptionFactory.AccessToPathDenied(location.FullPath);
+		}
+
 		_accessLock = file.RequestAccess(access, share);
 
 		_container = file;

--- a/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
@@ -47,7 +47,8 @@ internal static class PathHelper
 		string? paramName = null,
 		bool? includeIsEmptyCheck = null)
 	{
-		CheckPathArgument(path, paramName ?? nameof(path), includeIsEmptyCheck ?? Execute.IsWindows);
+		CheckPathArgument(path, paramName ?? nameof(path),
+			includeIsEmptyCheck ?? Execute.IsWindows);
 		CheckPathCharacters(path, fileSystem, paramName ?? nameof(path), null);
 		return path;
 	}
@@ -104,6 +105,11 @@ internal static class PathHelper
 			throw ExceptionFactory.PathHasIncorrectSyntax(
 				fileSystem.Path.GetFullPath(path), hResult);
 		}
+
+		Execute.OnWindowsIf(path.LastIndexOf(':') > 1 &&
+		                    path.LastIndexOf(':') < path.IndexOf(Path.DirectorySeparatorChar),
+			() => throw ExceptionFactory.PathHasIncorrectSyntax(
+				fileSystem.Path.GetFullPath(path), hResult));
 	}
 
 	internal static string TrimOnWindows(this string path)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
@@ -1,6 +1,7 @@
 #if FEATURE_FILESYSTEM_ASYNC
 using AutoFixture;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -59,6 +60,21 @@ public abstract partial class AppendAllLinesAsyncTests<TFileSystem>
 		FileSystem.File.ReadAllLines(path).Should()
 		   .BeEquivalentTo(previousContents.Concat(contents),
 				o => o.WithStrictOrdering());
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public async Task AppendAllLinesAsync_MissingDirectory_ShouldThrowDirectoryNotFoundException(
+		string missingPath, string fileName, List<string> contents)
+	{
+		string filePath = FileSystem.Path.Combine(missingPath, fileName);
+		Exception? exception = await Record.ExceptionAsync(async() =>
+		{
+			await FileSystem.File.AppendAllLinesAsync(filePath, contents);
+		});
+
+		exception.Should().BeOfType<DirectoryNotFoundException>()
+		   .Which.HResult.Should().Be(-2147024893);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
@@ -1,5 +1,6 @@
 using AutoFixture;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 
@@ -23,6 +24,21 @@ public abstract partial class AppendAllLinesTests<TFileSystem>
 		FileSystem.File.ReadAllLines(path).Should()
 		   .BeEquivalentTo(previousContents.Concat(contents),
 				o => o.WithStrictOrdering());
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void AppendAllLines_MissingDirectory_ShouldThrowDirectoryNotFoundException(
+		string missingPath, string fileName, List<string> contents)
+	{
+		string filePath = FileSystem.Path.Combine(missingPath, fileName);
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.AppendAllLines(filePath, contents);
+		});
+
+		exception.Should().BeOfType<DirectoryNotFoundException>()
+		   .Which.HResult.Should().Be(-2147024893);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
@@ -1,5 +1,6 @@
 #if FEATURE_FILESYSTEM_ASYNC
 using AutoFixture;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -55,6 +56,21 @@ public abstract partial class AppendAllTextAsyncTests<TFileSystem>
 		FileSystem.File.Exists(path).Should().BeTrue();
 		FileSystem.File.ReadAllText(path).Should()
 		   .BeEquivalentTo(previousContents + contents);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public async Task AppendAllTextAsync_MissingDirectory_ShouldThrowDirectoryNotFoundException(
+		string missingPath, string fileName, string contents)
+	{
+		string filePath = FileSystem.Path.Combine(missingPath, fileName);
+		Exception? exception = await Record.ExceptionAsync(async () =>
+		{
+			await FileSystem.File.AppendAllTextAsync(filePath, contents);
+		});
+
+		exception.Should().BeOfType<DirectoryNotFoundException>()
+		   .Which.HResult.Should().Be(-2147024893);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
@@ -1,4 +1,5 @@
 using AutoFixture;
+using System.IO;
 using System.Text;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
@@ -24,6 +25,21 @@ public abstract partial class AppendAllTextTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void AppendAllText_MissingDirectory_ShouldThrowDirectoryNotFoundException(
+		string missingPath, string fileName, string contents)
+	{
+		string filePath = FileSystem.Path.Combine(missingPath, fileName);
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.AppendAllText(filePath, contents);
+		});
+
+		exception.Should().BeOfType<DirectoryNotFoundException>()
+		   .Which.HResult.Should().Be(-2147024893);
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void AppendAllText_MissingFile_ShouldCreateFile(
 		string path, string contents)
 	{
@@ -35,7 +51,7 @@ public abstract partial class AppendAllTextTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void AppendAllText_MissingFile_ShouldCreateFileWithBOM(
+	public void AppendAllText_MissingFile_ShouldCreateFileWithByteOrderMark(
 		string path)
 	{
 		byte[] expectedBytes = { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0 };

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -28,42 +28,6 @@ public abstract partial class CopyTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[InlineData(@"C::\something\demo.txt", @"C:\elsewhere\demo.txt")]
-	public void
-		Copy_InvalidPath_ShouldThrowIOException(
-			string source, string destination)
-	{
-		Skip.IfNot(Test.RunsOnWindows);
-
-		Exception? exception = Record.Exception(() =>
-		{
-			FileSystem.File.Copy(source, destination);
-		});
-
-		exception.Should().BeOfType<IOException>()
-		   .Which.HResult.Should().Be(-2147024773);
-	}
-
-	[SkippableTheory]
-	[InlineData(@"0:\something\demo.txt", @"C:\elsewhere\demo.txt")]
-	[InlineData(@"C:\something\demo.txt", @"^:\elsewhere\demo.txt")]
-	[InlineData(@"C:\something\demo.txt", @"C:\elsewhere:\demo.txt")]
-	public void
-		Copy_InvalidDriveName_ShouldThrowDirectoryNotFoundException(
-			string source, string destination)
-	{
-		Skip.IfNot(Test.RunsOnWindows);
-
-		Exception? exception = Record.Exception(() =>
-		{
-			FileSystem.File.Copy(source, destination);
-		});
-
-		exception.Should().BeOfType<DirectoryNotFoundException>()
-		   .Which.HResult.Should().Be(-2147024893);
-	}
-
-	[SkippableTheory]
 	[AutoData]
 	public void Copy_DestinationExists_ShouldThrowIOExceptionAndNotCopyFile(
 		string sourceName,
@@ -116,6 +80,58 @@ public abstract partial class CopyTests<TFileSystem>
 		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
 	}
 #endif
+
+	[SkippableTheory]
+	[InlineData(@"0:\something\demo.txt", @"C:\elsewhere\demo.txt")]
+	[InlineData(@"C:\something\demo.txt", @"^:\elsewhere\demo.txt")]
+	[InlineData(@"C:\something\demo.txt", @"C:\elsewhere:\demo.txt")]
+	public void
+		Copy_InvalidDriveName_ShouldThrowCorrectException(
+			string source, string destination)
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.Copy(source, destination);
+		});
+
+		if (Test.IsNetFramework)
+		{
+			exception.Should().BeOfType<NotSupportedException>()
+			   .Which.HResult.Should().Be(-2146233067);
+		}
+		else
+		{
+			exception.Should().BeOfType<IOException>()
+			   .Which.HResult.Should().Be(-2147024773);
+		}
+	}
+
+	[SkippableTheory]
+	[InlineData(@"C::\something\demo.txt", @"C:\elsewhere\demo.txt")]
+	public void
+		Copy_InvalidPath_ShouldThrowCorrectException(
+			string source, string destination)
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.Copy(source, destination);
+		});
+
+		if (Test.IsNetFramework)
+		{
+			exception.Should().BeOfType<NotSupportedException>()
+			   .Which.HResult.Should().Be(-2146233067);
+		}
+		else
+		{
+			exception.Should().BeOfType<IOException>()
+			   .Which.HResult.Should().Be(-2147024773);
+		}
+	}
 
 	[SkippableTheory]
 	[AutoData]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -89,23 +89,15 @@ public abstract partial class CopyTests<TFileSystem>
 		Copy_InvalidDriveName_ShouldThrowCorrectException(
 			string source, string destination)
 	{
-		Skip.IfNot(Test.RunsOnWindows);
+		Skip.IfNot(Test.IsNetFramework);
 
 		Exception? exception = Record.Exception(() =>
 		{
 			FileSystem.File.Copy(source, destination);
 		});
 
-		if (Test.IsNetFramework)
-		{
-			exception.Should().BeOfType<NotSupportedException>()
-			   .Which.HResult.Should().Be(-2146233067);
-		}
-		else
-		{
-			exception.Should().BeOfType<IOException>()
-			   .Which.HResult.Should().Be(-2147024773);
-		}
+		exception.Should().BeOfType<NotSupportedException>()
+		   .Which.HResult.Should().Be(-2146233067);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
@@ -10,6 +10,56 @@ public abstract partial class CreateTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
+	public void Create_ExistingFile_ShouldBeOverwritten(
+		string path, string originalContent, string newContent)
+	{
+		FileSystem.File.WriteAllText(path, originalContent);
+
+		using FileSystemStream stream = FileSystem.File.Create(path);
+
+		using StreamWriter streamWriter = new(stream);
+		streamWriter.Write(newContent);
+
+		streamWriter.Dispose();
+		stream.Dispose();
+		FileSystem.File.ReadAllText(path).Should().Be(newContent);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void Create_ReadOnlyFile_ShouldThrowUnauthorizedAccessException(
+		string path, string content)
+	{
+		FileSystem.File.WriteAllText(path, content);
+		FileSystem.File.SetAttributes(path, FileAttributes.ReadOnly);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.Create(path);
+		});
+
+		exception.Should().BeOfType<UnauthorizedAccessException>()
+		   .Which.HResult.Should().Be(-2147024891);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void Create_MissingDirectory_ShouldThrowDirectoryNotFoundException(
+		string missingDirectory, string fileName, string content)
+	{
+		string filePath = FileSystem.Path.Combine(missingDirectory, fileName);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.Create(filePath);
+		});
+
+		exception.Should().BeOfType<DirectoryNotFoundException>()
+		   .Which.HResult.Should().Be(-2147024893);
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void Create_MissingFile_ShouldCreateFile(string path)
 	{
 		using FileSystemStream stream = FileSystem.File.Create(path);
@@ -21,8 +71,6 @@ public abstract partial class CreateTests<TFileSystem>
 	[AutoData]
 	public void Create_ShouldUseReadWriteAccessAndNoneShare(string path)
 	{
-		FileSystem.File.WriteAllText(path, null);
-
 		using FileSystemStream stream = FileSystem.File.Create(path);
 
 		FileTestHelper.CheckFileAccess(stream).Should().Be(FileAccess.ReadWrite);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -77,7 +77,7 @@ public abstract partial class WriteAllTextTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void WriteAllText_ShouldCreateFileWithBOM(
+	public void WriteAllText_ShouldCreateFileWithByteOrderMark(
 		string path)
 	{
 		byte[] expectedBytes = { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0 };

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/OptionsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/OptionsTests.cs
@@ -18,6 +18,7 @@ public abstract partial class OptionsTests<TFileSystem>
 
 		using FileSystemStream stream = FileSystem.FileStream.New(path, FileMode.Open,
 			FileAccess.ReadWrite, FileShare.None, 10, FileOptions.DeleteOnClose);
+		FileSystem.File.Exists(path).Should().BeTrue();
 
 		stream.Close();
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/Tests.cs
@@ -170,6 +170,33 @@ public abstract partial class Tests<TFileSystem>
 	}
 
 	[SkippableTheory]
+	[InlineAutoData(FileAccess.Read)]
+	[InlineAutoData(FileAccess.ReadWrite)]
+	[InlineAutoData(FileAccess.Write)]
+	public void
+		New_ReadOnlyFlag_WhenAccessContainsWrite_ShouldThrowUnauthorizedAccessException(
+			FileAccess access,
+			string path)
+	{
+		FileSystem.File.WriteAllText(path, "some content");
+		FileSystem.File.SetAttributes(path, FileAttributes.ReadOnly);
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.FileStream.New(path, FileMode.Open, access);
+		});
+
+		if (access.HasFlag(FileAccess.Write))
+		{
+			exception.Should().BeOfType<UnauthorizedAccessException>()
+			   .Which.HResult.Should().Be(-2147024891);
+		}
+		else
+		{
+			exception.Should().BeNull();
+		}
+	}
+
+	[SkippableTheory]
 	[AutoData]
 	public void New_SamePathAsExistingDirectory_ShouldThrowException(
 		string path)


### PR DESCRIPTION
When trying to open a FileSystemStream on a read-only file with write access, it should throw an `UnauthorizedAccessException`