### PR TITLE
fix: update version used in Examples to "1.*"

### DIFF
--- a/Examples/Directory.Build.props
+++ b/Examples/Directory.Build.props
@@ -4,7 +4,7 @@
 	        Condition="Exists('$(MSBuildThisFileDirectory)/../Directory.Build.props')" />
 
 	<PropertyGroup>
-		<TestablyAbstractionsVersion>0.18.*</TestablyAbstractionsVersion>
+		<TestablyAbstractionsVersion>1.*</TestablyAbstractionsVersion>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -32,7 +32,6 @@
 
 	<ItemGroup Condition="'$(UseFileReferenceToTestablyLibraries)' != 'True'">
 		<PackageReference Include="Testably.Abstractions" Version="$(TestablyAbstractionsVersion)" />
-		<PackageReference Include="Testably.Abstractions.Extensions" Version="$(TestablyAbstractionsVersion)" />
 		<PackageReference Include="Testably.Abstractions.Testing" Version="$(TestablyAbstractionsVersion)" />
 	</ItemGroup>
 


### PR DESCRIPTION
Currently the example projects use version "0.18.*". This is updated to "1.*", so that it uses the latest release version with `1` as major version.