### PR TITLE
fix: sonar issues

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
@@ -110,8 +110,10 @@ public static class FileSystemInitializerExtensions
 			int lastSeparator = fileName.LastIndexOf(Path.DirectorySeparatorChar);
 			if (lastSeparator > 0)
 			{
+				#pragma warning disable CA1845
 				fileName = fileName.Substring(0, lastSeparator) + "." +
 				           fileName.Substring(lastSeparator + 1);
+				#pragma warning restore CA1845
 			}
 
 			if (relativePath != null)
@@ -124,11 +126,13 @@ public static class FileSystemInitializerExtensions
 				fileName = fileName.Substring(relativePath.Length);
 			}
 
+			#pragma warning disable CA2249 // string.Contains with char is not supported on netstandard2.0
 			if (!enumerationOptions.RecurseSubdirectories &&
 			    fileName.IndexOf(Path.DirectorySeparatorChar) >= 0)
 			{
 				continue;
 			}
+			#pragma warning restore CA2249
 
 			if (EnumerationOptionsHelper.MatchesPattern(enumerationOptions,
 				fileName, searchPattern))


### PR DESCRIPTION
Fix two sonar issues in `FileSystemInitializerExtensions.cs`:
- Use span-based 'string.Concat' and 'AsSpan' instead of 'Substring'
- Use 'string.Contains' instead of 'string.IndexOf' to improve readability

Both issues are deactivated via `#pragma` directives, as the issues don't work under `netstandard2.0`.