### PR TITLE
feat: Add a sample Directory.Build.props

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Additionally each push to the `main` branch checks the quality of the unit tests
 
 ## Tests
 On the build system, unit tests are executed both against the `MockFileSystem` and the `RealFileSystem`. This ensures that the tests verify correct assumptions.
-In order to simplify and speedup the development process, per default some tests are disabled in DEBUG mode. These can be enabled by adding a `Directory.Build.props` file in the root directory and set the corresponding constants:
+In order to simplify and speedup the development process, per default some tests are disabled in DEBUG mode. These can be enabled by editing the sample [`Directory.Build.props`](https://github.com/Testably/Testably.Abstractions/blob/main/Directory.Build.props) file in the root directory and set the corresponding constants:
 - [`ENABLE_REALFILESYSTEMTESTS_IN_DEBUG`](https://github.com/Testably/Testably.Abstractions/blob/main/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs#L59)  
   If set, the classes for executing tests against the real file system are created also in DEBUG mode.
 - [`INCLUDE_LONGRUNNING_TESTS_ALSO_IN_DEBUG_MODE`](https://github.com/Testably/Testably.Abstractions/blob/main/Tests/Helpers/Testably.Abstractions.TestHelpers/Test.cs#L51)  

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+	<PropertyGroup>
+		<!-- Uncomment a line to enable the desired behavior. See https://github.com/Testably/Testably.Abstractions/blob/main/CONTRIBUTING.md#tests for more information! -->
+
+		<!--<DefineConstants>$(DefineConstants);ENABLE_REALFILESYSTEMTESTS_IN_DEBUG</DefineConstants>-->
+		<!--<DefineConstants>$(DefineConstants);INCLUDE_LONGRUNNING_TESTS_ALSO_IN_DEBUG_MODE</DefineConstants>-->
+		<!--<DefineConstants>$(DefineConstants);SKIP_TESTS_ON_REAL_FILESYSTEM</DefineConstants>-->
+	</PropertyGroup>
+</Project>

--- a/Testably.Abstractions.sln
+++ b/Testably.Abstractions.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{94F99274-3518-45
 		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
 		CONTRIBUTING.md = CONTRIBUTING.md
 		Directory.Packages.props = Directory.Packages.props
+		Directory.Build.props = Directory.Build.props
 		Feature.Flags.props = Feature.Flags.props
 		LICENSE = LICENSE
 		nuget.config = nuget.config


### PR DESCRIPTION
I added a sample Directory.Build.props on the root path and adapted the CONTRIBUTING.md to simplify activating tests for the `RealFileSystem` 