### PR TITLE
feat: improve release pipeline to automatically create a Github release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,12 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Tag current commit
+        id: tag
         shell: bash
         run: |
           version="${GITHUB_REF#refs/heads/release/}"
           git tag "${version}"
+          echo "release_version=${version}" >> "$GITHUB_OUTPUT"
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:
@@ -316,12 +318,27 @@ jobs:
         run: dotnet build --configuration "Release"
       - name: Publish
         run: nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ steps.tag.outputs.release_version }}
+          tag_name: ${{ steps.tag.outputs.release_version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: true
 
   cleanup:
     name: Cleanup
     runs-on: ubuntu-latest
     needs: [deploy, stryker-windows, stryker-ubuntu]
     steps:
+      - name: Comment relevant issues and pull requests
+        uses: apexskier/github-release-commenter@v1.3.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          comment-template: |
+            This is addressed in release {release_link}.
+          label-template: |
+            state: released
       - name: Checkout sources
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Use [softprops/action-gh-release](https://github.com/softprops/action-gh-release) to automatically create Github releases in the release build pipeline.

Also use [apexskier/github-release-commenter](https://github.com/apexskier/github-release-commenter) to add a comment in relevant issues and pull requests.