### PR TITLE
fix: failing tests on .NET framework

### DIFF
--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
@@ -91,7 +91,7 @@ public abstract partial class CreateTests<TFileSystem>
 		{
 			sut1.Exists.Should().BeFalse();
 			sut2.Exists.Should().BeFalse();
-			sut3.Exists.Should().BeFalse();
+			sut3.Exists.Should().BeTrue();
 		}
 		else
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTests.cs
@@ -36,7 +36,7 @@ public abstract partial class CreateTests<TFileSystem>
 		{
 			sut1.Exists.Should().BeFalse();
 			sut2.Exists.Should().BeFalse();
-			sut3.Exists.Should().BeFalse();
+			sut3.Exists.Should().BeTrue();
 		}
 		else
 		{


### PR DESCRIPTION
The tests `Create_ShouldRefreshExistsCacheForCurrentItem_ExceptOnNetFramework` introduced in #313 fail on .NET Framework.
![image](https://github.com/Testably/Testably.Abstractions/assets/3438234/c972da45-9232-40f6-b5e6-a7ae21cce75c)
