### PR TITLE
doc: include information for local testing against the `RealFileSystem`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,7 @@
 # Ignore the Directory.Build.props in the root directory so that
 # the setting of specific constants can improve the developer experience
-# without affecting the origin GIT repository:
-# - `SKIP_TESTS_ON_REAL_FILESYSTEM`
-#   By setting this flag, all tests against the real file system are skipped when in DEBUG mode.
-# - `INCLUDE_LONGRUNNING_TESTS_ALSO_IN_DEBUG_MODE`
-#   Per default, long-running tests against the real file system are skipped when in DEBUG mode. By setting this flag, these tests are run also in this mode.
-# - `EXECUTE_EXAMPLE_TESTS`
-#   Tests in the example projects are only executed when this flag is set.
+# without affecting the origin GIT repository.
+# > https://github.com/Testably/Testably.Abstractions/blob/main/CONTRIBUTING.md#tests
 /Directory.Build.props
 
 # Set up Visual Studio to use WSL to execute unit tests in Ubuntu:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,29 @@ In order to support this, static code analysis is performed using [SonarCloud](h
 
 Additionally each push to the `main` branch checks the quality of the unit tests using [Stryker.NET](https://stryker-mutator.io/docs/stryker-net/introduction/).
 
+## Tests
+On the build system, unit tests are executed both against the `MockFileSystem` and the `RealFileSystem`. This ensures that the tests verify correct assumptions.
+In order to simplify and speedup the development process, per default some tests are disabled in DEBUG mode. These can be enabled by adding a `Directory.Build.props` file in the root directory and set the corresponding constants:
+- [`ENABLE_REALFILESYSTEMTESTS_IN_DEBUG`](https://github.com/Testably/Testably.Abstractions/blob/main/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs#L59)  
+  If set, the classes for executing tests against the real file system are created also in DEBUG mode.
+- [`INCLUDE_LONGRUNNING_TESTS_ALSO_IN_DEBUG_MODE`](https://github.com/Testably/Testably.Abstractions/blob/main/Tests/Helpers/Testably.Abstractions.TestHelpers/Test.cs#L51)  
+  In order to increase the test execution speed during development, long running tests are disabled in DEBUG mode.
+  When this constant is set, the corresponding tests are no longer skipped.
+- [`SKIP_TESTS_ON_REAL_FILESYSTEM`](https://github.com/Testably/Testably.Abstractions/blob/main/Tests/Helpers/Testably.Abstractions.TestHelpers/Test.cs#L61)  
+  In order to avoid unnecessary side-effects on development machines, tests against the real file system are not executed in DEBUG mode.
+  When this constant is set, this restriction no longer applies.
+
+**Example:**
+```xml
+<Project>
+    <PropertyGroup>
+        <DefineConstants>$(DefineConstants);ENABLE_REALFILESYSTEMTESTS_IN_DEBUG</DefineConstants>
+    </PropertyGroup>
+</Project>
+```
+
+*Note: This file is excluded in [`.gitignore`](https://github.com/Testably/Testably.Abstractions/blob/main/.gitignore) and remains local!*
+
 ## Versioning
 This project uses [MinVer](https://github.com/adamralph/minver) for versioning.  
 Tags are automatically added during a release build. In order to trigger a release, create a release branch. After all tests are successful and the manual check is approved, that Tag is automatically applied and Nuget Packages are pushed to [nuget.org](https://www.nuget.org/packages/Testably.Abstractions).


### PR DESCRIPTION
Document the available constants to run tests against the `RealFileSystem` also on the local machine:
- [`ENABLE_REALFILESYSTEMTESTS_IN_DEBUG`](https://github.com/Testably/Testably.Abstractions/blob/main/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs#L59)  
  If set, the classes for executing tests against the real file system are created also in DEBUG mode.
- [`INCLUDE_LONGRUNNING_TESTS_ALSO_IN_DEBUG_MODE`](https://github.com/Testably/Testably.Abstractions/blob/main/Tests/Helpers/Testably.Abstractions.TestHelpers/Test.cs#L51)  
  In order to increase the test execution speed during development, long running tests are disabled in DEBUG mode.
  When this constant is set, the corresponding tests are no longer skipped.
- [`SKIP_TESTS_ON_REAL_FILESYSTEM`](https://github.com/Testably/Testably.Abstractions/blob/main/Tests/Helpers/Testably.Abstractions.TestHelpers/Test.cs#L61)  
  In order to avoid unnecessary side-effects on development machines, tests against the real file system are not executed in DEBUG mode.
  When this constant is set, this restriction no longer applies.