### PR TITLE
fix: parameter validation in `Path.GetFullPath`

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
@@ -55,6 +55,11 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 	/// <inheritdoc cref="IFileSystemInfo.CreateAsSymbolicLink(string)" />
 	public void CreateAsSymbolicLink(string pathToTarget)
 	{
+		if (!Execute.IsWindows && string.IsNullOrWhiteSpace(FullName))
+		{
+			return;
+		}
+
 		FullName.EnsureValidFormat(_fileSystem);
 		pathToTarget.ThrowCommonExceptionsIfPathToTargetIsInvalid(_fileSystem);
 		if (_fileSystem.Storage.TryAddContainer(Location, InMemoryContainer.NewFile,

--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -34,10 +34,7 @@ internal sealed class PathMock : PathSystemBase
 	/// <inheritdoc cref="IPath.GetFullPath(string)" />
 	public override string GetFullPath(string path)
 	{
-		if (string.IsNullOrEmpty(path))
-		{
-			return string.Empty;
-		}
+		path.EnsureValidArgument(FileSystem, nameof(path));
 
 		return Path.GetFullPath(Path.Combine(
 			_fileSystem.Storage.CurrentDirectory,

--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Testably.Abstractions.Helpers;
+using Testably.Abstractions.Testing.Helpers;
 #if FEATURE_FILESYSTEM_NET7
 using System.Diagnostics.CodeAnalysis;
 using Testably.Abstractions.Testing.Storage;

--- a/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
@@ -72,16 +72,15 @@ internal static class PathHelper
 
 	/// <summary>
 	///     Get the <see cref="IPath.GetFullPath(string)" /> of the <paramref name="path" />
-	///     or an empty string, if <paramref name="path" /> is <see langword="null" /> or empty.
+	///     if the <paramref name="path" /> is not <see langword="null" /> or white space.<br />
+	///     Otherwise an empty string if the <paramref name="path" /> is <see langword="null" />
+	///     or the <paramref name="path" /> itself.
 	/// </summary>
-	/// <param name="path"></param>
-	/// <param name="fileSystem"></param>
-	/// <returns></returns>
-	internal static string GetFullPathOrEmpty(this string? path, IFileSystem fileSystem)
+	internal static string GetFullPathOrWhiteSpace(this string? path, IFileSystem fileSystem)
 	{
-		if (string.IsNullOrEmpty(path))
+		if (string.IsNullOrWhiteSpace(path))
 		{
-			return string.Empty;
+			return path ?? string.Empty;
 		}
 
 		return fileSystem.Path.GetFullPath(path);

--- a/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
@@ -32,7 +32,7 @@ internal static class PathHelper
 			() => false);
 	}
 
-	internal static bool IsUncPath([NotNullWhen(true)]this string? path)
+	internal static bool IsUncPath([NotNullWhen(true)] this string? path)
 	{
 		if (path == null)
 		{
@@ -68,6 +68,23 @@ internal static class PathHelper
 	{
 		CheckPathArgument(pathToTarget, nameof(pathToTarget), false);
 		CheckPathCharacters(pathToTarget, fileSystem, nameof(pathToTarget), -2147024713);
+	}
+
+	/// <summary>
+	///     Get the <see cref="IPath.GetFullPath(string)" /> of the <paramref name="path" />
+	///     or an empty string, if <paramref name="path" /> is <see langword="null" /> or empty.
+	/// </summary>
+	/// <param name="path"></param>
+	/// <param name="fileSystem"></param>
+	/// <returns></returns>
+	internal static string GetFullPathOrEmpty(this string? path, IFileSystem fileSystem)
+	{
+		if (string.IsNullOrEmpty(path))
+		{
+			return string.Empty;
+		}
+
+		return fileSystem.Path.GetFullPath(path);
 	}
 
 	private static void CheckPathArgument([NotNull] string? path, string paramName,

--- a/Source/Testably.Abstractions.Testing/InterceptionHandlerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/InterceptionHandlerExtensions.cs
@@ -42,7 +42,7 @@ public static class InterceptionHandlerExtensions
 			changeDescription => changeDescription.Matches(
 				fileSystemType,
 				WatcherChangeTypes.Changed,
-				path.GetFullPathOrEmpty(handler.FileSystem),
+				path.GetFullPathOrWhiteSpace(handler.FileSystem),
 				searchPattern,
 				predicate));
 
@@ -78,7 +78,7 @@ public static class InterceptionHandlerExtensions
 			changeDescription => changeDescription.Matches(
 				fileSystemType,
 				WatcherChangeTypes.Created,
-				path.GetFullPathOrEmpty(handler.FileSystem),
+				path.GetFullPathOrWhiteSpace(handler.FileSystem),
 				searchPattern,
 				predicate));
 
@@ -114,7 +114,7 @@ public static class InterceptionHandlerExtensions
 			changeDescription => changeDescription.Matches(
 				fileSystemType,
 				WatcherChangeTypes.Deleted,
-				path.GetFullPathOrEmpty(handler.FileSystem),
+				path.GetFullPathOrWhiteSpace(handler.FileSystem),
 				searchPattern,
 				predicate));
 }

--- a/Source/Testably.Abstractions.Testing/InterceptionHandlerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/InterceptionHandlerExtensions.cs
@@ -42,7 +42,7 @@ public static class InterceptionHandlerExtensions
 			changeDescription => changeDescription.Matches(
 				fileSystemType,
 				WatcherChangeTypes.Changed,
-				handler.FileSystem.Path.GetFullPath(path),
+				path.GetFullPathOrEmpty(handler.FileSystem),
 				searchPattern,
 				predicate));
 
@@ -78,7 +78,7 @@ public static class InterceptionHandlerExtensions
 			changeDescription => changeDescription.Matches(
 				fileSystemType,
 				WatcherChangeTypes.Created,
-				handler.FileSystem.Path.GetFullPath(path),
+				path.GetFullPathOrEmpty(handler.FileSystem),
 				searchPattern,
 				predicate));
 
@@ -114,7 +114,7 @@ public static class InterceptionHandlerExtensions
 			changeDescription => changeDescription.Matches(
 				fileSystemType,
 				WatcherChangeTypes.Deleted,
-				handler.FileSystem.Path.GetFullPath(path),
+				path.GetFullPathOrEmpty(handler.FileSystem),
 				searchPattern,
 				predicate));
 }

