### PR TITLE
feat: make Random.Shared thread-static singleton

### DIFF
--- a/Source/Testably.Abstractions.Testing/RandomSystem/RandomFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/RandomSystem/RandomFactoryMock.cs
@@ -1,4 +1,5 @@
-﻿using Testably.Abstractions.RandomSystem;
+﻿using System;
+using Testably.Abstractions.RandomSystem;
 
 namespace Testably.Abstractions.Testing.RandomSystem;
 

--- a/Source/Testably.Abstractions.Testing/RandomSystem/RandomProviderMock.cs
+++ b/Source/Testably.Abstractions.Testing/RandomSystem/RandomProviderMock.cs
@@ -6,6 +6,8 @@ namespace Testably.Abstractions.Testing.RandomSystem;
 
 internal sealed class RandomProviderMock : IRandomProvider
 {
+	[ThreadStatic] private static IRandom? _shared;
+
 	private static Generator<Guid> DefaultGuidGenerator
 		=> Generator<Guid>.FromCallback(Guid.NewGuid);
 
@@ -33,5 +35,12 @@ internal sealed class RandomProviderMock : IRandomProvider
 	#endregion
 
 	private IRandom DefaultRandomGenerator(int seed)
-		=> new RandomMock(seed: seed);
+	{
+		if (seed == SharedSeed)
+		{
+			return _shared ??= new RandomMock(seed: SharedSeed);
+		}
+
+		return new RandomMock(seed: seed);
+	}
 }

--- a/Source/Testably.Abstractions.Testing/RandomSystem/RandomProviderMock.cs
+++ b/Source/Testably.Abstractions.Testing/RandomSystem/RandomProviderMock.cs
@@ -34,7 +34,7 @@ internal sealed class RandomProviderMock : IRandomProvider
 
 	#endregion
 
-	private IRandom DefaultRandomGenerator(int seed)
+	private static IRandom DefaultRandomGenerator(int seed)
 	{
 		if (seed == SharedSeed)
 		{

--- a/Tests/Testably.Abstractions.Tests/RandomSystem/RandomFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/RandomSystem/RandomFactoryTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Testably.Abstractions.RandomSystem;
 
 namespace Testably.Abstractions.Tests.RandomSystem;
 
@@ -46,5 +47,14 @@ public abstract partial class RandomFactoryTests<TRandomSystem>
 		}
 
 		results.Should().OnlyHaveUniqueItems();
+	}
+
+	[SkippableFact]
+	public void Shared_ShouldReturnSameReference()
+	{
+		IRandom shared1 = RandomSystem.Random.Shared;
+		IRandom shared2 = RandomSystem.Random.Shared;
+
+		shared1.Should().Be(shared2);
 	}
 }


### PR DESCRIPTION
IRandomSystem.Random.Shared should be a thread-static singleton instance (same as on the real [Random](https://learn.microsoft.com/en-us/dotnet/api/system.random.shared#system-random-shared) class).