### PR TITLE
fix: Timer should support swallowing exceptions

### DIFF
--- a/Source/Testably.Abstractions.Testing/TimeSystem/ITimerStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/ITimerStrategy.cs
@@ -1,4 +1,6 @@
-﻿namespace Testably.Abstractions.Testing.TimeSystem;
+﻿using System.Threading;
+
+namespace Testably.Abstractions.Testing.TimeSystem;
 
 /// <summary>
 ///     The strategy how to handle mocked timers for testing.
@@ -9,4 +11,12 @@ public interface ITimerStrategy
 	///     The timer mode.
 	/// </summary>
 	TimerMode Mode { get; }
+
+	/// <summary>
+	///     Flag indicating, if exceptions in the <see cref="TimerCallback" /> should be swallowed or thrown.
+	///     <para />
+	///     The real <see cref="Timer" /> will crash the application in case of an exception in the
+	///     <see cref="TimerCallback" />.
+	/// </summary>
+	bool SwallowExceptions { get; }
 }

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimerExecution.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimerExecution.cs
@@ -17,9 +17,15 @@ public class TimerExecution
 	/// </summary>
 	public ITimerMock Timer { get; }
 
-	internal TimerExecution(DateTime time, ITimerMock timer)
+	/// <summary>
+	///     The exception thrown during this timer execution.
+	/// </summary>
+	public Exception? Exception { get; }
+
+	internal TimerExecution(DateTime time, ITimerMock timer, Exception? exception)
 	{
 		Time = time;
 		Timer = timer;
+		Exception = exception;
 	}
 }

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimerMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimerMock.cs
@@ -121,20 +121,21 @@ internal sealed class TimerMock : ITimerMock
 		while (!cancellationToken.IsCancellationRequested)
 		{
 			nextPlannedExecution += _period;
+			Exception? exception = null;
 			try
 			{
 				_callback(_state);
 			}
 			catch (Exception swallowedException)
 			{
-				_exception = swallowedException;
+				_exception = exception = swallowedException;
 			}
 			Interlocked.Increment(ref _executionCount);
 			_callbackHandler.InvokeTimerExecutedCallbacks(
 				new TimerExecution(
 					_mockTimeSystem.DateTime.UtcNow,
 					this,
-					_exception));
+					exception));
 			if (_countdownEvent?.Signal() == true)
 			{
 				_continueEvent.Wait(cancellationToken);

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimerMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimerMock.cs
@@ -121,14 +121,16 @@ internal sealed class TimerMock : ITimerMock
 			{
 				_callback(_state);
 			}
-			catch (Exception ex)
+			catch (Exception swallowedException)
 			{
-				// timer swallow exceptions
-				exception = ex;
+				exception = swallowedException;
 			}
 			Interlocked.Increment(ref _executionCount);
 			_callbackHandler.InvokeTimerExecutedCallbacks(
-				new TimerExecution(_mockTimeSystem.DateTime.UtcNow, this, exception));
+				new TimerExecution(
+					_mockTimeSystem.DateTime.UtcNow,
+					this,
+					exception));
 			if (_countdownEvent?.Signal() == true)
 			{
 				_continueEvent.Wait(cancellationToken);

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimerStrategy.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimerStrategy.cs
@@ -11,17 +11,22 @@ public class TimerStrategy : ITimerStrategy
 	public static ITimerStrategy Default { get; }
 		= new TimerStrategy(TimerMode.StartImmediately);
 
-	/// <summary>
-	///     The timer mode.
-	/// </summary>
+	/// <inheritdoc cref="ITimerStrategy.Mode"/>
 	public TimerMode Mode { get; }
+
+	/// <inheritdoc cref="ITimerStrategy.SwallowExceptions"/>
+	public bool SwallowExceptions { get; }
 
 	/// <summary>
 	///     Initializes a new instance of <see cref="TimerStrategy" />.
 	/// </summary>
 	/// <param name="mode">The timer mode.</param>
-	public TimerStrategy(TimerMode mode)
+	/// <param name="swallowExceptions">Flag, indicating if exceptions should be swallowed.</param>
+	public TimerStrategy(
+		TimerMode mode = TimerMode.StartImmediately,
+		bool swallowExceptions = false)
 	{
 		Mode = mode;
+		SwallowExceptions = swallowExceptions;
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using Testably.Abstractions.Testing.Tests.TestHelpers;
 using Testably.Abstractions.Testing.TimeSystem;
 using Testably.Abstractions.TimeSystem;
 
@@ -22,6 +23,25 @@ public class TimerMockTests
 		});
 
 		exception.Should().BeOfType<NotSupportedException>();
