### PR TITLE
fix: add distribution to setup-java build task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 1.11
+          distribution: 'oracle'
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis


### PR DESCRIPTION
Updating the setup-java build to v3 in #249 resulted in build errors due to missing required parameter `distribution`