### PR TITLE
feat(file): add strategy for dealing with `SafeFileHandle`s

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/DefaultSafeFileHandleStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DefaultSafeFileHandleStrategy.cs
@@ -15,7 +15,7 @@ public class DefaultSafeFileHandleStrategy : ISafeFileHandleStrategy
 	public DefaultSafeFileHandleStrategy(
 		Func<SafeFileHandle, SafeFileHandleMock> callback)
 	{
-		_callback = callback;
+		_callback = callback ?? throw new ArgumentNullException(nameof(callback));
 	}
 
 	/// <inheritdoc cref="ISafeFileHandleStrategy.MapSafeFileHandle(SafeFileHandle)" />

--- a/Source/Testably.Abstractions.Testing/FileSystem/DefaultSafeFileHandleStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DefaultSafeFileHandleStrategy.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Win32.SafeHandles;
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Testably.Abstractions.Testing.FileSystem;
+
+/// <summary>
+///     Default implementation of an <see cref="ISafeFileHandleStrategy" /> which uses a callback for mapping
+///     <see cref="SafeFileHandle" />s.
+/// </summary>
+public class DefaultSafeFileHandleStrategy : ISafeFileHandleStrategy
+{
+	private readonly Func<SafeFileHandle, SafeFileHandleMock> _callback;
+
+	public DefaultSafeFileHandleStrategy(
+		Func<SafeFileHandle, SafeFileHandleMock> callback)
+	{
+		_callback = callback;
+	}
+
+	/// <inheritdoc cref="ISafeFileHandleStrategy.MapSafeFileHandle(SafeFileHandle)" />
+#if NET6_0_OR_GREATER
+	[ExcludeFromCodeCoverage(Justification = "SafeFileHandle cannot be unit tested.")]
+#endif
+	public SafeFileHandleMock MapSafeFileHandle(SafeFileHandle fileHandle)
+		=> _callback.Invoke(fileHandle);
+}

