### PR TITLE
coverage: Add tests for updating the cache for IFileInfo and IDirectoryInfo

### DIFF
--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
@@ -75,6 +75,31 @@ public abstract partial class CreateTests<TFileSystem>
 	}
 
 	[SkippableTheory]
+	[AutoData]
+	public void Create_ShouldRefreshExistsCache_ExceptOnNetFramework(string path)
+	{
+		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
+		IDirectoryInfo sut2 = FileSystem.DirectoryInfo.New(path);
+		sut.Exists.Should().BeFalse();
+		sut2.Exists.Should().BeFalse();
+
+		sut.Create();
+
+		if (Test.IsNetFramework)
+		{
+			sut.Exists.Should().BeFalse();
+			sut2.Exists.Should().BeFalse();
+		}
+		else
+		{
+			sut.Exists.Should().BeTrue();
+			sut2.Exists.Should().BeTrue();
+		}
+
+		FileSystem.Directory.Exists(path).Should().BeTrue();
+	}
+
+	[SkippableTheory]
 	[InlineData("")]
 	[InlineData("/")]
 	[InlineData("\\")]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTests.cs
@@ -24,17 +24,21 @@ public abstract partial class CreateTests<TFileSystem>
 	public void Create_ShouldRefreshExistsCache_ExceptOnNetFramework(string path)
 	{
 		IFileInfo sut = FileSystem.FileInfo.New(path);
+		IFileInfo sut2 = FileSystem.FileInfo.New(path);
 		sut.Exists.Should().BeFalse();
+		sut2.Exists.Should().BeFalse();
 
 		using FileSystemStream stream = sut.Create();
 
 		if (Test.IsNetFramework)
 		{
 			sut.Exists.Should().BeFalse();
+			sut2.Exists.Should().BeFalse();
 		}
 		else
 		{
 			sut.Exists.Should().BeTrue();
+			sut2.Exists.Should().BeTrue();
 		}
 
 		FileSystem.File.Exists(path).Should().BeTrue();


### PR DESCRIPTION
When creating a File or Directory the exists-cache for existing 