### PR TITLE
fix: Remove single quotes from test

### DIFF
--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
@@ -21,7 +21,7 @@ public abstract partial class GetFilesTests<TFileSystem>
 			Record.Exception(()
 				=> FileSystem.Directory.GetFiles(path).ToList());
 
-		exception.Should().BeException<DirectoryNotFoundException>($"'{expectedPath}'.",
+		exception.Should().BeException<DirectoryNotFoundException>(expectedPath,
 			hResult: -2147024893);
 		FileSystem.Directory.Exists(path).Should().BeFalse();
 	}


### PR DESCRIPTION
The `GetFiles_MissingDirectory_ShouldThrowDirectoryNotFoundException` test failed because exceptions are thrown in German on my system and with double quotes, therefore I deleted the quotes from the assertion.