### PR TITLE
fix: time-related tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           .\.sonar\scanner\dotnet-sonarscanner begin /k:"Testably_Testably.Abstractions" /o:"testably" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /v:"$productVersion" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
           dotnet tool install --global dotnet-coverage
           dotnet restore -s 'nuget.config'
-          dotnet build --no-incremental /p:NetCoreOnly=True
+          dotnet build --no-incremental /p:NetCoreOnly=True --configuration "Release"
           dotnet-coverage collect 'dotnet test --no-build' -f xml  -o 'coverage.xml'
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
 
@@ -74,7 +74,7 @@ jobs:
             6.0.x
             7.0.x
       - name: Build solution
-        run: dotnet build /p:NetCoreOnly=True
+        run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
         run: dotnet test --no-build --collect:"XPlat Code Coverage"
       - name: Upload coverage
@@ -98,7 +98,7 @@ jobs:
             6.0.x
             7.0.x
       - name: Build solution
-        run: dotnet build /p:NetCoreOnly=True
+        run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
         run: dotnet test --no-build --collect:"XPlat Code Coverage"
       - name: Upload coverage
@@ -122,7 +122,7 @@ jobs:
             6.0.x
             7.0.x
       - name: Build solution
-        run: dotnet build /p:NetCoreOnly=True
+        run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
         run: dotnet test --no-build --collect:"XPlat Code Coverage"
       - name: Upload coverage
@@ -171,7 +171,7 @@ jobs:
             6.0.x
             7.0.x
       - name: Build solution
-        run: dotnet build /p:NetCoreOnly=True
+        run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Build example solution
         run: dotnet build Examples /p:UseFileReferenceToTestablyLibraries=True
       - name: Run example tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             6.0.x
             7.0.x
       - name: Build solution
-        run: dotnet build /p:NetCoreOnly=True
+        run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
         run: dotnet test --no-build --collect:"XPlat Code Coverage" --logger trx --results-directory "TestResults"
       - name: Upload test results (MacOS)
@@ -51,7 +51,7 @@ jobs:
             6.0.x
             7.0.x
       - name: Build solution
-        run: dotnet build /p:NetCoreOnly=True
+        run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
         run: dotnet test --no-build --collect:"XPlat Code Coverage" --logger trx --results-directory "TestResults"
       - name: Upload test results (Ubuntu)
@@ -81,7 +81,7 @@ jobs:
             6.0.x
             7.0.x
       - name: Build solution
-        run: dotnet build /p:NetCoreOnly=True
+        run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
         run: dotnet test --no-build --collect:"XPlat Code Coverage" --logger trx --results-directory "TestResults"
       - name: Upload test results (Windows)
@@ -143,7 +143,7 @@ jobs:
             6.0.x
             7.0.x
       - name: Build solution
-        run: dotnet build /p:NetCoreOnly=True
+        run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Build example solution
         run: dotnet build Examples /p:UseFileReferenceToTestablyLibraries=True
       - name: Run example tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           .\.sonar\scanner\dotnet-sonarscanner begin /k:"Testably_Testably.Abstractions" /o:"testably" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /v:"$productVersion" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
           dotnet tool install --global dotnet-coverage
           dotnet restore -s 'nuget.config'
-          dotnet build --no-incremental /p:NetCoreOnly=True
+          dotnet build --no-incremental /p:NetCoreOnly=True --configuration "Release"
           dotnet-coverage collect 'dotnet test --no-build' -f xml  -o 'coverage.xml'
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
 
@@ -85,7 +85,7 @@ jobs:
             6.0.x
             7.0.x
       - name: Build solution
-        run: dotnet build /p:NetCoreOnly=True
+        run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
         run: dotnet test --no-build
 
@@ -109,7 +109,7 @@ jobs:
             6.0.x
             7.0.x
       - name: Build solution
-        run: dotnet build /p:NetCoreOnly=True
+        run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
         run: dotnet test --no-build
 
@@ -133,7 +133,7 @@ jobs:
             6.0.x
             7.0.x
       - name: Build solution
-        run: dotnet build /p:NetCoreOnly=True
+        run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
         run: dotnet test --no-build
 
@@ -183,7 +183,7 @@ jobs:
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True
       - name: Build example solution
