### PR TITLE
refactor: improve compatibility with System.IO.Abstractions

### DIFF
--- a/Examples/AccessControlLists/AccessControlLists/CustomAccessControlStrategy.cs
+++ b/Examples/AccessControlLists/AccessControlLists/CustomAccessControlStrategy.cs
@@ -13,7 +13,7 @@ public sealed class CustomAccessControlStrategy : IAccessControlStrategy
 		_callback = callback;
 	}
 
-	/// <inheritdoc cref="CustomAccessControlStrategy.IsAccessGranted(string, IFileSystemExtensionContainer)" />
-	public bool IsAccessGranted(string fullPath, IFileSystemExtensionContainer extensionContainer)
+	/// <inheritdoc cref="CustomAccessControlStrategy.IsAccessGranted(string, IFileSystemExtensibility)" />
+	public bool IsAccessGranted(string fullPath, IFileSystemExtensibility extensibility)
 		=> _callback(fullPath);
 }

--- a/Feature.Flags.props
+++ b/Feature.Flags.props
@@ -2,10 +2,7 @@
 
 	<PropertyGroup>
 		<DefineConstants Condition="'$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NETFRAMEWORK</DefineConstants>
-		<DefineConstants
-			Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'netstandard2.1'">
-			$(DefineConstants);FEATURE_FILESYSTEM_ASYNC;FEATURE_FILESYSTEM_ENUMERATION_OPTIONS;FEATURE_PATH_JOIN;FEATURE_PATH_RELATIVE;FEATURE_SPAN;FEATURE_GUID_PARSE;FEATURE_VALUETASK;FEATURE_COMPRESSION_OVERWRITE;FEATURE_COMPRESSION_ADVANCED
-		</DefineConstants>
+		<DefineConstants Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);FEATURE_FILESYSTEM_ASYNC;FEATURE_FILESYSTEM_ENUMERATION_OPTIONS;FEATURE_PATH_JOIN;FEATURE_PATH_RELATIVE;FEATURE_SPAN;FEATURE_GUID_PARSE;FEATURE_VALUETASK;FEATURE_COMPRESSION_OVERWRITE;FEATURE_COMPRESSION_ADVANCED</DefineConstants>
 		<DefineConstants Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">$(DefineConstants);FEATURE_FILESYSTEM_STREAM_OPTIONS;FEATURE_FILESYSTEM_LINK;FEATURE_PATH_ADVANCED;FEATURE_FILE_MOVETO_OVERWRITE;FEATURE_RANDOM_ADVANCED;FEATURE_FILESYSTEMWATCHER_ADVANCED;FEATURE_EXCEPTION_HRESULT</DefineConstants>
 		<DefineConstants Condition="'$(TargetFramework)' == 'net7.0'">$(DefineConstants);FEATURE_ZIPFILE_NET7;FEATURE_FILESYSTEM_NET7;FEATURE_FILESYSTEM_SAFEFILEHANDLE;FEATURE_FILESYSTEM_UNIXFILEMODE;FEATURE_GUID_FORMATPROVIDER</DefineConstants>
 	</PropertyGroup>

--- a/Feature.Flags.props
+++ b/Feature.Flags.props
@@ -2,7 +2,10 @@
 
 	<PropertyGroup>
 		<DefineConstants Condition="'$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NETFRAMEWORK</DefineConstants>
-		<DefineConstants Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);FEATURE_FILESYSTEM_ASYNC;FEATURE_FILESYSTEM_ENUMERATION_OPTIONS;FEATURE_PATH_JOIN;FEATURE_PATH_RELATIVE;FEATURE_SPAN;FEATURE_GUID_PARSE;FEATURE_VALUETASK;FEATURE_COMPRESSION_OVERWRITE;FEATURE_COMPRESSION_ADVANCED</DefineConstants>
+		<DefineConstants
+			Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'netstandard2.1'">
+			$(DefineConstants);FEATURE_FILESYSTEM_ASYNC;FEATURE_FILESYSTEM_ENUMERATION_OPTIONS;FEATURE_PATH_JOIN;FEATURE_PATH_RELATIVE;FEATURE_SPAN;FEATURE_GUID_PARSE;FEATURE_VALUETASK;FEATURE_COMPRESSION_OVERWRITE;FEATURE_COMPRESSION_ADVANCED
+		</DefineConstants>
 		<DefineConstants Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">$(DefineConstants);FEATURE_FILESYSTEM_STREAM_OPTIONS;FEATURE_FILESYSTEM_LINK;FEATURE_PATH_ADVANCED;FEATURE_FILE_MOVETO_OVERWRITE;FEATURE_RANDOM_ADVANCED;FEATURE_FILESYSTEMWATCHER_ADVANCED;FEATURE_EXCEPTION_HRESULT</DefineConstants>
 		<DefineConstants Condition="'$(TargetFramework)' == 'net7.0'">$(DefineConstants);FEATURE_ZIPFILE_NET7;FEATURE_FILESYSTEM_NET7;FEATURE_FILESYSTEM_SAFEFILEHANDLE;FEATURE_FILESYSTEM_UNIXFILEMODE;FEATURE_GUID_FORMATPROVIDER</DefineConstants>
 	</PropertyGroup>

--- a/Source/Testably.Abstractions.AccessControl/AccessControlHelpers.cs
+++ b/Source/Testably.Abstractions.AccessControl/AccessControlHelpers.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.AccessControl/AccessControlHelpers.cs
+++ b/Source/Testably.Abstractions.AccessControl/AccessControlHelpers.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions;
 
@@ -37,6 +37,7 @@ internal static class AccessControlHelpers
 
 		return fileSystemInfo;
 	}
+
 	public static IDirectoryInfo ThrowIfParentMissing(
 		this IDirectoryInfo fileSystemInfo)
 	{

--- a/Source/Testably.Abstractions.AccessControl/DirectoryAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/DirectoryAclExtensions.cs
@@ -18,9 +18,9 @@ public static class DirectoryAclExtensions
 	{
 		IDirectoryInfo directoryInfo =
 			directory.FileSystem.DirectoryInfo.New(path);
-		IFileSystemExtensionContainer extensionContainer =
-			directoryInfo.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out DirectoryInfo? di))
+		IFileSystemExtensibility extensibility =
+			directoryInfo.Extensibility;
+		if (extensibility.TryGetWrappedInstance(out DirectoryInfo? di))
 		{
 			di.Create(directorySecurity);
 		}
@@ -29,7 +29,7 @@ public static class DirectoryAclExtensions
 			_ = directorySecurity ?? throw new ArgumentNullException(nameof(directorySecurity));
 			directoryInfo.ThrowIfParentMissing();
 			directoryInfo.Create();
-			directoryInfo.ExtensionContainer.StoreMetadata(AccessControlHelpers.AccessControl,
+			directoryInfo.Extensibility.StoreMetadata(AccessControlHelpers.AccessControl,
 				directorySecurity);
 		}
 	}
@@ -42,11 +42,11 @@ public static class DirectoryAclExtensions
 		IDirectoryInfo directoryInfo =
 			directory.FileSystem.DirectoryInfo.New(path);
 		directoryInfo.ThrowIfMissing();
-		IFileSystemExtensionContainer extensionContainer =
-			directoryInfo.ExtensionContainer;
-		return extensionContainer.HasWrappedInstance(out DirectoryInfo? di)
+		IFileSystemExtensibility extensibility =
+			directoryInfo.Extensibility;
+		return extensibility.TryGetWrappedInstance(out DirectoryInfo? di)
 			? di.GetAccessControl()
-			: extensionContainer.RetrieveMetadata<DirectorySecurity>(
+			: extensibility.RetrieveMetadata<DirectorySecurity>(
 				AccessControlHelpers.AccessControl) ?? new DirectorySecurity();
 	}
 
@@ -60,11 +60,11 @@ public static class DirectoryAclExtensions
 		IDirectoryInfo directoryInfo =
 			directory.FileSystem.DirectoryInfo.New(path);
 		directoryInfo.ThrowIfMissing();
-		IFileSystemExtensionContainer extensionContainer =
-			directoryInfo.ExtensionContainer;
-		return extensionContainer.HasWrappedInstance(out DirectoryInfo? di)
+		IFileSystemExtensibility extensibility =
+			directoryInfo.Extensibility;
+		return extensibility.TryGetWrappedInstance(out DirectoryInfo? di)
 			? di.GetAccessControl(includeSections)
-			: extensionContainer.RetrieveMetadata<DirectorySecurity>(
+			: extensibility.RetrieveMetadata<DirectorySecurity>(
 				AccessControlHelpers.AccessControl) ?? new DirectorySecurity();
 	}
 
@@ -76,15 +76,15 @@ public static class DirectoryAclExtensions
 	{
 		IDirectoryInfo directoryInfo =
 			directory.FileSystem.DirectoryInfo.New(path);
-		IFileSystemExtensionContainer extensionContainer =
-			directoryInfo.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out DirectoryInfo? di))
+		IFileSystemExtensibility extensibility =
+			directoryInfo.Extensibility;
+		if (extensibility.TryGetWrappedInstance(out DirectoryInfo? di))
 		{
 			di.SetAccessControl(directorySecurity);
 		}
 		else
 		{
-			extensionContainer.StoreMetadata(AccessControlHelpers.AccessControl,
+			extensibility.StoreMetadata(AccessControlHelpers.AccessControl,
 				directorySecurity);
 		}
 	}

--- a/Source/Testably.Abstractions.AccessControl/DirectoryAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/DirectoryAclExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
-using System.Security.AccessControl;
-using Testably.Abstractions.FileSystem;
+using System.Security.AccessControl;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.AccessControl/DirectoryAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/DirectoryAclExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO;
-using System.Security.AccessControl;
+using System.Security.AccessControl;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.AccessControl/DirectoryInfoAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/DirectoryInfoAclExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
-using System.Security.AccessControl;
-using Testably.Abstractions.FileSystem;
+using System.Security.AccessControl;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.AccessControl/DirectoryInfoAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/DirectoryInfoAclExtensions.cs
@@ -15,9 +15,9 @@ public static class DirectoryInfoAclExtensions
 	public static void Create(this IDirectoryInfo directoryInfo,
 		DirectorySecurity directorySecurity)
 	{
-		IFileSystemExtensionContainer extensionContainer =
-			directoryInfo.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out DirectoryInfo? di))
+		IFileSystemExtensibility extensibility =
+			directoryInfo.Extensibility;
+		if (extensibility.TryGetWrappedInstance(out DirectoryInfo? di))
 		{
 			di.Create(directorySecurity);
 		}
@@ -26,7 +26,7 @@ public static class DirectoryInfoAclExtensions
 			_ = directorySecurity ?? throw new ArgumentNullException(nameof(directorySecurity));
 			directoryInfo.ThrowIfParentMissing();
 			directoryInfo.Create();
-			directoryInfo.ExtensionContainer.StoreMetadata(AccessControlHelpers.AccessControl,
+			directoryInfo.Extensibility.StoreMetadata(AccessControlHelpers.AccessControl,
 				directorySecurity);
 		}
 	}
@@ -37,11 +37,11 @@ public static class DirectoryInfoAclExtensions
 		this IDirectoryInfo directoryInfo)
 	{
 		directoryInfo.ThrowIfMissing();
-		IFileSystemExtensionContainer extensionContainer =
-			directoryInfo.ExtensionContainer;
-		return extensionContainer.HasWrappedInstance(out DirectoryInfo? di)
+		IFileSystemExtensibility extensibility =
+			directoryInfo.Extensibility;
+		return extensibility.TryGetWrappedInstance(out DirectoryInfo? di)
 			? di.GetAccessControl()
-			: extensionContainer.RetrieveMetadata<DirectorySecurity>(
+			: extensibility.RetrieveMetadata<DirectorySecurity>(
 				AccessControlHelpers.AccessControl) ?? new DirectorySecurity();
 	}
 
@@ -52,11 +52,11 @@ public static class DirectoryInfoAclExtensions
 		AccessControlSections includeSections)
 	{
 		directoryInfo.ThrowIfMissing();
-		IFileSystemExtensionContainer extensionContainer =
-			directoryInfo.ExtensionContainer;
-		return extensionContainer.HasWrappedInstance(out DirectoryInfo? di)
+		IFileSystemExtensibility extensibility =
+			directoryInfo.Extensibility;
+		return extensibility.TryGetWrappedInstance(out DirectoryInfo? di)
 			? di.GetAccessControl(includeSections)
-			: extensionContainer.RetrieveMetadata<DirectorySecurity>(
+			: extensibility.RetrieveMetadata<DirectorySecurity>(
 				AccessControlHelpers.AccessControl) ?? new DirectorySecurity();
 	}
 
@@ -65,15 +65,15 @@ public static class DirectoryInfoAclExtensions
 	public static void SetAccessControl(this IDirectoryInfo directoryInfo,
 		DirectorySecurity directorySecurity)
 	{
-		IFileSystemExtensionContainer extensionContainer =
-			directoryInfo.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out DirectoryInfo? di))
+		IFileSystemExtensibility extensibility =
+			directoryInfo.Extensibility;
+		if (extensibility.TryGetWrappedInstance(out DirectoryInfo? di))
 		{
 			di.SetAccessControl(directorySecurity);
 		}
 		else
 		{
-			extensionContainer.StoreMetadata(AccessControlHelpers.AccessControl,
+			extensibility.StoreMetadata(AccessControlHelpers.AccessControl,
 				directorySecurity);
 		}
 	}

--- a/Source/Testably.Abstractions.AccessControl/DirectoryInfoAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/DirectoryInfoAclExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO;
-using System.Security.AccessControl;
+using System.Security.AccessControl;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.AccessControl/FileAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileAclExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
-using System.Security.AccessControl;
-using Testably.Abstractions.FileSystem;
+using System.Security.AccessControl;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.AccessControl/FileAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileAclExtensions.cs
@@ -16,11 +16,11 @@ public static class FileAclExtensions
 	{
 		IFileInfo fileInfo = file.FileSystem.FileInfo.New(path);
 		fileInfo.ThrowIfMissing();
-		IFileSystemExtensionContainer extensionContainer =
-			fileInfo.ExtensionContainer;
-		return extensionContainer.HasWrappedInstance(out FileInfo? fi)
+		IFileSystemExtensibility extensibility =
+			fileInfo.Extensibility;
+		return extensibility.TryGetWrappedInstance(out FileInfo? fi)
 			? fi.GetAccessControl()
-			: extensionContainer.RetrieveMetadata<FileSecurity>(
+			: extensibility.RetrieveMetadata<FileSecurity>(
 				AccessControlHelpers.AccessControl) ?? new FileSecurity();
 	}
 
@@ -33,11 +33,11 @@ public static class FileAclExtensions
 	{
 		IFileInfo fileInfo = file.FileSystem.FileInfo.New(path);
 		fileInfo.ThrowIfMissing();
-		IFileSystemExtensionContainer extensionContainer =
-			fileInfo.ExtensionContainer;
-		return extensionContainer.HasWrappedInstance(out FileInfo? fi)
+		IFileSystemExtensibility extensibility =
+			fileInfo.Extensibility;
+		return extensibility.TryGetWrappedInstance(out FileInfo? fi)
 			? fi.GetAccessControl(includeSections)
-			: extensionContainer.RetrieveMetadata<FileSecurity>(
+			: extensibility.RetrieveMetadata<FileSecurity>(
 				AccessControlHelpers.AccessControl) ?? new FileSecurity();
 	}
 
@@ -48,15 +48,15 @@ public static class FileAclExtensions
 		FileSecurity fileSecurity)
 	{
 		IFileInfo fileInfo = file.FileSystem.FileInfo.New(path);
-		IFileSystemExtensionContainer extensionContainer =
-			fileInfo.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out FileInfo? fi))
+		IFileSystemExtensibility extensibility =
+			fileInfo.Extensibility;
+		if (extensibility.TryGetWrappedInstance(out FileInfo? fi))
 		{
 			fi.SetAccessControl(fileSecurity);
 		}
 		else
 		{
-			extensionContainer.StoreMetadata(AccessControlHelpers.AccessControl,
+			extensibility.StoreMetadata(AccessControlHelpers.AccessControl,
 				fileSecurity);
 		}
 	}

