### PR TITLE
fix: Support relative paths with multiple subfolders in Directory.GetFiles

### DIFF
--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
@@ -45,7 +45,7 @@ internal static class FileSystemExtensions
 			return fullFilePath;
 		}
 
-		string currentDirectory = fileSystem.Directory.GetCurrentDirectory();
+		string currentDirectory = fileSystem.Path.GetFullPath(givenPath);
 		if (currentDirectory == string.Empty.PrefixRoot())
 		{
 			fullFilePath = fullFilePath.Substring(currentDirectory.Length);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
@@ -12,24 +12,6 @@ public abstract partial class GetFilesTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
-	public void GetFiles_WithRelativePathAndSubfolders_ShouldReturnRelativeFilePath(string subfolder1, string subfolder2, string[] files)
-	{
-		string workingDirectory = System.IO.Path.Combine(BasePath, subfolder1, subfolder2);
-		FileSystem.Directory.CreateDirectory(workingDirectory);
-		foreach (string file in files)
-		{
-			FileSystem.File.Create(System.IO.Path.Combine(workingDirectory, file));
-		}
-		
-		FileSystem.Directory.SetCurrentDirectory($@".\{subfolder1}");
-		var result = FileSystem.Directory.GetFiles($@"..\{subfolder1}\{subfolder2}").ToList();
-
-		IEnumerable<string> expectation = files.Select(f => System.IO.Path.Combine("..", subfolder1, subfolder2, f));
-		result.Should().BeEquivalentTo(expectation);
-	}
-
-	[SkippableTheory]
-	[AutoData]
 	public void
 		GetFiles_MissingDirectory_ShouldThrowDirectoryNotFoundException(
 			string path)
@@ -190,6 +172,27 @@ public abstract partial class GetFilesTests<TFileSystem>
 		result.Should().Contain(initialized[0].ToString());
 		result.Should().Contain(initialized[1].ToString());
 		result.Should().NotContain(initialized[3].ToString());
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void GetFiles_WithRelativePathAndSubfolders_ShouldReturnRelativeFilePath(
+		string subfolder1, string subfolder2, string[] files)
+	{
+		string workingDirectory = System.IO.Path.Combine(BasePath, subfolder1, subfolder2);
+		FileSystem.Directory.CreateDirectory(workingDirectory);
+		foreach (string file in files)
+		{
+			FileSystem.File.Create(System.IO.Path.Combine(workingDirectory, file));
+		}
+		FileSystem.Directory.SetCurrentDirectory(subfolder1);
+		IEnumerable<string> expectation =
+			files.Select(f => System.IO.Path.Combine("..", subfolder1, subfolder2, f));
+		var path = System.IO.Path.Combine("..", subfolder1, subfolder2);
+
+		List<string> result = FileSystem.Directory.GetFiles(path).ToList();
+
+		result.Should().BeEquivalentTo(expectation);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
@@ -12,6 +12,24 @@ public abstract partial class GetFilesTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
+	public void GetFiles_WithRelativePathAndSubfolders_ShouldReturnRelativeFilePath(string subfolder1, string subfolder2, string[] files)
+	{
+		string workingDirectory = System.IO.Path.Combine(BasePath, subfolder1, subfolder2);
+		FileSystem.Directory.CreateDirectory(workingDirectory);
+		foreach (string file in files)
+		{
+			FileSystem.File.Create(System.IO.Path.Combine(workingDirectory, file));
+		}
+		
+		FileSystem.Directory.SetCurrentDirectory($@".\{subfolder1}");
+		var result = FileSystem.Directory.GetFiles($@"..\{subfolder1}\{subfolder2}").ToList();
+
+		IEnumerable<string> expectation = files.Select(f => System.IO.Path.Combine("..", subfolder1, subfolder2, f));
+		result.Should().BeEquivalentTo(expectation);
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void
 		GetFiles_MissingDirectory_ShouldThrowDirectoryNotFoundException(
 			string path)


### PR DESCRIPTION
`FileSystem.Directory.GetFiles(string path)` returns an invalid file path when the argument consists of `..` and two subfolders, when the current directory was located in the first subfolder.
The returned file path contains the second subfolder twice. (e.g. `..\subfolder1\subfolder2\subfolder2\file.txt`)
