### PR TITLE
fix: throw correct exception when creating a file or directory when a conflicting directory or file already exists

### DIFF
--- a/Examples/ZipFile/ZipFile/ZipFileHelper.cs
+++ b/Examples/ZipFile/ZipFile/ZipFileHelper.cs
@@ -54,10 +54,13 @@ public sealed class ZipFileHelper
 			{
 				_fileSystem.Directory.CreateDirectory(directoryPath);
 			}
-
-			using MemoryStream ms = new();
-			entry.Open().CopyTo(ms);
-			_fileSystem.File.WriteAllBytes(filePath, ms.ToArray());
+			
+			if (!entry.FullName.EndsWith("/"))
+			{
+				using MemoryStream ms = new();
+				entry.Open().CopyTo(ms);
+				_fileSystem.File.WriteAllBytes(filePath, ms.ToArray());
+			}
 		}
 	}
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
@@ -46,6 +46,11 @@ internal sealed class DirectoryInfoMock
 			InMemoryContainer.NewDirectory,
 			this);
 
+		if (Container.Type != FileSystemTypes.Directory)
+		{
+			throw ExceptionFactory.CannotCreateFileAsAlreadyExists(FullName);
+		}
+
 		ResetCache(!Execute.IsNetFramework);
 	}
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -799,9 +799,10 @@ internal sealed class FileMock : IFile
 			return;
 		}
 
-		if (container.Type != FileSystemTypes.File)
+		if (container.Type == FileSystemTypes.Directory)
 		{
-			throw ExceptionFactory.AccessToPathDenied(path);
+			throw ExceptionFactory.AccessToPathDenied(path,
+				hResult: Execute.IsWindows ? -2147024891 : 17);
 		}
 
 		Execute.OnWindowsIf(
@@ -889,9 +890,10 @@ internal sealed class FileMock : IFile
 			return;
 		}
 
-		if (container.Type != FileSystemTypes.File)
+		if (container.Type == FileSystemTypes.Directory)
 		{
-			throw ExceptionFactory.AccessToPathDenied(path);
+			throw ExceptionFactory.AccessToPathDenied(path,
+				hResult: Execute.IsWindows ? - 2147024891 : 17);
 		}
 
 		if (contents != null)

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -799,10 +799,9 @@ internal sealed class FileMock : IFile
 			return;
 		}
 
-		if (container.Type == FileSystemTypes.Directory)
+		if (container.Type != FileSystemTypes.File)
 		{
-			throw ExceptionFactory.AccessToPathDenied(path,
-				hResult: Execute.IsWindows ? -2147024891 : 17);
+			throw ExceptionFactory.AccessToPathDenied(path);
 		}
 
 		Execute.OnWindowsIf(
@@ -890,10 +889,9 @@ internal sealed class FileMock : IFile
 			return;
 		}
 
-		if (container.Type == FileSystemTypes.Directory)
+		if (container.Type != FileSystemTypes.File)
 		{
-			throw ExceptionFactory.AccessToPathDenied(path,
-				hResult: Execute.IsWindows ? - 2147024891 : 17);
+			throw ExceptionFactory.AccessToPathDenied(path);
 		}
 
 		if (contents != null)

--- a/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
@@ -31,13 +31,13 @@ internal static class ExceptionFactory
 			"Unable seek backward to overwrite data that previously existed in a file opened in Append mode.",
 			-2146232800);
 
-	internal static UnauthorizedAccessException AccessToPathDenied(string path = "", int hResult = -2147024891)
+	internal static UnauthorizedAccessException AccessToPathDenied(string path = "")
 		=> new(string.IsNullOrEmpty(path)
 			? "Access to the path is denied."
 			: $"Access to the path '{path}' is denied.")
 		{
 #if FEATURE_EXCEPTION_HRESULT
-			HResult = hResult
+			HResult = -2147024891
 #endif
 		};
 

--- a/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
@@ -31,13 +31,13 @@ internal static class ExceptionFactory
 			"Unable seek backward to overwrite data that previously existed in a file opened in Append mode.",
 			-2146232800);
 
