### PR TITLE
fix: implementation of `Path.GetRelativePath`

### DIFF
--- a/Source/Testably.Abstractions.Interface/Helpers/PathSystemBase.cs
+++ b/Source/Testably.Abstractions.Interface/Helpers/PathSystemBase.cs
@@ -146,7 +146,7 @@ public abstract class PathSystemBase : IPath
 
 #if FEATURE_PATH_RELATIVE
 	/// <inheritdoc cref="Path.GetRelativePath(string, string)" />
-	public string GetRelativePath(string relativeTo, string path)
+	public virtual string GetRelativePath(string relativeTo, string path)
 		=> Path.GetRelativePath(relativeTo, path);
 #endif
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -1,9 +1,12 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Text;
 using Testably.Abstractions.Helpers;
 using Testably.Abstractions.Testing.Helpers;
+using Testably.Abstractions.Testing.Storage;
+
 #if FEATURE_FILESYSTEM_NET7
 using System.Diagnostics.CodeAnalysis;
-using Testably.Abstractions.Testing.Storage;
 #endif
 
 namespace Testably.Abstractions.Testing.FileSystem;
@@ -41,4 +44,141 @@ internal sealed class PathMock : PathSystemBase
 			_fileSystem.Storage.CurrentDirectory,
 			path));
 	}
-}
+
+#if FEATURE_PATH_RELATIVE
+	/// <inheritdoc cref="IPath.GetRelativePath(string, string)" />
+	public override string GetRelativePath(string relativeTo, string path)
+	{
+		relativeTo.EnsureValidArgument(FileSystem, nameof(relativeTo));
+		path.EnsureValidArgument(FileSystem, nameof(path));
+
+		relativeTo = FileSystem.Path.GetFullPath(relativeTo);
+		path = FileSystem.Path.GetFullPath(path);
+
+		if (GetPathRoot(path) != GetPathRoot(relativeTo))
+		{
+			return path;
+		}
+
+		int commonLength = GetCommonPathLength(relativeTo, path);
+
+		// If there is nothing in common they can't share the same root, return the "to" path as is.
+		if (commonLength == 0)
+		{
+			return path;
+		}
+
+		// Trailing separators aren't significant for comparison
+		int relativeToLength = relativeTo.Length;
+		if (EndsInDirectorySeparator(relativeTo.AsSpan()))
+			relativeToLength--;
+
+		bool pathEndsInSeparator = EndsInDirectorySeparator(path.AsSpan());
+		int pathLength = path.Length;
+		if (pathEndsInSeparator)
+			pathLength--;
+
+		// If we have effectively the same path, return "."
+		if (relativeToLength == pathLength && commonLength >= relativeToLength)
+		{
+			return ".";
+		}
+
+
+        // We have the same root, we need to calculate the difference now using the
+        // common Length and Segment count past the length.
+        //
+        // Some examples:
+        //
+        //  C:\Foo C:\Bar L3, S1 -> ..\Bar
+        //  C:\Foo C:\Foo\Bar L6, S0 -> Bar
+        //  C:\Foo\Bar C:\Bar\Bar L3, S2 -> ..\..\Bar\Bar
+        //  C:\Foo\Foo C:\Foo\Bar L7, S1 -> ..\Bar
+
+        var sb = new StringBuilder();
+
+        // Add parent segments for segments past the common on the "from" path
+        if (commonLength < relativeToLength)
+        {
+            sb.Append("..");
+
+            for (int i = commonLength + 1; i < relativeToLength; i++)
+            {
+                if (EndsInDirectorySeparator(relativeTo.AsSpan(0, i)))
+                {
+                    sb.Append(DirectorySeparatorChar);
+                    sb.Append("..");
+                }
+            }
+        }
+        else if (path[commonLength] == DirectorySeparatorChar)
+        {
+            // No parent segments and we need to eat the initial separator
+            //  (C:\Foo C:\Foo\Bar case)
+            commonLength++;
+        }
+
+        // Now add the rest of the "to" path, adding back the trailing separator
+        int differenceLength = pathLength - commonLength;
+        if (pathEndsInSeparator)
+            differenceLength++;
+
+        if (differenceLength > 0)
+        {
+            if (sb.Length > 0)
+            {
+                sb.Append(DirectorySeparatorChar);
+            }
+
+            sb.Append(path.Substring(commonLength, differenceLength));
+        }
+
+        return sb.ToString();
+	}
+
+#if !FEATURE_PATH_ADVANCED
+    private bool EndsInDirectorySeparator(ReadOnlySpan<char> path)
+    {
+	    return path[path.Length - 1] == DirectorySeparatorChar;
+
+    }
+#endif
+
+    /// <summary>
+    ///     Get the common path length from the start of the string.
+    /// </summary>
+    private int GetCommonPathLength(string first, string second)
+	{
+		int commonChars = 0;
+		var charsToCheck = first.IndexOf(DirectorySeparatorChar);
+		if (charsToCheck <= 0)
+		{
+			return 0;
+		}
+		while (charsToCheck <= first.Length)
+		{
+			if (!first.Substring(0, charsToCheck).Equals(second.Substring(0, charsToCheck), InMemoryLocation.StringComparisonMode))
+			{
+				return commonChars;
+			}
+
+			commonChars = charsToCheck;
+			int nextSeparator = first.Substring(commonChars).IndexOf(DirectorySeparatorChar);
+			if (nextSeparator < 0)
+			{
+				if (charsToCheck >= first.Length)
+				{
+					return charsToCheck;
+				}
+				charsToCheck = first.Length;
+			}
+			else
+			{
+				charsToCheck += nextSeparator + 1;
+            }
+		}
+
+		return 0;
+	}
+#endif
+    }

