### PR TITLE
feat: simplify initialization of file systems

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryDescription.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryDescription.cs
@@ -3,11 +3,17 @@ using System.Linq;
 
 namespace Testably.Abstractions.Testing.FileSystemInitializer;
 
+/// <summary>
+///     The description of a directory for the <see cref="IFileSystem" />.
+/// </summary>
 public class DirectoryDescription : FileSystemInfoDescription
 {
+	/// <summary>
+	///     The defined children of this directory.
+	/// </summary>
 	public FileSystemInfoDescription[] Children => GetChildren();
 
-	/// <inheritdoc />
+	/// <inheritdoc cref="FileSystemInfoDescription.this[string]" />
 	public override FileSystemInfoDescription this[string path]
 	{
 		get
@@ -23,12 +29,18 @@ public class DirectoryDescription : FileSystemInfoDescription
 
 	private readonly Dictionary<string, FileSystemInfoDescription> _children;
 
+	/// <summary>
+	///     Describes an empty directory with the given <paramref name="name" />.
+	/// </summary>
 	public DirectoryDescription(string name)
 		: base(name)
 	{
 		_children = new Dictionary<string, FileSystemInfoDescription>();
 	}
 
+	/// <summary>
+	///     Describes a directory with the given <paramref name="name" /> and the <paramref name="children" />.
+	/// </summary>
 	public DirectoryDescription(string name, params FileSystemInfoDescription[] children)
 		: base(name)
 	{
@@ -36,10 +48,8 @@ public class DirectoryDescription : FileSystemInfoDescription
 	}
 
 	private FileSystemInfoDescription[] GetChildren()
-	{
-		return _children
+		=> _children
 			.OrderBy(x => x.Key)
 			.Select(x => x.Value)
 			.ToArray();
-	}
 }

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryDescription.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryDescription.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Testably.Abstractions.Testing.FileSystemInitializer;
+
+public class DirectoryDescription : FileSystemInfoDescription
+{
+	public FileSystemInfoDescription[] Children => GetChildren();
+
+	/// <inheritdoc />
+	public override FileSystemInfoDescription this[string path]
+	{
+		get
+		{
+			if (_children.TryGetValue(path, out FileSystemInfoDescription? value))
+			{
+				return value!;
+			}
+
+			throw new TestingException($"The child named '{path}' does not exist.!");
+		}
+	}
+
+	private readonly Dictionary<string, FileSystemInfoDescription> _children;
+
+	public DirectoryDescription(string name)
+		: base(name)
+	{
+		_children = new Dictionary<string, FileSystemInfoDescription>();
+	}
+
+	public DirectoryDescription(string name, params FileSystemInfoDescription[] children)
+		: base(name)
+	{
+		_children = children.ToDictionary(c => c.Name);
+	}
+
+	private FileSystemInfoDescription[] GetChildren()
+	{
+		return _children
+			.OrderBy(x => x.Key)
+			.Select(x => x.Value)
+			.ToArray();
+	}
+}

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileDescription.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileDescription.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Testably.Abstractions.Testing.FileSystemInitializer;
+
+public class FileDescription : FileSystemInfoDescription
+{
+	public byte[]? Bytes { get; }
+	public string? Content { get; }
+	public bool IsReadOnly { get; set; }
+
+	/// <inheritdoc />
+	public override FileSystemInfoDescription this[string path]
+		=> throw new TestingException("Files cannot have children.");
+
+	public FileDescription(string name, string? content = null)
+		: base(name)
+	{
+		Content = content;
+	}
+
+	public FileDescription(string name, byte[] bytes)
+		: base(name)
+	{
+		Bytes = bytes;
+	}
+}

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileDescription.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileDescription.cs
@@ -1,23 +1,43 @@
-﻿using System;
+﻿namespace Testably.Abstractions.Testing.FileSystemInitializer;
 
-namespace Testably.Abstractions.Testing.FileSystemInitializer;
-
+/// <summary>
+///     The description of a file for the <see cref="IFileSystem" />.
+/// </summary>
 public class FileDescription : FileSystemInfoDescription
 {
+	/// <summary>
+	///     The bytes content.
+	/// </summary>
 	public byte[]? Bytes { get; }
+
+	/// <summary>
+	///     The string content.
+	/// </summary>
 	public string? Content { get; }
+
+	/// <summary>
+	///     Flag indicating, if the file is read-only.
+	/// </summary>
+	/// <remarks>This sets <seealso cref="IFileInfo.IsReadOnly" />.</remarks>
 	public bool IsReadOnly { get; set; }
 
-	/// <inheritdoc />
+	/// <inheritdoc cref="FileSystemInfoDescription.this[string]" />
 	public override FileSystemInfoDescription this[string path]
 		=> throw new TestingException("Files cannot have children.");
 
+	/// <summary>
+	///     Describes a text file with the given <paramref name="name" /> and the string content set to
+	///     <paramref name="content" />.
+	/// </summary>
 	public FileDescription(string name, string? content = null)
 		: base(name)
 	{
 		Content = content;
 	}
 
+	/// <summary>
+	///     Describes a binary file with the given <paramref name="name" /> and the content set to <paramref name="bytes" />.
+	/// </summary>
 	public FileDescription(string name, byte[] bytes)
 		: base(name)
 	{

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInfoDescription.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInfoDescription.cs
@@ -1,14 +1,28 @@
 ﻿namespace Testably.Abstractions.Testing.FileSystemInitializer;
 
+/// <summary>
+///     Abstract class for defining directories or files.
+///     <para />
+///     See <see cref="DirectoryDescription" /> or <see cref="FileDescription" /> for implementations.
+/// </summary>
 public abstract class FileSystemInfoDescription
 {
+	/// <summary>
+	///     Gives access to the child at the given <paramref name="path" />.
+	/// </summary>
 	public abstract FileSystemInfoDescription this[string path]
 	{
 		get;
 	}
 
+	/// <summary>
+	///     The name of the file or directory.
+	/// </summary>
 	public string Name { get; }
 
+	/// <summary>
+	///     Initializes a new instance of <see cref="FileSystemInfoDescription" /> with the given <paramref name="name" />.
+	/// </summary>
 	protected FileSystemInfoDescription(string name)
 	{
 		Name = name;

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInfoDescription.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInfoDescription.cs
@@ -1,4 +1,6 @@
-﻿namespace Testably.Abstractions.Testing.FileSystemInitializer;
+﻿using System.IO;
+
+namespace Testably.Abstractions.Testing.FileSystemInitializer;
 
 /// <summary>
 ///     Abstract class for defining directories or files.
@@ -25,6 +27,6 @@ public abstract class FileSystemInfoDescription
 	/// </summary>
 	protected FileSystemInfoDescription(string name)
 	{
-		Name = name;
+		Name = name.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
 	}
 }

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInfoDescription.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInfoDescription.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace Testably.Abstractions.Testing.FileSystemInitializer;
 
@@ -27,6 +28,11 @@ public abstract class FileSystemInfoDescription
 	/// </summary>
 	protected FileSystemInfoDescription(string name)
 	{
-		Name = name.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+		if (name.IndexOf(Path.AltDirectorySeparatorChar) >= 0)
+		{
+			throw new NotSupportedException("Name must not contain path separators.");
+		}
+
+		Name = name;
 	}
 }

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInfoDescription.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInfoDescription.cs
@@ -1,0 +1,16 @@
+﻿namespace Testably.Abstractions.Testing.FileSystemInitializer;
+
+public abstract class FileSystemInfoDescription
+{
+	public abstract FileSystemInfoDescription this[string path]
+	{
+		get;
+	}
+
+	public string Name { get; }
+
+	protected FileSystemInfoDescription(string name)
+	{
+		Name = name;
+	}
+}

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInfoDescription.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInfoDescription.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-
-namespace Testably.Abstractions.Testing.FileSystemInitializer;
+﻿namespace Testably.Abstractions.Testing.FileSystemInitializer;
 
 /// <summary>
 ///     Abstract class for defining directories or files.
@@ -28,11 +25,6 @@ public abstract class FileSystemInfoDescription
 	/// </summary>
 	protected FileSystemInfoDescription(string name)
 	{
-		if (name.IndexOf(Path.AltDirectorySeparatorChar) >= 0)
-		{
-			throw new NotSupportedException("Name must not contain path separators.");
-		}
-
 		Name = name;
 	}
 }

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInitializer.cs
@@ -145,8 +145,7 @@ internal class FileSystemInitializer<TFileSystem>
 
 		if (directory.Children.Length > 0)
 		{
-			DirectoryInitializer<TFileSystem> subdirectoryInitializer =
-				new DirectoryInitializer<TFileSystem>(this, directoryInfo);
+			DirectoryInitializer<TFileSystem> subdirectoryInitializer = new(this, directoryInfo);
 			foreach (FileSystemInfoDescription children in directory.Children)
 			{
 				subdirectoryInitializer.WithFileOrDirectory(children);

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInitializer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Testably.Abstractions.RandomSystem;
 using Testably.Abstractions.Testing.Helpers;
 
@@ -47,6 +48,23 @@ internal class FileSystemInitializer<TFileSystem>
 	public IFileSystemInfo this[int index]
 		=> _initializedFileSystemInfos[index];
 
+	/// <inheritdoc cref="IFileSystemInitializer{TFileSystem}.With{TDescription}(TDescription[])" />
+	public IFileSystemInitializer<TFileSystem> With<TDescription>(TDescription[] descriptions)
+		where TDescription : FileSystemInfoDescription
+		=> With(descriptions.Cast<FileSystemInfoDescription>().ToArray());
+
+	/// <inheritdoc cref="IFileSystemInitializer{TFileSystem}.With(FileSystemInfoDescription[])" />
+	public IFileSystemInitializer<TFileSystem> With(
+		params FileSystemInfoDescription[] descriptions)
+	{
+		foreach (FileSystemInfoDescription description in descriptions)
+		{
+			WithFileOrDirectory(description);
+		}
+
+		return this;
+	}
+
 	/// <inheritdoc cref="IFileSystemInitializer{TFileSystem}.WithAFile(string?)" />
 	public IFileSystemFileInitializer<TFileSystem> WithAFile(string? extension = null)
 	{
@@ -82,8 +100,71 @@ internal class FileSystemInitializer<TFileSystem>
 	/// <inheritdoc cref="IFileSystemInitializer{TFileSystem}.WithFile(string)" />
 	public IFileSystemFileInitializer<TFileSystem> WithFile(string fileName)
 	{
+		IFileInfo fileInfo = WithFile(new FileDescription(fileName));
+		return new FileInitializer<TFileSystem>(this, fileInfo);
+	}
+
+	/// <inheritdoc cref="IFileSystemInitializer{TFileSystem}.WithSubdirectories(string[])" />
+	public IFileSystemInitializer<TFileSystem> WithSubdirectories(params string[] paths)
+	{
+		foreach (string directory in paths)
+		{
+			WithSubdirectory(directory);
+		}
+
+		return this;
+	}
+
+	/// <inheritdoc cref="IFileSystemInitializer{TFileSystem}.WithSubdirectory(string)" />
+	public IFileSystemDirectoryInitializer<TFileSystem> WithSubdirectory(
+		string directoryName)
+	{
+		IDirectoryInfo directoryInfo = WithDirectory(new DirectoryDescription(directoryName));
+		return new DirectoryInitializer<TFileSystem>(this, directoryInfo);
+	}
+
+	#endregion
+
+	private IDirectoryInfo WithDirectory(DirectoryDescription directory)
+	{
+		IDirectoryInfo directoryInfo = FileSystem.DirectoryInfo.New(
+			FileSystem.Path.Combine(_basePath, directory.Name));
+		if (directoryInfo.Exists)
+		{
+			throw new TestingException(
+				$"The directory '{directoryInfo.FullName}' already exists!");
+		}
+
+		if (FileSystem.File.Exists(directoryInfo.FullName))
+		{
+			throw new TestingException(
+				$"A file '{directoryInfo.FullName}' already exists!");
+		}
+
+		FileSystem.Directory.CreateDirectory(directoryInfo.FullName);
+
+		if (directory.Children.Length > 0)
+		{
+			DirectoryInitializer<TFileSystem> subdirectoryInitializer =
+				new DirectoryInitializer<TFileSystem>(this, directoryInfo);
+			foreach (FileSystemInfoDescription children in directory.Children)
+			{
+				subdirectoryInitializer.WithFileOrDirectory(children);
+			}
+		}
+
+		_initializedFileSystemInfos.Add(
+			_initializedFileSystemInfos.Count,
+			directoryInfo);
+
+		directoryInfo.Refresh();
+		return directoryInfo;
+	}
+
+	private IFileInfo WithFile(FileDescription file)
+	{
 		IFileInfo fileInfo = FileSystem.FileInfo.New(
-			FileSystem.Path.Combine(_basePath, fileName));
+			FileSystem.Path.Combine(_basePath, file.Name));
 		if (fileInfo.Exists)
 		{
 			throw new TestingException(
@@ -101,52 +182,35 @@ internal class FileSystemInitializer<TFileSystem>
 			FileSystem.Directory.CreateDirectory(fileInfo.Directory.FullName);
 		}
 
-		FileSystem.File.WriteAllText(fileInfo.FullName, null);
+		if (file.Bytes != null)
+		{
+			FileSystem.File.WriteAllBytes(fileInfo.FullName, file.Bytes);
+		}
+		else
+		{
+			FileSystem.File.WriteAllText(fileInfo.FullName, file.Content);
+		}
+
 		_initializedFileSystemInfos.Add(
 			_initializedFileSystemInfos.Count,
 			fileInfo);
 
 		fileInfo.Refresh();
-		return new FileInitializer<TFileSystem>(this, fileInfo);
+
+		fileInfo.IsReadOnly = file.IsReadOnly;
+		return fileInfo;
 	}
 
-	/// <inheritdoc cref="IFileSystemInitializer{TFileSystem}.WithSubdirectory(string)" />
-	public IFileSystemDirectoryInitializer<TFileSystem> WithSubdirectory(
-		string directoryName)
+	private void WithFileOrDirectory(FileSystemInfoDescription description)
 	{
-		IDirectoryInfo directoryInfo = FileSystem.DirectoryInfo.New(
-			FileSystem.Path.Combine(_basePath, directoryName));
-		if (directoryInfo.Exists)
+		if (description is FileDescription file)
 		{
-			throw new TestingException(
-				$"The directory '{directoryInfo.FullName}' already exists!");
+			WithFile(file);
 		}
 
-		if (FileSystem.File.Exists(directoryInfo.FullName))
+		if (description is DirectoryDescription directory)
 		{
-			throw new TestingException(
-				$"A file '{directoryInfo.FullName}' already exists!");
+			WithDirectory(directory);
 		}
-
-		FileSystem.Directory.CreateDirectory(directoryInfo.FullName);
-		_initializedFileSystemInfos.Add(
-			_initializedFileSystemInfos.Count,
-			directoryInfo);
-
-		directoryInfo.Refresh();
-		return new DirectoryInitializer<TFileSystem>(this, directoryInfo);
 	}
-
-	/// <inheritdoc cref="IFileSystemInitializer{TFileSystem}.WithSubdirectories(string[])" />
-	public IFileSystemInitializer<TFileSystem> WithSubdirectories(params string[] paths)
-	{
-		foreach (string directory in paths)
-		{
-			WithSubdirectory(directory);
-		}
-
-		return this;
-	}
-
-	#endregion
 }

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileSystemInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/IFileSystemInitializer.cs
@@ -28,6 +28,17 @@ public interface IFileSystemInitializer<out TFileSystem>
 	}
 
 	/// <summary>
+	///     Initializes the <see cref="FileSystem" /> with the provided <paramref name="descriptions" />.
+	/// </summary>
+	IFileSystemInitializer<TFileSystem> With<TDescription>( TDescription[] descriptions)
+		where TDescription : FileSystemInfoDescription;
+
+	/// <summary>
+	///     Initializes the <see cref="FileSystem" /> with the provided <paramref name="descriptions" />.
+	/// </summary>
+	IFileSystemInitializer<TFileSystem> With(params FileSystemInfoDescription[] descriptions);
+
+	/// <summary>
 	///     Initializes the <see cref="IFileSystem" /> with a randomly named file.
 	/// </summary>
 	/// <param name="extension">(optional) If specified, uses the given extension for the file.</param>
@@ -45,14 +56,14 @@ public interface IFileSystemInitializer<out TFileSystem>
 	IFileSystemFileInitializer<TFileSystem> WithFile(string fileName);
 
 	/// <summary>
-	///     Initializes the <see cref="IFileSystem" /> with a subdirectory with the given <paramref name="directoryName" />.
-	/// </summary>
-	IFileSystemDirectoryInitializer<TFileSystem> WithSubdirectory(
-		string directoryName);
-
-	/// <summary>
 	///     Initializes the <see cref="IFileSystem" /> with all given subdirectory <paramref name="paths" />.
 	/// </summary>
 	IFileSystemInitializer<TFileSystem> WithSubdirectories(
 		params string[] paths);
+
+	/// <summary>
+	///     Initializes the <see cref="IFileSystem" /> with a subdirectory with the given <paramref name="directoryName" />.
+	/// </summary>
+	IFileSystemDirectoryInitializer<TFileSystem> WithSubdirectory(
+		string directoryName);
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/DirectoryCleanerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/DirectoryCleanerTests.cs
@@ -9,10 +9,14 @@ namespace Testably.Abstractions.Testing.Tests.FileSystemInitializer;
 [Collection(nameof(IDirectoryCleaner))]
 public class DirectoryCleanerTests
 {
+	#region Test Setup
+
 	public DirectoryCleanerTests()
 	{
 		Skip.If(Test.RunsOnMac, "No access to temporary directories under `/private`");
 	}
+
+	#endregion
 
 	[SkippableTheory]
 	[AutoData]

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/DirectoryDescriptionTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/DirectoryDescriptionTests.cs
@@ -1,0 +1,43 @@
+﻿using Testably.Abstractions.Testing.FileSystemInitializer;
+
+namespace Testably.Abstractions.Testing.Tests.FileSystemInitializer;
+
+public class DirectoryDescriptionTests
+{
+	[Fact]
+	public void Index_AccessToMissingChildShouldThrowTestingException()
+	{
+		DirectoryDescription sut = new("foo");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			_ = sut["bar"];
+		});
+
+		exception.Should().BeOfType<TestingException>();
+	}
+
+	[Fact]
+	public void Index_ShouldGiveAccessToExistingChildDirectory()
+	{
+		DirectoryDescription child = new("bar");
+		DirectoryDescription sut = new("foo", child);
+
+		FileSystemInfoDescription result = sut["bar"];
+
+		result.Should().Be(child);
+	}
+
+	[Fact]
+	public void Index_ShouldGiveAccessToNestedChildren()
+	{
+		FileDescription child3 = new("child3", "some-content");
+		DirectoryDescription child2 = new("child2", child3);
+		DirectoryDescription child1 = new("child1", child2);
+		DirectoryDescription sut = new("foo", child1);
+
+		FileSystemInfoDescription result = sut["child1"]["child2"]["child3"];
+
+		result.Should().Be(child3);
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileDescriptionTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileDescriptionTests.cs
@@ -1,0 +1,19 @@
+﻿using Testably.Abstractions.Testing.FileSystemInitializer;
+
+namespace Testably.Abstractions.Testing.Tests.FileSystemInitializer;
+
+public class FileDescriptionTests
+{
+	[Fact]
+	public void Index_AccessShouldThrowTestingException()
+	{
+		FileDescription sut = new("foo");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			_ = sut["bar"];
+		});
+
+		exception.Should().BeOfType<TestingException>();
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
@@ -94,7 +94,7 @@ public class FileSystemInitializerTests
 
 		sut.With(file);
 
-		fileSystem.Directory.Exists(Path.GetDirectoryName(path))
+		fileSystem.Directory.Exists(Path.Combine("foo", "bar"))
 			.Should().BeTrue();
 		fileSystem.File.Exists(path)
 			.Should().BeTrue();

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
@@ -84,23 +84,6 @@ public class FileSystemInitializerTests
 	}
 
 	[Theory]
-	[InlineAutoData("foo/bar/file.txt")]
-	[InlineAutoData("foo\\bar\\file.txt")]
-	public void With_Path_ShouldSupportAlternatePathSeparator(string path)
-	{
-		FileDescription file = new(path);
-		MockFileSystem fileSystem = new();
-		IFileSystemInitializer<MockFileSystem> sut = fileSystem.Initialize();
-
-		sut.With(file);
-
-		fileSystem.Directory.Exists(Path.Combine("foo", "bar"))
-			.Should().BeTrue();
-		fileSystem.File.Exists(path)
-			.Should().BeTrue();
-	}
-
-	[Theory]
 	[AutoData]
 	public void WithFile_ExistingDirectory_ShouldThrowTestingException(string path)
 	{


### PR DESCRIPTION
Simplify the initialization of a `IFileSystem` by providing `FileSystemInfoDescription`s to the initializers `With` method, e.g.
```csharp
var fileSystem = new MockFileSystem();
fileSystem.Initialize().With(
    new DirectoryDescription("some-empty-directory"),
    new FileDescription("filename.txt", "some file content"));
```