-	internal static UnauthorizedAccessException AccessToPathDenied(string path = "")
+	internal static UnauthorizedAccessException AccessToPathDenied(string path = "", int hResult = -2147024891)
 		=> new(string.IsNullOrEmpty(path)
 			? "Access to the path is denied."
 			: $"Access to the path '{path}' is denied.")
 		{
 #if FEATURE_EXCEPTION_HRESULT
-			HResult = -2147024891
+			HResult = hResult
 #endif
 		};
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -61,7 +61,8 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 			FileSystem.Directory.CreateDirectory(name);
 		});
 
-		exception.Should().BeException<IOException>(hResult: -2147024713);
+		exception.Should().BeException<IOException>(
+			hResult: Test.RunsOnWindows ? -2147024713 : 17);
 		FileSystem.Directory.Exists(name).Should().BeFalse();
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -50,6 +50,21 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 		}
 	}
 
+	[SkippableTheory]
+	[AutoData]
+	public void CreateDirectory_FileWithSameNameAlreadyExists_ShouldThrowIOException(string name)
+	{
+		FileSystem.File.WriteAllText(name, "");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.Directory.CreateDirectory(name);
+		});
+
+		exception.Should().BeException<IOException>(hResult: -2147024713);
+		FileSystem.Directory.Exists(name).Should().BeFalse();
+	}
+
 	[SkippableFact]
 	public void CreateDirectory_Root_ShouldNotThrowException()
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateSubdirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateSubdirectoryTests.cs
@@ -20,7 +20,8 @@ public abstract partial class CreateSubdirectoryTests<TFileSystem>
 			sut.CreateSubdirectory(name);
 		});
 
-		exception.Should().BeException<IOException>(hResult: -2147024713);
+		exception.Should().BeException<IOException>(
+			hResult: Test.RunsOnWindows ? -2147024713 : 17);
 		FileSystem.Directory.Exists(name).Should().BeFalse();
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateSubdirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateSubdirectoryTests.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 
 // ReSharper disable once PartialTypeWithSinglePart
@@ -5,6 +7,23 @@ public abstract partial class CreateSubdirectoryTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
+	[SkippableTheory]
+	[AutoData]
+	public void CreateSubdirectory_FileWithSameNameAlreadyExists_ShouldThrowIOException(
+		string name)
+	{
+		FileSystem.File.WriteAllText(name, "");
+		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(".");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.CreateSubdirectory(name);
+		});
+
+		exception.Should().BeException<IOException>(hResult: -2147024713);
+		FileSystem.Directory.Exists(name).Should().BeFalse();
+	}
+
 	[SkippableTheory]
 	[AutoData]
 	public void CreateSubdirectory_MissingParent_ShouldCreateDirectory(

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
@@ -19,7 +19,8 @@ public abstract partial class CreateTests<TFileSystem>
 			sut.Create();
 		});
 
-		exception.Should().BeException<IOException>(hResult: -2147024713);
+		exception.Should().BeException<IOException>(
+			hResult: Test.RunsOnWindows ? -2147024713 : 17);
 		FileSystem.Directory.Exists(name).Should().BeFalse();
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 
 // ReSharper disable once PartialTypeWithSinglePart
@@ -5,6 +7,22 @@ public abstract partial class CreateTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
+	[SkippableTheory]
+	[AutoData]
+	public void Create_FileWithSameNameAlreadyExists_ShouldThrowIOException(string name)
+	{
+		FileSystem.File.WriteAllText(name, "");
+		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(name);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Create();
+		});
+
+		exception.Should().BeException<IOException>(hResult: -2147024713);
+		FileSystem.Directory.Exists(name).Should().BeFalse();
+	}
+
 	[SkippableTheory]
 	[AutoData]
 	public void Create_ShouldCreateDirectory(string path)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
@@ -131,6 +131,25 @@ public abstract partial class AppendAllLinesAsyncTests<TFileSystem>
 	}
 
 	[SkippableTheory]
