### PR TITLE
fix: use AccessControlSections.None in tests

### DIFF
--- a/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryAclExtensionsTests.cs
@@ -69,7 +69,7 @@ public abstract partial class DirectoryAclExtensionsTests<TFileSystem>
 
 		#pragma warning disable CA1416
 		DirectorySecurity result =
-			FileSystem.Directory.GetAccessControl("foo", AccessControlSections.All);
+			FileSystem.Directory.GetAccessControl("foo", AccessControlSections.None);
 		#pragma warning restore CA1416
 
 		result.Should().NotBeNull();

--- a/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryInfoAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryInfoAclExtensionsTests.cs
@@ -70,7 +70,7 @@ public abstract partial class DirectoryInfoAclExtensionsTests<TFileSystem>
 
 		#pragma warning disable CA1416
 		DirectorySecurity result =
-			FileSystem.DirectoryInfo.New("foo").GetAccessControl(AccessControlSections.All);
+			FileSystem.DirectoryInfo.New("foo").GetAccessControl(AccessControlSections.None);
 		#pragma warning restore CA1416
 
 		result.Should().NotBeNull();

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileAclExtensionsTests.cs
@@ -32,7 +32,7 @@ public abstract partial class FileAclExtensionsTests<TFileSystem>
 		FileSystem.File.WriteAllText("foo", null);
 
 		#pragma warning disable CA1416
-		FileSecurity result = FileSystem.File.GetAccessControl("foo", AccessControlSections.All);
+		FileSecurity result = FileSystem.File.GetAccessControl("foo", AccessControlSections.None);
 		#pragma warning restore CA1416
 
 		result.Should().NotBeNull();

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileInfoAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileInfoAclExtensionsTests.cs
@@ -34,7 +34,7 @@ public abstract partial class FileInfoAclExtensionsTests<TFileSystem>
 		IFileInfo fileInfo = FileSystem.FileInfo.New("foo");
 
 		#pragma warning disable CA1416
-		FileSecurity result = fileInfo.GetAccessControl(AccessControlSections.All);
+		FileSecurity result = fileInfo.GetAccessControl(AccessControlSections.None);
 		#pragma warning restore CA1416
 
 		result.Should().NotBeNull();


### PR DESCRIPTION
Using "AccessControlSections.All" does violate windows security principles.