### PR TITLE
feat: add initializer options to create the temporary directory.

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
@@ -38,9 +38,9 @@ public static class FileSystemInitializerExtensions
 
 		fileSystem.Directory.CreateDirectory(basePath);
 		fileSystem.Directory.SetCurrentDirectory(basePath);
-		FileSystemInitializerOptions value = new();
-		options?.Invoke(value);
-		if (value.InitializeTempDirectory)
+		FileSystemInitializerOptions optionsValue = new();
+		options?.Invoke(optionsValue);
+		if (optionsValue.InitializeTempDirectory)
 		{
 			fileSystem.Directory.CreateDirectory(Path.GetTempPath());
 		}

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
@@ -15,16 +15,18 @@ public static class FileSystemInitializerExtensions
 	///     Initializes the <see cref="IFileSystem" /> in the working directory with test data.
 	/// </summary>
 	public static IFileSystemInitializer<TFileSystem> Initialize<TFileSystem>(
-		this TFileSystem fileSystem)
+		this TFileSystem fileSystem,
+		Action<FileSystemInitializerOptions>? options = null)
 		where TFileSystem : IFileSystem
-		=> fileSystem.InitializeIn(".");
+		=> fileSystem.InitializeIn(".", options);
 
 	/// <summary>
 	///     Initializes the <see cref="IFileSystem" /> in the <paramref name="basePath" /> with test data.
 	/// </summary>
 	public static IFileSystemInitializer<TFileSystem> InitializeIn<TFileSystem>(
 		this TFileSystem fileSystem,
-		string basePath)
+		string basePath,
+		Action<FileSystemInitializerOptions>? options = null)
 		where TFileSystem : IFileSystem
 	{
 		if (Path.IsPathRooted(basePath) &&
@@ -36,6 +38,13 @@ public static class FileSystemInitializerExtensions
 
 		fileSystem.Directory.CreateDirectory(basePath);
 		fileSystem.Directory.SetCurrentDirectory(basePath);
+		FileSystemInitializerOptions value = new();
+		options?.Invoke(value);
+		if (value.InitializeTempDirectory)
+		{
+			fileSystem.Directory.CreateDirectory(Path.GetTempPath());
+		}
+
 		return new FileSystemInitializer<TFileSystem>(fileSystem, ".");
 	}
 

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializerOptions.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializerOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace Testably.Abstractions.Testing;
+
+/// <summary>
+///     Options for the file system initializer.
+/// </summary>
+public class FileSystemInitializerOptions
+{
+	/// <summary>
+	///     If set to <see langword="true" /> create the directory at <see cref="System.IO.Path.GetTempPath()" />.
+	/// </summary>
+	public bool InitializeTempDirectory { get; set; } = true;
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
@@ -112,6 +112,19 @@ public class FileSystemInitializerExtensionsTests
 	}
 
 	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public void Initialize_WithOptions_ShouldConsiderValueOfInitializeTempDirectory(
+		bool initializeTempDirectory)
+	{
+		MockFileSystem sut = new();
+
+		sut.Initialize(options => options.InitializeTempDirectory = initializeTempDirectory);
+
+		sut.Directory.Exists(sut.Path.GetTempPath()).Should().Be(initializeTempDirectory);
+	}
+
+	[Theory]
 	[AutoData]
 	public void Initialize_WithSubdirectory_Existing_ShouldThrowTestingException(
 		string directoryName)

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
@@ -33,7 +33,7 @@ public class FileSystemInitializerExtensionsTests
 	public void Initialize_WithASubdirectory_ShouldCreateDirectory()
 	{
 		MockFileSystem sut = new();
-		sut.Initialize().WithASubdirectory();
+		sut.InitializeIn("base-directory").WithASubdirectory();
 
 		sut.Directory.EnumerateDirectories(".").Should().ContainSingle();
 	}
@@ -97,7 +97,7 @@ public class FileSystemInitializerExtensionsTests
 	public void Initialize_WithNestedSubdirectories_ShouldCreateAllNestedDirectories()
 	{
 		MockFileSystem sut = new();
-		sut.Initialize()
+		sut.InitializeIn("base-directory")
 			.WithSubdirectory("foo").Initialized(d => d
 				.WithSubdirectory("bar").Initialized(s => s
 					.WithSubdirectory("xyz")));


### PR DESCRIPTION
Add options to the FileSystemInitializer with the option to automatically create the temporary directory.
If this is not set (or the file system is not initialized) `Path.GetTempPath()` will not exist.

This fixes the issue in System.IO.Abstractions: https://github.com/TestableIO/System.IO.Abstractions/issues/983