--- a/Source/Testably.Abstractions.AccessControl/FileAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileAclExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-using System.Security.AccessControl;
+using System.Security.AccessControl;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.AccessControl/FileInfoAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileInfoAclExtensions.cs
@@ -15,11 +15,11 @@ public static class FileInfoAclExtensions
 		this IFileInfo fileInfo)
 	{
 		fileInfo.ThrowIfMissing();
-		IFileSystemExtensionContainer extensionContainer =
-			fileInfo.ExtensionContainer;
-		return extensionContainer.HasWrappedInstance(out FileInfo? fi)
+		IFileSystemExtensibility extensibility =
+			fileInfo.Extensibility;
+		return extensibility.TryGetWrappedInstance(out FileInfo? fi)
 			? fi.GetAccessControl()
-			: extensionContainer.RetrieveMetadata<FileSecurity>(
+			: extensibility.RetrieveMetadata<FileSecurity>(
 				AccessControlHelpers.AccessControl) ?? new FileSecurity();
 	}
 
@@ -30,11 +30,11 @@ public static class FileInfoAclExtensions
 		AccessControlSections includeSections)
 	{
 		fileInfo.ThrowIfMissing();
-		IFileSystemExtensionContainer extensionContainer =
-			fileInfo.ExtensionContainer;
-		return extensionContainer.HasWrappedInstance(out FileInfo? fi)
+		IFileSystemExtensibility extensibility =
+			fileInfo.Extensibility;
+		return extensibility.TryGetWrappedInstance(out FileInfo? fi)
 			? fi.GetAccessControl(includeSections)
-			: extensionContainer.RetrieveMetadata<FileSecurity>(
+			: extensibility.RetrieveMetadata<FileSecurity>(
 				AccessControlHelpers.AccessControl) ?? new FileSecurity();
 	}
 
@@ -43,15 +43,15 @@ public static class FileInfoAclExtensions
 	public static void SetAccessControl(this IFileInfo fileInfo,
 		FileSecurity fileSecurity)
 	{
-		IFileSystemExtensionContainer extensionContainer =
-			fileInfo.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out FileInfo? fi))
+		IFileSystemExtensibility extensibility =
+			fileInfo.Extensibility;
+		if (extensibility.TryGetWrappedInstance(out FileInfo? fi))
 		{
 			fi.SetAccessControl(fileSecurity);
 		}
 		else
 		{
-			extensionContainer.StoreMetadata(AccessControlHelpers.AccessControl,
+			extensibility.StoreMetadata(AccessControlHelpers.AccessControl,
 				fileSecurity);
 		}
 	}

