### PR TITLE
feat: add renovate package group for Testably.Abstractions packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
 		"config:base"
+	],
+	"packageRules": [
+		{
+			"matchPackagePatterns": "^Testably.Abstractions",
+			"groupName": ["Testably.Abstractions packages"]
+		}
 	]
 }


### PR DESCRIPTION
See the FAQ entry [`Group all packages starting with abc together in one PR`](https://docs.renovatebot.com/faq/#group-all-packages-starting-with-abc-together-in-one-pr).