### PR TITLE
fix: update java version for sonarcloud analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 1.11
-          distribution: 'oracle'
+          distribution: 'temurin'
+          java-version: '17'
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis


### PR DESCRIPTION
https://community.sonarsource.com/t/build-fail-in-github-set-up-jdk-17-failed/58761/2