### PR TITLE
fix: return correct extension on `IFileInfo`

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
@@ -53,11 +53,22 @@ internal sealed class DirectoryInfoMock
 		DirectoryInfoMock directory = New(
 			FileSystem.Storage.GetLocation(
 				FileSystem.Path.Combine(FullName, path
-			   .EnsureValidFormat(FileSystem, nameof(path),
+				   .EnsureValidFormat(FileSystem, nameof(path),
 						Execute.IsWindows && !Execute.IsNetFramework))),
 			FileSystem);
 		directory.Create();
 		return directory;
+	}
+
+	/// <inheritdoc />
+	public override void Delete()
+	{
+		if (!FileSystem.Storage.DeleteContainer(Location))
+		{
+			throw ExceptionFactory.DirectoryNotFound(Location.FullPath);
+		}
+
+		ResetCache(!Execute.IsNetFramework);
 	}
 
 	/// <inheritdoc cref="IDirectoryInfo.Delete(bool)" />
@@ -251,19 +262,20 @@ internal sealed class DirectoryInfoMock
 		return new DirectoryInfoMock(location, fileSystem);
 	}
 
-	private IEnumerable<IStorageLocation> EnumerateInternal(FileSystemTypes fileSystemTypes,
-	                                              string path,
-	                                              string searchPattern,
-	                                              EnumerationOptions enumerationOptions)
+	private IEnumerable<IStorageLocation> EnumerateInternal(
+		FileSystemTypes fileSystemTypes,
+		string path,
+		string searchPattern,
+		EnumerationOptions enumerationOptions)
 	{
 		StorageExtensions.AdjustedLocation adjustedLocation = FileSystem.Storage
 		   .AdjustLocationFromSearchPattern(
 				path.EnsureValidFormat(FileSystem),
 				searchPattern);
 		return FileSystem.Storage.EnumerateLocations(
-				adjustedLocation.Location,
-				fileSystemTypes,
-				adjustedLocation.SearchPattern,
-				enumerationOptions);
+			adjustedLocation.Location,
+			fileSystemTypes,
+			adjustedLocation.SearchPattern,
+			enumerationOptions);
 	}
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
@@ -85,14 +85,9 @@ internal class FileSystemInfoMock : IFileSystemInfo
 	}
 
 	/// <inheritdoc cref="IFileSystemInfo.Delete()" />
-	public void Delete()
+	public virtual void Delete()
 	{
-		if (!FileSystem.Storage.DeleteContainer(Location) &&
-		    this is IDirectoryInfo)
-		{
-			throw ExceptionFactory.DirectoryNotFound(Location.FullPath);
-		}
-
+		FileSystem.Storage.DeleteContainer(Location);
 		ResetCache(!Execute.IsNetFramework);
 	}
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
@@ -105,7 +105,18 @@ internal class FileSystemInfoMock : IFileSystemInfo
 
 	/// <inheritdoc cref="IFileSystemInfo.Extension" />
 	public string Extension
-		=> FileSystem.Path.GetExtension(Location.FullPath);
+	{
+		get
+		{
+			if (Location.FullPath.EndsWith(".") &&
+			    !Execute.IsWindows)
+			{
+				return ".";
+			}
+
+			return FileSystem.Path.GetExtension(Location.FullPath);
+		}
+	}
 
 	/// <inheritdoc cref="IFileSystemInfo.ExtensionContainer" />
 	public IFileSystemExtensionContainer ExtensionContainer

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -203,7 +203,7 @@ public class MockFileSystemTests
 	[SkippableTheory]
 	[AutoData]
 	public void WithUncDrive_ShouldNotBeIncludedInGetDrives(
-		string server, string path, byte[] bytes)
+		string server)
 	{
 		MockFileSystem sut = new();
 		string uncPrefix = new(sut.Path.DirectorySeparatorChar, 2);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
@@ -45,7 +45,7 @@ public abstract partial class CreateTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public void Create_MissingDirectory_ShouldThrowDirectoryNotFoundException(
-		string missingDirectory, string fileName, string content)
+		string missingDirectory, string fileName)
 	{
 		string filePath = FileSystem.Path.Combine(missingDirectory, fileName);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/EncryptDecryptTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/EncryptDecryptTests.cs
@@ -1,7 +1,6 @@
 using System.IO;
-using Testably.Abstractions.FileSystem;
 
-namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
+namespace Testably.Abstractions.Tests.FileSystem.File;
 
 // ReSharper disable once PartialTypeWithSinglePart
 public abstract partial class EncryptDecryptTests<TFileSystem>
@@ -18,10 +17,9 @@ public abstract partial class EncryptDecryptTests<TFileSystem>
 			"Encryption depends on the underlying device, if it is supported or not.");
 
 		FileSystem.File.WriteAllText(path, contents);