-        run: dotnet build Examples /p:UseFileReferenceToTestablyLibraries=True
+        run: dotnet build Examples /p:UseFileReferenceToTestablyLibraries=True --configuration "Release"
       - name: Run example tests
         run: dotnet test Examples --no-build
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
@@ -345,7 +345,8 @@ internal sealed class DirectoryMock : IDirectory
 		catch (IOException ex)
 			when (ex.HResult != -2147024773)
 		{
-			throw ExceptionFactory.FileNameCannotBeResolved(linkPath);
+			throw ExceptionFactory.FileNameCannotBeResolved(linkPath,
+				Execute.IsWindows ? -2147022975 : -2146232800);
 		}
 	}
 #endif

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿#if FEATURE_FILESYSTEM_SAFEFILEHANDLE
+using Microsoft.Win32.SafeHandles;
+#endif
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -6,10 +10,6 @@ using System.Linq;
 using System.Text;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
-#if FEATURE_FILESYSTEM_SAFEFILEHANDLE
-using Microsoft.Win32.SafeHandles;
-#endif
-
 #if FEATURE_FILESYSTEM_ASYNC
 using System.Threading;
 using System.Threading.Tasks;
@@ -466,7 +466,9 @@ internal sealed class FileMock : IFile
 			FileAccess.Read,
 			FileStreamFactoryMock.DefaultShare))
 		{
-			container.AdjustTimes(TimeAdjustments.LastAccessTime);
+			Execute.NotOnWindows(() => 
+				container.AdjustTimes(TimeAdjustments.LastAccessTime));
+
 			return container.GetBytes().ToArray();
 		}
 	}
@@ -520,7 +522,9 @@ internal sealed class FileMock : IFile
 			FileAccess.Read,
 			FileStreamFactoryMock.DefaultShare))
 		{
-			container.AdjustTimes(TimeAdjustments.LastAccessTime);
+			Execute.NotOnWindows(() =>
+				container.AdjustTimes(TimeAdjustments.LastAccessTime));
+
 			using (MemoryStream ms = new(container.GetBytes()))
 			using (StreamReader sr = new(ms, encoding))
 			{

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -156,7 +156,8 @@ internal sealed class FileStreamMock : FileSystemStream
 	/// <inheritdoc cref="FileSystemStream.CopyTo(Stream, int)" />
 	public override void CopyTo(Stream destination, int bufferSize)
 	{
-		_container.AdjustTimes(TimeAdjustments.LastAccessTime);
+		Execute.NotOnWindows(() =>
+			_container.AdjustTimes(TimeAdjustments.LastAccessTime));
 		base.CopyTo(destination, bufferSize);
 	}
 
@@ -209,7 +210,8 @@ internal sealed class FileStreamMock : FileSystemStream
 			throw ExceptionFactory.StreamDoesNotSupportReading();
 		}
 
-		_container.AdjustTimes(TimeAdjustments.LastAccessTime);
+		Execute.NotOnWindows(() =>
+			_container.AdjustTimes(TimeAdjustments.LastAccessTime));
 		return base.Read(buffer, offset, count);
 	}
 
@@ -222,7 +224,8 @@ internal sealed class FileStreamMock : FileSystemStream
 			throw ExceptionFactory.StreamDoesNotSupportReading();
 		}
 
-		_container.AdjustTimes(TimeAdjustments.LastAccessTime);
+		Execute.NotOnWindows(() =>
+			_container.AdjustTimes(TimeAdjustments.LastAccessTime));
 		return base.Read(buffer);
 	}
 #endif
@@ -236,7 +239,8 @@ internal sealed class FileStreamMock : FileSystemStream
 			throw ExceptionFactory.StreamDoesNotSupportReading();
 		}
 
-		_container.AdjustTimes(TimeAdjustments.LastAccessTime);
+		Execute.NotOnWindows(() =>
+			_container.AdjustTimes(TimeAdjustments.LastAccessTime));
 		return base.ReadAsync(buffer, offset, count, cancellationToken);
 	}
 
@@ -251,7 +255,8 @@ internal sealed class FileStreamMock : FileSystemStream
 			throw ExceptionFactory.StreamDoesNotSupportReading();
 		}
 
-		_container.AdjustTimes(TimeAdjustments.LastAccessTime);
+		Execute.NotOnWindows(() =>
+			_container.AdjustTimes(TimeAdjustments.LastAccessTime));
 		return base.ReadAsync(buffer, cancellationToken);
 	}
 #endif
