### PR TITLE
doc: add a changelog batch to the README.md for nuget packages

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
           types: |
             chore
             coverage
-            docs
+            doc
             feat
             fix
             refactor

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
           types: |
             chore
             coverage
-            doc
+            docs
             feat
             fix
             refactor

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,11 +283,13 @@ jobs:
       - name: Prepare README.md
         shell: bash
         run: |
+          version="${GITHUB_REF#refs/heads/release/}"
+          # Add changelog badge to README.md
+          sed -i -e "2 a\[!\[Changelog](https:\/\/img\.shields\.io\/badge\/Changelog-${version}-blue)](https:\/\/github\.com\/Testably\/Testably\.Abstractions\/releases\/tag\/${version})" "./README.md"
           for f in "README.md" "Docs/AccessControl.md" "Docs/Compression.md" "Docs/Interface.md" "Docs/Testing.md"
           do
             echo "Processing $f" # always double quote "$f" filename
             # do something on $f
-            version="${GITHUB_REF#refs/heads/release/}"
             # Remove the codacy badge as it is not aligned to the release
             grep -v "Codacy Badge" "./$f" > "./$f.backup" && mv "./$f.backup" "./$f"
             # Change status badges to display explicit version


### PR DESCRIPTION
Add a changelog batch in the Nuget README.md that links to the Github Release for the generated release tag.

**Example-Badge:**
[![Changelog](https://img.shields.io/badge/Changelog-v2.2.0-blue)](https://github.com/Testably/Testably.Abstractions/releases/tag/v2.2.0)