--- a/Source/Testably.Abstractions.Testing/NotificationHandlerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/NotificationHandlerExtensions.cs
@@ -43,7 +43,7 @@ public static class NotificationHandlerExtensions
 			changeDescription => changeDescription.Matches(
 				fileSystemType,
 				WatcherChangeTypes.Changed,
-				handler.FileSystem.Path.GetFullPath(path),
+				path.GetFullPathOrEmpty(handler.FileSystem),
 				searchPattern,
 				predicate));
 
@@ -80,7 +80,7 @@ public static class NotificationHandlerExtensions
 			changeDescription => changeDescription.Matches(
 				fileSystemType,
 				WatcherChangeTypes.Created,
-				handler.FileSystem.Path.GetFullPath(path),
+				path.GetFullPathOrEmpty(handler.FileSystem),
 				searchPattern,
 				predicate));
 
@@ -117,7 +117,7 @@ public static class NotificationHandlerExtensions
 			changeDescription => changeDescription.Matches(
 				fileSystemType,
 				WatcherChangeTypes.Deleted,
-				handler.FileSystem.Path.GetFullPath(path),
+				path.GetFullPathOrEmpty(handler.FileSystem),
 				searchPattern,
 				predicate));
 }

--- a/Source/Testably.Abstractions.Testing/NotificationHandlerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/NotificationHandlerExtensions.cs
@@ -43,7 +43,7 @@ public static class NotificationHandlerExtensions
 			changeDescription => changeDescription.Matches(
 				fileSystemType,
 				WatcherChangeTypes.Changed,
-				path.GetFullPathOrEmpty(handler.FileSystem),
+				path.GetFullPathOrWhiteSpace(handler.FileSystem),
 				searchPattern,
 				predicate));
 
@@ -80,7 +80,7 @@ public static class NotificationHandlerExtensions
 			changeDescription => changeDescription.Matches(
 				fileSystemType,
 				WatcherChangeTypes.Created,
-				path.GetFullPathOrEmpty(handler.FileSystem),
+				path.GetFullPathOrWhiteSpace(handler.FileSystem),
 				searchPattern,
 				predicate));
 