@@ -264,7 +269,8 @@ internal sealed class FileStreamMock : FileSystemStream
 			throw ExceptionFactory.StreamDoesNotSupportReading();
 		}
 
-		_container.AdjustTimes(TimeAdjustments.LastAccessTime);
+		Execute.NotOnWindows(() =>
+			_container.AdjustTimes(TimeAdjustments.LastAccessTime));
 		return base.ReadByte();
 	}
 

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -200,7 +200,11 @@ internal class InMemoryContainer : IStorageContainer
 		{
 			IStorageContainer? directoryContainer =
 				_fileSystem.Storage.GetContainer(_location.GetParent());
-			directoryContainer?.AdjustTimes(TimeAdjustments.LastAccessTime);
+			if (directoryContainer != null &&
+			    directoryContainer is not NullContainer)
+			{
+				directoryContainer.AdjustTimes(TimeAdjustments.LastAccessTime);
+			}
 		});
 		_fileSystem.ChangeHandler.NotifyCompletedChange(fileSystemChange);
 	}

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -196,6 +196,12 @@ internal class InMemoryContainer : IStorageContainer
 		_location.Drive?.ChangeUsedBytes(bytes.Length - _bytes.Length);
 		_bytes = bytes;
 		this.AdjustTimes(timeAdjustment);
+		Execute.OnWindows(() =>
+		{
+			IStorageContainer? directoryContainer =
+				_fileSystem.Storage.GetContainer(_location.GetParent());
+			directoryContainer?.AdjustTimes(TimeAdjustments.LastAccessTime);
+		});
 		_fileSystem.ChangeHandler.NotifyCompletedChange(fileSystemChange);
 	}
 

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -69,6 +69,10 @@ internal sealed class InMemoryStorage : IStorage
 			if (_containers.TryAdd(destination, copiedContainer))
 			{
 				copiedContainer.WriteBytes(sourceContainer.GetBytes().ToArray());
+				Execute.OnMac(
+					() => copiedContainer.LastAccessTime.Set(
+						sourceContainer.LastAccessTime.Get(DateTimeKind.Local),
+						DateTimeKind.Local));
 				Execute.NotOnWindows(()
 					=> sourceContainer.AdjustTimes(TimeAdjustments.LastAccessTime));
 

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -400,12 +400,15 @@ internal sealed class InMemoryStorage : IStorage
 						source.Drive?.ChangeUsedBytes(-1 * sourceBytesLength);
 						destination.Drive?.ChangeUsedBytes(sourceBytesLength);
 						Execute.OnWindowsIf(sourceContainer.Type == FileSystemTypes.File,
-							() => existingSourceContainer.Attributes |=
-								FileAttributes.Archive);
-						existingSourceContainer.CreationTime.Set(
-							existingDestinationContainer.CreationTime.Get(
-								DateTimeKind.Utc),
-							DateTimeKind.Utc);
+							() =>
+							{
+								existingSourceContainer.Attributes |=
+									FileAttributes.Archive;
+								existingSourceContainer.CreationTime.Set(
+									existingDestinationContainer.CreationTime.Get(
+										DateTimeKind.Utc),
+									DateTimeKind.Utc);
+							});
 						_containers.TryAdd(destination, existingSourceContainer);
 						return destination;
 					}

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileStreamFactoryMockTests.SafeFileHandle.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileStreamFactoryMockTests.SafeFileHandle.cs
@@ -13,6 +13,8 @@ public sealed partial class FileStreamFactoryMockTests
 	public void MissingFile_ShouldThrowFileNotFoundException(
 		string path, string contents)
 	{
+		Skip.If(Test.IsNetFramework);
+
 		path = RealFileSystem.Path.GetFullPath(path);
 		RealFileSystem.File.WriteAllText(path, contents);
 

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Test.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Test.cs
@@ -4,6 +4,18 @@ namespace Testably.Abstractions.Testing.Tests.TestHelpers;
 
 public static class Test
 {
+	private static bool? _isNetFramework;
+
+	public static bool IsNetFramework
+	{
+		get
+		{
+			_isNetFramework ??= RuntimeInformation
+				.FrameworkDescription.StartsWith(".NET Framework");
+			return _isNetFramework.Value;
+		}
+	}
+
 	public static bool RunsOnLinux
 		=> RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ResolveLinkTargetTests.cs
@@ -111,7 +111,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 		});
 
 		exception.Should().BeException<IOException>($"'{previousPath}'",
-			hResult: -2147022975);
+			hResult: Test.RunsOnWindows ? -2147022975 : -2146232800);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.AdjustTimes.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.AdjustTimes.cs
@@ -181,7 +181,7 @@ public abstract partial class Tests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void AdjustTimes_WhenUpdatingAFile_ShouldAdjustTimesOnlyOnNetFramework(
+	public void AdjustTimes_WhenUpdatingAFile_ShouldAdjustTimesOnlyOnWindows(
 		string path1, string path2, string fileName)
 	{
 		Skip.If(Test.IsNetFramework && FileSystem is RealFileSystem,
@@ -195,6 +195,7 @@ public abstract partial class Tests<TFileSystem>
 		FileSystem.File.WriteAllText(filePath, "");
 		DateTime creationTimeEnd = TimeSystem.DateTime.UtcNow;
 		TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
+		DateTime updateTimeStart = TimeSystem.DateTime.UtcNow;
 
 		FileSystem.File.AppendAllText(filePath, "foo");
 
@@ -208,9 +209,18 @@ public abstract partial class Tests<TFileSystem>
 		parentCreationTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);
-		parentLastAccessTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+		if (Test.RunsOnWindows)
+		{
+			parentLastAccessTime.Should()
+				.BeOnOrAfter(updateTimeStart.ApplySystemClockTolerance());
+		}
+		else
+		{
+			parentLastAccessTime.Should()
+				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
+				.BeOnOrBefore(creationTimeEnd);
+		}
+
 		parentLastWriteTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -183,8 +183,11 @@ public abstract partial class CopyTests<TFileSystem>
 				.BeOnOrBefore(creationTimeEnd);
 		}
 
-		destinationLastAccessTime.Should()
-			.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
+		if (!Test.RunsOnMac)
+		{
+			destinationLastAccessTime.Should()
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
+		}
 		destinationLastWriteTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadAllBytesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadAllBytesTests.cs
@@ -53,10 +53,17 @@ public abstract partial class ReadAllBytesTests<TFileSystem>
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance())
 				.And
 				.BeOnOrBefore(creationTimeEnd);
