### PR TITLE
refactor: fix sonar issues and stryker config

### DIFF
--- a/.github/stryker/Stryker.Config.Testing.json
+++ b/.github/stryker/Stryker.Config.Testing.json
@@ -19,13 +19,13 @@
     "mutation-level": "Advanced",
     "mutate": [
       // The enumeration options helper is a wrapper around Microsoft code
-      "!**/Testably.Abstractions.Testing/Internal/EnumerationOptionsHelper.cs",
+      "!**/Testably.Abstractions.Testing/Helpers/EnumerationOptionsHelper.cs",
       // The exception type is checked, but not the message, as this could be language dependent
-      "!**/Testably.Abstractions.Testing/Internal/ExceptionFactory.cs",
+      "!**/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs",
       // Indicates operating system specific code
-      "!**/Testably.Abstractions.Testing/Internal/Execute.cs",
+      "!**/Testably.Abstractions.Testing/Helpers/Execute.cs",
       // The directory cleaner should cleanup the real file system
-      "!**/Testably.Abstractions.Testing/FileSystemInitializer.DirectoryCleaner.cs"
+      "!**/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryCleaner.cs"
     ],
     "ignore-methods": [
       // The exception type is checked, but not the message, as this could be language dependent
@@ -33,7 +33,7 @@
       // Some checks are redundant but there for performance improvements
       "InMemoryLocation.Equals",
       // Indicates operating system specific code
-      "Testably.Abstractions.Testing.Internal.Execute.*On*",
+      "Testably.Abstractions.Testing.Helpers.Execute.*On*",
       // Drives are not used in Linux
       "ValidateDriveLetter",
       // The encryption helper is only valid for testing purposes

--- a/Source/Testably.Abstractions.Testing/Helpers/EncryptionHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/EncryptionHelper.cs
@@ -33,9 +33,9 @@ internal static class EncryptionHelper
 
 	private static Aes CreateDummyEncryptionAlgorithm()
 	{
+#pragma warning disable CA1850
 		byte[] bytes = Encoding.UTF8.GetBytes(
 			"THIS IS ONLY A DUMMY ENCRYPTION FOR TESTING HELPERS!");
-
 		using (SHA256 sha256Hash = SHA256.Create())
 		{
 			byte[] key = sha256Hash.ComputeHash(bytes);
@@ -45,6 +45,7 @@ internal static class EncryptionHelper
 			algorithm.IV = iv;
 			return algorithm;
 		}
+#pragma warning restore CA1850
 	}
 
 	/// <summary>

--- a/Source/Testably.Abstractions.Testing/Helpers/FilePlatformIndependenceExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FilePlatformIndependenceExtensions.cs
@@ -9,7 +9,9 @@ namespace Testably.Abstractions.Testing.Helpers;
 /// </summary>
 internal static class FilePlatformIndependenceExtensions
 {
+#pragma warning disable SYSLIB1045
 	private static readonly Regex PathTransformRegex = new(@"^[a-zA-Z]:(?<path>.*)$");
+#pragma warning restore SYSLIB1045
 
 	/// <summary>
 	///     Normalizes the given path so that it works on all platforms.

--- a/Tests/Testably.Abstractions.AccessControl.Tests/TestHelpers/FileSystemSecurityExtensions.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/TestHelpers/FileSystemSecurityExtensions.cs
@@ -92,12 +92,11 @@ internal static class FileSystemSecurityExtensions
 			KeyValuePair<IdentityReference, FileSystemRights> combinedChildAccessAllowRule
 			in combinedChildAccessAllowRules)
 		{
-			if (combinedParentAccessAllowRules.ContainsKey(combinedChildAccessAllowRule
-			   .Key))
+			if (combinedParentAccessAllowRules.TryGetValue(
+				combinedChildAccessAllowRule.Key, out FileSystemRights value))
 			{
 				FileSystemRights accessAllowRuleGainedByChild =
-					combinedChildAccessAllowRule.Value &
-					~combinedParentAccessAllowRules[combinedChildAccessAllowRule.Key];
+					combinedChildAccessAllowRule.Value & ~value;
 				if (accessAllowRuleGainedByChild != default)
 				{
 					accessAllowRulesGainedByChild.Add(combinedChildAccessAllowRule.Key,
@@ -117,12 +116,11 @@ internal static class FileSystemSecurityExtensions
 			KeyValuePair<IdentityReference, FileSystemRights> combinedChildAccessDenyRule
 			in combinedChildAccessDenyRules)
 		{
-			if (combinedParentAccessDenyRules.ContainsKey(combinedChildAccessDenyRule
-			   .Key))
+			if (combinedParentAccessDenyRules.TryGetValue(
+				combinedChildAccessDenyRule.Key, out FileSystemRights value))
 			{
 				FileSystemRights accessDenyRuleGainedByChild =
-					combinedChildAccessDenyRule.Value &
-					~combinedParentAccessDenyRules[combinedChildAccessDenyRule.Key];
+					combinedChildAccessDenyRule.Value & ~value;
 				if (accessDenyRuleGainedByChild != default)
 				{
 					accessDenyRulesGainedByChild.Add(combinedChildAccessDenyRule.Key,
@@ -142,12 +140,11 @@ internal static class FileSystemSecurityExtensions
 			KeyValuePair<IdentityReference, FileSystemRights>
 				combinedParentAccessAllowRule in combinedParentAccessAllowRules)
 		{
-			if (combinedChildAccessAllowRules.ContainsKey(combinedParentAccessAllowRule
-			   .Key))
+			if (combinedChildAccessAllowRules.TryGetValue(
+				combinedParentAccessAllowRule.Key, out FileSystemRights value))
 			{
 				FileSystemRights accessAllowRuleGainedByParent =
-					combinedParentAccessAllowRule.Value &
-					~combinedChildAccessAllowRules[combinedParentAccessAllowRule.Key];
+					combinedParentAccessAllowRule.Value & ~value;
 				if (accessAllowRuleGainedByParent != default)
 				{
 					accessAllowRulesGainedByParent.Add(combinedParentAccessAllowRule.Key,
@@ -167,12 +164,11 @@ internal static class FileSystemSecurityExtensions
 			KeyValuePair<IdentityReference, FileSystemRights> combinedParentAccessDenyRule
 			in combinedParentAccessDenyRules)
 		{
-			if (combinedChildAccessDenyRules.ContainsKey(combinedParentAccessDenyRule
-			   .Key))
+			if (combinedChildAccessDenyRules.TryGetValue(
+				combinedParentAccessDenyRule.Key, out FileSystemRights value))
 			{
 				FileSystemRights accessDenyRuleGainedByParent =
-					combinedParentAccessDenyRule.Value &
-					~combinedChildAccessDenyRules[combinedParentAccessDenyRule.Key];
+					combinedParentAccessDenyRule.Value & ~value;
 				if (accessDenyRuleGainedByParent != default)
 				{
 					accessDenyRulesGainedByParent.Add(combinedParentAccessDenyRule.Key,

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DefaultSafeFileHandleStrategyTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DefaultSafeFileHandleStrategyTests.cs
@@ -14,10 +14,8 @@ public class DefaultSafeFileHandleStrategyTests
 		FileSystem = new MockFileSystem();
 	}
 
-	[SkippableTheory]
-	[AutoData]
-	public void MapSafeFileHandle_NullCallback_ShouldThrowArgumentNullException(
-		string path, Exception exceptionToThrow)
+	[SkippableFact]
+	public void MapSafeFileHandle_NullCallback_ShouldThrowArgumentNullException()
 	{
 		Exception? exception = Record.Exception(() =>
 		{
@@ -28,16 +26,16 @@ public class DefaultSafeFileHandleStrategyTests
 		   .Which.ParamName.Should().Be("callback");
 	}
 
-	[SkippableTheory]
-	[AutoData]
-	public void MapSafeFileHandle_ShouldReturnExpectedValue(
-		string path, Exception exceptionToThrow)
+	[SkippableFact]
+	public void MapSafeFileHandle_ShouldReturnExpectedValue()
 	{
 		SafeFileHandle fooSafeFileHandle = new();
 		SafeFileHandle barSafeFileHandle = new();
-		Dictionary<SafeFileHandle, SafeFileHandleMock> mapping = new();
-		mapping.Add(fooSafeFileHandle, new SafeFileHandleMock("foo"));
-		mapping.Add(barSafeFileHandle, new SafeFileHandleMock("bar"));
+		Dictionary<SafeFileHandle, SafeFileHandleMock> mapping = new()
+		{
+			{ fooSafeFileHandle, new SafeFileHandleMock("foo") },
+			{ barSafeFileHandle, new SafeFileHandleMock("bar") }
+		};
 		FileSystem.File.WriteAllText("foo", "foo-content");
 		FileSystem.File.WriteAllText("bar", "bar-content");
 


### PR DESCRIPTION
Fix issues found by SonarCloud after updating to .NET 7 and fix incorrect exclude paths in the Stryker config