### PR TITLE
coverage: add internal tests for `RealFileSystem`

### DIFF
--- a/Source/Testably.Abstractions/Testably.Abstractions.csproj
+++ b/Source/Testably.Abstractions/Testably.Abstractions.csproj
@@ -19,6 +19,9 @@
 			<_Parameter1>true</_Parameter1>
 			<_Parameter1_TypeName>System.Boolean</_Parameter1_TypeName>
 		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>Testably.Abstractions.Tests</_Parameter1>
+		</AssemblyAttribute>
 	</ItemGroup>
 
 </Project>

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
@@ -31,7 +31,7 @@ namespace {@class.Namespace}
 namespace {@class.Namespace}.{@class.Name}
 {{
 	// ReSharper disable once UnusedMember.Global
-	public sealed class MockFileSystemTests : {@class.Name}<MockFileSystem>
+	public sealed class MockFileSystemTests : {@class.Name}<MockFileSystem>, IDisposable
 	{{
 		/// <inheritdoc cref=""{@class.Name}{{TFileSystem}}.BasePath"" />
 		public override string BasePath => _directoryCleaner.BasePath;
@@ -62,7 +62,7 @@ namespace {@class.Namespace}.{@class.Name}
 {{
 	// ReSharper disable once UnusedMember.Global
 	[Collection(nameof(RealFileSystemTests))]
-	public sealed class RealFileSystemTests : {@class.Name}<RealFileSystem>
+	public sealed class RealFileSystemTests : {@class.Name}<RealFileSystem>, IDisposable
 	{{
 		/// <inheritdoc cref=""{@class.Name}{{TFileSystem}}.BasePath"" />
 		public override string BasePath => _directoryCleaner.BasePath;

--- a/Tests/Testably.Abstractions.Tests/Internal/DirectoryInfoWrapperTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Internal/DirectoryInfoWrapperTests.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+
+namespace Testably.Abstractions.Tests.Internal;
+
+public class DirectoryInfoWrapperTests
+{
+	[Fact]
+	public void FromDirectoryInfo_Null_ShouldReturnNull()
+	{
+		RealFileSystem fileSystem = new();
+
+		DirectoryInfoWrapper? result = DirectoryInfoWrapper
+			.FromDirectoryInfo(null, fileSystem);
+
+		result.Should().BeNull();
+	}
+
+	[Theory]
+	[AutoData]
+	public void FromDirectoryInfo_ShouldUseFileSystem(string path)
+	{
+		RealFileSystem fileSystem = new();
+
+		DirectoryInfoWrapper result = DirectoryInfoWrapper
+			.FromDirectoryInfo(new DirectoryInfo(path), fileSystem);
+
+		result.Root.Should().NotBeNull();
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/Internal/DirectoryInfoWrapperTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Internal/DirectoryInfoWrapperTests.cs
@@ -17,7 +17,7 @@ public class DirectoryInfoWrapperTests
 
 	[Theory]
 	[AutoData]
-	public void FromDirectoryInfo_ShouldUseFileSystem(string path)
+	public void FromDirectoryInfo_ShouldBePartOfFileSystem(string path)
 	{
 		RealFileSystem fileSystem = new();
 

--- a/Tests/Testably.Abstractions.Tests/Internal/DriveInfoWrapperTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Internal/DriveInfoWrapperTests.cs
@@ -1,0 +1,15 @@
+﻿namespace Testably.Abstractions.Tests.Internal;
+
+public class DriveInfoWrapperTests
+{
+	[Fact]
+	public void FromDriveInfo_Null_ShouldReturnNull()
+	{
+		RealFileSystem fileSystem = new();
+
+		DriveInfoWrapper? result = DriveInfoWrapper
+			.FromDriveInfo(null, fileSystem);
+
+		result.Should().BeNull();
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/Internal/FileInfoWrapperTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Internal/FileInfoWrapperTests.cs
@@ -17,7 +17,7 @@ public class FileInfoWrapperTests
 
 	[Theory]
 	[AutoData]
-	public void FromFileInfo_ShouldBeLinkedToFileSystem(string path)
+	public void FromFileInfo_ShouldBePartOfFileSystem(string path)
 	{
 		RealFileSystem fileSystem = new();
 

--- a/Tests/Testably.Abstractions.Tests/Internal/FileInfoWrapperTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Internal/FileInfoWrapperTests.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+
+namespace Testably.Abstractions.Tests.Internal;
+
+public class FileInfoWrapperTests
+{
+	[Fact]
+	public void FromFileInfo_Null_ShouldReturnNull()
+	{
+		RealFileSystem fileSystem = new();
+
+		FileInfoWrapper? result = FileInfoWrapper
+			.FromFileInfo(null, fileSystem);
+
+		result.Should().BeNull();
+	}
+
+	[Theory]
+	[AutoData]
+	public void FromFileInfo_ShouldUseFileSystem(string path)
+	{
+		RealFileSystem fileSystem = new();
+
+		FileInfoWrapper result = FileInfoWrapper
+			.FromFileInfo(new FileInfo(path), fileSystem);
+
+		result.Directory.Should().NotBeNull();
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/Internal/FileInfoWrapperTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Internal/FileInfoWrapperTests.cs
@@ -17,7 +17,7 @@ public class FileInfoWrapperTests
 
 	[Theory]
 	[AutoData]
-	public void FromFileInfo_ShouldUseFileSystem(string path)
+	public void FromFileInfo_ShouldBeLinkedToFileSystem(string path)
 	{
 		RealFileSystem fileSystem = new();
 

--- a/Tests/Testably.Abstractions.Tests/Internal/FileStreamWrapperTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Internal/FileStreamWrapperTests.cs
@@ -1,0 +1,60 @@
+﻿using System.IO;
+using Testably.Abstractions.Helpers;
+using Testably.Abstractions.Testing.FileSystemInitializer;
+using Xunit.Abstractions;
+
+namespace Testably.Abstractions.Tests.Internal;
+
+[Collection("RealFileSystemTests")]
+public sealed class FileStreamWrapperTests : IDisposable
+{
+	#region Test Setup
+
+	public RealFileSystem FileSystem { get; }
+
+	private readonly IDirectoryCleaner _directoryCleaner;
+
+	public FileStreamWrapperTests(ITestOutputHelper testOutputHelper)
+	{
+		FileSystem = new RealFileSystem();
+		_directoryCleaner = FileSystem
+			.SetCurrentDirectoryToEmptyTemporaryDirectory(
+				$"Testably.Abstractions.Tests.Internal{FileSystem.Path.DirectorySeparatorChar}FileStreamWrapperTests-",
+				testOutputHelper.WriteLine);
+	}
+
+	/// <inheritdoc cref="IDisposable.Dispose()" />
+	public void Dispose()
+		=> _directoryCleaner.Dispose();
+
+	#endregion
+
+	[Theory]
+	[AutoData]
+	public void RetrieveMetadata_ShouldReturnStoredValue(string path, string key, object value)
+	{
+		using FileSystemStream sut = FileSystem.FileStream.New(path, FileMode.OpenOrCreate);
+
+		IFileSystemExtensibility? extensibility = sut as IFileSystemExtensibility;
+
+		extensibility!.StoreMetadata(key, value);
+
+		object? result = extensibility.RetrieveMetadata<object>(key);
+
+		result.Should().Be(value);
+	}
+
+	[Theory]
+	[AutoData]
+	public void TryGetWrappedInstance_ShouldReturnWrappedInstance(string path)
+	{
+		using FileSystemStream sut = FileSystem.FileStream.New(path, FileMode.OpenOrCreate);
+
+		IFileSystemExtensibility? extensibility = sut as IFileSystemExtensibility;
+
+		bool result = extensibility!.TryGetWrappedInstance(out FileStream? fileStream);
+
+		result.Should().BeTrue();
+		fileStream.Should().NotBeNull();
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/Internal/FileSystemExtensibilityTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Internal/FileSystemExtensibilityTests.cs
@@ -22,21 +22,7 @@ public class FileSystemExtensibilityTests
 
 	[Theory]
 	[AutoData]
-	public void RetrieveMetadata_ShouldReturnStoredValue(string path, string key, object value)
-	{
-		RealFileSystem fileSystem = new();
-		IFileInfo sut = fileSystem.FileInfo.New(path);
-		IFileSystemExtensibility? extensibility = sut as IFileSystemExtensibility;
-		extensibility!.StoreMetadata(key, value);
-
-		object? result = extensibility.RetrieveMetadata<object>(key);
-
-		result.Should().Be(value);
-	}
-
-	[Theory]
-	[AutoData]
-	public void RetrieveMetadata_WithoutStoring_ShouldReturnDefault(string path, string key)
+	public void RetrieveMetadata_WithoutStoringBefore_ShouldReturnDefault(string path, string key)
 	{
 		RealFileSystem fileSystem = new();
 		IFileInfo sut = fileSystem.FileInfo.New(path);
@@ -45,6 +31,20 @@ public class FileSystemExtensibilityTests
 		object? result = extensibility!.RetrieveMetadata<object?>(key);
 
 		result.Should().BeNull();
+	}
+
+	[Theory]
+	[AutoData]
+	public void StoreMetadata_ShouldMakeValueRetrievable(string path, string key, object value)
+	{
+		RealFileSystem fileSystem = new();
+		IFileInfo sut = fileSystem.FileInfo.New(path);
+		IFileSystemExtensibility? extensibility = sut as IFileSystemExtensibility;
+
+		extensibility!.StoreMetadata(key, value);
+
+		object? result = extensibility.RetrieveMetadata<object>(key);
+		result.Should().Be(value);
 	}
 
 	[Theory]

--- a/Tests/Testably.Abstractions.Tests/Internal/FileSystemExtensibilityTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Internal/FileSystemExtensibilityTests.cs
@@ -1,0 +1,77 @@
+﻿using System.IO;
+using Testably.Abstractions.Helpers;
+
+namespace Testably.Abstractions.Tests.Internal;
+
+public class FileSystemExtensibilityTests
+{
+	[Theory]
+	[AutoData]
+	public void RetrieveMetadata_IncorrectType_ShouldReturnNull(string path, string key)
+	{
+		FileInfo value = new(path);
+		RealFileSystem fileSystem = new();
+		IFileInfo sut = fileSystem.FileInfo.New(path);
+		IFileSystemExtensibility? extensibility = sut as IFileSystemExtensibility;
+		extensibility!.StoreMetadata(key, value);
+
+		DirectoryInfo? result = extensibility.RetrieveMetadata<DirectoryInfo>(key);
+
+		result.Should().BeNull();
+	}
+
+	[Theory]
+	[AutoData]
+	public void RetrieveMetadata_ShouldReturnStoredValue(string path, string key, object value)
+	{
+		RealFileSystem fileSystem = new();
+		IFileInfo sut = fileSystem.FileInfo.New(path);
+		IFileSystemExtensibility? extensibility = sut as IFileSystemExtensibility;
+		extensibility!.StoreMetadata(key, value);
+
+		object? result = extensibility.RetrieveMetadata<object>(key);
+
+		result.Should().Be(value);
+	}
+
+	[Theory]
+	[AutoData]
+	public void RetrieveMetadata_WithoutStoring_ShouldReturnDefault(string path, string key)
+	{
+		RealFileSystem fileSystem = new();
+		IFileInfo sut = fileSystem.FileInfo.New(path);
+		IFileSystemExtensibility? extensibility = sut as IFileSystemExtensibility;
+
+		object? result = extensibility!.RetrieveMetadata<object?>(key);
+
+		result.Should().BeNull();
+	}
+
+	[Theory]
+	[AutoData]
+	public void TryGetWrappedInstance_IncorrectType_ShouldReturnNull(string path)
+	{
+		RealFileSystem fileSystem = new();
+		IFileInfo sut = fileSystem.FileInfo.New(path);
+		IFileSystemExtensibility? extensibility = sut as IFileSystemExtensibility;
+
+		bool result = extensibility!.TryGetWrappedInstance(out DirectoryInfo? fileInfo);
+
+		result.Should().BeFalse();
+		fileInfo.Should().BeNull();
+	}
+
+	[Theory]
+	[AutoData]
+	public void TryGetWrappedInstance_ShouldReturnWrappedInstance(string path)
+	{
+		RealFileSystem fileSystem = new();
+		IFileInfo sut = fileSystem.FileInfo.New(path);
+		IFileSystemExtensibility? extensibility = sut as IFileSystemExtensibility;
+
+		bool result = extensibility!.TryGetWrappedInstance(out FileInfo? fileInfo);
+
+		result.Should().BeTrue();
+		fileInfo.Should().NotBeNull();
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/Internal/FileSystemInfoWrapperTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Internal/FileSystemInfoWrapperTests.cs
@@ -1,0 +1,41 @@
+﻿using System.IO;
+
+namespace Testably.Abstractions.Tests.Internal;
+
+public class FileSystemInfoWrapperTests
+{
+	[Fact]
+	public void FromFileSystemInfo_Null_ShouldReturnNull()
+	{
+		RealFileSystem fileSystem = new();
+
+		FileSystemInfoWrapper? result = FileSystemInfoWrapper
+			.FromFileSystemInfo(null, fileSystem);
+
+		result.Should().BeNull();
+	}
+
+	[Theory]
+	[AutoData]
+	public void FromFileSystemInfo_WithDirectoryInfo_ShouldReturnDirectoryInfoWrapper(string path)
+	{
+		RealFileSystem fileSystem = new();
+
+		FileSystemInfoWrapper result = FileSystemInfoWrapper
+			.FromFileSystemInfo(new DirectoryInfo(path), fileSystem);
+
+		result.Should().BeOfType<DirectoryInfoWrapper>();
+	}
+
+	[Theory]
+	[AutoData]
+	public void FromFileSystemInfo_WithFileInfo_ShouldReturnFileInfoWrapper(string path)
+	{
+		RealFileSystem fileSystem = new();
+
+		FileSystemInfoWrapper result = FileSystemInfoWrapper
+			.FromFileSystemInfo(new FileInfo(path), fileSystem);
+
+		result.Should().BeOfType<FileInfoWrapper>();
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/Internal/FileSystemWatcherWrapperTests.cs
+++ b/Tests/Testably.Abstractions.Tests/Internal/FileSystemWatcherWrapperTests.cs
@@ -1,0 +1,15 @@
+﻿namespace Testably.Abstractions.Tests.Internal;
+
+public class FileSystemWatcherWrapperTests
+{
+	[Fact]
+	public void FromFileSystemWatcher_Null_ShouldReturnNull()
+	{
+		RealFileSystem fileSystem = new();
+
+		using FileSystemWatcherWrapper? result = FileSystemWatcherWrapper
+			.FromFileSystemWatcher(null, fileSystem);
+
+		result.Should().BeNull();
+	}
+}


### PR DESCRIPTION
Add tests for internal functionality of the `RealFileSystem` to test edge cases.