### PR TITLE
fix: support rooted paths under Windows

### DIFF
--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -265,7 +265,7 @@ internal sealed class InMemoryStorage : IStorage
 
 		IStorageDrive? drive = _fileSystem.Storage.GetDrive(path);
 		if (drive == null &&
-		    !_fileSystem.Path.IsPathRooted(path))
+		    !path.IsUncPath())
 		{
 			drive = _fileSystem.Storage.MainDrive;
 		}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetRelativePathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetRelativePathTests.cs
@@ -55,6 +55,8 @@ public abstract partial class GetRelativePathTests<TFileSystem>
 	[SkippableFact]
 	public void GetRelativePath_RootedPath_ShouldWorkOnAnyDrive()
 	{
+		Skip.IfNot(Test.RunsOnWindows);
+		
 		string rootedPath = "/dir/subDirectory";
 		FileSystem.Directory.CreateDirectory(rootedPath);
 		string directory = FileSystem.Directory.GetDirectories("/dir").Single();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetRelativePathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetRelativePathTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 #if FEATURE_PATH_RELATIVE
 namespace Testably.Abstractions.Tests.FileSystem.Path;
 
@@ -49,6 +50,18 @@ public abstract partial class GetRelativePathTests<TFileSystem>
 		string result = FileSystem.Path.GetRelativePath(path1, path2);
 
 		result.Should().Be(expectedRelativePath);
+	}
+
+	[SkippableFact]
+	public void GetRelativePath_RootedPath_ShouldWorkOnAnyDrive()
+	{
+		string rootedPath = "/dir/subDirectory";
+		FileSystem.Directory.CreateDirectory(rootedPath);
+		string directory = FileSystem.Directory.GetDirectories("/dir").Single();
+
+		string result = FileSystem.Path.GetRelativePath("/dir", directory);
+
+		result.Should().Be("subDirectory");
 	}
 
 	[SkippableTheory]


### PR DESCRIPTION
Support rooted paths under Windows and ensure that Path.GetRelativePath works on multiple drives.

*This tests and fixes https://github.com/TestableIO/System.IO.Abstractions/issues/728 in Testably.Abstractions...*