### PR TITLE
feat: initialize `MockFileSystem` with drive from current directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@
 # Generated files
 /Tests/*/Generated
 
+# NCrunch
+*.ncrunchproject
+*.ncrunchsolution
+
 ############################################################
 ################## VISUAL STUDIO TEMPLATE ##################
 ############################################################

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 # NCrunch
 *.ncrunchproject
 *.ncrunchsolution
+/.NCrunch_*/StoredText/
 
 ############################################################
 ################## VISUAL STUDIO TEMPLATE ##################

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -154,7 +154,7 @@ public sealed class MockFileSystem : IFileSystem
 
 	private void AddDriveFromCurrentDirectory()
 	{
-		string? root = Path.GetPathRoot(Directory.GetCurrentDirectory());
+		string? root = Path.GetPathRoot(System.IO.Directory.GetCurrentDirectory());
 		if (root != null &&
 		    root[0] != _storage.MainDrive.Name[0])
 		{

--- a/Source/Testably.Abstractions.Testing/MockFileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystemExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing;
@@ -8,6 +10,17 @@ namespace Testably.Abstractions.Testing;
 /// </summary>
 public static class MockFileSystemExtensions
 {
+	/// <summary>
+	///     Returns the default drive in the <paramref name="mockFileSystem" />.
+	/// </summary>
+	public static IDriveInfo GetDefaultDrive(this MockFileSystem mockFileSystem)
+	{
+		string driveName = "".PrefixRoot();
+		return mockFileSystem.DriveInfo
+			.GetDrives()
+			.First(d => d.Name.StartsWith(driveName));
+	}
+
 	/// <summary>
 	///     Changes the parameters of the default drive (e.g. 'C:\' on Windows or '/' on Linux)
 	/// </summary>

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DriveInfoMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DriveInfoMockTests.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Linq;
 using System.Text;
 using Testably.Abstractions.Testing.FileSystem;
 
@@ -23,7 +22,7 @@ public class DriveInfoMockTests
 	public void AvailableFreeSpace_CannotGetNegative(long size)
 	{
 		FileSystem.WithDrive(d => d.SetTotalSize(size));
-		IDriveInfo drive = FileSystem.DriveInfo.GetDrives().Single();
+		IDriveInfo drive = FileSystem.GetDefaultDrive();
 
 		FileSystem.WithDrive(d => d.ChangeUsedBytes(-1));
 
@@ -44,7 +43,7 @@ public class DriveInfoMockTests
 			FileSystem.File.WriteAllBytes(path, bytes);
 		});
 
-		IDriveInfo drive = FileSystem.DriveInfo.GetDrives().Single();
+		IDriveInfo drive = FileSystem.GetDefaultDrive();
 		exception.Should().BeOfType<IOException>()
 			.Which.Message.Should().Contain($"'{drive.Name}'");
 		drive.AvailableFreeSpace.Should().Be(fileSize - 1);
@@ -60,7 +59,7 @@ public class DriveInfoMockTests
 		int fileSize2 = encoding.GetBytes(fileContent2).Length;
 		FileSystem.WithDrive(d
 			=> d.SetTotalSize(fileSize1 + fileSize2 + expectedRemainingBytes));
-		IDriveInfo drive = FileSystem.DriveInfo.GetDrives().Single();
+		IDriveInfo drive = FileSystem.GetDefaultDrive();
 
 		FileSystem.File.WriteAllText(path, fileContent1, encoding);
 		drive.AvailableFreeSpace.Should().Be(expectedRemainingBytes + fileSize2);
@@ -77,7 +76,7 @@ public class DriveInfoMockTests
 		int reduceLength, string path, string previousContent)
 	{
 		FileSystem.File.WriteAllText(path, previousContent);
-		IDriveInfo drive = FileSystem.DriveInfo.GetDrives().Single();
+		IDriveInfo drive = FileSystem.GetDefaultDrive();
 		long previousFreeSpace = drive.AvailableFreeSpace;
 
 		FileSystemStream stream = FileSystem.File.OpenWrite(path);
@@ -101,7 +100,7 @@ public class DriveInfoMockTests
 
 		FileSystem.File.WriteAllBytes(path, bytes);
 
-		IDriveInfo drive = FileSystem.DriveInfo.GetDrives().Single();
+		IDriveInfo drive = FileSystem.GetDefaultDrive();
 
 		drive.AvailableFreeSpace.Should().Be(0);
 	}
@@ -118,7 +117,7 @@ public class DriveInfoMockTests
 		FileSystem.File.WriteAllBytes(path, bytes);
 		FileSystem.File.Delete(path);
 
-		IDriveInfo drive = FileSystem.DriveInfo.GetDrives().Single();
+		IDriveInfo drive = FileSystem.GetDefaultDrive();
 
 		drive.AvailableFreeSpace.Should().Be(fileSize);
 	}