-		IFileInfo sut = FileSystem.FileInfo.New(path);
 
-		sut.Encrypt();
-		sut.Decrypt();
+		FileSystem.File.Encrypt(path);
+		FileSystem.File.Decrypt(path);
 
 		string result = FileSystem.File.ReadAllText(path);
 		result.Should().Be(contents);
@@ -36,9 +34,8 @@ public abstract partial class EncryptDecryptTests<TFileSystem>
 		Skip.IfNot(Test.RunsOnWindows);
 
 		FileSystem.File.WriteAllText(path, contents);
-		IFileInfo sut = FileSystem.FileInfo.New(path);
 
-		sut.Decrypt();
+		FileSystem.File.Decrypt(path);
 
 		string result = FileSystem.File.ReadAllText(path);
 		result.Should().Be(contents);
@@ -54,12 +51,13 @@ public abstract partial class EncryptDecryptTests<TFileSystem>
 			"Encryption depends on the underlying device, if it is supported or not.");
 
 		FileSystem.File.WriteAllText(path, contents);
-		IFileInfo sut = FileSystem.FileInfo.New(path);
 
-		sut.Encrypt();
-		sut.Attributes.Should().HaveFlag(FileAttributes.Encrypted);
-		sut.Decrypt();
-		sut.Attributes.Should().NotHaveFlag(FileAttributes.Encrypted);
+		FileSystem.File.Encrypt(path);
+		FileSystem.File.GetAttributes(path)
+		   .Should().HaveFlag(FileAttributes.Encrypted);
+		FileSystem.File.Decrypt(path);
+		FileSystem.File.GetAttributes(path)
+		   .Should().NotHaveFlag(FileAttributes.Encrypted);
 	}
 
 	[SkippableTheory]
@@ -72,9 +70,8 @@ public abstract partial class EncryptDecryptTests<TFileSystem>
 			"Encryption depends on the underlying device, if it is supported or not.");
 
 		FileSystem.File.WriteAllBytes(path, bytes);
-		IFileInfo sut = FileSystem.FileInfo.New(path);
 
-		sut.Encrypt();
+		FileSystem.File.Encrypt(path);
 
 		byte[] result = FileSystem.File.ReadAllBytes(path);
 		result.Should().NotBeEquivalentTo(bytes);
@@ -90,12 +87,11 @@ public abstract partial class EncryptDecryptTests<TFileSystem>
 			"Encryption depends on the underlying device, if it is supported or not.");
 
 		FileSystem.File.WriteAllText(path, contents);
-		IFileInfo sut = FileSystem.FileInfo.New(path);
 
-		sut.Encrypt();
-		sut.Encrypt();
+		FileSystem.File.Encrypt(path);
+		FileSystem.File.Encrypt(path);
 
-		sut.Decrypt();
+		FileSystem.File.Decrypt(path);
 		string result = FileSystem.File.ReadAllText(path);
 		result.Should().Be(contents);
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
@@ -63,13 +63,28 @@ public abstract partial class Tests<TFileSystem>
 
 	[SkippableTheory]
 	[InlineData("foo", "")]
-	[InlineData("foo.", "")]
 	[InlineData("foo.txt", ".txt")]
