### PR TITLE
fix: set `ToString()` correctly for IDirectoryInfo.Parent on .NET Framework

### DIFF
--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
@@ -95,27 +95,15 @@ internal sealed class InMemoryLocation : IStorageLocation
 
 		return New(Drive,
 			parentPath,
-			GetFriendlyNameParent(FriendlyName));
+			GetFriendlyNameParent(parentPath));
 	}
 
-	private static string? GetFriendlyNameParent(string friendlyName)
-	{
-		if (friendlyName == ".")
-		{
-			return "./..";
-		}
+	private static string GetFriendlyNameParent(string parentPath)
+		=> Execute.OnNetFramework(
+			() => Path.GetFileName(parentPath),
+			() => parentPath);
 
-		if (friendlyName.StartsWith("./"))
-		{
-#pragma warning disable CA1845
-			return "./../" + friendlyName.Substring(2);
-#pragma warning restore CA1845
-		}
-
-		return Path.GetDirectoryName(friendlyName);
-	}
-
-#endregion
+	#endregion
 
 	/// <summary>
 	///     Creates a new <see cref="IStorageLocation" /> on the specified <paramref name="drive" /> with the given

--- a/Source/Testably.Abstractions.Testing/Storage/StorageExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/StorageExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Testably.Abstractions.Testing.FileSystemInitializer;
 using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.Storage;
@@ -33,7 +34,9 @@ internal static class StorageExtensions
 				Execute.OnNetFramework(
 					() => throw ExceptionFactory.SearchPatternCannotContainTwoDots());
 				parentDirectories.Push(Path.GetFileName(location.FullPath));
-				location = location.GetParent() ?? throw new Exception("foo");
+				location = location.GetParent() ??
+				           throw new UnauthorizedAccessException(
+					           $"The searchPattern '{searchPattern}' has too many '../' for path '{path}'");
 #pragma warning disable CA1846
 				givenPathPrefix.Append(searchPattern.Substring(0, 3));
 #pragma warning restore CA1846

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/Tests.cs
@@ -358,4 +358,17 @@ public abstract partial class Tests<TFileSystem>
 		result.Root.Exists.Should().BeTrue();
 		result.Root.FullName.Should().Be(expectedRoot);
 	}
+
+	[SkippableTheory]
+	[InlineData("/foo")]
+	[InlineData("./foo")]
+	[InlineData("foo")]
+	public void ToString_ShouldReturnProvidedPath(string path)
+	{
+		IDirectoryInfo directoryInfo = FileSystem.DirectoryInfo.New(path);
+
+		string? result = directoryInfo.ToString();
+
+		result.Should().Be(path);
+	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/Tests.cs
@@ -286,6 +286,56 @@ public abstract partial class Tests<TFileSystem>
 		sut.Parent.Should().BeNull();
 	}
 
+	[SkippableTheory]
+	[InlineAutoData("./foo/bar", "foo")]
+	[InlineAutoData("./foo", ".")]
+	public void Parent_ToString_ShouldBeAbsolutePathOnNetCore(
+		string path, string expectedParent)
+	{
+		Skip.If(Test.IsNetFramework);
+
+		FileSystem.Initialize();
+		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
+		sut.ToString().Should().Be(path);
+
+		IDirectoryInfo? parent = sut.Parent;
+
+		parent.Should().NotBeNull();
+		if (Test.IsNetFramework)
+		{
+			parent!.ToString().Should().Be(expectedParent);
+		}
+		else
+		{
+			parent!.ToString().Should().Be(FileSystem.Path.GetFullPath(expectedParent));
+		}
+	}
+
+	[SkippableTheory]
+	[InlineAutoData("./foo/bar", "foo")]
+	[InlineAutoData("./foo", "bar", "bar")]
+	public void Parent_ToString_ShouldBeDirectoryNameOnNetFramework(
+		string path, string expectedParent, string directory)
+	{
+		Skip.IfNot(Test.IsNetFramework);
+
+		FileSystem.InitializeIn(directory);
+		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
+		sut.ToString().Should().Be(path);
+
+		IDirectoryInfo? parent = sut.Parent;
+
+		parent.Should().NotBeNull();
+		if (Test.IsNetFramework)
+		{
+			parent!.ToString().Should().Be(expectedParent);
+		}
+		else
+		{
+			parent!.ToString().Should().Be(FileSystem.Path.GetFullPath(expectedParent));
+		}
+	}
+
 	[SkippableFact]
 	[AutoData]
 	public void Root_Name_ShouldBeCorrect()

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
@@ -147,4 +147,17 @@ public abstract partial class Tests<TFileSystem>
 		fileInfo.IsReadOnly.Should().BeFalse();
 		fileInfo.Attributes.Should().NotHaveFlag(FileAttributes.ReadOnly);
 	}
+
+	[SkippableTheory]
+	[InlineData("/foo")]
+	[InlineData("./foo")]
+	[InlineData("foo")]
+	public void ToString_ShouldReturnProvidedPath(string path)
+	{
+		IFileInfo fileInfo = FileSystem.FileInfo.New(path);
+
+		string? result = fileInfo.ToString();
+
+		result.Should().Be(path);
+	}
 }


### PR DESCRIPTION
The friendly name visible by calling `ToString()` on the `IDirectoryInfo` is incorrect for the Parent on .NET Framework.
It should be
- the absolute path on .NET Core
- the name of the parent directory on .NET Framework

Also throw the correct exception when providing too many instances of "…/" in the search string in e.g. "Directory.GetFileSystemInfos()"