+			lastAccessTime.Should()
+				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance())
+				.And
+				.BeOnOrBefore(creationTimeEnd);
+		}
+		else
+		{
+			lastAccessTime.Should()
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 
-		lastAccessTime.Should()
-			.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		lastWriteTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance())
 			.And

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadAllTextTests.cs
@@ -86,10 +86,17 @@ public abstract partial class ReadAllTextTests<TFileSystem>
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance())
 				.And
 				.BeOnOrBefore(creationTimeEnd);
+			lastAccessTime.Should()
+				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance())
+				.And
+				.BeOnOrBefore(creationTimeEnd);
+		}
+		else
+		{
+			lastAccessTime.Should()
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 
-		lastAccessTime.Should()
-			.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		lastWriteTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance())
 			.And

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
@@ -145,15 +145,15 @@ public abstract partial class CopyToTests<TFileSystem>
 		DateTime updatedTime = TimeSystem.DateTime.Now;
 		sut.CopyTo(destinationName);
 
-		if (Test.RunsOnWindows)
+		if (Test.RunsOnLinux)
 		{
 			FileSystem.File.GetCreationTime(destinationName)
-				.Should().BeOnOrAfter(updatedTime.ApplySystemClockTolerance());
+				.Should().Be(sourceCreationTime);
 		}
 		else
 		{
 			FileSystem.File.GetCreationTime(destinationName)
-				.Should().Be(sourceCreationTime);
+				.Should().BeOnOrAfter(updatedTime.ApplySystemClockTolerance());
 		}
 
 		FileSystem.File.GetLastAccessTime(destinationName)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
@@ -157,8 +157,17 @@ public abstract partial class CopyToTests<TFileSystem>
 				.And.BeBefore(updatedTime);
 		}
 
