### PR TITLE
fix: release build problems after .NET 7 update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,12 @@ jobs:
     name: Static code analysis
     runs-on: windows-latest
     steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
@@ -173,7 +179,7 @@ jobs:
 
   upload-coverage:
     name: Upload coverage to Codacy
-    needs: [test-macos, test-ubuntu, test-windows]
+    needs: [test-macos, test-ubuntu, test-windows, test-net-framework]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,6 +196,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - name: Install .NET Stryker
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,12 @@ jobs:
     name: Static code analysis
     runs-on: windows-latest
     steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
@@ -211,6 +217,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - name: Install .NET Stryker
         shell: bash
         run: |

--- a/.github/workflows/stryker.yml
+++ b/.github/workflows/stryker.yml
@@ -42,6 +42,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - name: Install .NET Stryker
         shell: bash
         run: |


### PR DESCRIPTION
After .NET 7 update the release build is no longer working