### PR TITLE
fix: set `Directory` attribute correctly

### DIFF
--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -254,6 +254,15 @@ internal class InMemoryContainer : IStorageContainer
 			attributes |= FileAttributes.Encrypted;
 		}
 
+		if (Type == FileSystemTypes.Directory)
+		{
+			attributes |= FileAttributes.Directory;
+		}
+		else if (Type == FileSystemTypes.File)
+		{
+			attributes &= ~FileAttributes.Directory;
+		}
+
 		if (attributes == 0)
 		{
 			return FileAttributes.Normal;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/AttributesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/AttributesTests.cs
@@ -9,6 +9,20 @@ public abstract partial class AttributesTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
+	public void Attributes_ClearAllAttributes_ShouldRemainDirectory(string path)
+	{
+		FileSystem.Directory.CreateDirectory(path);
+		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
+
+		sut.Attributes = 0;
+
+		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.File.Exists(path).Should().BeFalse();
+		sut.Attributes.Should().HaveFlag(FileAttributes.Directory);
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void Attributes_WhenFileIsExisting_SetterShouldChangeAttributesOnFileSystem(
 		string path, FileAttributes attributes)
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/SetAttributesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/SetAttributesTests.cs
@@ -38,4 +38,16 @@ public abstract partial class SetAttributesTests<TFileSystem>
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);
 	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void SetAttributes_Directory_ShouldRemainFile(string path)
+	{
+		FileSystem.File.WriteAllText(path, null);
+
+		FileSystem.File.SetAttributes(path, FileAttributes.Directory);
+
+		FileSystem.Directory.Exists(path).Should().BeFalse();
+		FileSystem.File.Exists(path).Should().BeTrue();
+	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AttributesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AttributesTests.cs
@@ -1,0 +1,31 @@
+using System.IO;
+
+namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
+
+// ReSharper disable once PartialTypeWithSinglePart
+public abstract partial class AttributesTests<TFileSystem>
+	: FileSystemTestBase<TFileSystem>
+	where TFileSystem : IFileSystem
+{
+	[SkippableTheory]
+	[AutoData]
+	public void Attributes_SetDirectoryAttribute_ShouldRemainFile(string path)
+	{
+		FileSystem.File.WriteAllText(path, "foo");
+		IFileInfo sut = FileSystem.FileInfo.New(path);
+
+		sut.Attributes = FileAttributes.Directory;
+
+		sut.Attributes.Should().NotHaveFlag(FileAttributes.Directory);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void Attributes_ShouldNotHaveDirectoryAttribute(string path)
+	{
+		FileSystem.File.WriteAllText(path, "foo");
+		IFileInfo sut = FileSystem.FileInfo.New(path);
+
+		sut.Attributes.Should().NotHaveFlag(FileAttributes.Directory);
+	}
+}


### PR DESCRIPTION
Inspired by https://github.com/TestableIO/System.IO.Abstractions/issues/957:
Correctly set the `Directory` attribute on the mocked file system.