### PR TITLE
feat: add `ToString` methods to simplify debugging

### DIFF
--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensibility.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensibility.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Testably.Abstractions.Helpers;
 
 namespace Testably.Abstractions.Testing.Helpers;
@@ -43,5 +44,17 @@ internal class FileSystemExtensibility : IFileSystemExtensibility
 				targetContainer._metadata[item.Key] = item.Value;
 			}
 		}
+	}
+
+	/// <inheritdoc cref="object.ToString()" />
+	public override string ToString()
+	{
+		if (_metadata.Count == 0)
+		{
+			return "[]";
+		}
+
+		return
+			$"[{string.Join(", ", _metadata.Select(x => $"{x.Key}: {x.Value}"))}]";
 	}
 }

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Win32.SafeHandles;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystem;
 using Testably.Abstractions.Testing.Storage;
 
@@ -39,6 +41,12 @@ public sealed class MockFileSystem : IFileSystem
 	///     The underlying storage of directories and files.
 	/// </summary>
 	internal IStorage Storage => _storage;
+
+	/// <summary>
+	///     The registered containers in the in-Memory <see cref="Storage" />.
+	/// </summary>
+	internal IReadOnlyList<IStorageContainer> Containers
+		=> _storage.Containers.OrderBy(x => x.Key.FullPath).Select(x => x.Value).ToList();
 
 	private readonly DirectoryMock _directoryMock;
 	private readonly FileMock _fileMock;
@@ -109,6 +117,10 @@ public sealed class MockFileSystem : IFileSystem
 		=> _pathMock;
 
 	#endregion
+
+	/// <inheritdoc cref="object.ToString()" />
+	public override string ToString()
+		=> $"MockFileSystem (directories: {_storage.Containers.Count(x => x.Value.Type == FileSystemTypes.Directory)}, files: {_storage.Containers.Count(x => x.Value.Type == FileSystemTypes.File)})";
 
 	/// <summary>
 	///     Implements a custom access control (ACL) mechanism.

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -46,7 +46,10 @@ public sealed class MockFileSystem : IFileSystem
 	///     The registered containers in the in-Memory <see cref="Storage" />.
 	/// </summary>
 	internal IReadOnlyList<IStorageContainer> Containers
-		=> _storage.Containers.OrderBy(x => x.Key.FullPath).Select(x => x.Value).ToList();
+		=> _storage.Containers
+			.OrderBy(x => x.Key.FullPath)
+			.Select(x => x.Value)
+			.ToList();
 
 	private readonly DirectoryMock _directoryMock;
 	private readonly FileMock _fileMock;

--- a/Source/Testably.Abstractions.Testing/MockRandomSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockRandomSystem.cs
@@ -1,4 +1,5 @@
-﻿using Testably.Abstractions.RandomSystem;
+﻿using System;
+using Testably.Abstractions.RandomSystem;
 using Testably.Abstractions.Testing.RandomSystem;
 
 namespace Testably.Abstractions.Testing;
@@ -46,4 +47,8 @@ public sealed class MockRandomSystem : IRandomSystem
 		=> _randomFactoryMock;
 
 	#endregion
+
+	/// <inheritdoc cref="object.ToString()" />
+	public override string ToString()
+		=> "MockRandomSystem";
 }

--- a/Source/Testably.Abstractions.Testing/MockTimeSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockTimeSystem.cs
@@ -80,6 +80,10 @@ public sealed class MockTimeSystem : ITimeSystem
 
 	#endregion
 
+	/// <inheritdoc cref="object.ToString()" />
+	public override string ToString()
+		=> $"MockTimeSystem (now: {DateTime.UtcNow}Z)";
+
 	/// <summary>
 	///     Specifies the <see cref="ITimerStrategy" /> to use when dealing with timers.
 	/// </summary>

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -212,6 +212,22 @@ internal class InMemoryContainer : IStorageContainer
 
 	#endregion
 
+	/// <inheritdoc cref="object.ToString()" />
+	public override string ToString()
+	{
+		if (Type == FileSystemTypes.Directory)
+		{
+			return $"{_location.FullPath}: Directory";
+		}
+
+		if (Type == FileSystemTypes.File)
+		{
+			return $"{_location.FullPath}: File ({_bytes.Length} bytes)";
+		}
+
+		return $"{_location.FullPath}: Unknown Container";
+	}
+
 	/// <summary>
 	///     Create a new directory on the <paramref name="location" />.
 	/// </summary>
@@ -318,6 +334,10 @@ internal class InMemoryContainer : IStorageContainer
 		}
 
 		#endregion
+
+		/// <inheritdoc cref="object.ToString()" />
+		public override string ToString()
+			=> _time.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ssZ");
 	}
 
 	private sealed class FileHandle : IStorageAccessHandle


### PR DESCRIPTION
Add `ToString` methods and direct `Container` property to the `MockFileSystem` to simplify debugging.