### PR TITLE
fix: run examples on windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
 
   test-examples:
     name: Test (Examples)
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3


### PR DESCRIPTION
As the examples now include Drive management examples, they should run on Windows.
The build and ci pipelines were updated with #299, but the release pipeline was overlooked.