--- a/Source/Testably.Abstractions.AccessControl/FileInfoAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileInfoAclExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
-using System.Security.AccessControl;
-using Testably.Abstractions.FileSystem;
+using System.Security.AccessControl;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.AccessControl/FileInfoAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileInfoAclExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-using System.Security.AccessControl;
+using System.Security.AccessControl;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.AccessControl/FileStreamAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileStreamAclExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
-using System.Security.AccessControl;
-using Testably.Abstractions.FileSystem;
+using System.Security.AccessControl;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.AccessControl/FileStreamAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileStreamAclExtensions.cs
@@ -13,11 +13,11 @@ public static class FileStreamAclExtensions
 	[SupportedOSPlatform("windows")]
 	public static FileSecurity GetAccessControl(this FileSystemStream fileStream)
 	{
-		IFileSystemExtensionContainer extensionContainer =
-			fileStream.ExtensionContainer;
-		return extensionContainer.HasWrappedInstance(out FileStream? fs)
+		IFileSystemExtensibility extensibility =
+			fileStream.Extensibility;
+		return extensibility.TryGetWrappedInstance(out FileStream? fs)
 			? fs.GetAccessControl()
-			: extensionContainer.RetrieveMetadata<FileSecurity>(
+			: extensibility.RetrieveMetadata<FileSecurity>(
 				AccessControlHelpers.AccessControl) ?? new FileSecurity();
 	}
 
@@ -26,15 +26,15 @@ public static class FileStreamAclExtensions
 	public static void SetAccessControl(this FileSystemStream fileStream,
 		FileSecurity fileSecurity)
 	{
-		IFileSystemExtensionContainer extensionContainer =
-			fileStream.ExtensionContainer;
-		if (extensionContainer.HasWrappedInstance(out FileStream? fs))
+		IFileSystemExtensibility extensibility =
+			fileStream.Extensibility;
+		if (extensibility.TryGetWrappedInstance(out FileStream? fs))
 		{
 			fs.SetAccessControl(fileSecurity);
 		}
 		else
 		{
-			extensionContainer.StoreMetadata(AccessControlHelpers.AccessControl,
+			extensibility.StoreMetadata(AccessControlHelpers.AccessControl,
 				fileSecurity);
 		}
 	}

--- a/Source/Testably.Abstractions.AccessControl/FileStreamAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/FileStreamAclExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-using System.Security.AccessControl;
+using System.Security.AccessControl;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.AccessControl/Usings.cs
+++ b/Source/Testably.Abstractions.AccessControl/Usings.cs
@@ -3,3 +3,4 @@ global using Testably.Abstractions.Polyfills;
 #else
 global using System.Runtime.Versioning;
 #endif
+global using Testably.Abstractions.FileSystem;

--- a/Source/Testably.Abstractions.Compression/IZipArchive.cs
+++ b/Source/Testably.Abstractions.Compression/IZipArchive.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
-using System.IO.Compression;
+using System.IO.Compression;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.Compression/IZipArchive.cs
+++ b/Source/Testably.Abstractions.Compression/IZipArchive.cs
@@ -6,7 +6,7 @@ using Testably.Abstractions.FileSystem;
 namespace Testably.Abstractions;
 
 /// <inheritdoc cref="ZipArchive" />
-public interface IZipArchive : IFileSystemExtensionPoint, IDisposable
+public interface IZipArchive : IFileSystemEntity, IDisposable
 {
 #if FEATURE_ZIPFILE_NET7
 	/// <inheritdoc cref="ZipArchiveEntry.Comment" />

--- a/Source/Testably.Abstractions.Compression/IZipArchive.cs
+++ b/Source/Testably.Abstractions.Compression/IZipArchive.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
-using System.IO.Compression;
-using Testably.Abstractions.FileSystem;
+using System.IO.Compression;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.Compression/IZipArchiveEntry.cs
+++ b/Source/Testably.Abstractions.Compression/IZipArchiveEntry.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
-using System.IO.Compression;
-using Testably.Abstractions.FileSystem;
+using System.IO.Compression;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.Compression/IZipArchiveEntry.cs
+++ b/Source/Testably.Abstractions.Compression/IZipArchiveEntry.cs
@@ -6,7 +6,7 @@ using Testably.Abstractions.FileSystem;
 namespace Testably.Abstractions;
 
 /// <inheritdoc cref="ZipArchiveEntry" />
-public interface IZipArchiveEntry : IFileSystemExtensionPoint
+public interface IZipArchiveEntry : IFileSystemEntity
 {
 	/// <inheritdoc cref="ZipArchiveEntry.Archive" />
 	IZipArchive Archive { get; }

--- a/Source/Testably.Abstractions.Compression/IZipArchiveEntry.cs
+++ b/Source/Testably.Abstractions.Compression/IZipArchiveEntry.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO;
-using System.IO.Compression;
+using System.IO.Compression;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.Compression/IZipArchiveFactory.cs
+++ b/Source/Testably.Abstractions.Compression/IZipArchiveFactory.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 using System.IO.Compression;
-using System.Text;
+using System.Text;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.Compression/IZipArchiveFactory.cs
+++ b/Source/Testably.Abstractions.Compression/IZipArchiveFactory.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
 using System.IO.Compression;
-using System.Text;
-using Testably.Abstractions.FileSystem;
+using System.Text;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.Compression/IZipArchiveFactory.cs
+++ b/Source/Testably.Abstractions.Compression/IZipArchiveFactory.cs
@@ -6,7 +6,7 @@ using Testably.Abstractions.FileSystem;
 namespace Testably.Abstractions;
 
 /// <inheritdoc cref="ZipArchive" />
-public interface IZipArchiveFactory : IFileSystemExtensionPoint
+public interface IZipArchiveFactory : IFileSystemEntity
 {
 	/// <inheritdoc cref="ZipArchive(Stream)" />
 	IZipArchive New(Stream stream);

--- a/Source/Testably.Abstractions.Compression/IZipFile.cs
+++ b/Source/Testably.Abstractions.Compression/IZipFile.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO.Compression;
-using System.Text;
-using Testably.Abstractions.FileSystem;
+using System.Text;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.Compression/IZipFile.cs
+++ b/Source/Testably.Abstractions.Compression/IZipFile.cs
@@ -5,7 +5,7 @@ using Testably.Abstractions.FileSystem;
 namespace Testably.Abstractions;
 
 /// <inheritdoc cref="ZipFile" />
-public interface IZipFile : IFileSystemExtensionPoint
+public interface IZipFile : IFileSystemEntity
 {
 	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, string)" />
 	void CreateFromDirectory(string sourceDirectoryName,

--- a/Source/Testably.Abstractions.Compression/IZipFile.cs
+++ b/Source/Testably.Abstractions.Compression/IZipFile.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO.Compression;
-using System.Text;
+using System.Text;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
+++ b/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.IO.Compression;
-using System.Text;
-using Testably.Abstractions.FileSystem;
+using System.Text;
 
 namespace Testably.Abstractions.Internal;
 

--- a/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
+++ b/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.IO.Compression;
-using System.Text;
+using System.Text;
 
 namespace Testably.Abstractions.Internal;
 

--- a/Source/Testably.Abstractions.Compression/Usings.cs
+++ b/Source/Testably.Abstractions.Compression/Usings.cs
@@ -1,0 +1,1 @@
+﻿global using Testably.Abstractions.FileSystem;

--- a/Source/Testably.Abstractions.Compression/ZipArchiveEntryWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipArchiveEntryWrapper.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.IO.Compression;
-using Testably.Abstractions.FileSystem;
+using System.IO.Compression;
 using Testably.Abstractions.Internal;
 
 namespace Testably.Abstractions;

--- a/Source/Testably.Abstractions.Compression/ZipArchiveEntryWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipArchiveEntryWrapper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.IO.Compression;
+using System.IO.Compression;
 using Testably.Abstractions.Internal;
 
 namespace Testably.Abstractions;

--- a/Source/Testably.Abstractions.Compression/ZipArchiveEntryWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipArchiveEntryWrapper.cs
@@ -53,7 +53,7 @@ internal sealed class ZipArchiveEntryWrapper : IZipArchiveEntry
 	}
 #endif
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IZipArchiveEntry.FullName" />

--- a/Source/Testably.Abstractions.Compression/ZipArchiveFactory.cs
+++ b/Source/Testably.Abstractions.Compression/ZipArchiveFactory.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 using System.IO.Compression;
-using System.Text;
+using System.Text;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.Compression/ZipArchiveFactory.cs
+++ b/Source/Testably.Abstractions.Compression/ZipArchiveFactory.cs
@@ -14,7 +14,7 @@ internal sealed class ZipArchiveFactory : IZipArchiveFactory
 
 	#region IZipArchiveFactory Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IZipArchiveFactory.New(Stream)" />

--- a/Source/Testably.Abstractions.Compression/ZipArchiveFactory.cs
+++ b/Source/Testably.Abstractions.Compression/ZipArchiveFactory.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
 using System.IO.Compression;
-using System.Text;
-using Testably.Abstractions.FileSystem;
+using System.Text;
 
 namespace Testably.Abstractions;
 

--- a/Source/Testably.Abstractions.Compression/ZipArchiveWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipArchiveWrapper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.IO.Compression;
-using System.Linq;
+using System.Linq;
 using Testably.Abstractions.Internal;
 
 namespace Testably.Abstractions;

--- a/Source/Testably.Abstractions.Compression/ZipArchiveWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipArchiveWrapper.cs
@@ -32,7 +32,7 @@ internal sealed class ZipArchiveWrapper : IZipArchive
 	public ReadOnlyCollection<IZipArchiveEntry> Entries
 		=> MapToZipArchiveEntries(_instance.Entries);
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IZipArchive.Mode" />

--- a/Source/Testably.Abstractions.Compression/ZipArchiveWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipArchiveWrapper.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.IO.Compression;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 using Testably.Abstractions.Internal;
 
 namespace Testably.Abstractions;

--- a/Source/Testably.Abstractions.Compression/ZipFileWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipFileWrapper.cs
@@ -14,7 +14,7 @@ internal sealed class ZipFileWrapper : IZipFile
 
 	#region IZipFile Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, string)" />

--- a/Source/Testably.Abstractions.Compression/ZipFileWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipFileWrapper.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO.Compression;
-using System.Text;
-using Testably.Abstractions.FileSystem;
+using System.Text;
 using Testably.Abstractions.Internal;
 
 namespace Testably.Abstractions;

--- a/Source/Testably.Abstractions.Compression/ZipFileWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipFileWrapper.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO.Compression;
-using System.Text;
+using System.Text;
 using Testably.Abstractions.Internal;
 
 namespace Testably.Abstractions;

--- a/Source/Testably.Abstractions.Interface/FileSystem/FileSystemStream.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/FileSystemStream.cs
@@ -88,7 +88,7 @@ public abstract class FileSystemStream : Stream
 	/// <summary>
 	///     A container to support extensions on <see cref="FileSystemStream" />.
 	/// </summary>
-	public abstract IFileSystemExtensionContainer ExtensionContainer { get; }
+	public abstract IFileSystemExtensibility Extensibility { get; }
 
 	/// <inheritdoc cref="Stream.BeginRead(byte[], int, int, AsyncCallback?, object?)" />
 	public override IAsyncResult BeginRead(byte[] buffer,

--- a/Source/Testably.Abstractions.Interface/FileSystem/IDirectory.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IDirectory.cs
@@ -8,7 +8,7 @@ namespace Testably.Abstractions.FileSystem;
 /// <summary>
 ///     Abstractions for <see cref="Directory" />.
 /// </summary>
-public interface IDirectory : IFileSystemExtensionPoint
+public interface IDirectory : IFileSystemEntity
 {
 	/// <inheritdoc cref="Directory.CreateDirectory(string)" />
 	IDirectoryInfo CreateDirectory(string path);

--- a/Source/Testably.Abstractions.Interface/FileSystem/IDirectoryInfoFactory.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IDirectoryInfoFactory.cs
@@ -6,7 +6,7 @@ namespace Testably.Abstractions.FileSystem;
 /// <summary>
 ///     Factory for abstracting the creation of <see cref="DirectoryInfo" />.
 /// </summary>
-public interface IDirectoryInfoFactory : IFileSystemExtensionPoint
+public interface IDirectoryInfoFactory : IFileSystemEntity
 {
 	/// <inheritdoc cref="DirectoryInfo(string)" />
 	IDirectoryInfo New(string path);

--- a/Source/Testably.Abstractions.Interface/FileSystem/IDriveInfo.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IDriveInfo.cs
@@ -6,7 +6,7 @@ namespace Testably.Abstractions.FileSystem;
 /// <summary>
 ///     Abstractions for <see cref="DriveInfo" />.
 /// </summary>
-public interface IDriveInfo : IFileSystemExtensionPoint
+public interface IDriveInfo : IFileSystemEntity
 {
 	/// <inheritdoc cref="DriveInfo.AvailableFreeSpace" />
 	long AvailableFreeSpace { get; }

--- a/Source/Testably.Abstractions.Interface/FileSystem/IDriveInfoFactory.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IDriveInfoFactory.cs
@@ -6,7 +6,7 @@ namespace Testably.Abstractions.FileSystem;
 /// <summary>
 ///     Factory for abstracting the creation of <see cref="DriveInfo" />.
 /// </summary>
-public interface IDriveInfoFactory : IFileSystemExtensionPoint
+public interface IDriveInfoFactory : IFileSystemEntity
 {
 	/// <inheritdoc cref="DriveInfo.GetDrives()" />
 	IDriveInfo[] GetDrives();

--- a/Source/Testably.Abstractions.Interface/FileSystem/IFile.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IFile.cs
@@ -16,7 +16,7 @@ namespace Testably.Abstractions.FileSystem;
 /// <summary>
 ///     Abstractions for <see cref="File" />.
 /// </summary>
-public interface IFile : IFileSystemExtensionPoint
+public interface IFile : IFileSystemEntity
 {
 	/// <inheritdoc cref="File.AppendAllLines(string, IEnumerable{string})" />
 	void AppendAllLines(string path, IEnumerable<string> contents);

--- a/Source/Testably.Abstractions.Interface/FileSystem/IFileInfoFactory.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IFileInfoFactory.cs
@@ -6,7 +6,7 @@ namespace Testably.Abstractions.FileSystem;
 /// <summary>
 ///     Factory for abstracting the creation of <see cref="FileInfo" />.
 /// </summary>
-public interface IFileInfoFactory : IFileSystemExtensionPoint
+public interface IFileInfoFactory : IFileSystemEntity
 {
 	/// <inheritdoc cref="FileInfo(string)" />
 	IFileInfo New(string fileName);

--- a/Source/Testably.Abstractions.Interface/FileSystem/IFileStreamFactory.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IFileStreamFactory.cs
@@ -6,7 +6,7 @@ namespace Testably.Abstractions.FileSystem;
 /// <summary>
 ///     Factory for abstracting creation of <see cref="FileStream" />.
 /// </summary>
-public interface IFileStreamFactory : IFileSystemExtensionPoint
+public interface IFileStreamFactory : IFileSystemEntity
 {
 	/// <inheritdoc cref="FileStream(SafeFileHandle, FileAccess)" />
 	FileSystemStream New(SafeFileHandle handle, FileAccess access);

--- a/Source/Testably.Abstractions.Interface/FileSystem/IFileSystemEntity.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IFileSystemEntity.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///     Interface to support implementing extension methods on top of nested <see cref="IFileSystem" /> interfaces.
 /// </summary>
-public interface IFileSystemExtensionPoint
+public interface IFileSystemEntity
 {
 	/// <summary>
 	///     Exposes the underlying file system implementation.

--- a/Source/Testably.Abstractions.Interface/FileSystem/IFileSystemExtensibility.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IFileSystemExtensibility.cs
@@ -5,7 +5,7 @@ namespace Testably.Abstractions.FileSystem;
 /// <summary>
 ///     A container to support extensions on <see cref="IFileSystem" /> entities.
 /// </summary>
-public interface IFileSystemExtensionContainer
+public interface IFileSystemExtensibility
 {
 	/// <summary>
 	///     The wrapped instance on a real file system.
@@ -14,7 +14,7 @@ public interface IFileSystemExtensionContainer
 	///     <see langword="null" /> when not on a real file system or if the requested type does not match,
 	///     otherwise the wrapped instance.
 	/// </returns>
-	bool HasWrappedInstance<T>([NotNullWhen(true)] out T? wrappedInstance);
+	bool TryGetWrappedInstance<T>([NotNullWhen(true)] out T? wrappedInstance);
 
 	/// <summary>
 	///     Stores additional metadata to the <see cref="IFileSystemInfo" />.

--- a/Source/Testably.Abstractions.Interface/FileSystem/IFileSystemInfo.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IFileSystemInfo.cs
@@ -6,7 +6,7 @@ namespace Testably.Abstractions.FileSystem;
 /// <summary>
 ///     Abstractions for <see cref="FileSystemInfo" />.
 /// </summary>
-public interface IFileSystemInfo
+public interface IFileSystemInfo : IFileSystemEntity
 {
 	/// <inheritdoc cref="FileSystemInfo.Attributes" />
 	FileAttributes Attributes { get; set; }

--- a/Source/Testably.Abstractions.Interface/FileSystem/IFileSystemInfo.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IFileSystemInfo.cs
@@ -26,7 +26,7 @@ public interface IFileSystemInfo
 	/// <summary>
 	///     A container to support extensions on <see cref="IFileSystemInfo" />.
 	/// </summary>
-	IFileSystemExtensionContainer ExtensionContainer { get; }
+	IFileSystemExtensibility Extensibility { get; }
 
 	/// <inheritdoc cref="FileSystemInfo.FullName" />
 	string FullName { get; }

--- a/Source/Testably.Abstractions.Interface/FileSystem/IFileSystemWatcher.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IFileSystemWatcher.cs
@@ -10,7 +10,7 @@ namespace Testably.Abstractions.FileSystem;
 /// <summary>
 ///     Abstractions for <see cref="FileSystemWatcher" />.
 /// </summary>
-public interface IFileSystemWatcher : IFileSystemExtensionPoint, IDisposable
+public interface IFileSystemWatcher : IFileSystemEntity, IDisposable
 {
 	/// <inheritdoc cref="Component.Container" />
 	IContainer? Container { get; }

--- a/Source/Testably.Abstractions.Interface/FileSystem/IFileSystemWatcher.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IFileSystemWatcher.cs
@@ -75,22 +75,4 @@ public interface IFileSystemWatcher : IFileSystemEntity, IDisposable
 	/// <inheritdoc cref="FileSystemWatcher.WaitForChanged(WatcherChangeTypes, TimeSpan)" />
 	IWaitForChangedResult WaitForChanged(WatcherChangeTypes changeType, TimeSpan timeout);
 #endif
-
-	/// <summary>
-	///     Abstractions for <see cref="WaitForChangedResult" />.
-	/// </summary>
-	public interface IWaitForChangedResult
-	{
-		/// <inheritdoc cref="WaitForChangedResult.ChangeType" />
-		WatcherChangeTypes ChangeType { get; }
-
-		/// <inheritdoc cref="WaitForChangedResult.Name" />
-		string? Name { get; }
-
-		/// <inheritdoc cref="WaitForChangedResult.OldName" />
-		string? OldName { get; }
-
-		/// <inheritdoc cref="WaitForChangedResult.TimedOut" />
-		bool TimedOut { get; }
-	}
 }

--- a/Source/Testably.Abstractions.Interface/FileSystem/IFileSystemWatcherFactory.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IFileSystemWatcherFactory.cs
@@ -6,7 +6,7 @@ namespace Testably.Abstractions.FileSystem;
 /// <summary>
 ///     Factory for abstracting the creation of <see cref="FileSystemWatcher" />.
 /// </summary>
-public interface IFileSystemWatcherFactory : IFileSystemExtensionPoint
+public interface IFileSystemWatcherFactory : IFileSystemEntity
 {
 	/// <inheritdoc cref="FileSystemWatcher()" />
 	IFileSystemWatcher New();

--- a/Source/Testably.Abstractions.Interface/FileSystem/IPath.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IPath.cs
@@ -9,7 +9,7 @@ namespace Testably.Abstractions.FileSystem;
 /// <summary>
 ///     Abstractions for <see cref="Path" />.
 /// </summary>
-public interface IPath : IFileSystemExtensionPoint
+public interface IPath : IFileSystemEntity
 {
 	/// <inheritdoc cref="Path.AltDirectorySeparatorChar" />
 	char AltDirectorySeparatorChar { get; }

--- a/Source/Testably.Abstractions.Interface/FileSystem/IWaitForChangedResult.cs
+++ b/Source/Testably.Abstractions.Interface/FileSystem/IWaitForChangedResult.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+
+namespace Testably.Abstractions.FileSystem;
+
+/// <summary>
+///     Abstractions for <see cref="WaitForChangedResult" />.
+/// </summary>
+public interface IWaitForChangedResult
+{
+	/// <inheritdoc cref="WaitForChangedResult.ChangeType" />
+	WatcherChangeTypes ChangeType { get; }
+
+	/// <inheritdoc cref="WaitForChangedResult.Name" />
+	string? Name { get; }
+
+	/// <inheritdoc cref="WaitForChangedResult.OldName" />
+	string? OldName { get; }
+
+	/// <inheritdoc cref="WaitForChangedResult.TimedOut" />
+	bool TimedOut { get; }
+}

--- a/Source/Testably.Abstractions.Interface/Helpers/GuidSystemBase.cs
+++ b/Source/Testably.Abstractions.Interface/Helpers/GuidSystemBase.cs
@@ -26,7 +26,7 @@ public abstract class GuidSystemBase : IGuid
 	/// <inheritdoc cref="IGuid.Empty" />
 	public Guid Empty => Guid.Empty;
 
-	/// <inheritdoc cref="IRandomSystemExtensionPoint.RandomSystem" />
+	/// <inheritdoc cref="IRandomSystemEntity.RandomSystem" />
 	public IRandomSystem RandomSystem { get; }
 
 	/// <inheritdoc cref="IGuid.NewGuid()" />

--- a/Source/Testably.Abstractions.Interface/Helpers/PathSystemBase.cs
+++ b/Source/Testably.Abstractions.Interface/Helpers/PathSystemBase.cs
@@ -32,7 +32,7 @@ public abstract class PathSystemBase : IPath
 	public char DirectorySeparatorChar
 		=> Path.DirectorySeparatorChar;
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="Path.PathSeparator" />

--- a/Source/Testably.Abstractions.Interface/Helpers/PathSystemBase.cs
+++ b/Source/Testably.Abstractions.Interface/Helpers/PathSystemBase.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Testably.Abstractions.FileSystem;
+
 #if !NETSTANDARD2_0
 using System;
 #endif

--- a/Source/Testably.Abstractions.Interface/Helpers/PathSystemBase.cs
+++ b/Source/Testably.Abstractions.Interface/Helpers/PathSystemBase.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Testably.Abstractions.FileSystem;
-
 #if !NETSTANDARD2_0
 using System;
 #endif

--- a/Source/Testably.Abstractions.Interface/RandomSystem/IGuid.cs
+++ b/Source/Testably.Abstractions.Interface/RandomSystem/IGuid.cs
@@ -8,7 +8,7 @@ namespace Testably.Abstractions.RandomSystem;
 /// <summary>
 ///     Abstractions for <see cref="Guid" />.
 /// </summary>
-public interface IGuid : IRandomSystemExtensionPoint
+public interface IGuid : IRandomSystemEntity
 {
 	/// <inheritdoc cref="Guid.Empty" />
 	Guid Empty { get; }

--- a/Source/Testably.Abstractions.Interface/RandomSystem/IRandomFactory.cs
+++ b/Source/Testably.Abstractions.Interface/RandomSystem/IRandomFactory.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///     Factory for abstracting creation of <see cref="System.Random" />.
 /// </summary>
-public interface IRandomFactory : IRandomSystemExtensionPoint
+public interface IRandomFactory : IRandomSystemEntity
 {
 	/// <summary>
 	///     Provides a thread-safe <see cref="IRandom" /> instance that may be used concurrently from any thread.

--- a/Source/Testably.Abstractions.Interface/RandomSystem/IRandomSystemEntity.cs
+++ b/Source/Testably.Abstractions.Interface/RandomSystem/IRandomSystemEntity.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///     Interface to support implementing extension methods on top of nested <see cref="IRandomSystem" /> interfaces.
 /// </summary>
-public interface IRandomSystemExtensionPoint
+public interface IRandomSystemEntity
 {
 	/// <summary>
 	///     Exposes the underlying random system implementation.

--- a/Source/Testably.Abstractions.Interface/TimeSystem/IDateTime.cs
+++ b/Source/Testably.Abstractions.Interface/TimeSystem/IDateTime.cs
@@ -5,7 +5,7 @@ namespace Testably.Abstractions.TimeSystem;
 /// <summary>
 ///     Abstractions for <see cref="DateTime" />.
 /// </summary>
-public interface IDateTime : ITimeSystemExtensionPoint
+public interface IDateTime : ITimeSystemEntity
 {
 	/// <inheritdoc cref="DateTime.MaxValue" />
 	DateTime MaxValue { get; }

--- a/Source/Testably.Abstractions.Interface/TimeSystem/ITask.cs
+++ b/Source/Testably.Abstractions.Interface/TimeSystem/ITask.cs
@@ -7,7 +7,7 @@ namespace Testably.Abstractions.TimeSystem;
 /// <summary>
 ///     Abstractions for <see cref="Task" />.
 /// </summary>
-public interface ITask : ITimeSystemExtensionPoint
+public interface ITask : ITimeSystemEntity
 {
 	/// <inheritdoc cref="Task.Delay(int)" />
 	Task Delay(int millisecondsDelay);

--- a/Source/Testably.Abstractions.Interface/TimeSystem/IThread.cs
+++ b/Source/Testably.Abstractions.Interface/TimeSystem/IThread.cs
@@ -5,7 +5,7 @@ namespace Testably.Abstractions.TimeSystem;
 /// <summary>
 ///     Abstractions for <see cref="System.Threading.Thread" />.
 /// </summary>
-public interface IThread : ITimeSystemExtensionPoint
+public interface IThread : ITimeSystemEntity
 {
 	/// <inheritdoc cref="System.Threading.Thread.Sleep(int)" />
 	void Sleep(int millisecondsTimeout);

--- a/Source/Testably.Abstractions.Interface/TimeSystem/ITimeSystemEntity.cs
+++ b/Source/Testably.Abstractions.Interface/TimeSystem/ITimeSystemEntity.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///     Interface to support implementing extension methods on top of nested <see cref="ITimeSystem" /> interfaces.
 /// </summary>
-public interface ITimeSystemExtensionPoint
+public interface ITimeSystemEntity
 {
 	/// <summary>
 	///     Exposes the underlying time system implementation.

--- a/Source/Testably.Abstractions.Testing/FileSystem/ChangeHandler.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/ChangeHandler.cs
@@ -23,7 +23,7 @@ internal sealed class ChangeHandler : IInterceptionHandler,
 
 	#region IInterceptionHandler Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem => _mockFileSystem;
 
 	/// <inheritdoc

--- a/Source/Testably.Abstractions.Testing/FileSystem/ChangeHandler.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/ChangeHandler.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.IO;
+using System.IO;
 using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.FileSystem;

--- a/Source/Testably.Abstractions.Testing/FileSystem/ChangeHandler.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/ChangeHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.FileSystem;

--- a/Source/Testably.Abstractions.Testing/FileSystem/DefaultAccessControlStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DefaultAccessControlStrategy.cs
@@ -9,20 +9,20 @@ namespace Testably.Abstractions.Testing.FileSystem;
 /// </summary>
 public class DefaultAccessControlStrategy : IAccessControlStrategy
 {
-	private readonly Func<string, IFileSystemExtensionContainer, bool> _callback;
+	private readonly Func<string, IFileSystemExtensibility, bool> _callback;
 
 	/// <summary>
 	///     Initializes a new instance of <see cref="DefaultAccessControlStrategy" /> which takes a callback to determine if
 	///     access should be granted.
 	/// </summary>
 	public DefaultAccessControlStrategy(
-		Func<string, IFileSystemExtensionContainer, bool> callback)
+		Func<string, IFileSystemExtensibility, bool> callback)
 	{
 		_callback = callback ?? throw new ArgumentNullException(nameof(callback));
 	}
 
-	/// <inheritdoc cref="IAccessControlStrategy.IsAccessGranted(string, IFileSystemExtensionContainer)" />
+	/// <inheritdoc cref="IAccessControlStrategy.IsAccessGranted(string, IFileSystemExtensibility)" />
 	public bool IsAccessGranted(string fullPath,
-		IFileSystemExtensionContainer extensionContainer)
-		=> _callback(fullPath, extensionContainer);
+		IFileSystemExtensibility extensibility)
+		=> _callback(fullPath, extensibility);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/DefaultAccessControlStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DefaultAccessControlStrategy.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Testably.Abstractions.FileSystem;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.FileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/DefaultAccessControlStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DefaultAccessControlStrategy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.FileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoFactoryMock.cs
@@ -1,5 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.IO;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.FileSystem;

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoFactoryMock.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.FileSystem;

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoFactoryMock.cs
@@ -16,7 +16,7 @@ internal sealed class DirectoryInfoFactoryMock : IDirectoryInfoFactory
 
 	#region IDirectoryInfoFactory Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem
 		=> _fileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
+using System.Linq;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
@@ -42,7 +42,7 @@ internal sealed class DirectoryInfoMock
 
 		Container = FileSystem.Storage.GetOrCreateContainer(Location,
 			InMemoryContainer.NewDirectory,
-			ExtensionContainer);
+			Extensibility);
 
 		ResetCache(!Execute.IsNetFramework);
 	}

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
@@ -1,8 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
@@ -20,7 +20,7 @@ internal sealed class DirectoryMock : IDirectory
 
 	#region IDirectory Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem
 		=> _fileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
@@ -2,8 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
+using System.Linq;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoFactoryMock.cs
@@ -18,7 +18,7 @@ internal sealed class DriveInfoFactoryMock : IDriveInfoFactory
 
 	#region IDriveInfoFactory Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem
 		=> _fileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoFactoryMock.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.FileSystem;

--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoFactoryMock.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
+using System.Linq;
 using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.FileSystem;

--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
@@ -68,7 +68,7 @@ internal sealed class DriveInfoMock : IStorageDrive
 	/// <inheritdoc cref="IDriveInfo.DriveType" />
 	public DriveType DriveType { get; private set; }
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem
 		=> _fileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoFactoryMock.cs
@@ -17,7 +17,7 @@ internal sealed class FileInfoFactoryMock : IFileInfoFactory
 
 	#region IFileInfoFactory Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem
 		=> _fileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoFactoryMock.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.FileSystem;

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoFactoryMock.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.FileSystem;

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
@@ -1,5 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.IO;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
@@ -11,10 +11,13 @@ namespace Testably.Abstractions.Testing.FileSystem;
 internal sealed class FileInfoMock
 	: FileSystemInfoMock, IFileInfo
 {
+	private readonly MockFileSystem _fileSystem;
+
 	private FileInfoMock(IStorageLocation location,
 		MockFileSystem fileSystem)
 		: base(fileSystem, location, FileSystemTypes.File)
 	{
+		_fileSystem = fileSystem;
 	}
 
 	#region IFileInfo Members
@@ -22,7 +25,7 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.Directory" />
 	public IDirectoryInfo? Directory
 		=> DirectoryInfoMock.New(Location.GetParent(),
-			FileSystem);
+			_fileSystem);
 
 	/// <inheritdoc cref="IFileInfo.DirectoryName" />
 	public string? DirectoryName
@@ -74,37 +77,37 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.CopyTo(string)" />
 	public IFileInfo CopyTo(string destFileName)
 	{
-		destFileName.EnsureValidArgument(FileSystem, nameof(destFileName));
-		IStorageLocation destinationLocation = FileSystem.Storage.GetLocation(destFileName);
-		Location.ThrowExceptionIfNotFound(FileSystem);
-		IStorageLocation location = FileSystem.Storage
+		destFileName.EnsureValidArgument(_fileSystem, nameof(destFileName));
+		IStorageLocation destinationLocation = _fileSystem.Storage.GetLocation(destFileName);
+		Location.ThrowExceptionIfNotFound(_fileSystem);
+		IStorageLocation location = _fileSystem.Storage
 			                            .Copy(Location, destinationLocation)
 		                            ?? throw ExceptionFactory.FileNotFound(FullName);
-		return FileSystem.FileInfo.New(location.FullPath);
+		return _fileSystem.FileInfo.New(location.FullPath);
 	}
 
 	/// <inheritdoc cref="IFileInfo.CopyTo(string, bool)" />
 	public IFileInfo CopyTo(string destFileName, bool overwrite)
 	{
-		destFileName.EnsureValidArgument(FileSystem, nameof(destFileName));
-		IStorageLocation location = FileSystem.Storage.Copy(
+		destFileName.EnsureValidArgument(_fileSystem, nameof(destFileName));
+		IStorageLocation location = _fileSystem.Storage.Copy(
 			                            Location,
-			                            FileSystem.Storage.GetLocation(destFileName),
+			                            _fileSystem.Storage.GetLocation(destFileName),
 			                            overwrite)
 		                            ?? throw ExceptionFactory.FileNotFound(FullName);
-		return FileSystem.FileInfo.New(location.FullPath);
+		return _fileSystem.FileInfo.New(location.FullPath);
 	}
 
 	/// <inheritdoc cref="IFileInfo.Create()" />
 	public FileSystemStream Create()
 	{
 		Execute.NotOnNetFramework(Refresh);
-		return FileSystem.File.Create(FullName);
+		return _fileSystem.File.Create(FullName);
 	}
 
 	/// <inheritdoc cref="IFileInfo.CreateText()" />
 	public StreamWriter CreateText()
-		=> new(FileSystem.File.Create(FullName));
+		=> new(_fileSystem.File.Create(FullName));
 
 	/// <inheritdoc cref="IFileInfo.Decrypt()" />
 	[SupportedOSPlatform("windows")]
@@ -119,10 +122,10 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.MoveTo(string)" />
 	public void MoveTo(string destFileName)
 	{
-		Location = FileSystem.Storage.Move(
+		Location = _fileSystem.Storage.Move(
 			           Location,
-			           FileSystem.Storage.GetLocation(destFileName
-				           .EnsureValidArgument(FileSystem, nameof(destFileName))))
+			           _fileSystem.Storage.GetLocation(destFileName
+				           .EnsureValidArgument(_fileSystem, nameof(destFileName))))
 		           ?? throw ExceptionFactory.FileNotFound(FullName);
 	}
 
@@ -130,10 +133,10 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.MoveTo(string, bool)" />
 	public void MoveTo(string destFileName, bool overwrite)
 	{
-		Location = FileSystem.Storage.Move(
+		Location = _fileSystem.Storage.Move(
 			           Location,
-			           FileSystem.Storage.GetLocation(destFileName
-				           .EnsureValidArgument(FileSystem, nameof(destFileName))),
+			           _fileSystem.Storage.GetLocation(destFileName
+				           .EnsureValidArgument(_fileSystem, nameof(destFileName))),
 			           overwrite)
 		           ?? throw ExceptionFactory.FileNotFound(FullName);
 	}
@@ -146,7 +149,7 @@ internal sealed class FileInfoMock
 			() => throw ExceptionFactory.AppendAccessOnlyInWriteOnlyMode());
 
 		return new FileStreamMock(
-			FileSystem,
+			_fileSystem,
 			FullName,
 			mode,
 			mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite,
@@ -156,7 +159,7 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.Open(FileMode, FileAccess)" />
 	public FileSystemStream Open(FileMode mode, FileAccess access)
 		=> new FileStreamMock(
-			FileSystem,
+			_fileSystem,
 			FullName,
 			mode,
 			access,
@@ -165,7 +168,7 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.Open(FileMode, FileAccess, FileShare)" />
 	public FileSystemStream Open(FileMode mode, FileAccess access, FileShare share)
 		=> new FileStreamMock(
-			FileSystem,
+			_fileSystem,
 			FullName,
 			mode,
 			access,
@@ -174,13 +177,13 @@ internal sealed class FileInfoMock
 #if FEATURE_FILESYSTEM_STREAM_OPTIONS
 	/// <inheritdoc cref="IFileInfo.Open(FileStreamOptions)" />
 	public FileSystemStream Open(FileStreamOptions options)
-		=> FileSystem.File.Open(FullName, options);
+		=> _fileSystem.File.Open(FullName, options);
 #endif
 
 	/// <inheritdoc cref="IFileInfo.OpenRead()" />
 	public FileSystemStream OpenRead()
 		=> new FileStreamMock(
-			FileSystem,
+			_fileSystem,
 			FullName,
 			FileMode.Open,
 			FileAccess.Read);
@@ -192,7 +195,7 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.OpenWrite()" />
 	public FileSystemStream OpenWrite()
 		=> new FileStreamMock(
-			FileSystem,
+			_fileSystem,
 			FullName,
 			FileMode.OpenOrCreate,
 			FileAccess.Write,
@@ -203,10 +206,10 @@ internal sealed class FileInfoMock
 		string? destinationBackupFileName)
 	{
 		IStorageLocation location =
-			FileSystem
+			_fileSystem
 				.Storage
 				.Replace(
-					Location.ThrowIfNotFound(FileSystem,
+					Location.ThrowIfNotFound(_fileSystem,
 						() => { },
 						() =>
 						{
@@ -217,10 +220,10 @@ internal sealed class FileInfoMock
 
 							throw ExceptionFactory.DirectoryNotFound(FullName);
 						}),
-					FileSystem.Storage
+					_fileSystem.Storage
 						.GetLocation(destinationFileName
-							.EnsureValidFormat(FileSystem, nameof(destinationFileName)))
-						.ThrowIfNotFound(FileSystem,
+							.EnsureValidFormat(_fileSystem, nameof(destinationFileName)))
+						.ThrowIfNotFound(_fileSystem,
 							() => { },
 							() =>
 							{
@@ -231,9 +234,9 @@ internal sealed class FileInfoMock
 
 								throw ExceptionFactory.FileNotFound(FullName);
 							}),
-					FileSystem.Storage
+					_fileSystem.Storage
 						.GetLocation(destinationBackupFileName)
-						.ThrowIfNotFound(FileSystem,
+						.ThrowIfNotFound(_fileSystem,
 							() => { },
 							() =>
 							{
@@ -245,7 +248,7 @@ internal sealed class FileInfoMock
 								throw ExceptionFactory.DirectoryNotFound(FullName);
 							}))
 			?? throw ExceptionFactory.FileNotFound(FullName);
-		return FileSystem.FileInfo.New(location.FullPath);
+		return _fileSystem.FileInfo.New(location.FullPath);
 	}
 
 	/// <inheritdoc cref="IFileInfo.Replace(string, string?, bool)" />
@@ -253,17 +256,17 @@ internal sealed class FileInfoMock
 		string? destinationBackupFileName,
 		bool ignoreMetadataErrors)
 	{
-		IStorageLocation location = FileSystem.Storage.Replace(
+		IStorageLocation location = _fileSystem.Storage.Replace(
 			                            Location,
-			                            FileSystem.Storage.GetLocation(
+			                            _fileSystem.Storage.GetLocation(
 				                            destinationFileName
-					                            .EnsureValidFormat(FileSystem,
+					                            .EnsureValidFormat(_fileSystem,
 						                            nameof(destinationFileName))),
-			                            FileSystem.Storage.GetLocation(
+			                            _fileSystem.Storage.GetLocation(
 				                            destinationBackupFileName),
 			                            ignoreMetadataErrors)
 		                            ?? throw ExceptionFactory.FileNotFound(FullName);
-		return FileSystem.FileInfo.New(location.FullPath);
+		return _fileSystem.FileInfo.New(location.FullPath);
 	}
 
 	#endregion

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -28,7 +28,7 @@ internal sealed class FileMock : IFile
 
 	#region IFile Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem
 		=> _fileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -6,8 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Text;
-using Testably.Abstractions.FileSystem;
+using System.Text;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 #if FEATURE_FILESYSTEM_ASYNC

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -1,14 +1,15 @@
-﻿#if FEATURE_FILESYSTEM_SAFEFILEHANDLE
-using Microsoft.Win32.SafeHandles;
-#endif
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Text;
+using System.Text;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
+#if FEATURE_FILESYSTEM_SAFEFILEHANDLE
+using Microsoft.Win32.SafeHandles;
+#endif
+
 #if FEATURE_FILESYSTEM_ASYNC
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Win32.SafeHandles;
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 #if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
@@ -22,7 +22,7 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 
 	#region IFileStreamFactory Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem
 		=> _fileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Win32.SafeHandles;
-using System.IO;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 #if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
-using Testably.Abstractions.FileSystem;
+using System.Threading.Tasks;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -21,9 +21,9 @@ internal sealed class FileStreamMock : FileSystemStream
 	public override bool CanWrite
 		=> _access.HasFlag(FileAccess.Write);
 
-	/// <inheritdoc cref="FileSystemStream.ExtensionContainer" />
-	public override IFileSystemExtensionContainer ExtensionContainer
-		=> _container.ExtensionContainer;
+	/// <inheritdoc cref="FileSystemStream.Extensibility" />
+	public override IFileSystemExtensibility Extensibility
+		=> _container.Extensibility;
 
 	private readonly FileAccess _access;
 	private readonly IDisposable _accessLock;

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.IO;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
@@ -118,9 +118,9 @@ internal class FileSystemInfoMock : IFileSystemInfo
 		}
 	}
 
-	/// <inheritdoc cref="IFileSystemInfo.ExtensionContainer" />
-	public IFileSystemExtensionContainer ExtensionContainer
-		=> Container.ExtensionContainer;
+	/// <inheritdoc cref="IFileSystemInfo.Extensibility" />
+	public IFileSystemExtensibility Extensibility
+		=> Container.Extensibility;
 
 	/// <inheritdoc cref="IFileSystemInfo.FullName" />
 	public string FullName => Location.FullPath;

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherFactoryMock.cs
@@ -1,5 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.IO;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.FileSystem;

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherFactoryMock.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.FileSystem;

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherFactoryMock.cs
@@ -17,7 +17,7 @@ internal sealed class
 
 	#region IFileSystemWatcherFactory Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem
 		=> _fileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
@@ -6,8 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
-using Testably.Abstractions.FileSystem;
+using System.Threading.Tasks;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
@@ -165,18 +165,18 @@ public sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	public event RenamedEventHandler? Renamed;
 
 	/// <inheritdoc cref="IFileSystemWatcher.WaitForChanged(WatcherChangeTypes)" />
-	public IFileSystemWatcher.IWaitForChangedResult WaitForChanged(
+	public IWaitForChangedResult WaitForChanged(
 		WatcherChangeTypes changeType)
 		=> WaitForChanged(changeType, Timeout.Infinite);
 
 	/// <inheritdoc cref="IFileSystemWatcher.WaitForChanged(WatcherChangeTypes, int)" />
-	public IFileSystemWatcher.IWaitForChangedResult WaitForChanged(
+	public IWaitForChangedResult WaitForChanged(
 		WatcherChangeTypes changeType, int timeout)
 		=> WaitForChangedInternal(changeType, TimeSpan.FromMilliseconds(timeout));
 
 #if FEATURE_FILESYSTEM_NET7
 	/// <inheritdoc cref="IFileSystemWatcher.WaitForChanged(WatcherChangeTypes, TimeSpan)" />
-	public IFileSystemWatcher.IWaitForChangedResult WaitForChanged(
+	public IWaitForChangedResult WaitForChanged(
 		WatcherChangeTypes changeType, TimeSpan timeout)
 		=> WaitForChangedInternal(changeType, timeout);
 #endif
@@ -436,10 +436,10 @@ public sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 				InMemoryLocation.StringComparisonMode) ?? true;
 	}
 
-	private IFileSystemWatcher.IWaitForChangedResult WaitForChangedInternal(
+	private IWaitForChangedResult WaitForChangedInternal(
 		WatcherChangeTypes changeType, TimeSpan timeout)
 	{
-		TaskCompletionSource<IFileSystemWatcher.IWaitForChangedResult>
+		TaskCompletionSource<IWaitForChangedResult>
 			tcs = new();
 
 		void EventHandler(object? _, ChangeDescription c)
@@ -479,8 +479,7 @@ public sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 #endif
 	}
 
-	private struct WaitForChangedResultMock
-		: IFileSystemWatcher.IWaitForChangedResult
+	private struct WaitForChangedResultMock : IWaitForChangedResult
 	{
 		public WaitForChangedResultMock(
 			WatcherChangeTypes changeType,
@@ -500,16 +499,16 @@ public sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 		public static readonly WaitForChangedResultMock TimedOutResult =
 			new(changeType: 0, name: null, oldName: null, timedOut: true);
 
-		/// <inheritdoc cref="IFileSystemWatcher.IWaitForChangedResult.ChangeType" />
+		/// <inheritdoc cref="IWaitForChangedResult.ChangeType" />
 		public WatcherChangeTypes ChangeType { get; }
 
-		/// <inheritdoc cref="IFileSystemWatcher.IWaitForChangedResult.Name" />
+		/// <inheritdoc cref="IWaitForChangedResult.Name" />
 		public string? Name { get; }
 
-		/// <inheritdoc cref="IFileSystemWatcher.IWaitForChangedResult.OldName" />
+		/// <inheritdoc cref="IWaitForChangedResult.OldName" />
 		public string? OldName { get; }
 
-		/// <inheritdoc cref="IFileSystemWatcher.IWaitForChangedResult.TimedOut" />
+		/// <inheritdoc cref="IWaitForChangedResult.TimedOut" />
 		public bool TimedOut { get; }
 	}
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
@@ -67,7 +67,7 @@ public sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 		}
 	}
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem
 		=> _fileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/IAccessControlStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/IAccessControlStrategy.cs
@@ -11,10 +11,10 @@ public interface IAccessControlStrategy
 	///     Implements a custom strategy to simulate access control (ACL) in the <see cref="MockFileSystem" />.
 	/// </summary>
 	/// <param name="fullPath">The full path to the file or directory.</param>
-	/// <param name="extensionContainer">The extension container to store additional data.</param>
+	/// <param name="extensibility">The extension container to store additional data.</param>
 	/// <returns>
 	///     <see langword="true" /> if the access should be granted, otherwise <see langword="false" />.
 	/// </returns>
 	bool IsAccessGranted(string fullPath,
-		IFileSystemExtensionContainer extensionContainer);
+		IFileSystemExtensibility extensibility);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/IAccessControlStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/IAccessControlStrategy.cs
@@ -1,6 +1,4 @@
-﻿using Testably.Abstractions.FileSystem;
-
-namespace Testably.Abstractions.Testing.FileSystem;
+﻿namespace Testably.Abstractions.Testing.FileSystem;
 
 /// <summary>
 ///     The strategy to simulate access control (ACL) in the <see cref="MockFileSystem" />.

--- a/Source/Testably.Abstractions.Testing/FileSystem/IInterceptionHandler.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/IInterceptionHandler.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Testably.Abstractions.FileSystem;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.FileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/IInterceptionHandler.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/IInterceptionHandler.cs
@@ -6,7 +6,7 @@ namespace Testably.Abstractions.Testing.FileSystem;
 /// <summary>
 ///     The interception handler for the <see cref="MockFileSystem" />.
 /// </summary>
-public interface IInterceptionHandler : IFileSystemExtensionPoint
+public interface IInterceptionHandler : IFileSystemEntity
 {
 	/// <summary>
 	///     Callback executed before any change in the <see cref="MockFileSystem" /> matching the <paramref name="predicate" />

--- a/Source/Testably.Abstractions.Testing/FileSystem/IInterceptionHandler.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/IInterceptionHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.FileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/INotificationHandler.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/INotificationHandler.cs
@@ -6,7 +6,7 @@ namespace Testably.Abstractions.Testing.FileSystem;
 /// <summary>
 ///     The notification handler for the <see cref="MockFileSystem" />.
 /// </summary>
-public interface INotificationHandler : IFileSystemExtensionPoint
+public interface INotificationHandler : IFileSystemEntity
 {
 	/// <summary>
 	///     Callback executed when any change in the <see cref="MockFileSystem" /> matching the <paramref name="predicate" />

--- a/Source/Testably.Abstractions.Testing/FileSystem/INotificationHandler.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/INotificationHandler.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Testably.Abstractions.FileSystem;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.FileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/INotificationHandler.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/INotificationHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.FileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/NullAccessControlStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/NullAccessControlStrategy.cs
@@ -7,7 +7,7 @@ namespace Testably.Abstractions.Testing.FileSystem;
 /// </summary>
 public class NullAccessControlStrategy : IAccessControlStrategy
 {
-	/// <inheritdoc cref="IAccessControlStrategy.IsAccessGranted(string, IFileSystemExtensionContainer)" />
-	public bool IsAccessGranted(string fullPath, IFileSystemExtensionContainer extensionContainer)
+	/// <inheritdoc cref="IAccessControlStrategy.IsAccessGranted(string, IFileSystemExtensibility)" />
+	public bool IsAccessGranted(string fullPath, IFileSystemExtensibility extensibility)
 		=> true;
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/NullAccessControlStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/NullAccessControlStrategy.cs
@@ -1,6 +1,4 @@
-﻿using Testably.Abstractions.FileSystem;
-
-namespace Testably.Abstractions.Testing.FileSystem;
+﻿namespace Testably.Abstractions.Testing.FileSystem;
 
 /// <summary>
 ///     Null object of an <see cref="IAccessControlStrategy" /> which does not restrict access in any way.

--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using Testably.Abstractions.FileSystem;
+﻿using System.IO;
 using Testably.Abstractions.Helpers;
 #if FEATURE_FILESYSTEM_NET7
 using System.Diagnostics.CodeAnalysis;

--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+﻿using System.IO;
 using Testably.Abstractions.Helpers;
 #if FEATURE_FILESYSTEM_NET7
 using System.Diagnostics.CodeAnalysis;

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryCleaner.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryCleaner.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO;
-using System.Threading;
+using System.Threading;
 using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.FileSystemInitializer;

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryCleaner.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryCleaner.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
-using System.Threading;
-using Testably.Abstractions.FileSystem;
+using System.Threading;
 using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.FileSystemInitializer;

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryInitializer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Testably.Abstractions.FileSystem;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.FileSystemInitializer;
 

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryInitializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.FileSystemInitializer;
 

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileInitializer.cs
@@ -44,7 +44,7 @@ internal sealed class FileInitializer<TFileSystem>
 		/// <inheritdoc cref="IFileManipulator.File" />
 		public IFileInfo File { get; }
 
-		/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+		/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 		public IFileSystem FileSystem { get; }
 
 		/// <inheritdoc cref="IFileManipulator.HasBytesContent" />

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileInitializer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Testably.Abstractions.FileSystem;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.FileSystemInitializer;
 

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileInitializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.FileSystemInitializer;
 

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileManipulator.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileManipulator.cs
@@ -5,7 +5,7 @@ namespace Testably.Abstractions.Testing.FileSystemInitializer;
 /// <summary>
 ///     Manipulates the <see cref="File" /> in the <see cref="IFileSystem" /> with test data.
 /// </summary>
-public interface IFileManipulator : IFileSystemExtensionPoint
+public interface IFileManipulator : IFileSystemEntity
 {
 	/// <summary>
 	///     The file to initialize.

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileManipulator.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileManipulator.cs
@@ -1,6 +1,4 @@
-﻿using Testably.Abstractions.FileSystem;
-
-namespace Testably.Abstractions.Testing.FileSystemInitializer;
+﻿namespace Testably.Abstractions.Testing.FileSystemInitializer;
 
 /// <summary>
 ///     Manipulates the <see cref="File" /> in the <see cref="IFileSystem" /> with test data.

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileSystemDirectoryInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileSystemDirectoryInitializer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Testably.Abstractions.FileSystem;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.FileSystemInitializer;
 

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileSystemDirectoryInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileSystemDirectoryInitializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.FileSystemInitializer;
 

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileSystemFileInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileSystemFileInitializer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Testably.Abstractions.FileSystem;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.FileSystemInitializer;
 

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileSystemFileInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileSystemFileInitializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.FileSystemInitializer;
 

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileSystemInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileSystemInitializer.cs
@@ -1,6 +1,4 @@
-﻿using Testably.Abstractions.FileSystem;
-
-namespace Testably.Abstractions.Testing.FileSystemInitializer;
+﻿namespace Testably.Abstractions.Testing.FileSystemInitializer;
 
 /// <summary>
 ///     Initializes the <see cref="IFileSystem" /> with test data.

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/Initializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/Initializer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Testably.Abstractions.FileSystem;
+﻿using System.Collections.Generic;
 using Testably.Abstractions.RandomSystem;
 using Testably.Abstractions.Testing.Helpers;
 

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/Initializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/Initializer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Testably.Abstractions.RandomSystem;
 using Testably.Abstractions.Testing.Helpers;
 

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Testing;

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Testably.Abstractions.FileSystem;
+﻿using System;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Testing;

--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensibility.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensibility.cs
@@ -4,24 +4,24 @@ using Testably.Abstractions.FileSystem;
 
 namespace Testably.Abstractions.Testing.Helpers;
 
-internal class FileSystemExtensionContainer : IFileSystemExtensionContainer
+internal class FileSystemExtensibility : IFileSystemExtensibility
 {
 	private readonly Dictionary<string, object?> _metadata = new();
 
-	/// <inheritdoc cref="IFileSystemExtensionContainer.HasWrappedInstance{T}(out T)" />
-	public bool HasWrappedInstance<T>([NotNullWhen(true)] out T? wrappedInstance)
+	/// <inheritdoc cref="IFileSystemExtensibility.TryGetWrappedInstance{T}" />
+	public bool TryGetWrappedInstance<T>([NotNullWhen(true)] out T? wrappedInstance)
 	{
 		wrappedInstance = default;
 		return false;
 	}
 
-	/// <inheritdoc cref="IFileSystemExtensionContainer.StoreMetadata{T}(string, T)" />
+	/// <inheritdoc cref="IFileSystemExtensibility.StoreMetadata{T}(string, T)" />
 	public void StoreMetadata<T>(string key, T? value)
 	{
 		_metadata[key] = value;
 	}
 
-	/// <inheritdoc cref="IFileSystemExtensionContainer.RetrieveMetadata{T}(string)" />
+	/// <inheritdoc cref="IFileSystemExtensibility.RetrieveMetadata{T}(string)" />
 	public T? RetrieveMetadata<T>(string key)
 	{
 		if (_metadata.TryGetValue(key, out object? value) &&
@@ -34,9 +34,9 @@ internal class FileSystemExtensionContainer : IFileSystemExtensionContainer
 		return default;
 	}
 
-	internal void CopyMetadataTo(IFileSystemExtensionContainer target)
+	internal void CopyMetadataTo(IFileSystemExtensibility target)
 	{
-		if (target is FileSystemExtensionContainer targetContainer)
+		if (target is FileSystemExtensibility targetContainer)
 		{
 			foreach (KeyValuePair<string, object?> item in _metadata)
 			{

--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensibility.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensibility.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Testably.Abstractions.Testing.Helpers;
 

--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensibility.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensibility.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using Testably.Abstractions.FileSystem;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Testably.Abstractions.Testing.Helpers;
 

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Win32.SafeHandles;
-using System;
+using System;
 using Testably.Abstractions.Testing.FileSystem;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Win32.SafeHandles;
-using System;
-using Testably.Abstractions.FileSystem;
+using System;
 using Testably.Abstractions.Testing.FileSystem;
 using Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -116,7 +116,7 @@ public sealed class MockFileSystem : IFileSystem
 	///     The <see cref="IAccessControlStrategy" /> defines a method that receives two values and allows or denies access:
 	///     <br />
 	///     - The full path of the file or directory as first parameter<br />
-	///     - The <see cref="IFileSystemExtensionContainer" /> as second parameter
+	///     - The <see cref="IFileSystemExtensibility" /> as second parameter
 	/// </summary>
 	public MockFileSystem WithAccessControlStrategy(IAccessControlStrategy accessControlStrategy)
 	{

--- a/Source/Testably.Abstractions.Testing/Polyfills/FileFeatureExtensionMethods.cs
+++ b/Source/Testably.Abstractions.Testing/Polyfills/FileFeatureExtensionMethods.cs
@@ -1,5 +1,6 @@
 ﻿#if !FEATURE_PATH_ADVANCED
-using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
+
 using Testably.Abstractions.Testing.Helpers;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Testably.Abstractions.Testing/Polyfills/FileFeatureExtensionMethods.cs
+++ b/Source/Testably.Abstractions.Testing/Polyfills/FileFeatureExtensionMethods.cs
@@ -1,6 +1,5 @@
 ﻿#if !FEATURE_PATH_ADVANCED
-using System.Diagnostics.CodeAnalysis;
-using Testably.Abstractions.FileSystem;
+using System.Diagnostics.CodeAnalysis;
 using Testably.Abstractions.Testing.Helpers;
 
 // ReSharper disable once CheckNamespace

--- a/Source/Testably.Abstractions.Testing/RandomSystem/RandomFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/RandomSystem/RandomFactoryMock.cs
@@ -13,7 +13,7 @@ internal sealed class RandomFactoryMock : IRandomFactory
 
 	#region IRandomFactory Members
 
-	/// <inheritdoc cref="IRandomSystemExtensionPoint.RandomSystem" />
+	/// <inheritdoc cref="IRandomSystemEntity.RandomSystem" />
 	public IRandomSystem RandomSystem => _mockRandomSystem;
 
 	/// <inheritdoc cref="IRandomFactory.Shared" />

--- a/Source/Testably.Abstractions.Testing/Storage/IStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorage.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.Storage;

--- a/Source/Testably.Abstractions.Testing/Storage/IStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorage.cs
@@ -121,13 +121,11 @@ internal interface IStorage
 	/// </summary>
 	/// <param name="location">The location at which to get or create the container.</param>
 	/// <param name="containerGenerator">The callback used to create a new container at <paramref name="location" />.</param>
-	/// <param name="fileSystemExtensionContainer"></param>
+	/// <param name="fileSystemExtensibility"></param>
 	/// <returns>The container at <paramref name="location" />.</returns>
 	IStorageContainer GetOrCreateContainer(IStorageLocation location,
-		Func<IStorageLocation, MockFileSystem,
-			IStorageContainer> containerGenerator,
-		IFileSystemExtensionContainer?
-			fileSystemExtensionContainer = null);
+		Func<IStorageLocation, MockFileSystem, IStorageContainer> containerGenerator,
+		IFileSystemExtensibility? fileSystemExtensibility = null);
 
 	/// <summary>
 	///     Moves a specified file or directory to a new location and potentially a new file name.<br />

--- a/Source/Testably.Abstractions.Testing/Storage/IStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorage.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.Storage;

--- a/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
@@ -20,7 +20,7 @@ internal interface IStorageContainer : IFileSystemEntity,
 	/// <summary>
 	///     A container to support extensions on <see cref="IStorageContainer" />.
 	/// </summary>
-	IFileSystemExtensionContainer ExtensionContainer { get; }
+	IFileSystemExtensibility Extensibility { get; }
 
 	/// <inheritdoc cref="System.IO.FileSystemInfo.LastAccessTime" />
 	ITimeContainer LastAccessTime { get; }

--- a/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.TimeSystem;
 
 namespace Testably.Abstractions.Testing.Storage;

--- a/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.IO;
+using System.IO;
 using Testably.Abstractions.TimeSystem;
 
 namespace Testably.Abstractions.Testing.Storage;

--- a/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
@@ -8,8 +8,8 @@ namespace Testably.Abstractions.Testing.Storage;
 /// <summary>
 ///     A container for a stored file or directory in the <see cref="IStorage" />.
 /// </summary>
-internal interface IStorageContainer : IFileSystemExtensionPoint,
-	ITimeSystemExtensionPoint
+internal interface IStorageContainer : IFileSystemEntity,
+	ITimeSystemEntity
 {
 	/// <inheritdoc cref="System.IO.FileSystemInfo.Attributes" />
 	FileAttributes Attributes { get; set; }

--- a/Source/Testably.Abstractions.Testing/Storage/IStorageDrive.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageDrive.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+﻿using System.IO;
 using Testably.Abstractions.Testing.FileSystem;
 
 namespace Testably.Abstractions.Testing.Storage;

--- a/Source/Testably.Abstractions.Testing/Storage/IStorageDrive.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageDrive.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using Testably.Abstractions.FileSystem;
+﻿using System.IO;
 using Testably.Abstractions.Testing.FileSystem;
 
 namespace Testably.Abstractions.Testing.Storage;

--- a/Source/Testably.Abstractions.Testing/Storage/IStorageLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageLocation.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Testably.Abstractions.FileSystem;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/Storage/IStorageLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageLocation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System;
 
 namespace Testably.Abstractions.Testing.Storage;
 

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -2,7 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystem;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.TimeSystem;

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -67,7 +67,7 @@ internal class InMemoryContainer : IStorageContainer
 	public IFileSystemExtensionContainer ExtensionContainer
 		=> _extensionContainer;
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem => _fileSystem;
 
 	/// <inheritdoc cref="IStorageContainer.LastAccessTime" />
@@ -79,7 +79,7 @@ internal class InMemoryContainer : IStorageContainer
 	/// <inheritdoc cref="IStorageContainer.LinkTarget" />
 	public string? LinkTarget { get; set; }
 
-	/// <inheritdoc cref="ITimeSystemExtensionPoint.TimeSystem" />
+	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
 	public ITimeSystem TimeSystem => _fileSystem.TimeSystem;
 
 	/// <inheritdoc cref="IStorageContainer.Type" />

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -2,8 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystem;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.TimeSystem;

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -19,7 +19,7 @@ internal class InMemoryContainer : IStorageContainer
 	private readonly MockFileSystem _fileSystem;
 	private bool _isEncrypted;
 	private readonly IStorageLocation _location;
-	private readonly FileSystemExtensionContainer _extensionContainer = new();
+	private readonly FileSystemExtensibility _extensibility = new();
 
 	public InMemoryContainer(FileSystemTypes type,
 		IStorageLocation location,
@@ -63,9 +63,9 @@ internal class InMemoryContainer : IStorageContainer
 	/// <inheritdoc cref="IStorageContainer.CreationTime" />
 	public ITimeContainer CreationTime { get; } = new TimeContainer();
 
-	/// <inheritdoc cref="IStorageContainer.ExtensionContainer" />
-	public IFileSystemExtensionContainer ExtensionContainer
-		=> _extensionContainer;
+	/// <inheritdoc cref="IStorageContainer.Extensibility" />
+	public IFileSystemExtensibility Extensibility
+		=> _extensibility;
 
 	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem => _fileSystem;
@@ -157,7 +157,7 @@ internal class InMemoryContainer : IStorageContainer
 			() => throw ExceptionFactory.AccessToPathDenied());
 
 		if (!_fileSystem.AccessControlStrategy
-			.IsAccessGranted(_location.FullPath, ExtensionContainer))
+			.IsAccessGranted(_location.FullPath, Extensibility))
 		{
 			throw ExceptionFactory.AclAccessToPathDenied(_location.FullPath);
 		}

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -280,7 +280,7 @@ internal sealed class InMemoryStorage : IStorage
 	public IStorageContainer GetOrCreateContainer(
 		IStorageLocation location,
 		Func<IStorageLocation, MockFileSystem, IStorageContainer> containerGenerator,
-		IFileSystemExtensionContainer? fileSystemExtensionContainer = null)
+		IFileSystemExtensibility? fileSystemExtensibility = null)
 	{
 		ChangeDescription? fileSystemChange = null;
 		IStorageContainer container = _containers.GetOrAdd(location,
@@ -288,8 +288,8 @@ internal sealed class InMemoryStorage : IStorage
 			{
 				IStorageContainer container =
 					containerGenerator.Invoke(loc, _fileSystem);
-				(fileSystemExtensionContainer as FileSystemExtensionContainer)?
-					.CopyMetadataTo(container.ExtensionContainer);
+				(fileSystemExtensibility as FileSystemExtensibility)?
+					.CopyMetadataTo(container.Extensibility);
 				if (container.Type == FileSystemTypes.Directory)
 				{
 					CreateParents(_fileSystem, loc);

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -3,8 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystem;
 using Testably.Abstractions.Testing.Helpers;
 

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystem;
 using Testably.Abstractions.Testing.Helpers;
 
@@ -131,7 +131,7 @@ internal sealed class InMemoryStorage : IStorage
 			_fileSystem.ChangeHandler.NotifyPendingChange(WatcherChangeTypes.Deleted,
 				container.Type,
 				notifyFilters, location);
-		
+
 		using (container.RequestAccess(FileAccess.Write, FileShare.ReadWrite,
 			deleteAccess: true))
 		{
@@ -304,7 +304,7 @@ internal sealed class InMemoryStorage : IStorage
 				}
 
 				CheckAndAdjustParentDirectoryTimes(loc);
-				
+
 				using (container.RequestAccess(FileAccess.Write, FileShare.ReadWrite))
 				{
 					fileSystemChange = _fileSystem.ChangeHandler.NotifyPendingChange(
@@ -371,7 +371,7 @@ internal sealed class InMemoryStorage : IStorage
 		{
 			throw ExceptionFactory.AccessToPathDenied(source.FullPath);
 		}
-		
+
 		using (_ = sourceContainer.RequestAccess(FileAccess.ReadWrite, FileShare.None,
 			ignoreMetadataErrors: ignoreMetadataErrors))
 		{
@@ -535,7 +535,7 @@ internal sealed class InMemoryStorage : IStorage
 					{
 						IStorageContainer container =
 							InMemoryContainer.NewDirectory(loc, _fileSystem);
-						
+
 						accessHandles.Add(container.RequestAccess(FileAccess.Write,
 							FileShare.ReadWrite));
 						fileSystemChange =
@@ -587,7 +587,7 @@ internal sealed class InMemoryStorage : IStorage
 		{
 			throw ExceptionFactory.DirectoryNotEmpty(source.FullPath);
 		}
-		
+
 		using (container.RequestAccess(FileAccess.Write, FileShare.None,
 			hResult: sourceType == FileSystemTypes.Directory ? -2147024891 : -2147024864))
 		{

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.TimeSystem;
 

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.IO;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.TimeSystem;
 

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -12,7 +12,7 @@ internal sealed class NullContainer : IStorageContainer
 	{
 		FileSystem = fileSystem;
 		TimeSystem = timeSystem;
-		ExtensionContainer = new FileSystemExtensionContainer();
+		Extensibility = new FileSystemExtensibility();
 	}
 
 	#region IStorageContainer Members
@@ -28,8 +28,8 @@ internal sealed class NullContainer : IStorageContainer
 	public IStorageContainer.ITimeContainer CreationTime { get; } =
 		new CreationNullTime();
 
-	/// <inheritdoc cref="IStorageContainer.ExtensionContainer" />
-	public IFileSystemExtensionContainer ExtensionContainer { get; }
+	/// <inheritdoc cref="IStorageContainer.Extensibility" />
+	public IFileSystemExtensibility Extensibility { get; }
 
 	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -31,7 +31,7 @@ internal sealed class NullContainer : IStorageContainer
 	/// <inheritdoc cref="IStorageContainer.ExtensionContainer" />
 	public IFileSystemExtensionContainer ExtensionContainer { get; }
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IStorageContainer.LastAccessTime" />
@@ -47,7 +47,7 @@ internal sealed class NullContainer : IStorageContainer
 		set => _ = value;
 	}
 
-	/// <inheritdoc cref="ITimeSystemExtensionPoint.TimeSystem" />
+	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
 	public ITimeSystem TimeSystem { get; }
 
 	/// <inheritdoc cref="IStorageContainer.Type" />

--- a/Source/Testably.Abstractions.Testing/TimeSystem/DateTimeMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/DateTimeMock.cs
@@ -36,7 +36,7 @@ internal sealed class DateTimeMock : IDateTime
 		}
 	}
 
-	/// <inheritdoc cref="ITimeSystemExtensionPoint.TimeSystem" />
+	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
 	public ITimeSystem TimeSystem
 		=> _mockTimeSystem;
 

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TaskMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TaskMock.cs
@@ -20,7 +20,7 @@ internal sealed class TaskMock : ITask
 
 	#region ITask Members
 
-	/// <inheritdoc cref="ITimeSystemExtensionPoint.TimeSystem" />
+	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
 	public ITimeSystem TimeSystem
 		=> _mockTimeSystem;
 

--- a/Source/Testably.Abstractions.Testing/TimeSystem/ThreadMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/ThreadMock.cs
@@ -19,7 +19,7 @@ internal sealed class ThreadMock : IThread
 
 	#region IThread Members
 
-	/// <inheritdoc cref="ITimeSystemExtensionPoint.TimeSystem" />
+	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
 	public ITimeSystem TimeSystem
 		=> _mockTimeSystem;
 

--- a/Source/Testably.Abstractions.Testing/Usings.cs
+++ b/Source/Testably.Abstractions.Testing/Usings.cs
@@ -3,3 +3,4 @@ global using Testably.Abstractions.Polyfills;
 #else
 global using System.Runtime.Versioning;
 #endif
+global using Testably.Abstractions.FileSystem;

--- a/Source/Testably.Abstractions/FileSystem/DirectoryInfoFactory.cs
+++ b/Source/Testably.Abstractions/FileSystem/DirectoryInfoFactory.cs
@@ -12,7 +12,7 @@ internal sealed class DirectoryInfoFactory : IDirectoryInfoFactory
 
 	#region IDirectoryInfoFactory Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IDirectoryInfoFactory.New(string)" />

--- a/Source/Testably.Abstractions/FileSystem/DirectoryWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/DirectoryWrapper.cs
@@ -14,7 +14,7 @@ internal sealed class DirectoryWrapper : IDirectory
 
 	#region IDirectory Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IDirectory.CreateDirectory(string)" />

--- a/Source/Testably.Abstractions/FileSystem/DriveInfoFactory.cs
+++ b/Source/Testably.Abstractions/FileSystem/DriveInfoFactory.cs
@@ -13,7 +13,7 @@ internal sealed class DriveInfoFactory : IDriveInfoFactory
 
 	#region IDriveInfoFactory Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IDriveInfoFactory.GetDrives()" />

--- a/Source/Testably.Abstractions/FileSystem/DriveInfoWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/DriveInfoWrapper.cs
@@ -27,7 +27,7 @@ internal sealed class DriveInfoWrapper : IDriveInfo
 	public DriveType DriveType
 		=> _instance.DriveType;
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IDriveInfo.IsReady" />

--- a/Source/Testably.Abstractions/FileSystem/FileInfoFactory.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileInfoFactory.cs
@@ -12,7 +12,7 @@ internal sealed class FileInfoFactory : IFileInfoFactory
 
 	#region IFileInfoFactory Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IFileInfoFactory.New(string)" />

--- a/Source/Testably.Abstractions/FileSystem/FileStreamFactory.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileStreamFactory.cs
@@ -15,7 +15,7 @@ internal sealed class FileStreamFactory : IFileStreamFactory
 
 	#region IFileStreamFactory Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IFileStreamFactory.New(string, FileMode)" />

--- a/Source/Testably.Abstractions/FileSystem/FileStreamWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileStreamWrapper.cs
@@ -8,11 +8,11 @@ internal sealed class FileStreamWrapper : FileSystemStream
 		: base(fileStream, fileStream.Name, fileStream.IsAsync)
 
 	{
-		ExtensionContainer = new FileSystemExtensionContainer(fileStream);
+		Extensibility = new FileSystemExtensibility(fileStream);
 	}
 
-	/// <inheritdoc cref="FileSystemStream.ExtensionContainer" />
-	public override IFileSystemExtensionContainer ExtensionContainer
+	/// <inheritdoc cref="FileSystemStream.Extensibility" />
+	public override IFileSystemExtensibility Extensibility
 	{
 		get;
 	}

--- a/Source/Testably.Abstractions/FileSystem/FileSystemExtensibility.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileSystemExtensibility.cs
@@ -3,18 +3,18 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Testably.Abstractions.FileSystem;
 
-internal class FileSystemExtensionContainer : IFileSystemExtensionContainer
+internal class FileSystemExtensibility : IFileSystemExtensibility
 {
 	private readonly object _wrappedInstance;
 	private readonly Dictionary<string, object?> _metadata = new();
 
-	public FileSystemExtensionContainer(object wrappedInstance)
+	public FileSystemExtensibility(object wrappedInstance)
 	{
 		_wrappedInstance = wrappedInstance;
 	}
 
-	/// <inheritdoc cref="IFileSystemExtensionContainer.HasWrappedInstance{T}(out T)" />
-	public bool HasWrappedInstance<T>([NotNullWhen(true)] out T? wrappedInstance)
+	/// <inheritdoc cref="IFileSystemExtensibility.TryGetWrappedInstance{T}" />
+	public bool TryGetWrappedInstance<T>([NotNullWhen(true)] out T? wrappedInstance)
 	{
 		// ReSharper disable once MergeCastWithTypeCheck -- Not possible due to nullable
 		wrappedInstance = _wrappedInstance is T?

--- a/Source/Testably.Abstractions/FileSystem/FileSystemInfoWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileSystemInfoWrapper.cs
@@ -50,6 +50,10 @@ internal class FileSystemInfoWrapper : IFileSystemInfo
 	/// <inheritdoc cref="IFileSystemInfo.Extensibility" />
 	public IFileSystemExtensibility Extensibility { get; }
 
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
+	public IFileSystem FileSystem
+		=> _fileSystem;
+
 	/// <inheritdoc cref="IFileSystemInfo.FullName" />
 	public string FullName
 		=> _instance.FullName;

--- a/Source/Testably.Abstractions/FileSystem/FileSystemInfoWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileSystemInfoWrapper.cs
@@ -13,7 +13,7 @@ internal class FileSystemInfoWrapper : IFileSystemInfo
 	{
 		_instance = instance;
 		_fileSystem = fileSystem;
-		ExtensionContainer = new FileSystemExtensionContainer(_instance);
+		Extensibility = new FileSystemExtensibility(_instance);
 	}
 
 	#region IFileSystemInfo Members
@@ -47,8 +47,8 @@ internal class FileSystemInfoWrapper : IFileSystemInfo
 	public string Extension
 		=> _instance.Extension;
 
-	/// <inheritdoc cref="IFileSystemInfo.ExtensionContainer" />
-	public IFileSystemExtensionContainer ExtensionContainer { get; }
+	/// <inheritdoc cref="IFileSystemInfo.Extensibility" />
+	public IFileSystemExtensibility Extensibility { get; }
 
 	/// <inheritdoc cref="IFileSystemInfo.FullName" />
 	public string FullName

--- a/Source/Testably.Abstractions/FileSystem/FileSystemWatcherFactory.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileSystemWatcherFactory.cs
@@ -12,7 +12,7 @@ internal sealed class FileSystemWatcherFactory : IFileSystemWatcherFactory
 
 	#region IFileSystemWatcherFactory Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IFileSystemWatcherFactory.New()" />

--- a/Source/Testably.Abstractions/FileSystem/FileSystemWatcherWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileSystemWatcherWrapper.cs
@@ -32,7 +32,7 @@ internal sealed class FileSystemWatcherWrapper : IFileSystemWatcher
 		set => _instance.EnableRaisingEvents = value;
 	}
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IFileSystemWatcher.Filter" />

--- a/Source/Testably.Abstractions/FileSystem/FileSystemWatcherWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileSystemWatcherWrapper.cs
@@ -138,19 +138,19 @@ internal sealed class FileSystemWatcherWrapper : IFileSystemWatcher
 		=> _instance.EndInit();
 
 	/// <inheritdoc cref="IFileSystemWatcher.WaitForChanged(WatcherChangeTypes)" />
-	public IFileSystemWatcher.IWaitForChangedResult WaitForChanged(
+	public IWaitForChangedResult WaitForChanged(
 		WatcherChangeTypes changeType)
 		=> new WaitForChangedResultWrapper(_instance.WaitForChanged(changeType));
 
 	/// <inheritdoc cref="IFileSystemWatcher.WaitForChanged(WatcherChangeTypes, int)" />
-	public IFileSystemWatcher.IWaitForChangedResult WaitForChanged(
+	public IWaitForChangedResult WaitForChanged(
 		WatcherChangeTypes changeType, int timeout)
 		=> new WaitForChangedResultWrapper(
 			_instance.WaitForChanged(changeType, timeout));
 
 #if FEATURE_FILESYSTEM_NET7
 	/// <inheritdoc cref="IFileSystemWatcher.WaitForChanged(WatcherChangeTypes, TimeSpan)" />
-	public IFileSystemWatcher.IWaitForChangedResult WaitForChanged(WatcherChangeTypes changeType,
+	public IWaitForChangedResult WaitForChanged(WatcherChangeTypes changeType,
 		TimeSpan timeout)
 		=> new WaitForChangedResultWrapper(
 			_instance.WaitForChanged(changeType, timeout));
@@ -171,7 +171,7 @@ internal sealed class FileSystemWatcherWrapper : IFileSystemWatcher
 	}
 
 	private readonly struct WaitForChangedResultWrapper
-		: IFileSystemWatcher.IWaitForChangedResult
+		: IWaitForChangedResult
 	{
 		private readonly WaitForChangedResult _instance;
 
@@ -180,19 +180,19 @@ internal sealed class FileSystemWatcherWrapper : IFileSystemWatcher
 			_instance = instance;
 		}
 
-		/// <inheritdoc cref="IFileSystemWatcher.IWaitForChangedResult.ChangeType" />
+		/// <inheritdoc cref="IWaitForChangedResult.ChangeType" />
 		public WatcherChangeTypes ChangeType
 			=> _instance.ChangeType;
 
-		/// <inheritdoc cref="IFileSystemWatcher.IWaitForChangedResult.Name" />
+		/// <inheritdoc cref="IWaitForChangedResult.Name" />
 		public string? Name
 			=> _instance.Name;
 
-		/// <inheritdoc cref="IFileSystemWatcher.IWaitForChangedResult.OldName" />
+		/// <inheritdoc cref="IWaitForChangedResult.OldName" />
 		public string? OldName
 			=> _instance.OldName;
 
-		/// <inheritdoc cref="IFileSystemWatcher.IWaitForChangedResult.TimedOut" />
+		/// <inheritdoc cref="IWaitForChangedResult.TimedOut" />
 		public bool TimedOut
 			=> _instance.TimedOut;
 	}

--- a/Source/Testably.Abstractions/FileSystem/FileWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileWrapper.cs
@@ -22,7 +22,7 @@ internal sealed class FileWrapper : IFile
 
 	#region IFile Members
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IFile.AppendAllLines(string, IEnumerable{string})" />

--- a/Source/Testably.Abstractions/FileSystem/FileWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileWrapper.cs
@@ -1,11 +1,11 @@
-﻿#if FEATURE_FILESYSTEM_SAFEFILEHANDLE
-using Microsoft.Win32.SafeHandles;
-#endif
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
+#if FEATURE_FILESYSTEM_SAFEFILEHANDLE
+using Microsoft.Win32.SafeHandles;
+#endif
 #if FEATURE_FILESYSTEM_ASYNC
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/Testably.Abstractions/RandomSystem/RandomFactory.cs
+++ b/Source/Testably.Abstractions/RandomSystem/RandomFactory.cs
@@ -15,7 +15,7 @@ internal sealed class RandomFactory : IRandomFactory
 
 	#region IRandomFactory Members
 
-	/// <inheritdoc cref="IRandomSystemExtensionPoint.RandomSystem" />
+	/// <inheritdoc cref="IRandomSystemEntity.RandomSystem" />
 	public IRandomSystem RandomSystem { get; }
 
 	/// <inheritdoc cref="IRandomFactory.Shared" />

--- a/Source/Testably.Abstractions/TimeSystem/DateTimeWrapper.cs
+++ b/Source/Testably.Abstractions/TimeSystem/DateTimeWrapper.cs
@@ -40,7 +40,7 @@ internal sealed class DateTimeWrapper : IDateTime
 	public DateTime Today
 		=> DateTime.Today;
 
-	/// <inheritdoc cref="ITimeSystemExtensionPoint.TimeSystem" />
+	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
 	public ITimeSystem TimeSystem { get; }
 
 	#endregion

--- a/Source/Testably.Abstractions/TimeSystem/TaskWrapper.cs
+++ b/Source/Testably.Abstractions/TimeSystem/TaskWrapper.cs
@@ -13,7 +13,7 @@ internal sealed class TaskWrapper : ITask
 
 	#region ITask Members
 
-	/// <inheritdoc cref="ITimeSystemExtensionPoint.TimeSystem" />
+	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
 	public ITimeSystem TimeSystem { get; }
 
 	/// <inheritdoc cref="ITask.Delay(int)" />

--- a/Source/Testably.Abstractions/TimeSystem/ThreadWrapper.cs
+++ b/Source/Testably.Abstractions/TimeSystem/ThreadWrapper.cs
@@ -12,7 +12,7 @@ internal sealed class ThreadWrapper : IThread
 
 	#region IThread Members
 
-	/// <inheritdoc cref="ITimeSystemExtensionPoint.TimeSystem" />
+	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
 	public ITimeSystem TimeSystem { get; }
 
 	/// <inheritdoc cref="IThread.Sleep(int)" />

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileInfoAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileInfoAclExtensionsTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Security.AccessControl;
-using Testably.Abstractions.AccessControl.Tests.TestHelpers;
-using Testably.Abstractions.FileSystem;
+using Testably.Abstractions.AccessControl.Tests.TestHelpers;
 
 namespace Testably.Abstractions.AccessControl.Tests;
 

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileInfoAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileInfoAclExtensionsTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Security.AccessControl;
-using Testably.Abstractions.AccessControl.Tests.TestHelpers;
+using Testably.Abstractions.AccessControl.Tests.TestHelpers;
 
 namespace Testably.Abstractions.AccessControl.Tests;
 

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileStreamAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileStreamAclExtensionsTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Security.AccessControl;
-using Testably.Abstractions.AccessControl.Tests.TestHelpers;
-using Testably.Abstractions.FileSystem;
+using Testably.Abstractions.AccessControl.Tests.TestHelpers;
 
 namespace Testably.Abstractions.AccessControl.Tests;
 

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileStreamAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileStreamAclExtensionsTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Security.AccessControl;
-using Testably.Abstractions.AccessControl.Tests.TestHelpers;
+using Testably.Abstractions.AccessControl.Tests.TestHelpers;
 
 namespace Testably.Abstractions.AccessControl.Tests;
 

--- a/Tests/Testably.Abstractions.AccessControl.Tests/TestHelpers/Usings.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/TestHelpers/Usings.cs
@@ -1,5 +1,6 @@
 ﻿global using FluentAssertions;
 global using System;
+global using Testably.Abstractions.FileSystem;
 global using Testably.Abstractions.Testing;
 global using Testably.Abstractions.TestHelpers;
 global using Xunit;

--- a/Tests/Testably.Abstractions.Compression.Tests/TestHelpers/Usings.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/TestHelpers/Usings.cs
@@ -1,6 +1,7 @@
 ﻿global using AutoFixture.Xunit2;
 global using FluentAssertions;
 global using System;
+global using Testably.Abstractions.FileSystem;
 global using Testably.Abstractions.TestHelpers;
 global using Testably.Abstractions.Testing;
 global using Xunit;

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ZipArchiveTests.Extensions.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ZipArchiveTests.Extensions.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
 using System.IO.Compression;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 
 namespace Testably.Abstractions.Compression.Tests.ZipArchive;
 

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ZipArchiveTests.Extensions.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ZipArchiveTests.Extensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 using System.IO.Compression;
-using System.Linq;
+using System.Linq;
 
 namespace Testably.Abstractions.Compression.Tests.ZipArchive;
 

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ZipArchiveTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ZipArchiveTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO.Compression;
-#if FEATURE_ZIPFILE_NET7
+#if FEATURE_ZIPFILE_NET7
 #endif
 
 namespace Testably.Abstractions.Compression.Tests.ZipArchive;

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ZipArchiveTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ZipArchiveTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO.Compression;
-#if FEATURE_ZIPFILE_NET7
-using Testably.Abstractions.FileSystem;
+#if FEATURE_ZIPFILE_NET7
 #endif
 
 namespace Testably.Abstractions.Compression.Tests.ZipArchive;

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ZipArchiveEntryTests.Extensions.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ZipArchiveEntryTests.Extensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 using System.IO.Compression;
-using System.Linq;
+using System.Linq;
 
 namespace Testably.Abstractions.Compression.Tests.ZipArchiveEntry;
 

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ZipArchiveEntryTests.Extensions.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ZipArchiveEntryTests.Extensions.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
 using System.IO.Compression;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 
 namespace Testably.Abstractions.Compression.Tests.ZipArchiveEntry;
 

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ZipArchiveEntryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ZipArchiveEntryTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 using System.IO.Compression;
-using System.Linq;
+using System.Linq;
 
 namespace Testably.Abstractions.Compression.Tests.ZipArchiveEntry;
 

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ZipArchiveEntryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ZipArchiveEntryTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
 using System.IO.Compression;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 
 namespace Testably.Abstractions.Compression.Tests.ZipArchiveEntry;
 

--- a/Tests/Testably.Abstractions.Parity.Tests/ParityTests.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/ParityTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
+using System.IO.Compression;
 using Testably.Abstractions.RandomSystem;
 using Xunit.Abstractions;
 

--- a/Tests/Testably.Abstractions.Parity.Tests/ParityTests.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/ParityTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
-using Testably.Abstractions.FileSystem;
+using System.IO.Compression;
 using Testably.Abstractions.RandomSystem;
 using Xunit.Abstractions;
 

--- a/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/Parity.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/Parity.cs
@@ -1,8 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
-using System.IO.Compression;
-using Testably.Abstractions.FileSystem;
+using System.IO.Compression;
 
 namespace Testably.Abstractions.Parity.Tests.TestHelpers;
 

--- a/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/Parity.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/Parity.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
-using System.IO.Compression;
+using System.IO.Compression;
 
 namespace Testably.Abstractions.Parity.Tests.TestHelpers;
 

--- a/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/Usings.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/Usings.cs
@@ -1,3 +1,4 @@
 ﻿global using FluentAssertions;
 global using System;
+global using Testably.Abstractions.FileSystem;
 global using Xunit;

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DefaultAccessControlStrategyTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DefaultAccessControlStrategyTests.cs
@@ -29,7 +29,7 @@ public class DefaultAccessControlStrategyTests
 	{
 		DefaultAccessControlStrategy sut = new((p, _) => p.StartsWith("a"));
 
-		sut.IsAccessGranted("abc", new FileSystemExtensionContainer()).Should().BeTrue();
-		sut.IsAccessGranted("xyz", new FileSystemExtensionContainer()).Should().BeFalse();
+		sut.IsAccessGranted("abc", new FileSystemExtensibility()).Should().BeTrue();
+		sut.IsAccessGranted("xyz", new FileSystemExtensibility()).Should().BeFalse();
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DriveInfoMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DriveInfoMockTests.cs
@@ -1,6 +1,6 @@
 using System.IO;
 using System.Linq;
-using System.Text;
+using System.Text;
 using Testably.Abstractions.Testing.FileSystem;
 
 namespace Testably.Abstractions.Testing.Tests.FileSystem;

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DriveInfoMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DriveInfoMockTests.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using System.Linq;
-using System.Text;
-using Testably.Abstractions.FileSystem;
+using System.Text;
 using Testably.Abstractions.Testing.FileSystem;
 
 namespace Testably.Abstractions.Testing.Tests.FileSystem;

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherFactoryMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherFactoryMockTests.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+﻿using System.IO;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Testing.Tests.FileSystem;

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherFactoryMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherFactoryMockTests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using Testably.Abstractions.FileSystem;
+﻿using System.IO;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Testing.Tests.FileSystem;

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherMockTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-using System.Threading;
+using System.Threading;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Testing.Tests.FileSystem;

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherMockTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
-using System.Threading;
-using Testably.Abstractions.FileSystem;
+using System.Threading;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Testing.Tests.FileSystem;

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/PathHelperTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/PathHelperTests.cs
@@ -1,5 +1,5 @@
 ﻿using Moq;
-using System.IO;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/PathHelperTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/PathHelperTests.cs
@@ -1,6 +1,5 @@
 ﻿using Moq;
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-using System.Linq;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystem;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Tests.TestHelpers;

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystem;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Tests.TestHelpers;

--- a/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryStorageTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryStorageTests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using Testably.Abstractions.FileSystem;
+﻿using System.IO;
 using Testably.Abstractions.RandomSystem;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;

--- a/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryStorageTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryStorageTests.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+﻿using System.IO;
 using Testably.Abstractions.RandomSystem;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
@@ -51,7 +51,7 @@ internal sealed class LockableContainer : IStorageContainer
 	public IFileSystemExtensionContainer ExtensionContainer { get; }
 		= new FileSystemExtensionContainer();
 
-	/// <inheritdoc cref="IFileSystemExtensionPoint.FileSystem" />
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IStorageContainer.LastAccessTime" />
@@ -65,7 +65,7 @@ internal sealed class LockableContainer : IStorageContainer
 	/// <inheritdoc cref="IStorageContainer.LinkTarget" />
 	public string? LinkTarget { get; set; }
 
-	/// <inheritdoc cref="ITimeSystemExtensionPoint.TimeSystem" />
+	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
 	public ITimeSystem TimeSystem { get; }
 
 	/// <inheritdoc cref="IStorageContainer.Type" />

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
-using System.Security.AccessControl;
-using Testably.Abstractions.FileSystem;
+using System.Security.AccessControl;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 using Testably.Abstractions.TimeSystem;

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
-using System.Security.AccessControl;
+using System.Security.AccessControl;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 using Testably.Abstractions.TimeSystem;

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
@@ -47,9 +47,9 @@ internal sealed class LockableContainer : IStorageContainer
 	public IStorageContainer.ITimeContainer CreationTime { get; }
 		= new InMemoryContainer.TimeContainer();
 
-	/// <inheritdoc cref="IStorageContainer.ExtensionContainer" />
-	public IFileSystemExtensionContainer ExtensionContainer { get; }
-		= new FileSystemExtensionContainer();
+	/// <inheritdoc cref="IStorageContainer.Extensibility" />
+	public IFileSystemExtensibility Extensibility { get; }
+		= new FileSystemExtensibility();
 
 	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Usings.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Usings.cs
@@ -1,4 +1,5 @@
 ﻿global using AutoFixture.Xunit2;
 global using FluentAssertions;
 global using System;
+global using Testably.Abstractions.FileSystem;
 global using Xunit;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 
@@ -244,7 +244,7 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 			FileSystem.Path.DirectorySeparatorChar,
 			FileSystem.Path.AltDirectorySeparatorChar));
 		result.FullName.Should().Be(System.IO.Path.Combine(BasePath, expectedName
-		   .Replace(FileSystem.Path.AltDirectorySeparatorChar,
+			.Replace(FileSystem.Path.AltDirectorySeparatorChar,
 				FileSystem.Path.DirectorySeparatorChar)));
 		FileSystem.Directory.Exists(nameWithSuffix).Should().BeTrue();
 	}
@@ -266,7 +266,7 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 			FileSystem.Path.DirectorySeparatorChar,
 			FileSystem.Path.AltDirectorySeparatorChar));
 		result.FullName.Should().Be(System.IO.Path.Combine(BasePath, expectedName
-		   .Replace(FileSystem.Path.AltDirectorySeparatorChar,
+			.Replace(FileSystem.Path.AltDirectorySeparatorChar,
 				FileSystem.Path.DirectorySeparatorChar)));
 		FileSystem.Directory.Exists(nameWithSuffix).Should().BeTrue();
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Linq;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ExceptionTests.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
-using Testably.Abstractions.FileSystem;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ExceptionTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetDirectoriesTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Linq;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetDirectoriesTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/MoveTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 #if !NETFRAMEWORK
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/MoveTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 #if !NETFRAMEWORK
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ResolveLinkTargetTests.cs
@@ -1,5 +1,6 @@
 #if FEATURE_FILESYSTEM_LINK
-using System.IO;
+using System.IO;
+
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ResolveLinkTargetTests.cs
@@ -1,6 +1,5 @@
 #if FEATURE_FILESYSTEM_LINK
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.Times.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.Times.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.Times.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.Times.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/AttributesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/AttributesTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/AttributesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/AttributesTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateSubdirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateSubdirectoryTests.cs
@@ -1,5 +1,3 @@
-using Testably.Abstractions.FileSystem;
-
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 
 // ReSharper disable once PartialTypeWithSinglePart

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
@@ -1,5 +1,3 @@
-using Testably.Abstractions.FileSystem;
-
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 
 // ReSharper disable once PartialTypeWithSinglePart

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/DeleteTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/DeleteTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateDirectoriesTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateDirectoriesTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFileSystemInfosTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFileSystemInfosTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFileSystemInfosTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFileSystemInfosTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFilesTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFilesTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExceptionTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExceptionTests.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
-using Testably.Abstractions.FileSystem;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExistsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExistsTests.cs
@@ -1,5 +1,3 @@
-using Testably.Abstractions.FileSystem;
-
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 
 // ReSharper disable once PartialTypeWithSinglePart

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/GetDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/GetDirectoriesTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/GetDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/GetDirectoriesTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/GetFileSystemInfosTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/GetFileSystemInfosTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/GetFileSystemInfosTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/GetFileSystemInfosTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/GetFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/GetFilesTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/GetFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/GetFilesTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/MoveToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/MoveToTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 #if !NETFRAMEWORK
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/MoveToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/MoveToTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 #if !NETFRAMEWORK
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/Tests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/Tests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/ExceptionTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfoFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/ExceptionTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using Testably.Abstractions.FileSystem;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfoFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/Tests.cs
@@ -1,5 +1,3 @@
-using Testably.Abstractions.FileSystem;
-
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfoFactory;
 
 // ReSharper disable once PartialTypeWithSinglePart

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/Tests.cs
@@ -1,5 +1,3 @@
-using Testably.Abstractions.FileSystem;
-
 namespace Testably.Abstractions.Tests.FileSystem.DriveInfo;
 
 // ReSharper disable once PartialTypeWithSinglePart

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/ExceptionTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using Testably.Abstractions.FileSystem;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.DriveInfoFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/ExceptionTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.DriveInfoFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/Tests.cs
@@ -1,6 +1,5 @@
 using System.IO;
-using System.Linq;
-using Testably.Abstractions.FileSystem;
+using System.Linq;
 
 namespace Testably.Abstractions.Tests.FileSystem.DriveInfoFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/Tests.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using System.Linq;
+using System.Linq;
 
 namespace Testably.Abstractions.Tests.FileSystem.DriveInfoFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/DeleteTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/DeleteTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionMissingFileTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionMissingFileTests.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
-using System.Threading;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionMissingFileTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionMissingFileTests.cs
@@ -3,8 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
-using System.Threading;
-using Testably.Abstractions.FileSystem;
+using System.Threading;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionMissingFileTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionMissingFileTests.cs
@@ -3,6 +3,9 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
+#if FEATURE_FILESYSTEM_ASYNC
+using System.Threading;
+#endif
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionTests.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
-using System.Threading;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionTests.cs
@@ -3,8 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
-using System.Threading;
-using Testably.Abstractions.FileSystem;
+using System.Threading;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionTests.cs
@@ -3,6 +3,9 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
+#if FEATURE_FILESYSTEM_ASYNC
+using System.Threading;
+#endif
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenReadTests.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenReadTests.cs
@@ -1,6 +1,5 @@
 using System.IO;
-using System.Threading.Tasks;
-using Testably.Abstractions.FileSystem;
+using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenWriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenWriteTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenWriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenWriteTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ResolveLinkTargetTests.cs
@@ -1,5 +1,6 @@
 #if FEATURE_FILESYSTEM_LINK
-using System.IO;
+using System.IO;
+
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ResolveLinkTargetTests.cs
@@ -1,6 +1,5 @@
 #if FEATURE_FILESYSTEM_LINK
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AppendTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AppendTextTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AppendTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AppendTextTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/DeleteTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/DeleteTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/EncryptDecryptTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/EncryptDecryptTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/EncryptDecryptTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/EncryptDecryptTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExceptionTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExceptionTests.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
-using Testably.Abstractions.FileSystem;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExistsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExistsTests.cs
@@ -1,5 +1,3 @@
-using Testably.Abstractions.FileSystem;
-
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 
 // ReSharper disable once PartialTypeWithSinglePart

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/LengthTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/LengthTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/LengthTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/LengthTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenReadTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenReadTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 
@@ -19,7 +19,7 @@ public abstract partial class OpenTests<TFileSystem>
 		{
 			_ = sut.Open(FileMode.Append);
 		});
-		
+
 		exception.Should().BeException<ArgumentException>(hResult: -2147024809);
 	}
 #else

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenTextTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenTextTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenWriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenWriteTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenWriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenWriteTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/ExceptionTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using Testably.Abstractions.FileSystem;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfoFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/ExceptionTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfoFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfoFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfoFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/AdjustTimesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/AdjustTimesTests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 #if FEATURE_SPAN
 using System.Threading.Tasks;
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/AdjustTimesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/AdjustTimesTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 #if FEATURE_SPAN
 using System.Threading.Tasks;
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/DisposeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/DisposeTests.cs
@@ -2,8 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Threading;
-using Testably.Abstractions.FileSystem;
+using System.Threading;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/DisposeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/DisposeTests.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Threading;
+using System.Threading;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/FileAccessTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/FileAccessTests.cs
@@ -2,8 +2,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
-using Testably.Abstractions.FileSystem;
+using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/FileAccessTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/FileAccessTests.cs
@@ -2,7 +2,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/OptionsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/OptionsTests.cs
@@ -1,6 +1,5 @@
 using System.IO;
-using System.Text;
-using Testably.Abstractions.FileSystem;
+using System.Text;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/OptionsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/OptionsTests.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using System.Text;
+using System.Text;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -1,5 +1,4 @@
-using System.Threading;
-using Testably.Abstractions.FileSystem;
+using System.Threading;
 #if FEATURE_FILESYSTEM_ASYNC
 using System.Threading.Tasks;
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -1,4 +1,4 @@
-using System.Threading;
+using System.Threading;
 #if FEATURE_FILESYSTEM_ASYNC
 using System.Threading.Tasks;
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/Tests.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/Tests.cs
@@ -125,13 +125,13 @@ public abstract partial class Tests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void ExtensionContainer_ShouldWrapFileStreamOnRealFileSystem(
+	public void Extensibility_ShouldWrapFileStreamOnRealFileSystem(
 		string path)
 	{
 		FileSystem.File.WriteAllText(path, null);
 		using FileSystemStream readStream = FileSystem.File.OpenRead(path);
-		bool result = readStream.ExtensionContainer
-			.HasWrappedInstance(out System.IO.FileStream? fileStream);
+		bool result = readStream.Extensibility
+			.TryGetWrappedInstance(out System.IO.FileStream? fileStream);
 
 		if (FileSystem is RealFileSystem)
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/Tests.cs
@@ -1,6 +1,5 @@
 using System.IO;
-using System.Threading.Tasks;
-using Testably.Abstractions.FileSystem;
+using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using System.Threading;
+using System.Threading;
 #if FEATURE_FILESYSTEM_ASYNC
 using System.Threading.Tasks;
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
@@ -1,6 +1,5 @@
 using System.IO;
-using System.Threading;
-using Testably.Abstractions.FileSystem;
+using System.Threading;
 #if FEATURE_FILESYSTEM_ASYNC
 using System.Threading.Tasks;
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/ExceptionTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStreamFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/ExceptionTests.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
-using Testably.Abstractions.FileSystem;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStreamFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/SafeFileHandleTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/SafeFileHandleTests.cs
@@ -1,8 +1,7 @@
 #if EXECUTE_SAFEFILEHANDLE_TESTS
 using Microsoft.Win32.SafeHandles;
 using System.IO;
-using System.Text;
-using Testably.Abstractions.FileSystem;
+using System.Text;
 using Testably.Abstractions.Testing.FileSystem;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStreamFactory;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/SafeFileHandleTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/SafeFileHandleTests.cs
@@ -1,7 +1,7 @@
 #if EXECUTE_SAFEFILEHANDLE_TESTS
 using Microsoft.Win32.SafeHandles;
 using System.IO;
-using System.Text;
+using System.Text;
 using Testably.Abstractions.Testing.FileSystem;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStreamFactory;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/Tests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStreamFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/Tests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStreamFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/CreateAsSymbolicLinkTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/CreateAsSymbolicLinkTests.cs
@@ -1,6 +1,5 @@
 #if FEATURE_FILESYSTEM_LINK
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/CreateAsSymbolicLinkTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/CreateAsSymbolicLinkTests.cs
@@ -1,5 +1,6 @@
 #if FEATURE_FILESYSTEM_LINK
-using System.IO;
+using System.IO;
+
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ExceptionTests.cs
@@ -1,8 +1,7 @@
 #if FEATURE_FILESYSTEM_LINK
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using Testably.Abstractions.FileSystem;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ExceptionTests.cs
@@ -1,7 +1,8 @@
 #if FEATURE_FILESYSTEM_LINK
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
+using System.Linq.Expressions;
+
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ResolveLinkTargetTests.cs
@@ -1,6 +1,5 @@
 #if FEATURE_FILESYSTEM_LINK
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ResolveLinkTargetTests.cs
@@ -1,5 +1,6 @@
 #if FEATURE_FILESYSTEM_LINK
-using System.IO;
+using System.IO;
+
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/Tests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/Tests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/Tests.cs
@@ -10,13 +10,13 @@ public abstract partial class Tests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
-	public void ExtensionContainer_ShouldWrapFileSystemInfoOnRealFileSystem(
+	public void Extensibility_ShouldWrapFileSystemInfoOnRealFileSystem(
 		string path)
 	{
 		FileSystem.File.WriteAllText(path, null);
 		IFileInfo fileInfo = FileSystem.FileInfo.New(path);
-		bool result = fileInfo.ExtensionContainer
-			.HasWrappedInstance(out System.IO.FileSystemInfo? fileSystemInfo);
+		bool result = fileInfo.Extensibility
+			.TryGetWrappedInstance(out System.IO.FileSystemInfo? fileSystemInfo);
 
 		if (FileSystem is RealFileSystem)
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/UnixFileModeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/UnixFileModeTests.cs
@@ -1,6 +1,5 @@
 #if FEATURE_FILESYSTEM_UNIXFILEMODE
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/UnixFileModeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/UnixFileModeTests.cs
@@ -1,5 +1,6 @@
 #if FEATURE_FILESYSTEM_UNIXFILEMODE
-using System.IO;
+using System.IO;
+
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemInfo;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.Extensibility.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.Extensibility.cs
@@ -8,11 +8,11 @@ public abstract partial class FileSystemTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public void
-		ExtensionContainer_HasWrappedInstance_WithCorrectType_ShouldReturnTrueOnRealFileSystem(
+		Extensibility_HasWrappedInstance_WithCorrectType_ShouldReturnTrueOnRealFileSystem(
 			string name)
 	{
-		bool result = FileSystem.FileInfo.New(name).ExtensionContainer
-			.HasWrappedInstance(out System.IO.FileInfo? fileInfo);
+		bool result = FileSystem.FileInfo.New(name).Extensibility
+			.TryGetWrappedInstance(out System.IO.FileInfo? fileInfo);
 
 		if (FileSystem is RealFileSystem)
 		{
@@ -28,11 +28,11 @@ public abstract partial class FileSystemTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public void
-		ExtensionContainer_HasWrappedInstance_WithIncorrectType_ShouldReturnAlwaysFalse(
+		Extensibility_HasWrappedInstance_WithIncorrectType_ShouldReturnAlwaysFalse(
 			string name)
 	{
-		bool result = FileSystem.FileInfo.New(name).ExtensionContainer
-			.HasWrappedInstance(out System.IO.DirectoryInfo? directoryInfo);
+		bool result = FileSystem.FileInfo.New(name).Extensibility
+			.TryGetWrappedInstance(out System.IO.DirectoryInfo? directoryInfo);
 
 		result.Should().BeFalse();
 		directoryInfo.Should().BeNull();
@@ -41,11 +41,11 @@ public abstract partial class FileSystemTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public void
-		ExtensionContainer_RetrieveMetadata_CorrectKeyAndType_ShouldReturnStoredValue(
+		Extensibility_RetrieveMetadata_CorrectKeyAndType_ShouldReturnStoredValue(
 			string name, DateTime time)
 	{
-		IFileSystemExtensionContainer sut = FileSystem.FileInfo.New(name)
-			.ExtensionContainer;
+		IFileSystemExtensibility sut = FileSystem.FileInfo.New(name)
+			.Extensibility;
 
 		sut.StoreMetadata("foo", time);
 		DateTime? result = sut.RetrieveMetadata<DateTime?>("foo");
@@ -55,11 +55,11 @@ public abstract partial class FileSystemTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void ExtensionContainer_RetrieveMetadata_DifferentKey_ShouldReturnNull(
+	public void Extensibility_RetrieveMetadata_DifferentKey_ShouldReturnNull(
 		string name)
 	{
-		IFileSystemExtensionContainer sut = FileSystem.FileInfo.New(name)
-			.ExtensionContainer;
+		IFileSystemExtensibility sut = FileSystem.FileInfo.New(name)
+			.Extensibility;
 
 		sut.StoreMetadata("foo", DateTime.Now);
 		DateTime? result = sut.RetrieveMetadata<DateTime?>("bar");
@@ -69,11 +69,11 @@ public abstract partial class FileSystemTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void ExtensionContainer_RetrieveMetadata_DifferentType_ShouldReturnNull(
+	public void Extensibility_RetrieveMetadata_DifferentType_ShouldReturnNull(
 		string name)
 	{
-		IFileSystemExtensionContainer sut = FileSystem.FileInfo.New(name)
-			.ExtensionContainer;
+		IFileSystemExtensibility sut = FileSystem.FileInfo.New(name)
+			.Extensibility;
 
 		sut.StoreMetadata("foo", DateTime.Now);
 		TimeSpan? result = sut.RetrieveMetadata<TimeSpan?>("foo");
@@ -83,10 +83,10 @@ public abstract partial class FileSystemTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void ExtensionContainer_RetrieveMetadata_NotRegisteredKey_ShouldReturnNull(
+	public void Extensibility_RetrieveMetadata_NotRegisteredKey_ShouldReturnNull(
 		string name)
 	{
-		object? result = FileSystem.FileInfo.New(name).ExtensionContainer
+		object? result = FileSystem.FileInfo.New(name).Extensibility
 			.RetrieveMetadata<object?>("foo");
 
 		result.Should().BeNull();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.Extensibility.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.Extensibility.cs
@@ -1,5 +1,3 @@
-using Testably.Abstractions.FileSystem;
-
 namespace Testably.Abstractions.Tests.FileSystem;
 
 public abstract partial class FileSystemTests<TFileSystem>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EnableRaisingEventsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EnableRaisingEventsTests.cs
@@ -1,4 +1,4 @@
-using System.Threading;
+using System.Threading;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EnableRaisingEventsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EnableRaisingEventsTests.cs
@@ -1,5 +1,4 @@
-using System.Threading;
-using Testably.Abstractions.FileSystem;
+using System.Threading;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/FilterTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/FilterTests.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using System.Threading;
+using System.Threading;
 #if FEATURE_FILESYSTEMWATCHER_ADVANCED
 using System.Collections.Generic;
 using System.Linq;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/FilterTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/FilterTests.cs
@@ -1,6 +1,5 @@
 using System.IO;
-using System.Threading;
-using Testably.Abstractions.FileSystem;
+using System.Threading;
 #if FEATURE_FILESYSTEMWATCHER_ADVANCED
 using System.Collections.Generic;
 using System.Linq;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/IncludeSubdirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/IncludeSubdirectoriesTests.cs
@@ -1,6 +1,5 @@
 using System.IO;
-using System.Threading;
-using Testably.Abstractions.FileSystem;
+using System.Threading;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/IncludeSubdirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/IncludeSubdirectoriesTests.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using System.Threading;
+using System.Threading;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/NotifyFiltersTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/NotifyFiltersTests.cs
@@ -1,6 +1,5 @@
 using System.IO;
-using System.Threading;
-using Testably.Abstractions.FileSystem;
+using System.Threading;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/NotifyFiltersTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/NotifyFiltersTests.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using System.Threading;
+using System.Threading;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/PathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/PathTests.cs
@@ -1,5 +1,3 @@
-using Testably.Abstractions.FileSystem;
-
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 
 // ReSharper disable once PartialTypeWithSinglePart

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
@@ -37,7 +37,7 @@ public abstract partial class Tests<TFileSystem>
 					FileSystem.Directory.Delete(path);
 				}
 			});
-			IFileSystemWatcher.IWaitForChangedResult result =
+			IWaitForChangedResult result =
 				fileSystemWatcher.WaitForChanged(WatcherChangeTypes.Created, 1000);
 
 			fileSystemWatcher.EnableRaisingEvents.Should().BeTrue();
@@ -89,7 +89,7 @@ public abstract partial class Tests<TFileSystem>
 					FileSystem.Directory.Delete(path);
 				}
 			});
-			IFileSystemWatcher.IWaitForChangedResult result =
+			IWaitForChangedResult result =
 				fileSystemWatcher.WaitForChanged(WatcherChangeTypes.Created, 100);
 
 			fileSystemWatcher.EnableRaisingEvents.Should().BeTrue();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
@@ -2,8 +2,7 @@ using Moq;
 using System.ComponentModel;
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
-using Testably.Abstractions.FileSystem;
+using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
@@ -2,7 +2,7 @@ using Moq;
 using System.ComponentModel;
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
@@ -34,7 +34,7 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 			using (CancellationTokenSource cts = new(5000))
 			{
 				cts.Token.Register(() => throw new TimeoutException());
-				IFileSystemWatcher.IWaitForChangedResult result =
+				IWaitForChangedResult result =
 					fileSystemWatcher.WaitForChanged(WatcherChangeTypes.Created);
 				fileSystemWatcher.EnableRaisingEvents.Should().BeFalse();
 				result.TimedOut.Should().BeFalse();
@@ -71,7 +71,7 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 					FileSystem.Directory.Delete(path);
 				}
 			});
-			IFileSystemWatcher.IWaitForChangedResult result =
+			IWaitForChangedResult result =
 				fileSystemWatcher.WaitForChanged(WatcherChangeTypes.Changed, 100);
 
 			fileSystemWatcher.EnableRaisingEvents.Should().BeTrue();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
-using Testably.Abstractions.FileSystem;
+using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
@@ -1,6 +1,6 @@
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcherFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcherFactory/ExceptionTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcherFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcherFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcherFactory/ExceptionTests.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
-using Testably.Abstractions.FileSystem;
+using System.Linq.Expressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcherFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcherFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcherFactory/Tests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcherFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcherFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcherFactory/Tests.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcherFactory;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetRelativePathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetRelativePathTests.cs
@@ -1,5 +1,4 @@
 #if FEATURE_PATH_RELATIVE
-
 namespace Testably.Abstractions.Tests.FileSystem.Path;
 
 // ReSharper disable once PartialTypeWithSinglePart

--- a/Tests/Testably.Abstractions.Tests/RandomSystem/GuidTests.cs
+++ b/Tests/Testably.Abstractions.Tests/RandomSystem/GuidTests.cs
@@ -1,4 +1,7 @@
 using System.Collections.Concurrent;
+#if FEATURE_GUID_PARSE
+using System.Collections.Generic;
+#endif
 using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.RandomSystem;

--- a/Tests/Testably.Abstractions.Tests/RandomSystem/GuidTests.cs
+++ b/Tests/Testably.Abstractions.Tests/RandomSystem/GuidTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.RandomSystem;

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/FileTestHelper.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/FileTestHelper.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.TestHelpers;
 

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/FileTestHelper.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/FileTestHelper.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Testably.Abstractions.FileSystem;
+using System.IO;
 
 namespace Testably.Abstractions.Tests.TestHelpers;
 

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/Polyfills/StringExtensions.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/Polyfills/StringExtensions.cs
@@ -5,11 +5,11 @@ namespace System;
 public static class StringExtensions
 {
 	public static bool Contains(this string @this, string value,
-								StringComparison comparisonType)
+		StringComparison comparisonType)
 	{
-#pragma warning disable CA2249 // Consider using 'string.Contains' instead of 'string.IndexOf'... this is the implementation of Contains!
+		#pragma warning disable CA2249 // Consider using 'string.Contains' instead of 'string.IndexOf'... this is the implementation of Contains!
 		return @this.IndexOf(value, comparisonType) >= 0;
-#pragma warning restore CA2249
+		#pragma warning restore CA2249
 	}
 }
 #endif

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/Usings.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/Usings.cs
@@ -1,6 +1,7 @@
 ﻿global using AutoFixture.Xunit2;
 global using FluentAssertions;
 global using System;
+global using Testably.Abstractions.FileSystem;
 global using Testably.Abstractions.Testing;
 global using Testably.Abstractions.TestHelpers;
 global using Testably.Abstractions.Tests.TestHelpers;


### PR DESCRIPTION
- Apply renamings done in System.IO.Abstractions (see [Pull Request #906](https://github.com/TestableIO/System.IO.Abstractions/pull/906))
- Use `global using Testably.Abstractions.FileSystem` so that it can be more easily replaced with another namespace
- Add `IFileSystemEntity` to `IFileSystemInfo` 
- Remove nesting from IWaitForChangedResult