### PR TITLE
fix: disable `fail-on-test` in "Test Report" action

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,7 +1,7 @@
 name: 'Test Report'
 on:
   workflow_run:
-    workflows: ['CI']                     # runs after CI workflow
+    workflows: ['CI']
     types:
       - completed
 jobs:
@@ -15,6 +15,7 @@ jobs:
         name: MacOS Tests
         path: '*.trx'
         reporter: dotnet-trx
+        fail-on-error: 'false'
     - uses: dorny/test-reporter@v1
       if: success() || failure()
       with:
@@ -22,6 +23,7 @@ jobs:
         name: Ubuntu Tests
         path: '*.trx'
         reporter: dotnet-trx
+        fail-on-error: 'false'
     - uses: dorny/test-reporter@v1
       if: success() || failure()
       with:
@@ -29,6 +31,7 @@ jobs:
         name: Windows Tests
         path: '*.trx'
         reporter: dotnet-trx
+        fail-on-error: 'false'
     - uses: dorny/test-reporter@v1
       if: success() || failure()
       with:
@@ -36,3 +39,4 @@ jobs:
         name: .NET Framework Tests
         path: '*.trx'
         reporter: dotnet-trx
+        fail-on-error: 'false'


### PR DESCRIPTION
Disable `fail-on-error` in [test-reporter](https://github.com/dorny/test-reporter), as the test tasks themselves fail when an test failed.