+	[InlineData("foo.bar.txt", ".txt")]
 	public void Extension_ShouldReturnExpectedValue(string fileName, string expectedValue)
 	{
 		IFileInfo sut = FileSystem.FileInfo.New(fileName);
 
 		sut.Extension.Should().Be(expectedValue);
+	}
+
+	[SkippableFact]
+	public void Extension_WithTrailingDot_ShouldReturnExpectedValue()
+	{
+		IFileInfo sut = FileSystem.FileInfo.New("foo.");
+
+		if (Test.RunsOnWindows)
+		{
+			sut.Extension.Should().Be("");
+		}
+		else
+		{
+			sut.Extension.Should().Be(".");
+		}
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
@@ -9,6 +9,32 @@ public abstract partial class Tests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
+	[SkippableTheory]
+	[AutoData]
+	public void Attributes_WhenFileIsMissing_ShouldReturnMinusOne(string path)
+	{
+		FileAttributes expected = (FileAttributes)(-1);
+		IFileInfo sut = FileSystem.FileInfo.New(path);
+
+		sut.Attributes.Should().Be(expected);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void Attributes_WhenFileIsMissing_SetterShouldThrowFileNotFoundException(
+		string path)
+	{
+		IFileInfo sut = FileSystem.FileInfo.New(path);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Attributes = FileAttributes.ReadOnly;
+		});
+
+		exception.Should().BeOfType<FileNotFoundException>()
+		   .Which.HResult.Should().Be(-2147024894);
+	}
+
 	[SkippableFact]
 	public void Directory_ShouldReturnParentDirectory()
 	{
@@ -33,6 +59,17 @@ public abstract partial class Tests<TFileSystem>
 
 		file?.Should().NotBeNull();
 		file!.DirectoryName.Should().Be(initialized[0].FullName);
+	}
+
+	[SkippableTheory]
+	[InlineData("foo", "")]
+	[InlineData("foo.", "")]
+	[InlineData("foo.txt", ".txt")]
+	public void Extension_ShouldReturnExpectedValue(string fileName, string expectedValue)
+	{
+		IFileInfo sut = FileSystem.FileInfo.New(fileName);
+
+		sut.Extension.Should().Be(expectedValue);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetExtensionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetExtensionTests.cs
@@ -15,7 +15,7 @@ public abstract partial class GetExtensionTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void GetExtension_ShouldReturnDirectory(
+	public void GetExtension_ShouldReturnExtension(
 		string directory, string filename, string extension)
 	{
 		string path = directory + FileSystem.Path.DirectorySeparatorChar + filename +
@@ -26,10 +26,22 @@ public abstract partial class GetExtensionTests<TFileSystem>
 		result.Should().Be("." + extension);
 	}
 
+	[SkippableTheory]
+	[AutoData]
+	public void GetExtension_TrailingDot_ShouldReturnEmptyString(
+		string directory, string filename)
+	{
+		string path = directory + FileSystem.Path.DirectorySeparatorChar + filename + ".";
+
+		string result = FileSystem.Path.GetExtension(path);
+
+		result.Should().Be("");
+	}
+
 #if FEATURE_SPAN
 	[SkippableTheory]
 	[AutoData]
-	public void GetExtension_Span_ShouldReturnDirectory(
+	public void GetExtension_Span_ShouldReturnExtension(
 		string directory, string filename, string extension)
 	{
 		string path = directory + FileSystem.Path.DirectorySeparatorChar + filename +

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetExtensionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetExtensionTests.cs
@@ -26,18 +26,6 @@ public abstract partial class GetExtensionTests<TFileSystem>
 		result.Should().Be("." + extension);
 	}
 
-	[SkippableTheory]
-	[AutoData]
-	public void GetExtension_TrailingDot_ShouldReturnEmptyString(
-		string directory, string filename)
-	{
-		string path = directory + FileSystem.Path.DirectorySeparatorChar + filename + ".";
-
-		string result = FileSystem.Path.GetExtension(path);
-
-		result.Should().Be("");
-	}
-
 #if FEATURE_SPAN
 	[SkippableTheory]
 	[AutoData]
@@ -52,4 +40,16 @@ public abstract partial class GetExtensionTests<TFileSystem>
 		result.ToString().Should().Be("." + extension);
 	}
 #endif
+
+	[SkippableTheory]
+	[AutoData]
+	public void GetExtension_TrailingDot_ShouldReturnEmptyString(
+		string directory, string filename)
+	{
+		string path = directory + FileSystem.Path.DirectorySeparatorChar + filename + ".";
+
+		string result = FileSystem.Path.GetExtension(path);
+
+		result.Should().Be("");
+	}
 }


### PR DESCRIPTION
The `IFileInfo.Extension` should return `"."` when the file name ends with a dot and it is executed on Linux or MacOS.