--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.IO;
-using System.Text;
+﻿using System.IO;
 using Testably.Abstractions.Helpers;
 using Testably.Abstractions.Testing.Helpers;
-using Testably.Abstractions.Testing.Storage;
-
 #if FEATURE_FILESYSTEM_NET7
 using System.Diagnostics.CodeAnalysis;
+using Testably.Abstractions.Testing.Storage;
 #endif
 
 namespace Testably.Abstractions.Testing.FileSystem;
@@ -55,130 +52,7 @@ internal sealed class PathMock : PathSystemBase
 		relativeTo = FileSystem.Path.GetFullPath(relativeTo);
 		path = FileSystem.Path.GetFullPath(path);
 
-		if (GetPathRoot(path) != GetPathRoot(relativeTo))
-		{
-			return path;
-		}
-
-		int commonLength = GetCommonPathLength(relativeTo, path);
-
-		// If there is nothing in common they can't share the same root, return the "to" path as is.
-		if (commonLength == 0)
-		{
-			return path;
-		}
-
-		// Trailing separators aren't significant for comparison
-		int relativeToLength = relativeTo.Length;
-		if (EndsInDirectorySeparator(relativeTo.AsSpan()))
-			relativeToLength--;
-
-		bool pathEndsInSeparator = EndsInDirectorySeparator(path.AsSpan());
-		int pathLength = path.Length;
-		if (pathEndsInSeparator)
-			pathLength--;
-
-		// If we have effectively the same path, return "."
-		if (relativeToLength == pathLength && commonLength >= relativeToLength)
-		{
-			return ".";
-		}
-
-
-        // We have the same root, we need to calculate the difference now using the
-        // common Length and Segment count past the length.
-        //
-        // Some examples:
-        //
-        //  C:\Foo C:\Bar L3, S1 -> ..\Bar
-        //  C:\Foo C:\Foo\Bar L6, S0 -> Bar
-        //  C:\Foo\Bar C:\Bar\Bar L3, S2 -> ..\..\Bar\Bar
-        //  C:\Foo\Foo C:\Foo\Bar L7, S1 -> ..\Bar
-
-        var sb = new StringBuilder();
-
-        // Add parent segments for segments past the common on the "from" path
-        if (commonLength < relativeToLength)
-        {
-            sb.Append("..");
-
-            for (int i = commonLength + 1; i < relativeToLength; i++)
-            {
-                if (EndsInDirectorySeparator(relativeTo.AsSpan(0, i)))
-                {
-                    sb.Append(DirectorySeparatorChar);
-                    sb.Append("..");
-                }
-            }
-        }
-        else if (path[commonLength] == DirectorySeparatorChar)
-        {
-            // No parent segments and we need to eat the initial separator
-            //  (C:\Foo C:\Foo\Bar case)
-            commonLength++;
-        }
-
-        // Now add the rest of the "to" path, adding back the trailing separator
-        int differenceLength = pathLength - commonLength;
-        if (pathEndsInSeparator)
-            differenceLength++;
-
-        if (differenceLength > 0)
-        {
-            if (sb.Length > 0)
-            {
-                sb.Append(DirectorySeparatorChar);
-            }
-
-            sb.Append(path.Substring(commonLength, differenceLength));
-        }
-
-        return sb.ToString();
-	}
-
-#if !FEATURE_PATH_ADVANCED
-    private bool EndsInDirectorySeparator(ReadOnlySpan<char> path)
-    {
-	    return path[path.Length - 1] == DirectorySeparatorChar;
-
-    }
-#endif
-
-    /// <summary>
-    ///     Get the common path length from the start of the string.
-    /// </summary>
-    private int GetCommonPathLength(string first, string second)
-	{
-		int commonChars = 0;
-		var charsToCheck = first.IndexOf(DirectorySeparatorChar);
-		if (charsToCheck <= 0)
-		{
-			return 0;
-		}
-		while (charsToCheck <= first.Length)
-		{
-			if (!first.Substring(0, charsToCheck).Equals(second.Substring(0, charsToCheck), InMemoryLocation.StringComparisonMode))
-			{
-				return commonChars;
-			}
-
-			commonChars = charsToCheck;
-			int nextSeparator = first.Substring(commonChars).IndexOf(DirectorySeparatorChar);
-			if (nextSeparator < 0)
-			{
-				if (charsToCheck >= first.Length)
-				{
-					return charsToCheck;
-				}
-				charsToCheck = first.Length;
-			}
-			else
-			{
-				charsToCheck += nextSeparator + 1;
-            }
-		}
-
-		return 0;
+		return Path.GetRelativePath(relativeTo, path);
 	}
 #endif