@@ -129,7 +128,7 @@ public class DriveInfoMockTests
 	{
 		FileSystem.WithDrive(d => d.SetTotalSize(size));
 
-		IDriveInfo drive = FileSystem.DriveInfo.GetDrives().Single();
+		IDriveInfo drive = FileSystem.GetDefaultDrive();
 
 		drive.AvailableFreeSpace.Should().Be(size);
 	}
@@ -228,7 +227,7 @@ public class DriveInfoMockTests
 	{
 		FileSystem.WithDrive(d => d.SetDriveFormat());
 
-		IDriveInfo drive = FileSystem.DriveInfo.GetDrives().Single();
+		IDriveInfo drive = FileSystem.GetDefaultDrive();
 		drive.DriveFormat.Should().Be("NTFS");
 	}
 
@@ -238,7 +237,7 @@ public class DriveInfoMockTests
 	{
 		FileSystem.WithDrive(d => d.SetDriveFormat(driveFormat));
 
-		IDriveInfo drive = FileSystem.DriveInfo.GetDrives().Single();
+		IDriveInfo drive = FileSystem.GetDefaultDrive();
 		drive.DriveFormat.Should().Be(driveFormat);
 	}
 
@@ -247,7 +246,7 @@ public class DriveInfoMockTests
 	{
 		FileSystem.WithDrive(d => d.SetDriveType());
 
-		IDriveInfo drive = FileSystem.DriveInfo.GetDrives().Single();
+		IDriveInfo drive = FileSystem.GetDefaultDrive();
 		drive.DriveType.Should().Be(DriveType.Fixed);
 	}
 
@@ -257,7 +256,7 @@ public class DriveInfoMockTests
 	{
 		FileSystem.WithDrive(d => d.SetDriveType(driveType));
 
-		IDriveInfo drive = FileSystem.DriveInfo.GetDrives().Single();
+		IDriveInfo drive = FileSystem.GetDefaultDrive();
 		drive.DriveType.Should().Be(driveType);
 	}
 
@@ -268,7 +267,7 @@ public class DriveInfoMockTests
 	{
 		FileSystem.WithDrive(d => d.SetIsReady(isReady));
 
-		IDriveInfo drive = FileSystem.DriveInfo.GetDrives().Single();
+		IDriveInfo drive = FileSystem.GetDefaultDrive();
 		drive.IsReady.Should().Be(isReady);
 	}
 