-		FileSystem.File.GetLastAccessTime(destinationName)
-			.Should().BeOnOrAfter(updatedTime.ApplySystemClockTolerance());
+		if (Test.RunsOnMac)
+		{
+			FileSystem.File.GetLastAccessTime(destinationName)
+				.Should().BeOnOrAfter(sourceCreationTime.ApplySystemClockTolerance())
+				.And.BeBefore(updatedTime);
+		}
+		else
+		{
+			FileSystem.File.GetLastAccessTime(destinationName)
+				.Should().BeOnOrAfter(updatedTime.ApplySystemClockTolerance());
+		}
 		FileSystem.File.GetLastWriteTime(destinationName)
 			.Should().Be(sourceLastWriteTime);
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
@@ -145,15 +145,15 @@ public abstract partial class CopyToTests<TFileSystem>
 		DateTime updatedTime = TimeSystem.DateTime.Now;
 		sut.CopyTo(destinationName);
 
-		if (Test.RunsOnLinux)
+		if (Test.RunsOnWindows)
 		{
 			FileSystem.File.GetCreationTime(destinationName)
-				.Should().Be(sourceCreationTime);
+				.Should().BeOnOrAfter(updatedTime.ApplySystemClockTolerance());
 		}
 		else
 		{
 			FileSystem.File.GetCreationTime(destinationName)
-				.Should().BeOnOrAfter(updatedTime.ApplySystemClockTolerance());
+				.Should().Be(sourceCreationTime);
 		}
 
 		FileSystem.File.GetLastAccessTime(destinationName)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
@@ -153,7 +153,8 @@ public abstract partial class CopyToTests<TFileSystem>
 		else
 		{
 			FileSystem.File.GetCreationTime(destinationName)
-				.Should().Be(sourceCreationTime);
+				.Should().BeOnOrAfter(sourceCreationTime.ApplySystemClockTolerance())
+				.And.BeBefore(updatedTime);
 		}
 
 		FileSystem.File.GetLastAccessTime(destinationName)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
@@ -207,6 +207,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 		Test.SkipIfLongRunningTestsShouldBeSkipped(FileSystem);
 
 		FileSystem.File.WriteAllText(sourceName, sourceContents);
+		DateTime sourceCreationTime = FileSystem.File.GetCreationTime(sourceName);
 		DateTime sourceLastAccessTime = FileSystem.File.GetLastAccessTime(sourceName);
 		DateTime sourceLastWriteTime = FileSystem.File.GetLastWriteTime(sourceName);
 		TimeSystem.Thread.Sleep(1000);
@@ -223,8 +224,16 @@ public abstract partial class ReplaceTests<TFileSystem>
 
 		sut.Replace(destinationName, backupName);
 
-		FileSystem.File.GetCreationTime(destinationName)
-			.Should().Be(destinationCreationTime);
+		if (Test.RunsOnWindows)
+		{
+			FileSystem.File.GetCreationTime(destinationName)
+				.Should().Be(destinationCreationTime);
+		}
+		else
+		{
+			FileSystem.File.GetCreationTime(destinationName)
+				.Should().Be(sourceCreationTime);
+		}
 		FileSystem.File.GetLastAccessTime(destinationName)
 			.Should().Be(sourceLastAccessTime);
 		FileSystem.File.GetLastWriteTime(destinationName)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/AdjustTimesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/AdjustTimesTests.cs
@@ -81,11 +81,16 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 			creationTime.Should()
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 				.BeOnOrBefore(creationTimeEnd);
+			lastAccessTime.Should()
+				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
+				.BeOnOrBefore(creationTimeEnd);
+		}
+		else
+		{
+			lastAccessTime.Should()
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 
-		lastAccessTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
 		lastWriteTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);
@@ -120,11 +125,16 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 			creationTime.Should()
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 				.BeOnOrBefore(creationTimeEnd);
+			lastAccessTime.Should()
+				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
+				.BeOnOrBefore(creationTimeEnd);
 		}
-
-		lastAccessTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+		else
+		{
+			lastAccessTime.Should()
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
+		}
+		
 		lastWriteTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);