-    }
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetRelativePathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetRelativePathTests.cs
@@ -34,6 +34,18 @@ public abstract partial class GetRelativePathTests<TFileSystem>
 		result.Should().Be(path2);
 	}
 
+	[Fact]
+	public void GetRelativePath_FromAbsolutePathInCurrentDirectory_ShouldReturnRelativePath()
+	{
+		string rootedPath = FileSystem.Path.Combine(BasePath, "input");
+		FileSystem.Directory.CreateDirectory(rootedPath);
+		FileSystem.Directory.SetCurrentDirectory(rootedPath);
+
+		string result = FileSystem.Path.GetRelativePath(rootedPath, "a.txt");
+
+		Assert.Equal("a.txt", result);
+	}
+
 	[SkippableTheory]
 	[AutoData]
 	public void GetRelativePath_RootedPath_ShouldReturnAbsolutePath(
@@ -52,7 +64,7 @@ public abstract partial class GetRelativePathTests<TFileSystem>
 	public void GetRelativePath_RootedPath_ShouldWorkOnAnyDrive()
 	{
 		Skip.IfNot(Test.RunsOnWindows);
-		
+
 		string rootedPath = "/dir/subDirectory";
 		FileSystem.Directory.CreateDirectory(rootedPath);
 		string directory = FileSystem.Directory.GetDirectories("/dir").Single();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetRelativePathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetRelativePathTests.cs
@@ -25,11 +25,7 @@ public abstract partial class GetRelativePathTests<TFileSystem>
 	public void GetRelativePath_DifferentDrives_ShouldReturnAbsolutePath(
 		string path1, string path2)
 	{
-		if (!Test.RunsOnWindows)
-		{
-			// Different drives are only supported on Windows
-			return;
-		}
+		Skip.IfNot(Test.RunsOnWindows, "Different drives are only supported on Windows");
 
 		path1 = FileTestHelper.RootDrive(path1, 'A');
 		path2 = FileTestHelper.RootDrive(path2, 'B');


### PR DESCRIPTION
Prototype implementation for https://github.com/TestableIO/System.IO.Abstractions/issues/773, similar to [the implementation in .NET Runtime](https://github.com/dotnet/runtime/blob/release/7.0/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs#L886)