@@ -277,7 +276,7 @@ public class DriveInfoMockTests
 	{
 		FileSystem.WithDrive(d => d.SetTotalSize());
 
-		IDriveInfo drive = FileSystem.DriveInfo.GetDrives().Single();
+		IDriveInfo drive = FileSystem.GetDefaultDrive();
 
 		drive.AvailableFreeSpace.Should().Be(1024 * 1024 * 1024);
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
@@ -223,11 +223,23 @@ public class FileSystemInitializerExtensionsTests
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		directoryName = Path.Combine("D:\\", directoryName);
 		MockFileSystem sut = new();
+		IDriveInfo[] drives = sut.DriveInfo.GetDrives();
+		for (char c = 'D'; c <= 'Z'; c++)
+		{
+			if (drives.Any(d => d.Name.StartsWith($"{c}")))
+			{
+				continue;
+			}
+
+			directoryName = Path.Combine($"{c}:\\", directoryName);
+			break;
+		}
+
 		sut.InitializeIn(directoryName);
 
 		sut.Directory.Exists(directoryName).Should().BeTrue();
+		sut.DriveInfo.GetDrives().Length.Should().Be(drives.Length + 1);
 	}
 
 	[Theory]

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -94,24 +94,11 @@ public class MockFileSystemTests
 	[SkippableFact]
 	public void FileSystemMock_ShouldInitializeDriveFromCurrentDirectory()
 	{
-		Skip.IfNot(Test.RunsOnWindows);
+		string? driveName = Path.GetPathRoot(Directory.GetCurrentDirectory());
 
-		string driveName = "D:\\";
+		Skip.If(!Test.RunsOnWindows || driveName?.StartsWith("C") != false);
 
-		Skip.IfNot(Directory.Exists(driveName),
-			$"Skip test, as no alternative drive '{driveName}' is mapped on this computer.");
-
-		string currentDirectory = Directory.GetCurrentDirectory();
-		MockFileSystem sut;
-		try
-		{
-			Directory.SetCurrentDirectory(driveName);
-			sut = new MockFileSystem();
-		}
-		finally
-		{
-			Directory.SetCurrentDirectory(currentDirectory);
-		}
+		MockFileSystem sut = new();
 
 		IDriveInfo[] drives = sut.DriveInfo.GetDrives();
 		drives.Length.Should().Be(2);

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -210,7 +210,7 @@ public class MockFileSystemTests
 		MockFileSystem sut = new();
 		sut.WithDrive(d => d.SetTotalSize(totalSize));
 
-		IDriveInfo drive = sut.DriveInfo.GetDrives().Single();
+		IDriveInfo drive = sut.GetDefaultDrive();
 
 		drive.TotalSize.Should().Be(totalSize);
 		drive.TotalFreeSpace.Should().Be(totalSize);
@@ -239,11 +239,13 @@ public class MockFileSystemTests
 		MockFileSystem sut = new();
 		string uncPrefix = new(sut.Path.DirectorySeparatorChar, 2);
 		string uncDrive = $"{uncPrefix}{server}";
+		int expectedLogicalDrives = sut.Directory.GetLogicalDrives().Length;
+		int expectedDrives = sut.DriveInfo.GetDrives().Length;
 
 		sut.WithUncDrive(uncDrive);
 
-		sut.Directory.GetLogicalDrives().Length.Should().Be(1);
-		sut.DriveInfo.GetDrives().Length.Should().Be(1);
+		sut.Directory.GetLogicalDrives().Length.Should().Be(expectedLogicalDrives);
+		sut.DriveInfo.GetDrives().Length.Should().Be(expectedDrives);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -74,14 +74,15 @@ public class MockFileSystemTests
 	}
 
 	[SkippableFact]
-	public void FileSystemMock_ShouldBeInitializedWithASingleDefaultDrive()
+	public void FileSystemMock_ShouldBeInitializedWithADefaultDrive()
 	{
 		string expectedDriveName = "".PrefixRoot();
 		MockFileSystem sut = new();
 
 		IDriveInfo[] drives = sut.DriveInfo.GetDrives();
-		IDriveInfo drive = drives.Single();
+		IDriveInfo drive = sut.GetDefaultDrive();
 
+		drives.Should().NotBeEmpty();
 		drive.Name.Should().Be(expectedDriveName);
 		drive.AvailableFreeSpace.Should().BeGreaterThan(0);
 		drive.DriveFormat.Should()
@@ -167,7 +168,7 @@ public class MockFileSystemTests
 
 		IDriveInfo[] drives = sut.DriveInfo.GetDrives();
 
-		drives.Length.Should().Be(1);
+		drives.Length.Should().BeGreaterOrEqualTo(1);
 		drives.Should().ContainSingle(d => d.Name == driveName);
 	}
 

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -91,6 +91,33 @@ public class MockFileSystemTests
 		drive.VolumeLabel.Should().NotBeNullOrEmpty();
 	}
 
+	[SkippableFact]
+	public void FileSystemMock_ShouldInitializeDriveFromCurrentDirectory()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		string driveName = "D:\\";
+
+		Skip.IfNot(Directory.Exists(driveName),
+			$"Skip test, as no alternative drive '{driveName}' is mapped on this computer.");
+
+		string currentDirectory = Directory.GetCurrentDirectory();
+		MockFileSystem sut;
+		try
+		{
+			Directory.SetCurrentDirectory(driveName);
+			sut = new MockFileSystem();
+		}
+		finally
+		{
+			Directory.SetCurrentDirectory(currentDirectory);
+		}
+
+		IDriveInfo[] drives = sut.DriveInfo.GetDrives();
+		drives.Length.Should().Be(2);
+		drives.Should().Contain(d => d.Name == driveName);
+	}
+
 	[SkippableTheory]
 	[AutoData]
 	public void WithAccessControl_Denied_CreateDirectoryShouldThrowIOException(


### PR DESCRIPTION
Initialize the `MockFileSystem` with the drive from the current directory and support multiple drives in tests.
Add extension method `GetDefaultDrive` on `MockFileSystem` to return the default drive.

*Exclude NCrunch files in `.gitignore`*