+	[AutoData]
+	public async Task
+		AppendAllLinesAsync_WhenDirectoryWithSameNameExists_ShouldThrowUnauthorizedAccessException(
+			string path, string[] contents)
+	{
+		FileSystem.Directory.CreateDirectory(path);
+
+		Exception? exception = await Record.ExceptionAsync(async () =>
+		{
+			await FileSystem.File.AppendAllLinesAsync(path, contents);
+		});
+
+		exception.Should().BeException<UnauthorizedAccessException>(
+			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.File.Exists(path).Should().BeFalse();
+	}
+
+	[SkippableTheory]
 	[ClassData(typeof(TestDataGetEncodingDifference))]
 	public async Task
 		AppendAllLinesAsync_WithDifferentEncoding_ShouldNotReturnWrittenText(

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
@@ -144,7 +144,7 @@ public abstract partial class AppendAllLinesAsyncTests<TFileSystem>
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(
-			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+			hResult: -2147024891);
 		FileSystem.Directory.Exists(path).Should().BeTrue();
 		FileSystem.File.Exists(path).Should().BeFalse();
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
@@ -83,6 +83,25 @@ public abstract partial class AppendAllLinesTests<TFileSystem>
 	}
 
 	[SkippableTheory]
+	[AutoData]
+	public void
+		AppendAllLines_WhenDirectoryWithSameNameExists_ShouldThrowUnauthorizedAccessException(
+			string path, string[] contents)
+	{
+		FileSystem.Directory.CreateDirectory(path);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.AppendAllLines(path, contents);
+		});
+
+		exception.Should().BeException<UnauthorizedAccessException>(
+			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.File.Exists(path).Should().BeFalse();
+	}
+
+	[SkippableTheory]
 	[ClassData(typeof(TestDataGetEncodingDifference))]
 	public void AppendAllLines_WithDifferentEncoding_ShouldNotReturnWrittenText(
 		string specialLine, Encoding writeEncoding, Encoding readEncoding)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
@@ -96,7 +96,7 @@ public abstract partial class AppendAllLinesTests<TFileSystem>
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(
-			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+			hResult: -2147024891);
 		FileSystem.Directory.Exists(path).Should().BeTrue();
 		FileSystem.File.Exists(path).Should().BeFalse();
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
@@ -93,6 +93,25 @@ public abstract partial class AppendAllTextAsyncTests<TFileSystem>
 	}
 
 	[SkippableTheory]
+	[AutoData]
+	public async Task
+		AppendAllTextAsync_WhenDirectoryWithSameNameExists_ShouldThrowUnauthorizedAccessException(
+			string path, string contents)
+	{
+		FileSystem.Directory.CreateDirectory(path);
+
+		Exception? exception = await Record.ExceptionAsync(async () =>
+		{
+			await FileSystem.File.AppendAllTextAsync(path, contents);
+		});
+
+		exception.Should().BeException<UnauthorizedAccessException>(
+			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.File.Exists(path).Should().BeFalse();
+	}
+
+	[SkippableTheory]
 	[ClassData(typeof(TestDataGetEncodingDifference))]
 	public async Task AppendAllTextAsync_WithDifferentEncoding_ShouldNotReturnWrittenText(
 		string contents, Encoding writeEncoding, Encoding readEncoding)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
@@ -106,7 +106,7 @@ public abstract partial class AppendAllTextAsyncTests<TFileSystem>
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(
-			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+			hResult: -2147024891);
 		FileSystem.Directory.Exists(path).Should().BeTrue();
 		FileSystem.File.Exists(path).Should().BeFalse();
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
@@ -124,17 +124,22 @@ public abstract partial class AppendAllTextTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[ClassData(typeof(TestDataGetEncodingDifference))]
-	public void AppendAllText_WithDifferentEncoding_ShouldNotReturnWrittenText(
-		string contents, Encoding writeEncoding, Encoding readEncoding)
+	[AutoData]
+	public void
+		AppendAllText_WhenDirectoryWithSameNameExists_ShouldThrowUnauthorizedAccessException(
+			string path)
 	{
-		string path = new Fixture().Create<string>();
-		FileSystem.File.AppendAllText(path, contents, writeEncoding);
+		FileSystem.Directory.CreateDirectory(path);
 
-		string[] result = FileSystem.File.ReadAllLines(path, readEncoding);
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.AppendAllText(path, null);
+		});
 
-		result.Should().NotBeEquivalentTo(contents,
-			$"{contents} should be different when encoding from {writeEncoding} to {readEncoding}.");
+		exception.Should().BeException<UnauthorizedAccessException>(
+			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.File.Exists(path).Should().BeFalse();
 	}
 
 	[SkippableTheory]
@@ -151,5 +156,19 @@ public abstract partial class AppendAllTextTests<TFileSystem>
 		});
 
 		exception.Should().BeNull();
