### PR TITLE
fix: throw exception when trying to read the length of a directory

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
@@ -55,7 +55,8 @@ internal sealed class FileInfoMock
 	{
 		get
 		{
-			if (Container is NullContainer)
+			if (Container is NullContainer ||
+			    Container.Type != FileSystemTypes.File)
 			{
 				throw ExceptionFactory.FileNotFound(
 					Execute.OnNetFramework(

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/LengthTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/LengthTests.cs
@@ -32,6 +32,53 @@ public abstract partial class LengthTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void Length_MissingDirectory_ShouldThrowFileNotFoundException(
+		string missingDirectory, string fileName)
+	{
+		string path = FileSystem.Path.Combine(missingDirectory, fileName);
+		IFileInfo sut = FileSystem.FileInfo.New(path);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			_ = sut.Length;
+		});
+
+		exception.Should().BeOfType<FileNotFoundException>()
+		   .Which.HResult.Should().Be(-2147024894);
+#if NETFRAMEWORK
+		exception.Should().BeOfType<FileNotFoundException>()
+		   .Which.Message.Should().Contain($"'{path}'");
+#else
+		exception.Should().BeOfType<FileNotFoundException>()
+		   .Which.Message.Should().Contain($"'{FileSystem.Path.GetFullPath(path)}'");
+#endif
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void Length_PathIsDirectory_ShouldThrowFileNotFoundException(string path)
+	{
+		FileSystem.Directory.CreateDirectory(path);
+		IFileInfo sut = FileSystem.FileInfo.New(path);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			_ = sut.Length;
+		});
+
+		exception.Should().BeOfType<FileNotFoundException>()
+		   .Which.HResult.Should().Be(-2147024894);
+#if NETFRAMEWORK
+		exception.Should().BeOfType<FileNotFoundException>()
+		   .Which.Message.Should().Contain($"'{path}'");
+#else
+		exception.Should().BeOfType<FileNotFoundException>()
+		   .Which.Message.Should().Contain($"'{FileSystem.Path.GetFullPath(path)}'");
+#endif
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void Length_WhenFileExists_ShouldBeSetCorrectly(string path, byte[] bytes)
 	{
 		FileSystem.File.WriteAllBytes(path, bytes);


### PR DESCRIPTION
Throw the correct exception when trying to access the Length property of a `IFileInfo` that points to a directory.