### PR TITLE
chore: remove unnecessary reference

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageVersion Include="Testably.Abstractions" Version="2.3.3" />
 		<PackageVersion Include="Testably.Abstractions.Testing" Version="2.3.3" />
 	</ItemGroup>
 

--- a/Examples/Directory.Build.props
+++ b/Examples/Directory.Build.props
@@ -28,7 +28,6 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(UseFileReferenceToTestablyLibraries)' != 'True'">
-		<PackageReference Include="Testably.Abstractions" />
 		<PackageReference Include="Testably.Abstractions.Testing" />
 	</ItemGroup>
 


### PR DESCRIPTION
Remove unnecessary reference to `Testably.Abstractions` as it is indirectly referenced by `Testably.Abstractions.Testing`.