### PR TITLE
feat: add "global.json"

### DIFF
--- a/Testably.Abstractions.sln
+++ b/Testably.Abstractions.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{94F99274-3518-45
 		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
 		CONTRIBUTING.md = CONTRIBUTING.md
 		Feature.Flags.props = Feature.Flags.props
+		global.json = global.json
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+	"sdk": {
+		"version": "7.0.100",
+		"rollForward": "latestFeature"
+	}
+}


### PR DESCRIPTION
Add a "global.json" file, which limits the allowed .NET SDK versions for building the project:
```json
{
  "sdk": {
    "version": "7.0.100",
    "rollForward": "latestFeature"
  }
}
```
- version `"7.0.100"`
  is the latest [Visual Studio SDK-Version](https://dotnet.microsoft.com/en-us/download/visual-studio-sdks) supporting .NET 7.
- roll forward `"latestFeature"`
 uses the highest installed feature band and patch level that matches the requested major and minor with a feature band and patch level that is greater or equal than the specified value.

*see also [Microsoft Documentation](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json).*