@@ -247,10 +257,16 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 			creationTime.Should()
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 				.BeOnOrBefore(creationTimeEnd);
+			lastAccessTime.Should()
+				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
+				.BeOnOrBefore(creationTimeEnd);
+		}
+		else
+		{
+			lastAccessTime.Should()
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 
-		lastAccessTime.Should()
-			.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		lastWriteTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/AdjustTimesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/AdjustTimesTests.cs
@@ -40,10 +40,15 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 			creationTime.Should()
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 				.BeOnOrBefore(creationTimeEnd);
+			lastAccessTime.Should()
+				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
+				.BeOnOrBefore(creationTimeEnd);
 		}
-
-		lastAccessTime.Should()
-			.BeOnOrAfter(updateTime);
+		else
+		{
+			lastAccessTime.Should()
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
+		}
 		lastWriteTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);
@@ -79,7 +84,8 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		}
 
 		lastAccessTime.Should()
-			.BeOnOrAfter(updateTime);
+			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
+			.BeOnOrBefore(creationTimeEnd);
 		lastWriteTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);
@@ -117,7 +123,8 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		}
 
 		lastAccessTime.Should()
-			.BeOnOrAfter(updateTime);
+			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
+			.BeOnOrBefore(creationTimeEnd);
 		lastWriteTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);
@@ -150,10 +157,16 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 			creationTime.Should()
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 				.BeOnOrBefore(creationTimeEnd);
+			lastAccessTime.Should()
+				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
+				.BeOnOrBefore(creationTimeEnd);
+		}
+		else
+		{
+			lastAccessTime.Should()
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 
-		lastAccessTime.Should()
-			.BeOnOrAfter(updateTime);
 		lastWriteTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);
@@ -191,10 +204,16 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 			creationTime.Should()
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 				.BeOnOrBefore(creationTimeEnd);
+			lastAccessTime.Should()
+				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
+				.BeOnOrBefore(creationTimeEnd);
+		}
+		else
+		{
+			lastAccessTime.Should()
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 
-		lastAccessTime.Should()
-			.BeOnOrAfter(updateTime);
 		lastWriteTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);
@@ -231,7 +250,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		}
 
 		lastAccessTime.Should()
-			.BeOnOrAfter(updateTime);
+			.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		lastWriteTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);
@@ -300,7 +319,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 				.BeOnOrBefore(creationTimeEnd);
 			lastAccessTime.Should()
-				.BeOnOrAfter(updateTime);
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
@@ -310,7 +329,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		}
 
 		lastWriteTime.Should()
-			.BeOnOrAfter(updateTime);
+			.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 	}
 #endif
 
@@ -343,7 +362,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 				.BeOnOrBefore(creationTimeEnd);
 			lastAccessTime.Should()
-				.BeOnOrAfter(updateTime);
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
@@ -353,7 +372,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		}
 
 		lastWriteTime.Should()
-			.BeOnOrAfter(updateTime);
+			.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 	}
 
 #if FEATURE_SPAN
@@ -384,7 +403,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 				.BeOnOrBefore(creationTimeEnd);
 			lastAccessTime.Should()
-				.BeOnOrAfter(updateTime);
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
@@ -394,7 +413,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		}
 
 		lastWriteTime.Should()
-			.BeOnOrAfter(updateTime);
+			.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 	}
 #endif
 
@@ -430,7 +449,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 				.BeOnOrBefore(creationTimeEnd);
 			lastAccessTime.Should()
-				.BeOnOrAfter(updateTime);
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
@@ -440,7 +459,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		}
 
 		lastWriteTime.Should()
-			.BeOnOrAfter(updateTime);
+			.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 	}
 #endif
 
@@ -473,7 +492,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 				.BeOnOrBefore(creationTimeEnd);
 			lastAccessTime.Should()
-				.BeOnOrAfter(updateTime);
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
@@ -483,7 +502,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		}
 
 		lastWriteTime.Should()
-			.BeOnOrAfter(updateTime);
+			.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 	}
 
 	#region Helpers
@@ -491,10 +510,10 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 	private DateTime WaitToBeUpdatedToAfter(Func<DateTime> callback,
 		DateTime expectedAfter)
 	{
-		for (int i = 0; i < 100; i++)
+		for (int i = 0; i < 20; i++)
 		{
 			DateTime time = callback();
-			if (time >= expectedAfter)
+			if (time >= expectedAfter.ApplySystemClockTolerance())
 			{
 				return time;
 			}


### PR DESCRIPTION
Enable tests against real file system to run during CI build.
Fix failing tests, due to time-adjustment not being implemented correctly in all cases.