+	}
+
+	[SkippableTheory]
+	[ClassData(typeof(TestDataGetEncodingDifference))]
+	public void AppendAllText_WithDifferentEncoding_ShouldNotReturnWrittenText(
+		string contents, Encoding writeEncoding, Encoding readEncoding)
+	{
+		string path = new Fixture().Create<string>();
+		FileSystem.File.AppendAllText(path, contents, writeEncoding);
+
+		string[] result = FileSystem.File.ReadAllLines(path, readEncoding);
+
+		result.Should().NotBeEquivalentTo(contents,
+			$"{contents} should be different when encoding from {writeEncoding} to {readEncoding}.");
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
@@ -137,7 +137,7 @@ public abstract partial class AppendAllTextTests<TFileSystem>
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(
-			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+			hResult: -2147024891);
 		FileSystem.Directory.Exists(path).Should().BeTrue();
 		FileSystem.File.Exists(path).Should().BeFalse();
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesAsyncTests.cs
@@ -77,7 +77,7 @@ public abstract partial class WriteAllBytesAsyncTests<TFileSystem>
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(
-			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+			hResult: -2147024891);
 		FileSystem.Directory.Exists(path).Should().BeTrue();
 		FileSystem.File.Exists(path).Should().BeFalse();
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesAsyncTests.cs
@@ -66,6 +66,25 @@ public abstract partial class WriteAllBytesAsyncTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public async Task
+		WriteAllBytesAsync_WhenDirectoryWithSameNameExists_ShouldThrowUnauthorizedAccessException(
+			string path, byte[] bytes)
+	{
+		FileSystem.Directory.CreateDirectory(path);
+
+		Exception? exception = await Record.ExceptionAsync(async () =>
+		{
+			await FileSystem.File.WriteAllBytesAsync(path, bytes);
+		});
+
+		exception.Should().BeException<UnauthorizedAccessException>(
+			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.File.Exists(path).Should().BeFalse();
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public async Task
 		WriteAllTextAsync_WhenFileIsHidden_ShouldThrowUnauthorizedAccessException_OnWindows(
 			string path, byte[] bytes)
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesTests.cs
@@ -57,7 +57,7 @@ public abstract partial class WriteAllBytesTests<TFileSystem>
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(
-			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+			hResult: -2147024891);
 		FileSystem.Directory.Exists(path).Should().BeTrue();
 		FileSystem.File.Exists(path).Should().BeFalse();
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesTests.cs
@@ -23,6 +23,16 @@ public abstract partial class WriteAllBytesTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void WriteAllBytes_ShouldCreateFileWithBytes(string path, byte[] bytes)
+	{
+		FileSystem.File.WriteAllBytes(path, bytes);
+
+		byte[] result = FileSystem.File.ReadAllBytes(path);
+		result.Should().BeEquivalentTo(bytes);
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void WriteAllBytes_WhenBytesAreNull_ShouldThrowArgumentNullException(string path)
 	{
 		Exception? exception = Record.Exception(() =>
@@ -35,12 +45,21 @@ public abstract partial class WriteAllBytesTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void WriteAllBytes_ShouldCreateFileWithBytes(string path, byte[] bytes)
+	public void
+		WriteAllBytes_WhenDirectoryWithSameNameExists_ShouldThrowUnauthorizedAccessException(
+			string path, byte[] bytes)
 	{
-		FileSystem.File.WriteAllBytes(path, bytes);
+		FileSystem.Directory.CreateDirectory(path);
 
-		byte[] result = FileSystem.File.ReadAllBytes(path);
-		result.Should().BeEquivalentTo(bytes);
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.WriteAllBytes(path, bytes);
+		});
+
+		exception.Should().BeException<UnauthorizedAccessException>(
+			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.File.Exists(path).Should().BeFalse();
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesAsyncTests.cs
@@ -135,7 +135,7 @@ public abstract partial class WriteAllLinesAsyncTests<TFileSystem>
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(
-			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+			hResult: -2147024891);
 		FileSystem.Directory.Exists(path).Should().BeTrue();
 		FileSystem.File.Exists(path).Should().BeFalse();
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesAsyncTests.cs
@@ -124,6 +124,25 @@ public abstract partial class WriteAllLinesAsyncTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public async Task
+		WriteAllLinesAsync_WhenDirectoryWithSameNameExists_ShouldThrowUnauthorizedAccessException(
+			string path, string[] contents)
+	{
+		FileSystem.Directory.CreateDirectory(path);
+
+		Exception? exception = await Record.ExceptionAsync(async () =>
+		{
+			await FileSystem.File.WriteAllLinesAsync(path, contents);
+		});
+
+		exception.Should().BeException<UnauthorizedAccessException>(
+			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.File.Exists(path).Should().BeFalse();
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public async Task
 		WriteAllLinesAsync_WhenFileIsHidden_ShouldThrowUnauthorizedAccessException_OnWindows(
 			string path, string[] contents)
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesTests.cs
@@ -69,13 +69,21 @@ public abstract partial class WriteAllLinesTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void WriteAllLines_WithEncoding_ShouldCreateFileWithText(
-		Encoding encoding, string path, string[] contents)
+	public void
+		WriteAllLines_WhenDirectoryWithSameNameExists_ShouldThrowUnauthorizedAccessException(
+			string path, string[] contents)
 	{
-		FileSystem.File.WriteAllLines(path, contents, encoding);
+		FileSystem.Directory.CreateDirectory(path);
 
-		string[] result = FileSystem.File.ReadAllLines(path, encoding);
-		result.Should().BeEquivalentTo(contents, o => o.WithStrictOrdering());
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.WriteAllLines(path, contents);
+		});
+
+		exception.Should().BeException<UnauthorizedAccessException>(
+			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.File.Exists(path).Should().BeFalse();
 	}
 
 	[SkippableTheory]
@@ -94,5 +102,16 @@ public abstract partial class WriteAllLinesTests<TFileSystem>
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(hResult: -2147024891);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void WriteAllLines_WithEncoding_ShouldCreateFileWithText(
+		Encoding encoding, string path, string[] contents)
+	{
+		FileSystem.File.WriteAllLines(path, contents, encoding);
+
+		string[] result = FileSystem.File.ReadAllLines(path, encoding);
+		result.Should().BeEquivalentTo(contents, o => o.WithStrictOrdering());
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesTests.cs
@@ -81,7 +81,7 @@ public abstract partial class WriteAllLinesTests<TFileSystem>
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(
-			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+			hResult: -2147024891);
 		FileSystem.Directory.Exists(path).Should().BeTrue();
 		FileSystem.File.Exists(path).Should().BeFalse();
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextAsyncTests.cs
@@ -118,7 +118,7 @@ public abstract partial class WriteAllTextAsyncTests<TFileSystem>
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(
-			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+			hResult: -2147024891);
 		FileSystem.Directory.Exists(path).Should().BeTrue();
 		FileSystem.File.Exists(path).Should().BeFalse();
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextAsyncTests.cs
@@ -107,6 +107,25 @@ public abstract partial class WriteAllTextAsyncTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public async Task
+		WriteAllTextAsync_WhenDirectoryWithSameNameExists_ShouldThrowUnauthorizedAccessException(
+			string path, string contents)
+	{
+		FileSystem.Directory.CreateDirectory(path);
+
+		Exception? exception = await Record.ExceptionAsync(async () =>
+		{
+			await FileSystem.File.WriteAllTextAsync(path, contents);
+		});
+
+		exception.Should().BeException<UnauthorizedAccessException>(
+			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.File.Exists(path).Should().BeFalse();
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public async Task
 		WriteAllTextAsync_WhenFileIsHidden_ShouldThrowUnauthorizedAccessException_OnWindows(
 			string path, string contents)
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -151,6 +151,24 @@ public abstract partial class WriteAllTextTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void WriteAllText_WhenDirectoryWithSameNameExists_ShouldThrowUnauthorizedAccessException(
+		string path)
+	{
+		FileSystem.Directory.CreateDirectory(path);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.WriteAllText(path, null);
+		});
+
+		exception.Should().BeException<UnauthorizedAccessException>(
+			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.File.Exists(path).Should().BeFalse();
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void WriteAllText_WhenFileIsHidden_ShouldThrowUnauthorizedAccessException_OnWindows(
 		string path, string contents)
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -162,7 +162,7 @@ public abstract partial class WriteAllTextTests<TFileSystem>
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(
-			hResult: Test.RunsOnWindows ? -2147024891 : 17);
+			hResult: -2147024891);
 		FileSystem.Directory.Exists(path).Should().BeTrue();
 		FileSystem.File.Exists(path).Should().BeFalse();
 	}


### PR DESCRIPTION
Fix the issue described in https://github.com/TestableIO/System.IO.Abstractions/issues/968.