### PR TITLE
coverage: add test for IsReadOnly on missing FileInfo

### DIFF
--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
@@ -87,6 +87,15 @@ public abstract partial class Tests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void IsReadOnly_MissingFile_ShouldBeTrue(string path)
+	{
+		IFileInfo fileInfo = new RealFileSystem().FileInfo.New(path);
+
+		fileInfo.IsReadOnly.Should().BeTrue();
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void IsReadOnly_SetToFalse_ShouldRemoveReadOnlyAttribute(string path)
 	{
 		FileSystem.File.WriteAllText(path, null);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
@@ -89,7 +89,7 @@ public abstract partial class Tests<TFileSystem>
 	[AutoData]
 	public void IsReadOnly_MissingFile_ShouldBeTrue(string path)
 	{
-		IFileInfo fileInfo = new RealFileSystem().FileInfo.New(path);
+		IFileInfo fileInfo = FileSystem.FileInfo.New(path);
 
 		fileInfo.IsReadOnly.Should().BeTrue();
 	}


### PR DESCRIPTION
Based on https://github.com/TestableIO/System.IO.Abstractions/issues/942 add a test for correct behaviour of `FileInfo.IsReadOnly` when the file does not exist.