### PR TITLE
fix: exclude test on real file system in debug mode

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryCleaner.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryCleaner.cs
@@ -1,20 +1,22 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.FileSystemInitializer;
 
+[ExcludeFromCodeCoverage]
 internal sealed class DirectoryCleaner : IDirectoryCleaner
 {
 	private readonly IFileSystem _fileSystem;
 	private readonly Action<string>? _logger;
 
-	public DirectoryCleaner(IFileSystem fileSystem, Action<string>? logger)
+	public DirectoryCleaner(IFileSystem fileSystem, string? prefix, Action<string>? logger)
 	{
 		_fileSystem = fileSystem;
 		_logger = logger;
-		BasePath = InitializeBasePath();
+		BasePath = InitializeBasePath(prefix ?? "");
 	}
 
 	#region IDirectoryCleaner Members
@@ -30,7 +32,10 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 		{
 			// It is important to reset the current directory, as otherwise deleting the BasePath
 			// results in a IOException, because the process cannot access the file.
-			_fileSystem.Directory.SetCurrentDirectory(_fileSystem.Path.GetTempPath());
+			if (_fileSystem.Directory.GetCurrentDirectory() == BasePath)
+			{
+				_fileSystem.Directory.SetCurrentDirectory(_fileSystem.Path.GetTempPath());
+			}
 
 			_logger?.Invoke($"Cleaning up '{BasePath}'...");
 			for (int i = 10; i >= 0; i--)
@@ -109,7 +114,7 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 		_fileSystem.Directory.Delete(path);
 	}
 
-	private string InitializeBasePath()
+	private string InitializeBasePath(string prefix)
 	{
 		string basePath;
 
@@ -117,16 +122,43 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 		{
 			string localBasePath = _fileSystem.Path.Combine(
 				_fileSystem.Path.GetTempPath(),
-				_fileSystem.Path.GetFileNameWithoutExtension(_fileSystem.Path
-					.GetRandomFileName()));
+				prefix + _fileSystem.Path.GetFileNameWithoutExtension(
+					_fileSystem.Path.GetRandomFileName()));
 			Execute.OnMac(() => localBasePath = "/private" + localBasePath);
 			basePath = localBasePath;
 		} while (_fileSystem.Directory.Exists(basePath));
 
-		_fileSystem.Directory.CreateDirectory(basePath);
+		for (int i = 0; i <= 2; i++)
+		{
+			try
+			{
+				_fileSystem.Directory.CreateDirectory(basePath);
+				break;
+			}
+			catch (Exception)
+			{
+				// Give a transient condition like antivirus/indexing a chance to go away
+				Thread.Sleep(10);
+			}
+		}
+
+		if (!_fileSystem.Directory.Exists(basePath))
+		{
+			throw new Exception($"Could not create current directory '{basePath}' for tests");
+		}
 
 		_logger?.Invoke($"Use '{basePath}' as current directory.");
 		_fileSystem.Directory.SetCurrentDirectory(basePath);
+		for (int i = 0; i <= 10 && _fileSystem.Directory.GetCurrentDirectory() != basePath; i++)
+		{
+			Thread.Sleep(5);
+		}
+
+		if (_fileSystem.Directory.GetCurrentDirectory() != basePath)
+		{
+			throw new Exception($"Could not set current directory to '{basePath}' for tests");
+		}
+
 		return basePath;
 	}
 }

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
@@ -34,14 +34,18 @@ public static class FileSystemInitializerExtensions
 	///     <see cref="IDirectory.GetCurrentDirectory()" /> and all relative paths will use this directory.
 	/// </summary>
 	/// <param name="fileSystem">The file system.</param>
+	/// <param name="prefix">
+	///     A prefix to use for the temporary directory.<br />
+	///     This simplifies matching directories to tests.
+	/// </param>
 	/// <param name="logger">(optional) A callback to log the cleanup process.</param>
 	/// <returns>
 	///     A <see cref="IDirectoryCleaner" /> that will
 	///     force delete all content in the temporary directory on dispose.
 	/// </returns>
 	public static IDirectoryCleaner SetCurrentDirectoryToEmptyTemporaryDirectory(
-		this IFileSystem fileSystem, Action<string>? logger = null)
+		this IFileSystem fileSystem, string? prefix = null, Action<string>? logger = null)
 	{
-		return new DirectoryCleaner(fileSystem, logger);
+		return new DirectoryCleaner(fileSystem, prefix, logger);
 	}
 }

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
@@ -56,7 +56,7 @@ namespace {@class.Namespace}.{@class.Name}
 	}}
 }}
 
-#if !DEBUG || !DISABLE_TESTS_REALFILESYSTEM
+#if !DEBUG || ENABLE_REALFILESYSTEMTESTS_IN_DEBUG
 
 namespace {@class.Namespace}.{@class.Name}
 {{
@@ -73,7 +73,7 @@ namespace {@class.Namespace}.{@class.Name}
 			: base(new RealFileSystem(), new RealTimeSystem())
 		{{
 			_directoryCleaner = FileSystem
-			   .SetCurrentDirectoryToEmptyTemporaryDirectory(testOutputHelper.WriteLine);
+			   .SetCurrentDirectoryToEmptyTemporaryDirectory($""{@class.Namespace}{{FileSystem.Path.DirectorySeparatorChar}}{@class.Name}-"", testOutputHelper.WriteLine);
 		}}
 
 		/// <inheritdoc cref=""IDisposable.Dispose()"" />

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/DirectoryCleanerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/DirectoryCleanerTests.cs
@@ -21,7 +21,7 @@ public class DirectoryCleanerTests
 		MockFileSystem sut = new();
 		List<string> receivedLogs = new();
 		IDirectoryCleaner directoryCleaner =
-			sut.SetCurrentDirectoryToEmptyTemporaryDirectory(m => receivedLogs.Add(m));
+			sut.SetCurrentDirectoryToEmptyTemporaryDirectory(logger: m => receivedLogs.Add(m));
 		string currentDirectory = sut.Directory.GetCurrentDirectory();
 		int exceptionCount = 0;
 		sut.Intercept.Event(_ =>
@@ -57,7 +57,7 @@ public class DirectoryCleanerTests
 		MockFileSystem sut = new();
 		List<string> receivedLogs = new();
 		IDirectoryCleaner directoryCleaner =
-			sut.SetCurrentDirectoryToEmptyTemporaryDirectory(m => receivedLogs.Add(m));
+			sut.SetCurrentDirectoryToEmptyTemporaryDirectory(logger: m => receivedLogs.Add(m));
 		string currentDirectory = sut.Directory.GetCurrentDirectory();
 
 		directoryCleaner.Dispose();
@@ -105,7 +105,7 @@ public class DirectoryCleanerTests
 		List<string> receivedLogs = new();
 
 		using IDirectoryCleaner directoryCleaner =
-			sut.SetCurrentDirectoryToEmptyTemporaryDirectory(t => receivedLogs.Add(t));
+			sut.SetCurrentDirectoryToEmptyTemporaryDirectory(logger: t => receivedLogs.Add(t));
 
 		string currentDirectory = sut.Directory.GetCurrentDirectory();
 		sut.Directory.Exists(currentDirectory).Should().BeTrue();


### PR DESCRIPTION
Tests on the real file system sometimes fail on the local developer environment.
To simplify development, exclude the tests on the real file system in `DEBUG` mode, unless the variable `"ENABLE_REALFILESYSTEMTESTS_IN_DEBUG"` is set!