### PR TITLE
fix: avoid redundant object creation

### DIFF
--- a/Source/Testably.Abstractions/RandomSystem/RandomFactory.cs
+++ b/Source/Testably.Abstractions/RandomSystem/RandomFactory.cs
@@ -6,7 +6,7 @@ namespace Testably.Abstractions.RandomSystem;
 internal sealed class RandomFactory : IRandomFactory
 {
 	private static readonly Random Global = new();
-	private IRandom? _shared;
+	[ThreadStatic] private static IRandom? _shared;
 
 	internal RandomFactory(RealRandomSystem timeSystem)
 	{

--- a/Source/Testably.Abstractions/RealFileSystem.cs
+++ b/Source/Testably.Abstractions/RealFileSystem.cs
@@ -9,39 +9,47 @@ namespace Testably.Abstractions;
 /// </summary>
 public sealed class RealFileSystem : IFileSystem
 {
+	/// <summary>
+	///     Initializes a new instance of <see cref="RealFileSystem" />
+	///     which wraps the file-related system dependencies from <see cref="IFileSystem" />.
+	/// </summary>
+	public RealFileSystem()
+	{
+		Directory = new DirectoryWrapper(this);
+		DirectoryInfo = new DirectoryInfoFactory(this);
+		DriveInfo = new DriveInfoFactory(this);
+		File = new FileWrapper(this);
+		FileInfo = new FileInfoFactory(this);
+		FileStream = new FileStreamFactory(this);
+		FileSystemWatcher = new FileSystemWatcherFactory(this);
+		Path = new PathWrapper(this);
+	}
+
 	#region IFileSystem Members
 
 	/// <inheritdoc cref="IFileSystem.Directory" />
-	public IDirectory Directory
-		=> new DirectoryWrapper(this);
+	public IDirectory Directory { get; }
 
 	/// <inheritdoc cref="IFileSystem.DirectoryInfo" />
-	public IDirectoryInfoFactory DirectoryInfo
-		=> new DirectoryInfoFactory(this);
+	public IDirectoryInfoFactory DirectoryInfo { get; }
 
 	/// <inheritdoc cref="IFileSystem.DriveInfo" />
-	public IDriveInfoFactory DriveInfo
-		=> new DriveInfoFactory(this);
+	public IDriveInfoFactory DriveInfo { get; }
 
 	/// <inheritdoc cref="IFileSystem.File" />
-	public IFile File
-		=> new FileWrapper(this);
+	public IFile File { get; }
 
 	/// <inheritdoc cref="IFileSystem.FileInfo" />
-	public IFileInfoFactory FileInfo
-		=> new FileInfoFactory(this);
+	public IFileInfoFactory FileInfo { get; }
 
 	/// <inheritdoc cref="IFileSystem.FileStream" />
-	public IFileStreamFactory FileStream
-		=> new FileStreamFactory(this);
+	public IFileStreamFactory FileStream { get; }
 
 	/// <inheritdoc cref="IFileSystem.FileSystemWatcher" />
-	public IFileSystemWatcherFactory FileSystemWatcher
-		=> new FileSystemWatcherFactory(this);
+	public IFileSystemWatcherFactory FileSystemWatcher { get; }
 
 	/// <inheritdoc cref="IFileSystem.Path" />
-	public IPath Path
-		=> new PathWrapper(this);
+	public IPath Path { get; }
 
 	#endregion
 }

--- a/Source/Testably.Abstractions/RealRandomSystem.cs
+++ b/Source/Testably.Abstractions/RealRandomSystem.cs
@@ -9,15 +9,23 @@ namespace Testably.Abstractions;
 /// </summary>
 public sealed class RealRandomSystem : IRandomSystem
 {
+	/// <summary>
+	///     Initializes a new instance of <see cref="RealRandomSystem" />
+	///     which wraps the random-related system dependencies from <see cref="IRandomSystem" />.
+	/// </summary>
+	public RealRandomSystem()
+	{
+		Guid = new GuidWrapper(this);
+		Random = new RandomFactory(this);
+	}
+
 	#region IRandomSystem Members
 
 	/// <inheritdoc cref="IRandomSystem.Guid" />
-	public IGuid Guid
-		=> new GuidWrapper(this);
+	public IGuid Guid { get; }
 
 	/// <inheritdoc cref="IRandomSystem.Random" />
-	public IRandomFactory Random
-		=> new RandomFactory(this);
+	public IRandomFactory Random { get; }
 
 	#endregion
 }

--- a/Source/Testably.Abstractions/RealTimeSystem.cs
+++ b/Source/Testably.Abstractions/RealTimeSystem.cs
@@ -9,23 +9,31 @@ namespace Testably.Abstractions;
 /// </summary>
 public sealed class RealTimeSystem : ITimeSystem
 {
+	/// <summary>
+	///     Initializes a new instance of <see cref="RealTimeSystem" />
+	///     which wraps the time-related system dependencies from <see cref="ITimeSystem" />.
+	/// </summary>
+	public RealTimeSystem()
+	{
+		DateTime = new DateTimeWrapper(this);
+		Task = new TaskWrapper(this);
+		Thread = new ThreadWrapper(this);
+		Timer = new TimerFactory(this);
+	}
+
 	#region ITimeSystem Members
 
 	/// <inheritdoc cref="ITimeSystem.DateTime" />
-	public IDateTime DateTime
-		=> new DateTimeWrapper(this);
+	public IDateTime DateTime { get; }
 
 	/// <inheritdoc cref="ITimeSystem.Task" />
-	public ITask Task
-		=> new TaskWrapper(this);
+	public ITask Task { get; }
 
 	/// <inheritdoc cref="ITimeSystem.Thread" />
-	public IThread Thread
-		=> new ThreadWrapper(this);
+	public IThread Thread { get; }
 
 	/// <inheritdoc cref="ITimeSystem.Timer" />
-	public ITimerFactory Timer
-		=> new TimerFactory(this);
+	public ITimerFactory Timer { get; }
 
 	#endregion
 }


### PR DESCRIPTION
Avoid redundant object creation in `RealFileSystem`, `RealRandomSystem` and `RealTimeSystem`.