@@ -117,7 +117,7 @@ public static class NotificationHandlerExtensions
 			changeDescription => changeDescription.Matches(
 				fileSystemType,
 				WatcherChangeTypes.Deleted,
-				path.GetFullPathOrEmpty(handler.FileSystem),
+				path.GetFullPathOrWhiteSpace(handler.FileSystem),
 				searchPattern,
 				predicate));
 }

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 using Testably.Abstractions.Testing.Helpers;
 

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
@@ -85,13 +85,10 @@ internal sealed class InMemoryLocation : IStorageLocation
 	public IStorageLocation? GetParent()
 	{
 		string? parentPath = Path.GetDirectoryName(FullPath);
-		if (Path.GetPathRoot(FullPath) == FullPath)
+		if (Path.GetPathRoot(FullPath) == FullPath || parentPath == null)
 		{
 			return null;
 		}
-
-		Debug.Assert(parentPath != null,
-			"When parentPath is null, FullPath must be null or a root path!");
 
 		return New(Drive,
 			parentPath,

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -270,7 +270,7 @@ internal sealed class InMemoryStorage : IStorage
 			drive = _fileSystem.Storage.MainDrive;
 		}
 
-		return InMemoryLocation.New(drive, path.GetFullPathOrEmpty(_fileSystem), path);
+		return InMemoryLocation.New(drive, path.GetFullPathOrWhiteSpace(_fileSystem), path);
 	}
 
 	/// <inheritdoc cref="IStorage.GetOrAddDrive(string)" />

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -258,7 +258,7 @@ internal sealed class InMemoryStorage : IStorage
 	[return: NotNullIfNotNull("path")]
 	public IStorageLocation? GetLocation(string? path, string? friendlyName = null)
 	{
-		if (path == null)
+		if (string.IsNullOrWhiteSpace(path))
 		{
 			return null;
 		}

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -258,7 +258,7 @@ internal sealed class InMemoryStorage : IStorage
 	[return: NotNullIfNotNull("path")]
 	public IStorageLocation? GetLocation(string? path, string? friendlyName = null)
 	{
-		if (string.IsNullOrWhiteSpace(path))
+		if (path == null)
 		{
 			return null;
 		}
@@ -270,7 +270,7 @@ internal sealed class InMemoryStorage : IStorage
 			drive = _fileSystem.Storage.MainDrive;
 		}
 
-		return InMemoryLocation.New(drive, _fileSystem.Path.GetFullPath(path), path);
+		return InMemoryLocation.New(drive, path.GetFullPathOrEmpty(_fileSystem), path);
 	}
 
 	/// <inheritdoc cref="IStorage.GetOrAddDrive(string)" />

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/ExceptionTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Testably.Abstractions.Tests.FileSystem.Path;
+
+// ReSharper disable once PartialTypeWithSinglePart
+public abstract partial class ExceptionTests<TFileSystem>
+	: FileSystemTestBase<TFileSystem>
+	where TFileSystem : IFileSystem
+{
+	[SkippableTheory]
+	[MemberData(nameof(GetPathCallbacks), parameters: "")]
+	public void Operations_WhenValueIsEmpty_ShouldThrowArgumentException(
+		Expression<Action<IPath>> callback, string paramName,
+		bool ignoreParamCheck)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			callback.Compile().Invoke(FileSystem.Path);
+		});
+
+		exception.Should().BeException<ArgumentException>(
+			hResult: -2147024809,
+			paramName: ignoreParamCheck || Test.IsNetFramework ? null : paramName,
+			because:
+			$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
+	}
+
+	[SkippableTheory]
+	[MemberData(nameof(GetPathCallbacks), parameters: "  ")]
+	public void Operations_WhenValueIsWhitespace_ShouldThrowArgumentException(
+		Expression<Action<IPath>> callback, string paramName,
+		bool ignoreParamCheck)
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			callback.Compile().Invoke(FileSystem.Path);
+		});
+
+		exception.Should().BeException<ArgumentException>(
+			hResult: -2147024809,
+			paramName: ignoreParamCheck || Test.IsNetFramework ? null : paramName,
+			because:
+			$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
+	}
+
+	[SkippableTheory]
+	[MemberData(nameof(GetPathCallbacks), parameters: (string?)null)]
+	public void Operations_WhenValueIsNull_ShouldThrowArgumentNullException(
+		Expression<Action<IPath>> callback, string paramName,
+		bool ignoreParamCheck)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			callback.Compile().Invoke(FileSystem.Path);
+		});
+
+		exception.Should().BeException<ArgumentNullException>(
+			paramName: ignoreParamCheck ? null : paramName,
+			because:
+			$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
+	}
+
+	#region Helpers
+
+	public static IEnumerable<object?[]> GetPathCallbacks(string? path)
+		=> GetPathCallbackTestParameters(path!)
+			.Where(item => item.TestType.HasFlag(path.ToTestType()))
+			.Select(item => new object?[]
+			{
+				item.Callback,
+				item.ParamName,
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
+					.IgnoreParamNameCheck)
+			});
+
+	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,
+			Expression<Action<IPath>> Callback)>
+		GetPathCallbackTestParameters(string value)
+	{
+		yield return (ExceptionTestHelper.TestTypes.AllExceptInvalidPath, "path", path
+			=> path.GetFullPath(value));
+#if FEATURE_PATH_RELATIVE
+		yield return (ExceptionTestHelper.TestTypes.AllExceptInvalidPath, "relativeTo", path
+			=> path.GetRelativePath(value, "foo"));
+		yield return (ExceptionTestHelper.TestTypes.AllExceptInvalidPath, "path", path
+			=> path.GetRelativePath("foo", value));
+		yield return (ExceptionTestHelper.TestTypes.Null, "path", path
+			=> path.IsPathFullyQualified(value));
+#endif
+	}
+
+#endregion
+}


### PR DESCRIPTION
Throw correct exceptions in `Path.GetFullPath` when the parameter is `null`, empty or invalid.