+	}
+
+	[Fact]
+	public void Exception_ShouldBeIncludedInTimerExecutedNotification()
+	{
+		Exception exception = new Exception("foo");
+		MockTimeSystem timeSystem = new();
+		ITimerHandler timerHandler = timeSystem.TimerHandler;
+		TimerExecution? receivedTimeout = null;
+
+		using (timeSystem.On.TimerExecuted(d => receivedTimeout = d))
+		{
+			timeSystem.Timer.New(_ => throw exception, null,
+				TimeTestHelper.GetRandomInterval(),
+				TimeTestHelper.GetRandomInterval());
+			timerHandler[0].Wait();
+		}
+
+		receivedTimeout!.Exception.Should().Be(exception);
 	}
 
 	[Fact]

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -42,7 +42,8 @@ public abstract partial class TimerTests<TTimeSystem>
 		});
 
 		exception.Should()
-			.BeException<ArgumentOutOfRangeException>(hResult: -2146233086, paramName: nameof(dueTime));
+			.BeException<ArgumentOutOfRangeException>(hResult: -2146233086,
+				paramName: nameof(dueTime));
 	}
 
 	[SkippableTheory]
@@ -60,7 +61,8 @@ public abstract partial class TimerTests<TTimeSystem>
 		});
 
 		exception.Should()
-			.BeException<ArgumentOutOfRangeException>(hResult: -2146233086, paramName: nameof(period));
+			.BeException<ArgumentOutOfRangeException>(hResult: -2146233086,
+				paramName: nameof(period));
 	}
 
 	[SkippableFact]
@@ -264,29 +266,5 @@ public abstract partial class TimerTests<TTimeSystem>
 		bool result = timer.Dispose(waitHandle);
 
 		result.Should().BeFalse();
-	}
-
-	[SkippableFact]
-	public void Exception_ShouldBeSwallowedAndContinueTimerExecution()
-	{
-		Exception exception = new("foo");
-		int count = 0;
-		ManualResetEventSlim ms = new();
-		using ITimer timer = TimeSystem.Timer.New(_ =>
-		{
-			if (count++ == 1)
-			{
-				throw exception;
-			}
-
-			if (count == 3)
-			{
-				ms.Set();
-			}
-		}, null, 0, 20);
-
-		ms.Wait(10000).Should().BeTrue();
-
-		count.Should().BeGreaterThanOrEqualTo(3);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -265,4 +265,28 @@ public abstract partial class TimerTests<TTimeSystem>
 
 		result.Should().BeFalse();
 	}
+
+	[SkippableFact]
+	public void Exception_ShouldBeSwallowedAndContinueTimerExecution()
+	{
+		Exception exception = new("foo");
+		int count = 0;
+		ManualResetEventSlim ms = new();
+		using ITimer timer = TimeSystem.Timer.New(_ =>
+		{
+			if (count++ == 1)
+			{
+				throw exception;
+			}
+
+			if (count == 3)
+			{
+				ms.Set();
+			}
+		}, null, 0, 20);
+
+		ms.Wait(10000).Should().BeTrue();
+
+		count.Should().BeGreaterThanOrEqualTo(3);
+	}
 }


### PR DESCRIPTION
Exceptions thrown in the timer callback should be swallowed and thrown on the main thread