--- a/Source/Testably.Abstractions.Testing/FileSystem/DefaultSafeFileHandleStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DefaultSafeFileHandleStrategy.cs
@@ -12,6 +12,11 @@ public class DefaultSafeFileHandleStrategy : ISafeFileHandleStrategy
 {
 	private readonly Func<SafeFileHandle, SafeFileHandleMock> _callback;
 
+	/// <summary>
+	///     Initializes a new instance of <see cref="DefaultSafeFileHandleStrategy" /> which takes a
+	///     <paramref name="callback" /> to perform the mapping from <see cref="SafeFileHandle" /> to
+	///     <see cref="SafeFileHandleMock" />.
+	/// </summary>
 	public DefaultSafeFileHandleStrategy(
 		Func<SafeFileHandle, SafeFileHandleMock> callback)
 	{

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -975,7 +975,7 @@ internal sealed class FileMock : IFile
 	private IStorageContainer GetContainerFromSafeFileHandle(SafeFileHandle fileHandle)
 	{
 		SafeFileHandleMock safeFileHandleMock = _fileSystem
-		   .SafeFileHandleMapper.Invoke(fileHandle);
+		   .SafeFileHandleStrategy.MapSafeFileHandle(fileHandle);
 		IStorageContainer container = _fileSystem.Storage
 		   .GetContainer(_fileSystem.Storage.GetLocation(
 				safeFileHandleMock.Path));

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
@@ -90,7 +90,7 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 	public FileSystemStream New(SafeFileHandle handle, FileAccess access)
 	{
 		SafeFileHandleMock safeFileHandleMock = _fileSystem
-		   .SafeFileHandleMapper.Invoke(handle);
+		   .SafeFileHandleStrategy.MapSafeFileHandle(handle);
 		return New(
 			safeFileHandleMock.Path,
 			safeFileHandleMock.Mode,
@@ -105,7 +105,7 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 	public FileSystemStream New(SafeFileHandle handle, FileAccess access, int bufferSize)
 	{
 		SafeFileHandleMock safeFileHandleMock = _fileSystem
-		   .SafeFileHandleMapper.Invoke(handle);
+		   .SafeFileHandleStrategy.MapSafeFileHandle(handle);
 		return New(
 			safeFileHandleMock.Path,
 			safeFileHandleMock.Mode,
@@ -122,7 +122,7 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 	                            bool isAsync)
 	{
 		SafeFileHandleMock safeFileHandleMock = _fileSystem
-		   .SafeFileHandleMapper.Invoke(handle);
+		   .SafeFileHandleStrategy.MapSafeFileHandle(handle);
 		return New(
 			safeFileHandleMock.Path,
 			safeFileHandleMock.Mode,

--- a/Source/Testably.Abstractions.Testing/FileSystem/ISafeFileHandleStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/ISafeFileHandleStrategy.cs
@@ -11,7 +11,5 @@ public interface ISafeFileHandleStrategy
 	///     Maps the <paramref name="fileHandle" /> to a <see cref="SafeFileHandleMock" /> which contains information how this
 	///     <see cref="SafeFileHandle" /> should be treated in the <see cref="MockFileSystem" />.
 	/// </summary>
-	/// <param name="fileHandle"></param>
-	/// <returns></returns>
 	SafeFileHandleMock MapSafeFileHandle(SafeFileHandle fileHandle);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/ISafeFileHandlerStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/ISafeFileHandlerStrategy.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Win32.SafeHandles;
+
+namespace Testably.Abstractions.Testing.FileSystem;
+
+/// <summary>
+///     The strategy how to deal with <see cref="SafeFileHandle" />s.
+/// </summary>
+public interface ISafeFileHandleStrategy
+{
+	/// <summary>
+	///     Maps the <paramref name="fileHandle" /> to a <see cref="SafeFileHandleMock" /> which contains information how this
+	///     <see cref="SafeFileHandle" /> should be treated in the <see cref="MockFileSystem" />.
+	/// </summary>
+	/// <param name="fileHandle"></param>
+	/// <returns></returns>
+	SafeFileHandleMock MapSafeFileHandle(SafeFileHandle fileHandle);
+}

--- a/Source/Testably.Abstractions.Testing/FileSystem/NullSafeFileHandleStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/NullSafeFileHandleStrategy.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Win32.SafeHandles;
+using System.Diagnostics.CodeAnalysis;
+using Testably.Abstractions.Testing.Helpers;
+
+namespace Testably.Abstractions.Testing.FileSystem;
+
+/// <summary>
+///     Null object of an <see cref="ISafeFileHandleStrategy" /> which throws an exception.
+/// </summary>
+public class NullSafeFileHandleStrategy : ISafeFileHandleStrategy
+{
+	/// <inheritdoc cref="ISafeFileHandleStrategy.MapSafeFileHandle(SafeFileHandle)" />
+#if NET6_0_OR_GREATER
+	[ExcludeFromCodeCoverage(Justification = "SafeFileHandle cannot be unit tested.")]
+#endif
+	public SafeFileHandleMock MapSafeFileHandle(SafeFileHandle fileHandle)
+	{
+		if (fileHandle.IsInvalid)
+		{
+			throw ExceptionFactory.HandleIsInvalid();
+		}
+
+		throw ExceptionFactory.NotSupportedSafeFileHandle();
+	}
+}

--- a/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
@@ -17,7 +17,7 @@ internal static class ExceptionFactory
 
 	public static NotSupportedException NotSupportedSafeFileHandle()
 		=> new(
-			"You cannot mock a safe file handle in the mocked file system without registering it explicitly. Use `MockFileSystem.MapSafeFileHandle`!");
+			"You cannot mock a safe file handle in the mocked file system without registering a strategy explicitly. Use `MockFileSystem.WithSafeFileHandleStrategy`!");
 
 	public static ArgumentException SearchPatternCannotContainTwoDots()
 		=> new(

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -141,10 +141,9 @@ public sealed class MockFileSystem : IFileSystem
 	}
 
 	/// <summary>
-	///     Registers a callback to map a <see cref="SafeFileHandle" />
-	///     to a <see cref="SafeFileHandleMock" />.
+	///     Registers the strategy how to deal with <see cref="SafeFileHandle" />s in the <see cref="MockFileSystem" />.
 	///     <para />
-	///     If set to <see langword="null" /> resets to the default mapper for <see cref="SafeFileHandle" />s.
+	///     Defaults to <see cref="NullSafeFileHandleStrategy" />, if nothing is provided.
 	/// </summary>
 	public MockFileSystem WithSafeFileHandleStrategy(
 		ISafeFileHandleStrategy safeFileHandleStrategy)

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DefaultSafeFileHandleStrategyTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DefaultSafeFileHandleStrategyTests.cs
@@ -16,6 +16,20 @@ public class DefaultSafeFileHandleStrategyTests
 
 	[SkippableTheory]
 	[AutoData]
+	public void MapSafeFileHandle_NullCallback_ShouldThrowArgumentNullException(
+		string path, Exception exceptionToThrow)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			_ = new DefaultSafeFileHandleStrategy(null!);
+		});
+
+		exception.Should().BeOfType<ArgumentNullException>()
+		   .Which.ParamName.Should().Be("callback");
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void MapSafeFileHandle_ShouldReturnExpectedValue(
 		string path, Exception exceptionToThrow)
 	{

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DefaultSafeFileHandleStrategyTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DefaultSafeFileHandleStrategyTests.cs
@@ -1,0 +1,36 @@
+#if NET6_0_OR_GREATER
+using Microsoft.Win32.SafeHandles;
+using System.Collections.Generic;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace Testably.Abstractions.Testing.Tests.FileSystem;
+
+public class DefaultSafeFileHandleStrategyTests
+{
+	public MockFileSystem FileSystem { get; }
+
+	public DefaultSafeFileHandleStrategyTests()
+	{
+		FileSystem = new MockFileSystem();
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void MapSafeFileHandle_ShouldReturnExpectedValue(
+		string path, Exception exceptionToThrow)
+	{
+		SafeFileHandle fooSafeFileHandle = new();
+		SafeFileHandle barSafeFileHandle = new();
+		Dictionary<SafeFileHandle, SafeFileHandleMock> mapping = new();
+		mapping.Add(fooSafeFileHandle, new SafeFileHandleMock("foo"));
+		mapping.Add(barSafeFileHandle, new SafeFileHandleMock("bar"));
+		FileSystem.File.WriteAllText("foo", "foo-content");
+		FileSystem.File.WriteAllText("bar", "bar-content");
+
+		DefaultSafeFileHandleStrategy sut = new(fileHandle => mapping[fileHandle]);
+
+		sut.MapSafeFileHandle(fooSafeFileHandle).Path.Should().Be("foo");
+		sut.MapSafeFileHandle(barSafeFileHandle).Path.Should().Be("bar");
+	}
+}
+#endif

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileMockTests.cs
@@ -43,7 +43,7 @@ public class FileMockTests
 		fileSystem.File.SetAttributes("foo", attributes);
 		FileAttributes expectedAttributes = fileSystem.File.GetAttributes("foo");
 		fileSystem.File.WriteAllText(path, "some content");
-		fileSystem.MapSafeFileHandle(_ => new SafeFileHandleMock(path));
+		fileSystem.WithSafeFileHandleStrategy(new DefaultSafeFileHandleStrategy(_ => new SafeFileHandleMock(path)));
 
 		fileSystem.File.SetAttributes(fileHandle, attributes);
 
@@ -59,7 +59,7 @@ public class FileMockTests
 		SafeFileHandle fileHandle = new();
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText(path, "some content");
-		fileSystem.MapSafeFileHandle(_ => new SafeFileHandleMock(path));
+		fileSystem.WithSafeFileHandleStrategy(new DefaultSafeFileHandleStrategy(_ => new SafeFileHandleMock(path)));
 
 		fileSystem.File.SetCreationTime(fileHandle, creationTime);
 
@@ -76,7 +76,7 @@ public class FileMockTests
 		SafeFileHandle fileHandle = new();
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText(path, "some content");
-		fileSystem.MapSafeFileHandle(_ => new SafeFileHandleMock(path));
+		fileSystem.WithSafeFileHandleStrategy(new DefaultSafeFileHandleStrategy(_ => new SafeFileHandleMock(path)));
 
 		fileSystem.File.SetCreationTimeUtc(fileHandle, creationTimeUtc);
 
@@ -93,7 +93,7 @@ public class FileMockTests
 		SafeFileHandle fileHandle = new();
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText(path, "some content");
-		fileSystem.MapSafeFileHandle(_ => new SafeFileHandleMock(path));
+		fileSystem.WithSafeFileHandleStrategy(new DefaultSafeFileHandleStrategy(_ => new SafeFileHandleMock(path)));
 
 		fileSystem.File.SetLastAccessTime(fileHandle, lastAccessTime);
 
@@ -110,7 +110,7 @@ public class FileMockTests
 		SafeFileHandle fileHandle = new();
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText(path, "some content");
-		fileSystem.MapSafeFileHandle(_ => new SafeFileHandleMock(path));
+		fileSystem.WithSafeFileHandleStrategy(new DefaultSafeFileHandleStrategy(_ => new SafeFileHandleMock(path)));
 
 		fileSystem.File.SetLastAccessTimeUtc(fileHandle, lastAccessTimeUtc);
 
@@ -127,7 +127,7 @@ public class FileMockTests
 		SafeFileHandle fileHandle = new();
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText(path, "some content");
-		fileSystem.MapSafeFileHandle(_ => new SafeFileHandleMock(path));
+		fileSystem.WithSafeFileHandleStrategy(new DefaultSafeFileHandleStrategy(_ => new SafeFileHandleMock(path)));
 
 		fileSystem.File.SetLastWriteTime(fileHandle, lastWriteTime);
 
@@ -144,7 +144,7 @@ public class FileMockTests
 		SafeFileHandle fileHandle = new();
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText(path, "some content");
-		fileSystem.MapSafeFileHandle(_ => new SafeFileHandleMock(path));
+		fileSystem.WithSafeFileHandleStrategy(new DefaultSafeFileHandleStrategy(_ => new SafeFileHandleMock(path)));
 
 		fileSystem.File.SetLastWriteTimeUtc(fileHandle, lastWriteTimeUtc);
 
@@ -163,7 +163,7 @@ public class FileMockTests
 		SafeFileHandle fileHandle = new();
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText(path, "some content");
-		fileSystem.MapSafeFileHandle(_ => new SafeFileHandleMock(path));
+		fileSystem.WithSafeFileHandleStrategy(new DefaultSafeFileHandleStrategy(_ => new SafeFileHandleMock(path)));
 
 		fileSystem.File.SetUnixFileMode(fileHandle, mode);
 

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileStreamFactoryMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileStreamFactoryMockTests.cs
@@ -47,7 +47,7 @@ public sealed class FileStreamFactoryMockTests : IDisposable
 
 		exception.Should().BeOfType<NotSupportedException>()
 		   .Which.Message.Should().Contain(nameof(MockFileSystem) + "." +
-		                                   nameof(MockFileSystem.MapSafeFileHandle));
+		                                   nameof(MockFileSystem.WithSafeFileHandleStrategy));
 	}
 
 	[SkippableTheory]
@@ -68,7 +68,7 @@ public sealed class FileStreamFactoryMockTests : IDisposable
 
 		exception.Should().BeOfType<NotSupportedException>()
 		   .Which.Message.Should().Contain(nameof(MockFileSystem) + "." +
-		                                   nameof(MockFileSystem.MapSafeFileHandle));
+		                                   nameof(MockFileSystem.WithSafeFileHandleStrategy));
 	}
 
 	[SkippableTheory]
@@ -90,7 +90,7 @@ public sealed class FileStreamFactoryMockTests : IDisposable
 
 		exception.Should().BeOfType<NotSupportedException>()
 		   .Which.Message.Should().Contain(nameof(MockFileSystem) + "." +
-		                                   nameof(MockFileSystem.MapSafeFileHandle));
+		                                   nameof(MockFileSystem.WithSafeFileHandleStrategy));
 	}
 }
 #endif

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -255,7 +255,7 @@ public class MockFileSystemTests
 	{
 		MockFileSystem sut = new();
 		sut.File.WriteAllText(path, contents);
-		sut.MapSafeFileHandle(_ => new SafeFileHandleMock(path));
+		sut.WithSafeFileHandleStrategy(new DefaultSafeFileHandleStrategy(_ => new SafeFileHandleMock(path)));
 
 		using FileSystemStream stream =
 			sut.FileStream.New(new SafeFileHandle(), FileAccess.Read);

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -250,7 +250,7 @@ public class MockFileSystemTests
 #if NET6_0_OR_GREATER
 	[SkippableTheory]
 	[AutoData]
-	public void WithSafeFileHandle_WithCallback_ShouldUpdateDrive(
+	public void WithSafeFileHandleStrategy_DefaultStrategy_ShouldUseMappedSafeFileHandleMock(
 		string path, string contents)
 	{
 		MockFileSystem sut = new();
@@ -267,7 +267,7 @@ public class MockFileSystemTests
 
 	[SkippableTheory]
 	[AutoData]
-	public void WithSafeFileHandle_WithoutMapping_ShouldThrowException(
+	public void WithSafeFileHandleStrategy_NullStrategy_ShouldThrowException(
 		string path, string contents)
 	{
 		MockFileSystem sut = new();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/SafeFileHandleTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/SafeFileHandleTests.cs
@@ -86,8 +86,8 @@ public abstract partial class SafeFileHandleTests<TFileSystem>
 		realFileSystem.File.WriteAllText(path, contents);
 		FileSystem.File.WriteAllText(path, contents);
 		SafeFileHandle handle = UnmanagedFileLoader.CreateSafeFileHandle(path);
-		(FileSystem as MockFileSystem)?.MapSafeFileHandle(
-			_ => new SafeFileHandleMock(path));
+		(FileSystem as MockFileSystem)?.WithSafeFileHandleStrategy(
+			new DefaultSafeFileHandleStrategy(_ => new SafeFileHandleMock(path)));
 
 		FileSystemStream stream = FileSystem.FileStream.New(handle, FileAccess.ReadWrite);
 		stream.Write(Encoding.UTF8.GetBytes("foo"), 0, 3);
@@ -113,8 +113,8 @@ public abstract partial class SafeFileHandleTests<TFileSystem>
 		realFileSystem.File.WriteAllText(path, contents);
 		FileSystem.File.WriteAllText(path, contents);
 		SafeFileHandle handle = UnmanagedFileLoader.CreateSafeFileHandle(path);
-		(FileSystem as MockFileSystem)?.MapSafeFileHandle(
-			_ => new SafeFileHandleMock(path));
+		(FileSystem as MockFileSystem)?.WithSafeFileHandleStrategy(
+			new DefaultSafeFileHandleStrategy(_ => new SafeFileHandleMock(path)));
 
 		FileSystemStream stream =
 			FileSystem.FileStream.New(handle, FileAccess.ReadWrite, 1024);
@@ -142,8 +142,8 @@ public abstract partial class SafeFileHandleTests<TFileSystem>
 		realFileSystem.File.WriteAllText(path, contents);
 		FileSystem.File.WriteAllText(path, contents);
 		SafeFileHandle handle = UnmanagedFileLoader.CreateSafeFileHandle(path);
-		(FileSystem as MockFileSystem)?.MapSafeFileHandle(
-			_ => new SafeFileHandleMock(path));
+		(FileSystem as MockFileSystem)?.WithSafeFileHandleStrategy(
+			new DefaultSafeFileHandleStrategy(_ => new SafeFileHandleMock(path)));
 
 		FileSystemStream stream =
 			FileSystem.FileStream.New(handle, FileAccess.ReadWrite, 1024, false);


### PR DESCRIPTION
Replace the simple callback with an interface, so that we can provide multiple implementations for ease of testing:
- `NullSafeFileHandleStrategy` throws an exception
- `DefaultSafeFileHandleStrategy` takes a callback for mapping `SafeFileHandle`s to `SafeFileHandleMock`s.