### PR TITLE
refactor: use FluentAssertion extensions methods

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,7 +36,7 @@
 	<ItemGroup>
 		<PackageVersion Include="Testably.Abstractions" Version="2.3.4" />
 		<PackageVersion Include="Testably.Abstractions.Testing" Version="2.3.4" />
-		<PackageVersion Include="Testably.Abstractions.FluentAssertions" Version="0.3.0" />
+		<PackageVersion Include="Testably.Abstractions.FluentAssertions" Version="0.5.0" />
 	</ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,6 +36,7 @@
 	<ItemGroup>
 		<PackageVersion Include="Testably.Abstractions" Version="2.3.4" />
 		<PackageVersion Include="Testably.Abstractions.Testing" Version="2.3.4" />
+		<PackageVersion Include="Testably.Abstractions.FluentAssertions" Version="0.3.0" />
 	</ItemGroup>
 
 </Project>

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Xml.Linq;
 using Xunit.Abstractions;
 
 namespace Testably.Abstractions.Testing.Tests.FileSystem;

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Xml.Linq;
 using Xunit.Abstractions;
 
 namespace Testably.Abstractions.Testing.Tests.FileSystem;
@@ -22,7 +23,7 @@ public class ChangeHandlerTests
 	{
 		FileSystem.Intercept.Event(_ =>
 		{
-			FileSystem.Directory.Exists(path).Should().BeFalse();
+			FileSystem.Should().NotHaveDirectory(path);
 			throw exceptionToThrow;
 		});
 		Exception? exception = Record.Exception(() =>
@@ -30,7 +31,7 @@ public class ChangeHandlerTests
 			FileSystem.Directory.CreateDirectory(path);
 		});
 
-		FileSystem.Directory.Exists(path).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(path);
 		exception.Should().Be(exceptionToThrow);
 	}
 

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemExtensibilityTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemExtensibilityTests.cs
@@ -13,7 +13,7 @@ public class FileSystemExtensibilityTests
 
 		IFileSystem result = sut.FileSystem;
 
-		result.Should().Be(fileSystem);
+		result.Should().BeSameAs(fileSystem);
 	}
 
 	[SkippableTheory]
@@ -24,7 +24,7 @@ public class FileSystemExtensibilityTests
 
 		IFileSystem result = sut.FileSystem;
 
-		result.Should().Be(fileSystem);
+		result.Should().BeSameAs(fileSystem);
 	}
 
 	[SkippableTheory]
@@ -35,7 +35,7 @@ public class FileSystemExtensibilityTests
 
 		IFileSystem result = sut.FileSystem;
 
-		result.Should().Be(fileSystem);
+		result.Should().BeSameAs(fileSystem);
 	}
 
 	[SkippableTheory]
@@ -46,7 +46,7 @@ public class FileSystemExtensibilityTests
 
 		IFileSystem result = sut.FileSystem;
 
-		result.Should().Be(fileSystem);
+		result.Should().BeSameAs(fileSystem);
 	}
 
 	[SkippableTheory]
@@ -57,7 +57,7 @@ public class FileSystemExtensibilityTests
 
 		IFileSystem result = sut.FileSystem;
 
-		result.Should().Be(fileSystem);
+		result.Should().BeSameAs(fileSystem);
 	}
 
 	[SkippableTheory]
@@ -68,7 +68,7 @@ public class FileSystemExtensibilityTests
 
 		IFileSystem result = sut.FileSystem;
 
-		result.Should().Be(fileSystem);
+		result.Should().BeSameAs(fileSystem);
 	}
 
 	[SkippableTheory]
@@ -79,7 +79,7 @@ public class FileSystemExtensibilityTests
 
 		IFileSystem result = sut.FileSystem;
 
-		result.Should().Be(fileSystem);
+		result.Should().BeSameAs(fileSystem);
 	}
 
 	[SkippableTheory]
@@ -90,7 +90,7 @@ public class FileSystemExtensibilityTests
 
 		IFileSystem result = sut.FileSystem;
 
-		result.Should().Be(fileSystem);
+		result.Should().BeSameAs(fileSystem);
 	}
 
 	[SkippableTheory]
@@ -101,7 +101,7 @@ public class FileSystemExtensibilityTests
 
 		IFileSystem result = sut.FileSystem;
 
-		result.Should().Be(fileSystem);
+		result.Should().BeSameAs(fileSystem);
 	}
 
 	[SkippableTheory]
@@ -112,7 +112,7 @@ public class FileSystemExtensibilityTests
 
 		IFileSystem result = sut.FileSystem;
 
-		result.Should().Be(fileSystem);
+		result.Should().BeSameAs(fileSystem);
 	}
 
 	[SkippableTheory]
@@ -123,7 +123,7 @@ public class FileSystemExtensibilityTests
 
 		IFileSystem result = sut.FileSystem;
 
-		result.Should().Be(fileSystem);
+		result.Should().BeSameAs(fileSystem);
 	}
 
 	[SkippableTheory]
@@ -134,7 +134,7 @@ public class FileSystemExtensibilityTests
 
 		IFileSystem result = sut.FileSystem;
 
-		result.Should().Be(fileSystem);
+		result.Should().BeSameAs(fileSystem);
 	}
 
 	[SkippableTheory]
@@ -145,7 +145,7 @@ public class FileSystemExtensibilityTests
 
 		IFileSystem result = sut.FileSystem;
 
-		result.Should().Be(fileSystem);
+		result.Should().BeSameAs(fileSystem);
 	}
 
 	public static IEnumerable<object[]> GetFileSystems =>

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherMockTests.cs
@@ -165,8 +165,10 @@ public sealed class FileSystemWatcherMockTests : IDisposable
 			{
 				break;
 			}
+
 			FileSystem.Directory.CreateDirectory($"{i}_{path1}");
 		}
+
 		fileSystemWatcher.InternalBufferSize = 4196;
 		FileSystem.Directory.CreateDirectory(path2);
 		for (int i = 0; i < 4196 / 128; i++)
@@ -175,6 +177,7 @@ public sealed class FileSystemWatcherMockTests : IDisposable
 			{
 				break;
 			}
+
 			FileSystem.Directory.CreateDirectory($"{i}_{path2}");
 		}
 

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.IO.Abstractions;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Testing.Tests.FileSystemInitializer;
@@ -17,7 +18,7 @@ public class FileSystemInitializerTests
 
 		foreach (DirectoryDescription directory in directories)
 		{
-			fileSystem.Directory.Exists(directory.Name).Should().BeTrue();
+			fileSystem.Should().HaveDirectory(directory.Name);
 		}
 	}
 
@@ -31,7 +32,7 @@ public class FileSystemInitializerTests
 
 		sut.With(description);
 
-		fileSystem.File.Exists(name).Should().BeTrue();
+		fileSystem.Should().HaveFile(name);
 		fileSystem.File.ReadAllText(name).Should().Be(content);
 	}
 
@@ -46,7 +47,7 @@ public class FileSystemInitializerTests
 
 		foreach (FileDescription file in files)
 		{
-			fileSystem.File.Exists(file.Name).Should().BeTrue();
+			fileSystem.Should().HaveFile(file.Name);
 		}
 	}
 
@@ -64,7 +65,7 @@ public class FileSystemInitializerTests
 
 		sut.With(description);
 
-		fileSystem.File.Exists(name).Should().BeTrue();
+		fileSystem.Should().HaveFile(name);
 		fileSystem.FileInfo.New(name).IsReadOnly.Should().Be(isReadOnly);
 	}
 
@@ -79,8 +80,8 @@ public class FileSystemInitializerTests
 
 		sut.With(fileDescription, directoryDescription);
 
-		fileSystem.File.Exists(fileName).Should().BeTrue();
-		fileSystem.Directory.Exists(directoryName).Should().BeTrue();
+		fileSystem.Should().HaveFile(fileName);
+		fileSystem.Should().HaveDirectory(directoryName);
 	}
 
 	[Theory]
@@ -120,7 +121,7 @@ public class FileSystemInitializerTests
 
 		sut.WithFile(path).Which(f => f.HasStringContent("foo"));
 
-		fileSystem.File.Exists(path).Should().BeTrue();
+		fileSystem.Should().HaveFile(path);
 		fileSystem.File.ReadAllText(path).Should().Be("foo");
 	}
 
@@ -135,8 +136,8 @@ public class FileSystemInitializerTests
 
 		sut.WithFile(path);
 
-		fileSystem.File.Exists(path).Should().BeTrue();
-		fileSystem.Directory.Exists(directoryPath).Should().BeTrue();
+		fileSystem.Should().HaveFile(path);
+		fileSystem.Should().HaveDirectory(directoryPath);
 	}
 
 	[Theory]
@@ -151,7 +152,7 @@ public class FileSystemInitializerTests
 
 		foreach (string path in paths)
 		{
-			fileSystem.Directory.Exists(path).Should().BeTrue();
+			fileSystem.Should().HaveDirectory(path);
 		}
 
 		result.Should().Be(sut);
@@ -196,7 +197,7 @@ public class FileSystemInitializerTests
 		IFileSystemDirectoryInitializer<MockFileSystem> result = sut
 			.WithSubdirectory(path);
 
-		fileSystem.Directory.Exists(path).Should().BeTrue();
-		result.FileSystem.Should().Be(fileSystem);
+		fileSystem.Should().HaveDirectory(path);
+		result.FileSystem.Should().BeSameAs(fileSystem);
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.IO.Abstractions;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Testing.Tests.FileSystemInitializer;

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
 using Testably.Abstractions.Testing.FileSystemInitializer;

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
 using Testably.Abstractions.Testing.FileSystemInitializer;
@@ -207,7 +208,7 @@ public class FileSystemInitializerExtensionsTests
 		result.Length.Should().Be(2);
 		result.Should().Contain(x => x.EndsWith("TestFile1.txt"));
 		result.Should().Contain(x => x.EndsWith("TestFile2.txt"));
-		fileSystem.Directory.Exists(Path.Combine(path, "SubResource")).Should().BeFalse();
+		fileSystem.Should().NotHaveDirectory(Path.Combine(path, "SubResource"));
 	}
 
 	[Theory]

--- a/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryContainerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryContainerTests.cs
@@ -221,8 +221,8 @@ public class InMemoryContainerTests
 		IStorageLocation location = InMemoryLocation.New(null, path);
 		IStorageContainer sut = InMemoryContainer.NewFile(location, fileSystem);
 
-		sut.FileSystem.Should().Be(fileSystem);
-		sut.TimeSystem.Should().Be(fileSystem.TimeSystem);
+		sut.FileSystem.Should().BeSameAs(fileSystem);
+		sut.TimeSystem.Should().BeSameAs(fileSystem.TimeSystem);
 	}
 
 	[Theory]

--- a/Tests/Testably.Abstractions.Testing.Tests/Storage/NullContainerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Storage/NullContainerTests.cs
@@ -35,8 +35,8 @@ public class NullContainerTests
 
 		IStorageContainer sut = NullContainer.New(fileSystem);
 
-		sut.FileSystem.Should().Be(fileSystem);
-		sut.TimeSystem.Should().Be(fileSystem.TimeSystem);
+		sut.FileSystem.Should().BeSameAs(fileSystem);
+		sut.TimeSystem.Should().BeSameAs(fileSystem.TimeSystem);
 	}
 
 	[Fact]

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Usings.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Usings.cs
@@ -2,4 +2,5 @@
 global using FluentAssertions;
 global using System;
 global using System.IO.Abstractions;
+global using Testably.Abstractions.FluentAssertions;
 global using Xunit;

--- a/Tests/Testably.Abstractions.Testing.Tests/Testably.Abstractions.Testing.Tests.csproj
+++ b/Tests/Testably.Abstractions.Testing.Tests/Testably.Abstractions.Testing.Tests.csproj
@@ -22,6 +22,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Testably.Abstractions.FluentAssertions" />
+	</ItemGroup>
+
+	<ItemGroup>
 	  <Compile Update="Properties\Resources.Designer.cs">
 	    <DesignTime>True</DesignTime>
 	    <AutoGen>True</AutoGen>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -218,9 +218,8 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 	public void CreateDirectory_ShouldCreateDirectoryInBasePath()
 	{
 		IDirectoryInfo result = FileSystem.Directory.CreateDirectory("foo");
-		bool exists = FileSystem.Directory.Exists("foo");
 
-		exists.Should().BeTrue();
+		FileSystem.Should().HaveDirectory("foo");
 		result.FullName.Should().StartWith(BasePath);
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -19,7 +19,7 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 		});
 
 		exception.Should().BeNull();
-		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(path);
 	}
 
 	[SkippableTheory]
@@ -39,14 +39,14 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			exception.Should().BeNull();
-			FileSystem.Directory.Exists(subdirectoryPath).Should().BeTrue();
+			FileSystem.Should().HaveDirectory(subdirectoryPath);
 			FileSystem.DirectoryInfo.New(parent).Attributes
 				.Should().HaveFlag(FileAttributes.ReadOnly);
 		}
 		else
 		{
 			exception.Should().BeException<UnauthorizedAccessException>(hResult: -2147024891);
-			FileSystem.Directory.Exists(subdirectoryPath).Should().BeFalse();
+			FileSystem.Should().NotHaveDirectory(subdirectoryPath);
 		}
 	}
 
@@ -63,7 +63,7 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 
 		exception.Should().BeException<IOException>(
 			hResult: Test.RunsOnWindows ? -2147024713 : 17);
-		FileSystem.Directory.Exists(name).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(name);
 	}
 
 	[SkippableFact]
@@ -78,7 +78,7 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 		});
 
 		exception.Should().BeNull();
-		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(path);
 	}
 
 	[SkippableTheory]
@@ -263,7 +263,7 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 		result.FullName.Should().Be(System.IO.Path.Combine(BasePath, expectedName
 			.Replace(FileSystem.Path.AltDirectorySeparatorChar,
 				FileSystem.Path.DirectorySeparatorChar)));
-		FileSystem.Directory.Exists(nameWithSuffix).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(nameWithSuffix);
 	}
 
 	[SkippableTheory]
@@ -285,7 +285,7 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 		result.FullName.Should().Be(System.IO.Path.Combine(BasePath, expectedName
 			.Replace(FileSystem.Path.AltDirectorySeparatorChar,
 				FileSystem.Path.DirectorySeparatorChar)));
-		FileSystem.Directory.Exists(nameWithSuffix).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(nameWithSuffix);
 	}
 #else
 	[SkippableTheory]
@@ -317,7 +317,7 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 		result.FullName.Should().Be(System.IO.Path.Combine(BasePath, expectedName
 			.Replace(FileSystem.Path.AltDirectorySeparatorChar,
 				FileSystem.Path.DirectorySeparatorChar)));
-		FileSystem.Directory.Exists(nameWithSuffix).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(nameWithSuffix);
 	}
 #endif
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
@@ -144,7 +144,7 @@ public abstract partial class DeleteTests<TFileSystem>
 		FileSystem.Directory.Delete(path, true);
 
 		FileSystem.Should().NotHaveDirectory(path);
-		FileSystem.Should().NotHaveDirectory(subdirectory);
+		FileSystem.Should().NotHaveDirectory(subdirectoryPath);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
@@ -29,8 +29,7 @@ public abstract partial class DeleteTests<TFileSystem>
 		else
 		{
 			exception.Should().BeNull();
-			FileSystem.Directory.Exists(directoryName.ToUpperInvariant())
-				.Should().BeFalse();
+			FileSystem.Should().NotHaveDirectory(directoryName.ToUpperInvariant());
 		}
 	}
 
@@ -43,7 +42,7 @@ public abstract partial class DeleteTests<TFileSystem>
 
 		FileSystem.Directory.Delete(result.FullName);
 
-		FileSystem.Directory.Exists(directoryName).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(directoryName);
 		result.Exists.Should().BeFalse();
 	}
 
@@ -105,12 +104,12 @@ public abstract partial class DeleteTests<TFileSystem>
 		{
 			exception.Should().BeException<IOException>($"{filename}'",
 				hResult: -2147024864);
-			FileSystem.File.Exists(filePath).Should().BeTrue();
+			FileSystem.Should().HaveFile(filePath);
 		}
 		else
 		{
 			exception.Should().BeNull();
-			FileSystem.File.Exists(filePath).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(filePath);
 		}
 	}
 
@@ -129,8 +128,8 @@ public abstract partial class DeleteTests<TFileSystem>
 
 		FileSystem.Directory.Delete(subdirectory, true);
 
-		FileSystem.Directory.Exists(subdirectory).Should().BeFalse();
-		FileSystem.File.Exists(fileName).Should().BeTrue();
+		FileSystem.Should().NotHaveDirectory(subdirectory);
+		FileSystem.Should().HaveFile(fileName);
 	}
 
 	[SkippableTheory]
@@ -144,8 +143,8 @@ public abstract partial class DeleteTests<TFileSystem>
 
 		FileSystem.Directory.Delete(path, true);
 
-		FileSystem.Directory.Exists(path).Should().BeFalse();
-		FileSystem.Directory.Exists(subdirectoryPath).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(path);
+		FileSystem.Should().NotHaveDirectory(subdirectory);
 	}
 
 	[SkippableTheory]
@@ -195,9 +194,7 @@ public abstract partial class DeleteTests<TFileSystem>
 
 		FileSystem.Directory.Delete(directoryName);
 
-		bool exists = FileSystem.Directory.Exists(directoryName);
-
-		exists.Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(directoryName);
 		result.Exists.Should().BeFalse();
 	}
 
@@ -213,7 +210,7 @@ public abstract partial class DeleteTests<TFileSystem>
 
 		FileSystem.Directory.Delete(subdirectory);
 
-		FileSystem.Directory.Exists(subdirectory).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(subdirectory);
 		FileSystem.File.Exists(fileName).Should().BeTrue();
 	}
 
@@ -236,5 +233,6 @@ public abstract partial class DeleteTests<TFileSystem>
 			messageContains: !Test.RunsOnWindows || Test.IsNetFramework
 				? null
 				: $"'{System.IO.Path.Combine(BasePath, path)}'");
+		FileSystem.Should().HaveDirectory(path);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
@@ -139,7 +139,7 @@ public abstract partial class DeleteTests<TFileSystem>
 	{
 		string subdirectoryPath = FileSystem.Path.Combine(path, subdirectory);
 		FileSystem.Directory.CreateDirectory(subdirectoryPath);
-		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(path);
 
 		FileSystem.Directory.Delete(path, true);
 
@@ -211,7 +211,7 @@ public abstract partial class DeleteTests<TFileSystem>
 		FileSystem.Directory.Delete(subdirectory);
 
 		FileSystem.Should().NotHaveDirectory(subdirectory);
-		FileSystem.File.Exists(fileName).Should().BeTrue();
+		FileSystem.Should().HaveFile(fileName);
 	}
 
 	[SkippableTheory]
@@ -220,7 +220,7 @@ public abstract partial class DeleteTests<TFileSystem>
 		string path, string subdirectory)
 	{
 		FileSystem.Directory.CreateDirectory(FileSystem.Path.Combine(path, subdirectory));
-		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(path);
 
 		Exception? exception = Record.Exception(() =>
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
@@ -37,7 +37,7 @@ public abstract partial class EnumerateDirectoriesTests<TFileSystem>
 		exception.Should().BeException<DirectoryNotFoundException>(
 			$"'{expectedPath}'",
 			hResult: -2147024893);
-		FileSystem.Directory.Exists(path).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(path);
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateFileSystemInfosTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateFileSystemInfosTests.cs
@@ -24,7 +24,7 @@ public abstract partial class EnumerateFileSystemInfosTests<TFileSystem>
 		exception.Should().BeException<DirectoryNotFoundException>(
 			$"'{expectedPath}'",
 			hResult: -2147024893);
-		FileSystem.Directory.Exists(path).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateFilesTests.cs
@@ -24,7 +24,7 @@ public abstract partial class EnumerateFilesTests<TFileSystem>
 		exception.Should().BeException<DirectoryNotFoundException>(
 			$"'{expectedPath}'",
 			hResult: -2147024893);
-		FileSystem.Directory.Exists(path).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetDirectoriesTests.cs
@@ -22,7 +22,7 @@ public abstract partial class GetDirectoriesTests<TFileSystem>
 
 		exception.Should().BeException<DirectoryNotFoundException>($"'{expectedPath}'",
 			hResult: -2147024893);
-		FileSystem.Directory.Exists(path).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFileSystemInfosTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFileSystemInfosTests.cs
@@ -23,7 +23,7 @@ public abstract partial class GetFileSystemInfosTests<TFileSystem>
 
 		exception.Should().BeException<DirectoryNotFoundException>($"'{expectedPath}'.",
 			hResult: -2147024893);
-		FileSystem.Directory.Exists(path).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
@@ -23,7 +23,7 @@ public abstract partial class GetFilesTests<TFileSystem>
 
 		exception.Should().BeException<DirectoryNotFoundException>(expectedPath,
 			hResult: -2147024893);
-		FileSystem.Directory.Exists(path).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
@@ -185,10 +185,11 @@ public abstract partial class GetFilesTests<TFileSystem>
 		{
 			FileSystem.File.Create(System.IO.Path.Combine(workingDirectory, file));
 		}
+
 		FileSystem.Directory.SetCurrentDirectory(subfolder1);
 		IEnumerable<string> expectation =
 			files.Select(f => System.IO.Path.Combine("..", subfolder1, subfolder2, f));
-		var path = System.IO.Path.Combine("..", subfolder1, subfolder2);
+		string path = System.IO.Path.Combine("..", subfolder1, subfolder2);
 
 		List<string> result = FileSystem.Directory.GetFiles(path).ToList();
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/MoveTests.cs
@@ -29,7 +29,7 @@ public abstract partial class MoveTests<TFileSystem>
 		FileSystem.Directory.Move(source, destination);
 
 		FileSystem.Directory.Exists(source).Should().Be(!Test.RunsOnLinux);
-		FileSystem.Directory.Exists(destination).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(destination);
 		FileSystem.Directory.GetDirectories(".").Should()
 			.ContainSingle(d => d.Contains(destination));
 		FileSystem.Directory.GetFiles(destination, initialized[1].Name)
@@ -110,8 +110,8 @@ public abstract partial class MoveTests<TFileSystem>
 
 		FileSystem.Directory.Move(source, destination);
 
-		FileSystem.Directory.Exists(source).Should().BeFalse();
-		FileSystem.Directory.Exists(destination).Should().BeTrue();
+		FileSystem.Should().NotHaveDirectory(source);
+		FileSystem.Should().HaveDirectory(destination);
 		FileSystem.Directory.GetFiles(destination, initialized[1].Name)
 			.Should().ContainSingle();
 		FileSystem.Directory.GetDirectories(destination, initialized[2].Name)
@@ -201,8 +201,8 @@ public abstract partial class MoveTests<TFileSystem>
 		});
 
 		exception.Should().BeException<IOException>(hResult: -2147024891);
-		FileSystem.Directory.Exists(source).Should().BeTrue();
-		FileSystem.Directory.Exists(destination).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(source);
+		FileSystem.Should().NotHaveDirectory(destination);
 		IDirectoryInfo sourceDirectory =
 			FileSystem.DirectoryInfo.New(source);
 		sourceDirectory.GetFiles(initialized[1].Name)
@@ -241,8 +241,8 @@ public abstract partial class MoveTests<TFileSystem>
 		});
 
 		exception.Should().BeNull();
-		FileSystem.Directory.Exists(source).Should().BeFalse();
-		FileSystem.Directory.Exists(destination).Should().BeTrue();
+		FileSystem.Should().NotHaveDirectory(source);
+		FileSystem.Should().HaveDirectory(destination);
 		IDirectoryInfo destinationDirectory =
 			FileSystem.DirectoryInfo.New(destination);
 		destinationDirectory.GetFiles(initialized[1].Name)
@@ -273,8 +273,8 @@ public abstract partial class MoveTests<TFileSystem>
 
 		FileSystem.Directory.Move(source, destination);
 
-		FileSystem.Directory.Exists(source).Should().BeFalse();
-		FileSystem.Directory.Exists(destination).Should().BeTrue();
+		FileSystem.Should().NotHaveDirectory(source);
+		FileSystem.Should().HaveDirectory(destination);
 		IDirectoryInfo destinationDirectory =
 			FileSystem.DirectoryInfo.New(destination);
 		destinationDirectory.GetFiles(initialized[1].Name)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/AttributesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/AttributesTests.cs
@@ -16,8 +16,8 @@ public abstract partial class AttributesTests<TFileSystem>
 
 		sut.Attributes = 0;
 
-		FileSystem.Directory.Exists(path).Should().BeTrue();
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(path);
+		FileSystem.Should().NotHaveFile(path);
 		sut.Attributes.Should().HaveFlag(FileAttributes.Directory);
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateSubdirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateSubdirectoryTests.cs
@@ -22,7 +22,7 @@ public abstract partial class CreateSubdirectoryTests<TFileSystem>
 
 		exception.Should().BeException<IOException>(
 			hResult: Test.RunsOnWindows ? -2147024713 : 17);
-		FileSystem.Directory.Exists(name).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(name);
 	}
 
 	[SkippableTheory]
@@ -35,9 +35,9 @@ public abstract partial class CreateSubdirectoryTests<TFileSystem>
 		IDirectoryInfo result = sut.CreateSubdirectory(subdirectory);
 
 		sut.Exists.Should().BeFalse();
-		FileSystem.Directory.Exists(sut.FullName).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(sut.FullName);
 		result.Exists.Should().BeTrue();
-		FileSystem.Directory.Exists(result.FullName).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(result.FullName);
 	}
 
 	[SkippableTheory]
@@ -49,8 +49,8 @@ public abstract partial class CreateSubdirectoryTests<TFileSystem>
 		IDirectoryInfo result = sut.CreateSubdirectory(subdirectory);
 
 		sut.Exists.Should().BeTrue();
-		FileSystem.Directory.Exists(sut.FullName).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(sut.FullName);
 		result.Exists.Should().BeTrue();
-		FileSystem.Directory.Exists(result.FullName).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(result.FullName);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
@@ -21,7 +21,7 @@ public abstract partial class CreateTests<TFileSystem>
 
 		exception.Should().BeException<IOException>(
 			hResult: Test.RunsOnWindows ? -2147024713 : 17);
-		FileSystem.Directory.Exists(name).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(name);
 	}
 
 	[SkippableTheory]
@@ -39,17 +39,17 @@ public abstract partial class CreateTests<TFileSystem>
 #else
 		sut.Exists.Should().BeTrue();
 #endif
-		FileSystem.Directory.Exists(sut.FullName).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(sut.FullName);
 	}
 
 	[SkippableFact]
 	public void Create_ShouldCreateInBasePath()
 	{
 		IDirectoryInfo result = FileSystem.DirectoryInfo.New("foo");
-		result.Create();
-		bool exists = FileSystem.Directory.Exists("foo");
 
-		exists.Should().BeTrue();
+		result.Create();
+
+		FileSystem.Should().HaveDirectory("foo");
 		result.FullName.Should().StartWith(BasePath);
 	}
 
@@ -100,7 +100,7 @@ public abstract partial class CreateTests<TFileSystem>
 			sut3.Exists.Should().BeTrue();
 		}
 
-		FileSystem.Directory.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(path);
 	}
 
 	[SkippableTheory]
@@ -133,6 +133,6 @@ public abstract partial class CreateTests<TFileSystem>
 		result.FullName.Should().Be(System.IO.Path.Combine(BasePath, expectedName
 			.Replace(FileSystem.Path.AltDirectorySeparatorChar,
 				FileSystem.Path.DirectorySeparatorChar)));
-		FileSystem.Directory.Exists(nameWithSuffix).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(nameWithSuffix);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/DeleteTests.cs
@@ -52,12 +52,12 @@ public abstract partial class DeleteTests<TFileSystem>
 		{
 			exception.Should().BeException<IOException>($"{filename}'",
 				hResult: -2147024864);
-			FileSystem.File.Exists(filePath).Should().BeTrue();
+			FileSystem.Should().HaveFile(filePath);
 		}
 		else
 		{
 			exception.Should().BeNull();
-			FileSystem.File.Exists(filePath).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(filePath);
 		}
 	}
 
@@ -79,8 +79,8 @@ public abstract partial class DeleteTests<TFileSystem>
 #else
 		sut.Exists.Should().BeFalse();
 #endif
-		FileSystem.Directory.Exists(sut.FullName).Should().BeFalse();
-		FileSystem.Directory.Exists(subdirectoryPath).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(sut.FullName);
+		FileSystem.Should().NotHaveDirectory(subdirectoryPath);
 	}
 
 	[SkippableTheory]
@@ -99,7 +99,7 @@ public abstract partial class DeleteTests<TFileSystem>
 #else
 		sut.Exists.Should().BeFalse();
 #endif
-		FileSystem.Directory.Exists(sut.FullName).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(sut.FullName);
 	}
 
 	[SkippableTheory]
@@ -124,6 +124,6 @@ public abstract partial class DeleteTests<TFileSystem>
 				: $"'{sut.FullName}'");
 
 		sut.Exists.Should().BeTrue();
-		FileSystem.Directory.Exists(sut.FullName).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(sut.FullName);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExistsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExistsTests.cs
@@ -12,7 +12,7 @@ public abstract partial class ExistsTests<TFileSystem>
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
 
 		sut.Exists.Should().BeFalse();
-		FileSystem.Directory.Exists(sut.FullName).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(sut.FullName);
 	}
 
 	[SkippableTheory]
@@ -25,7 +25,7 @@ public abstract partial class ExistsTests<TFileSystem>
 		FileSystem.Directory.Delete(path);
 
 		sut.Exists.Should().BeTrue();
-		FileSystem.Directory.Exists(sut.FullName).Should().BeFalse();
+		FileSystem.Should().NotHaveDirectory(sut.FullName);
 	}
 
 	[SkippableTheory]
@@ -47,7 +47,7 @@ public abstract partial class ExistsTests<TFileSystem>
 		FileSystem.Directory.CreateDirectory(path);
 
 		sut.Exists.Should().BeFalse();
-		FileSystem.Directory.Exists(sut.FullName).Should().BeTrue();
+		FileSystem.Should().HaveDirectory(sut.FullName);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/MoveToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/MoveToTests.cs
@@ -25,8 +25,8 @@ public abstract partial class MoveToTests<TFileSystem>
 
 		sut.MoveTo(destination);
 
-		FileSystem.Directory.Exists(source).Should().BeFalse();
-		FileSystem.Directory.Exists(destination).Should().BeTrue();
+		FileSystem.Should().NotHaveDirectory(source);
+		FileSystem.Should().HaveDirectory(destination);
 		FileSystem.Directory.GetFiles(destination, initialized[1].Name)
 			.Should().ContainSingle();
 		FileSystem.Directory.GetDirectories(destination, initialized[2].Name)
@@ -94,8 +94,8 @@ public abstract partial class MoveToTests<TFileSystem>
 			exception.Should().BeException<IOException>(hResult: -2147024891);
 		}
 
-		FileSystem.Directory.Exists(source).Should().BeTrue();
-		FileSystem.Directory.Exists(destination).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(source);
+		FileSystem.Should().NotHaveDirectory(destination);
 		IDirectoryInfo sourceDirectory =
 			FileSystem.DirectoryInfo.New(source);
 		sourceDirectory.GetFiles(initialized[1].Name)
@@ -135,8 +135,8 @@ public abstract partial class MoveToTests<TFileSystem>
 		});
 
 		exception.Should().BeNull();
-		FileSystem.Directory.Exists(source).Should().BeFalse();
-		FileSystem.Directory.Exists(destination).Should().BeTrue();
+		FileSystem.Should().NotHaveDirectory(source);
+		FileSystem.Should().HaveDirectory(destination);
 		IDirectoryInfo destinationDirectory =
 			FileSystem.DirectoryInfo.New(destination);
 		destinationDirectory.GetFiles(initialized[1].Name)
@@ -168,8 +168,8 @@ public abstract partial class MoveToTests<TFileSystem>
 
 		sut.MoveTo(destination);
 
-		FileSystem.Directory.Exists(source).Should().BeFalse();
-		FileSystem.Directory.Exists(destination).Should().BeTrue();
+		FileSystem.Should().NotHaveDirectory(source);
+		FileSystem.Should().HaveDirectory(destination);
 		IDirectoryInfo destinationDirectory =
 			FileSystem.DirectoryInfo.New(destination);
 		destinationDirectory.GetFiles(initialized[1].Name)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/Tests.cs
@@ -42,7 +42,7 @@ public abstract partial class Tests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public void MissingDrive_WriteAllBytes_ShouldThrowDirectoryNotFoundException(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
@@ -52,7 +52,7 @@ public abstract partial class Tests<TFileSystem>
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.File.WriteAllBytes(path, contents);
+			FileSystem.File.WriteAllBytes(path, bytes);
 		});
 
 		exception.Should().BeException<DirectoryNotFoundException>($"'{path}'",

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
@@ -54,7 +54,7 @@ public abstract partial class AppendAllLinesAsyncTests<TFileSystem>
 
 		await FileSystem.File.AppendAllLinesAsync(path, contents);
 
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 		FileSystem.File.ReadAllLines(path).Should()
 			.BeEquivalentTo(previousContents.Concat(contents),
 				o => o.WithStrictOrdering());
@@ -81,7 +81,7 @@ public abstract partial class AppendAllLinesAsyncTests<TFileSystem>
 	{
 		await FileSystem.File.AppendAllLinesAsync(path, contents);
 
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 		FileSystem.File.ReadAllLines(path).Should().BeEquivalentTo(contents);
 	}
 
@@ -145,8 +145,8 @@ public abstract partial class AppendAllLinesAsyncTests<TFileSystem>
 
 		exception.Should().BeException<UnauthorizedAccessException>(
 			hResult: -2147024891);
-		FileSystem.Directory.Exists(path).Should().BeTrue();
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(path);
+		FileSystem.Should().NotHaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
@@ -50,14 +50,14 @@ public abstract partial class AppendAllLinesAsyncTests<TFileSystem>
 	public async Task AppendAllLinesAsync_ExistingFile_ShouldAppendLinesToFile(
 		string path, List<string> previousContents, List<string> contents)
 	{
+		string expectedContent = string.Join(Environment.NewLine, previousContents.Concat(contents))
+		                         + Environment.NewLine;
 		await FileSystem.File.AppendAllLinesAsync(path, previousContents);
 
 		await FileSystem.File.AppendAllLinesAsync(path, contents);
 
-		FileSystem.Should().HaveFile(path);
-		FileSystem.File.ReadAllLines(path).Should()
-			.BeEquivalentTo(previousContents.Concat(contents),
-				o => o.WithStrictOrdering());
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(expectedContent);
 	}
 
 	[SkippableTheory]
@@ -79,10 +79,13 @@ public abstract partial class AppendAllLinesAsyncTests<TFileSystem>
 	public async Task AppendAllLinesAsync_MissingFile_ShouldCreateFile(
 		string path, List<string> contents)
 	{
+		string expectedContent = string.Join(Environment.NewLine, contents)
+		                         + Environment.NewLine;
+
 		await FileSystem.File.AppendAllLinesAsync(path, contents);
 
-		FileSystem.Should().HaveFile(path);
-		FileSystem.File.ReadAllLines(path).Should().BeEquivalentTo(contents);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(expectedContent);
 	}
 
 	[SkippableTheory]
@@ -127,7 +130,8 @@ public abstract partial class AppendAllLinesAsyncTests<TFileSystem>
 
 		await FileSystem.File.AppendAllLinesAsync(path, contents);
 
-		FileSystem.File.ReadAllText(path).Should().BeEquivalentTo(expectedResult);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(expectedResult);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
@@ -15,14 +15,14 @@ public abstract partial class AppendAllLinesTests<TFileSystem>
 	public void AppendAllLines_ExistingFile_ShouldAppendLinesToFile(
 		string path, List<string> previousContents, List<string> contents)
 	{
+		string expectedContent = string.Join(Environment.NewLine, previousContents.Concat(contents))
+		                         + Environment.NewLine;
 		FileSystem.File.AppendAllLines(path, previousContents);
 
 		FileSystem.File.AppendAllLines(path, contents);
 
-		FileSystem.Should().HaveFile(path);
-		FileSystem.File.ReadAllLines(path).Should()
-			.BeEquivalentTo(previousContents.Concat(contents),
-				o => o.WithStrictOrdering());
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(expectedContent);
 	}
 
 	[SkippableTheory]
@@ -30,11 +30,12 @@ public abstract partial class AppendAllLinesTests<TFileSystem>
 	public void AppendAllLines_MissingFile_ShouldCreateFile(
 		string path, List<string> contents)
 	{
+		string expectedContent = string.Join(Environment.NewLine, contents)
+		                         + Environment.NewLine;
 		FileSystem.File.AppendAllLines(path, contents);
 
-		FileSystem.Should().HaveFile(path);
-		FileSystem.File.ReadAllLines(path).Should()
-			.BeEquivalentTo(contents, o => o.WithStrictOrdering());
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(expectedContent);
 	}
 
 	[SkippableTheory]
@@ -79,7 +80,8 @@ public abstract partial class AppendAllLinesTests<TFileSystem>
 
 		FileSystem.File.AppendAllLines(path, contents);
 
-		FileSystem.File.ReadAllText(path).Should().BeEquivalentTo(expectedResult);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(expectedResult);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
@@ -19,7 +19,7 @@ public abstract partial class AppendAllLinesTests<TFileSystem>
 
 		FileSystem.File.AppendAllLines(path, contents);
 
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 		FileSystem.File.ReadAllLines(path).Should()
 			.BeEquivalentTo(previousContents.Concat(contents),
 				o => o.WithStrictOrdering());
@@ -32,7 +32,7 @@ public abstract partial class AppendAllLinesTests<TFileSystem>
 	{
 		FileSystem.File.AppendAllLines(path, contents);
 
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 		FileSystem.File.ReadAllLines(path).Should()
 			.BeEquivalentTo(contents, o => o.WithStrictOrdering());
 	}
@@ -97,8 +97,8 @@ public abstract partial class AppendAllLinesTests<TFileSystem>
 
 		exception.Should().BeException<UnauthorizedAccessException>(
 			hResult: -2147024891);
-		FileSystem.Directory.Exists(path).Should().BeTrue();
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(path);
+		FileSystem.Should().NotHaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
@@ -51,7 +51,7 @@ public abstract partial class AppendAllTextAsyncTests<TFileSystem>
 
 		await FileSystem.File.AppendAllTextAsync(path, contents);
 
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 		FileSystem.File.ReadAllText(path).Should()
 			.BeEquivalentTo(previousContents + contents);
 	}
@@ -77,7 +77,7 @@ public abstract partial class AppendAllTextAsyncTests<TFileSystem>
 	{
 		await FileSystem.File.AppendAllTextAsync(path, contents);
 
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 		FileSystem.File.ReadAllLines(path).Should().BeEquivalentTo(contents);
 	}
 
@@ -107,8 +107,8 @@ public abstract partial class AppendAllTextAsyncTests<TFileSystem>
 
 		exception.Should().BeException<UnauthorizedAccessException>(
 			hResult: -2147024891);
-		FileSystem.Directory.Exists(path).Should().BeTrue();
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(path);
+		FileSystem.Should().NotHaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
@@ -51,9 +51,8 @@ public abstract partial class AppendAllTextAsyncTests<TFileSystem>
 
 		await FileSystem.File.AppendAllTextAsync(path, contents);
 
-		FileSystem.Should().HaveFile(path);
-		FileSystem.File.ReadAllText(path).Should()
-			.BeEquivalentTo(previousContents + contents);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(previousContents + contents);
 	}
 
 	[SkippableTheory]
@@ -77,8 +76,8 @@ public abstract partial class AppendAllTextAsyncTests<TFileSystem>
 	{
 		await FileSystem.File.AppendAllTextAsync(path, contents);
 
-		FileSystem.Should().HaveFile(path);
-		FileSystem.File.ReadAllLines(path).Should().BeEquivalentTo(contents);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(contents);
 	}
 
 	[SkippableTheory]
@@ -89,7 +88,8 @@ public abstract partial class AppendAllTextAsyncTests<TFileSystem>
 
 		await FileSystem.File.AppendAllTextAsync(path, contents);
 
-		FileSystem.File.ReadAllText(path).Should().BeEquivalentTo(contents);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(contents);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
@@ -18,7 +18,7 @@ public abstract partial class AppendAllTextTests<TFileSystem>
 
 		FileSystem.File.AppendAllText(path, contents);
 
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 		FileSystem.File.ReadAllText(path).Should()
 			.BeEquivalentTo(previousContents + contents);
 	}
@@ -44,7 +44,7 @@ public abstract partial class AppendAllTextTests<TFileSystem>
 	{
 		FileSystem.File.AppendAllText(path, contents);
 
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 		FileSystem.File.ReadAllText(path).Should().Be(contents);
 	}
 
@@ -138,8 +138,8 @@ public abstract partial class AppendAllTextTests<TFileSystem>
 
 		exception.Should().BeException<UnauthorizedAccessException>(
 			hResult: -2147024891);
-		FileSystem.Directory.Exists(path).Should().BeTrue();
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(path);
+		FileSystem.Should().NotHaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
@@ -18,9 +18,8 @@ public abstract partial class AppendAllTextTests<TFileSystem>
 
 		FileSystem.File.AppendAllText(path, contents);
 
-		FileSystem.Should().HaveFile(path);
-		FileSystem.File.ReadAllText(path).Should()
-			.BeEquivalentTo(previousContents + contents);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(previousContents + contents);
 	}
 
 	[SkippableTheory]
@@ -44,8 +43,8 @@ public abstract partial class AppendAllTextTests<TFileSystem>
 	{
 		FileSystem.File.AppendAllText(path, contents);
 
-		FileSystem.Should().HaveFile(path);
-		FileSystem.File.ReadAllText(path).Should().Be(contents);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(contents);
 	}
 
 	[SkippableTheory]
@@ -71,8 +70,8 @@ public abstract partial class AppendAllTextTests<TFileSystem>
 
 		FileSystem.File.AppendAllText(path, "AA", Encoding.UTF32);
 
-		FileSystem.File.ReadAllBytes(path)
-			.Should().BeEquivalentTo(expectedBytes);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(expectedBytes);
 	}
 
 	[SkippableTheory]
@@ -120,7 +119,8 @@ public abstract partial class AppendAllTextTests<TFileSystem>
 
 		FileSystem.File.AppendAllText(path, contents);
 
-		FileSystem.File.ReadAllText(path).Should().BeEquivalentTo(contents);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(contents);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendTextTests.cs
@@ -17,10 +17,8 @@ public abstract partial class AppendTextTests<TFileSystem>
 			stream.Write(appendText);
 		}
 
-		string result = FileSystem.File.ReadAllText(path);
-
-		result.Should().Be(appendText);
-		FileSystem.Should().HaveFile(path);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(appendText);
 	}
 
 	[SkippableTheory]
@@ -35,8 +33,7 @@ public abstract partial class AppendTextTests<TFileSystem>
 			stream.Write(appendText);
 		}
 
-		string result = FileSystem.File.ReadAllText(path);
-
-		result.Should().Be(contents + appendText);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(contents + appendText);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendTextTests.cs
@@ -20,7 +20,7 @@ public abstract partial class AppendTextTests<TFileSystem>
 		string result = FileSystem.File.ReadAllText(path);
 
 		result.Should().Be(appendText);
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -43,9 +43,9 @@ public abstract partial class CopyTests<TFileSystem>
 
 		exception.Should().BeException<IOException>(hResult: Test.RunsOnWindows ? -2147024816 : 17);
 
-		FileSystem.File.Exists(sourceName).Should().BeTrue();
+		FileSystem.Should().HaveFile(sourceName);
 		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
 	}
 
@@ -63,9 +63,9 @@ public abstract partial class CopyTests<TFileSystem>
 
 		FileSystem.File.Copy(sourceName, destinationName, true);
 
-		FileSystem.File.Exists(sourceName).Should().BeTrue();
+		FileSystem.Should().HaveFile(sourceName);
 		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
 	}
 #endif
@@ -121,8 +121,8 @@ public abstract partial class CopyTests<TFileSystem>
 
 		FileSystem.File.Copy(sourceName, destinationName);
 
-		FileSystem.File.Exists(sourceName).Should().BeTrue();
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(sourceName);
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.GetAttributes(destinationName)
 			.Should().HaveFlag(FileAttributes.ReadOnly);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
@@ -252,9 +252,9 @@ public abstract partial class CopyTests<TFileSystem>
 		TimeSystem.Thread.Sleep(1000);
 
 		FileSystem.File.Copy(sourceName, destinationName);
-		FileSystem.File.Exists(sourceName).Should().BeTrue();
+		FileSystem.Should().HaveFile(sourceName);
 		FileSystem.File.ReadAllText(sourceName).Should().Be(contents);
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
 	}
 
@@ -276,8 +276,8 @@ public abstract partial class CopyTests<TFileSystem>
 			messageContains: Test.IsNetFramework
 				? $"'{sourceName}'"
 				: $"'{FileSystem.Path.GetFullPath(sourceName)}'");
-		FileSystem.Directory.Exists(sourceName).Should().BeTrue();
-		FileSystem.File.Exists(destinationName).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(sourceName);
+		FileSystem.Should().NotHaveFile(destinationName);
 	}
 
 	[SkippableTheory]
@@ -298,12 +298,12 @@ public abstract partial class CopyTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			exception.Should().BeException<IOException>(hResult: -2147024864);
-			FileSystem.File.Exists(destinationName).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(destinationName);
 		}
 		else
 		{
-			FileSystem.File.Exists(sourceName).Should().BeTrue();
-			FileSystem.File.Exists(destinationName).Should().BeFalse();
+			FileSystem.Should().HaveFile(sourceName);
+			FileSystem.Should().NotHaveFile(destinationName);
 		}
 	}
 
@@ -323,6 +323,6 @@ public abstract partial class CopyTests<TFileSystem>
 			messageContains: Test.IsNetFramework
 				? null
 				: $"'{FileSystem.Path.GetFullPath(sourceName)}'");
-		FileSystem.File.Exists(destinationName).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(destinationName);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -43,10 +43,10 @@ public abstract partial class CopyTests<TFileSystem>
 
 		exception.Should().BeException<IOException>(hResult: Test.RunsOnWindows ? -2147024816 : 17);
 
-		FileSystem.Should().HaveFile(sourceName);
-		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
+		FileSystem.Should().HaveFile(sourceName)
+			.Which.HasContent(sourceContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(destinationContents);
 	}
 
 #if FEATURE_FILE_MOVETO_OVERWRITE
@@ -63,10 +63,10 @@ public abstract partial class CopyTests<TFileSystem>
 
 		FileSystem.File.Copy(sourceName, destinationName, true);
 
-		FileSystem.Should().HaveFile(sourceName);
-		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
+		FileSystem.Should().HaveFile(sourceName)
+			.Which.HasContent(sourceContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(sourceContents);
 	}
 #endif
 
@@ -121,11 +121,12 @@ public abstract partial class CopyTests<TFileSystem>
 
 		FileSystem.File.Copy(sourceName, destinationName);
 
-		FileSystem.Should().HaveFile(sourceName);
-		FileSystem.Should().HaveFile(destinationName);
+		FileSystem.Should().HaveFile(sourceName)
+			.Which.HasContent(contents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(contents);
 		FileSystem.File.GetAttributes(destinationName)
 			.Should().HaveFlag(FileAttributes.ReadOnly);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
 	}
 
 	[SkippableTheory]
@@ -212,8 +213,8 @@ public abstract partial class CopyTests<TFileSystem>
 			binaryWriter.Write("Some text");
 		}
 
-		FileSystem.File.ReadAllBytes(destination).Should()
-			.BeEquivalentTo(original);
+		FileSystem.Should().HaveFile(destination)
+			.Which.HasContent(original);
 		FileSystem.File.ReadAllBytes(destination).Should()
 			.NotBeEquivalentTo(FileSystem.File.ReadAllBytes(source));
 	}
@@ -252,10 +253,10 @@ public abstract partial class CopyTests<TFileSystem>
 		TimeSystem.Thread.Sleep(1000);
 
 		FileSystem.File.Copy(sourceName, destinationName);
-		FileSystem.Should().HaveFile(sourceName);
-		FileSystem.File.ReadAllText(sourceName).Should().Be(contents);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
+		FileSystem.Should().HaveFile(sourceName)
+			.Which.HasContent(contents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(contents);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
@@ -21,7 +21,8 @@ public abstract partial class CreateTests<TFileSystem>
 
 		streamWriter.Dispose();
 		stream.Dispose();
-		FileSystem.File.ReadAllText(path).Should().Be(newContent);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(newContent);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
@@ -61,7 +61,7 @@ public abstract partial class CreateTests<TFileSystem>
 	{
 		using FileSystemStream stream = FileSystem.File.Create(path);
 
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTextTests.cs
@@ -17,10 +17,8 @@ public abstract partial class CreateTextTests<TFileSystem>
 			stream.Write(appendText);
 		}
 
-		string result = FileSystem.File.ReadAllText(path);
-
-		result.Should().Be(appendText);
-		FileSystem.Should().HaveFile(path);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(appendText);
 	}
 
 	[SkippableTheory]
@@ -35,8 +33,7 @@ public abstract partial class CreateTextTests<TFileSystem>
 			stream.Write(appendText);
 		}
 
-		string result = FileSystem.File.ReadAllText(path);
-
-		result.Should().Be(appendText);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(appendText);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTextTests.cs
@@ -20,7 +20,7 @@ public abstract partial class CreateTextTests<TFileSystem>
 		string result = FileSystem.File.ReadAllText(path);
 
 		result.Should().Be(appendText);
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/DeleteTests.cs
@@ -60,12 +60,12 @@ public abstract partial class DeleteTests<TFileSystem>
 		{
 			exception.Should().BeException<IOException>($"{filename}'",
 				hResult: -2147024864);
-			FileSystem.File.Exists(filename).Should().BeTrue();
+			FileSystem.Should().HaveFile(filename);
 		}
 		else
 		{
 			exception.Should().BeNull();
-			FileSystem.File.Exists(filename).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(filename);
 		}
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/EncryptDecryptTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/EncryptDecryptTests.cs
@@ -72,7 +72,7 @@ public abstract partial class EncryptDecryptTests<TFileSystem>
 		FileSystem.File.WriteAllBytes(path, bytes);
 
 		FileSystem.File.Encrypt(path);
-
+		
 		byte[] result = FileSystem.File.ReadAllBytes(path);
 		result.Should().NotBeEquivalentTo(bytes);
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/EncryptDecryptTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/EncryptDecryptTests.cs
@@ -72,7 +72,7 @@ public abstract partial class EncryptDecryptTests<TFileSystem>
 		FileSystem.File.WriteAllBytes(path, bytes);
 
 		FileSystem.File.Encrypt(path);
-		
+
 		byte[] result = FileSystem.File.ReadAllBytes(path);
 		result.Should().NotBeEquivalentTo(bytes);
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
@@ -181,7 +181,7 @@ public abstract partial class MoveTests<TFileSystem>
 		exception.Should().BeException<FileNotFoundException>(
 			$"'{FileSystem.Path.GetFullPath(sourcePath)}'",
 			hResult: -2147024894);
-		FileSystem.Should().NotHaveFile(destinationName);	
+		FileSystem.Should().NotHaveFile(destinationName);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
@@ -24,8 +24,8 @@ public abstract partial class MoveTests<TFileSystem>
 			FileSystem.Should().NotHaveFile(sourceName);
 		}
 
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(contents);
 	}
 
 	[SkippableTheory]
@@ -65,10 +65,10 @@ public abstract partial class MoveTests<TFileSystem>
 		exception.Should().BeException<IOException>(
 			hResult: Test.RunsOnWindows ? -2147024713 : 17);
 
-		FileSystem.Should().HaveFile(sourceName);
-		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
+		FileSystem.Should().HaveFile(sourceName)
+			.Which.HasContent(sourceContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(destinationContents);
 	}
 
 #if FEATURE_FILE_MOVETO_OVERWRITE
@@ -86,8 +86,8 @@ public abstract partial class MoveTests<TFileSystem>
 		FileSystem.File.Move(sourceName, destinationName, true);
 
 		FileSystem.Should().NotHaveFile(sourceName);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(sourceContents);
 	}
 #endif
 
@@ -102,10 +102,10 @@ public abstract partial class MoveTests<TFileSystem>
 		FileSystem.File.Move(sourceName, destinationName);
 
 		FileSystem.Should().NotHaveFile(sourceName);
-		FileSystem.Should().HaveFile(destinationName);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(contents);
 		FileSystem.File.GetAttributes(destinationName)
 			.Should().HaveFlag(FileAttributes.ReadOnly);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
 	}
 
 	[SkippableTheory]
@@ -118,8 +118,8 @@ public abstract partial class MoveTests<TFileSystem>
 		FileSystem.File.Move(sourceName, destinationName);
 
 		FileSystem.Should().NotHaveFile(sourceName);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(contents);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
@@ -21,10 +21,10 @@ public abstract partial class MoveTests<TFileSystem>
 		if (Test.RunsOnLinux)
 		{
 			// sourceName and destinationName are considered different only on Linux
-			FileSystem.File.Exists(sourceName).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(sourceName);
 		}
 
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
 	}
 
@@ -65,9 +65,9 @@ public abstract partial class MoveTests<TFileSystem>
 		exception.Should().BeException<IOException>(
 			hResult: Test.RunsOnWindows ? -2147024713 : 17);
 
-		FileSystem.File.Exists(sourceName).Should().BeTrue();
+		FileSystem.Should().HaveFile(sourceName);
 		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
 	}
 
@@ -85,8 +85,8 @@ public abstract partial class MoveTests<TFileSystem>
 
 		FileSystem.File.Move(sourceName, destinationName, true);
 
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().NotHaveFile(sourceName);
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
 	}
 #endif
@@ -101,8 +101,8 @@ public abstract partial class MoveTests<TFileSystem>
 
 		FileSystem.File.Move(sourceName, destinationName);
 
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().NotHaveFile(sourceName);
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.GetAttributes(destinationName)
 			.Should().HaveFlag(FileAttributes.ReadOnly);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
@@ -117,8 +117,8 @@ public abstract partial class MoveTests<TFileSystem>
 
 		FileSystem.File.Move(sourceName, destinationName);
 
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().NotHaveFile(sourceName);
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
 	}
 
@@ -181,7 +181,7 @@ public abstract partial class MoveTests<TFileSystem>
 		exception.Should().BeException<FileNotFoundException>(
 			$"'{FileSystem.Path.GetFullPath(sourcePath)}'",
 			hResult: -2147024894);
-		FileSystem.File.Exists(destinationName).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(destinationName);	
 	}
 
 	[SkippableTheory]
@@ -203,12 +203,12 @@ public abstract partial class MoveTests<TFileSystem>
 		{
 			exception.Should().BeException<IOException>(
 				hResult: -2147024864);
-			FileSystem.File.Exists(destinationName).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(destinationName);
 		}
 		else
 		{
-			FileSystem.File.Exists(sourceName).Should().BeFalse();
-			FileSystem.File.Exists(destinationName).Should().BeTrue();
+			FileSystem.Should().NotHaveFile(sourceName);
+			FileSystem.Should().HaveFile(destinationName);
 		}
 	}
 
@@ -241,6 +241,6 @@ public abstract partial class MoveTests<TFileSystem>
 		exception.Should().BeException<FileNotFoundException>(
 			$"'{FileSystem.Path.GetFullPath(sourceName)}'",
 			hResult: -2147024894);
-		FileSystem.File.Exists(destinationName).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(destinationName);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenWriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenWriteTests.cs
@@ -13,7 +13,7 @@ public abstract partial class OpenWriteTests<TFileSystem>
 	{
 		using FileSystemStream stream = FileSystem.File.OpenWrite(path);
 
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadAllBytesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadAllBytesTests.cs
@@ -80,7 +80,9 @@ public abstract partial class ReadAllBytesTests<TFileSystem>
 		byte[] results = FileSystem.File.ReadAllBytes(path);
 		results[0] = (byte)~results[0];
 
-		FileSystem.File.ReadAllBytes(path).Should().BeEquivalentTo(bytes);
+		byte[] result = FileSystem.File.ReadAllBytes(path);
+
+		result.Should().BeEquivalentTo(bytes);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
@@ -65,7 +65,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 		});
 
 		exception.Should().BeException<FileNotFoundException>(hResult: -2147024894);
-		FileSystem.File.Exists(backupName).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(backupName);
 	}
 
 	[SkippableTheory]
@@ -83,12 +83,12 @@ public abstract partial class ReplaceTests<TFileSystem>
 
 		FileSystem.File.Replace(sourceName, destinationName, backupName, true);
 
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().NotHaveFile(sourceName);
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
 		FileSystem.File.GetAttributes(destinationName)
 			.Should().HaveFlag(FileAttributes.ReadOnly);
-		FileSystem.File.Exists(backupName).Should().BeTrue();
+		FileSystem.Should().HaveFile(backupName);
 		FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
 	}
 
@@ -114,21 +114,21 @@ public abstract partial class ReplaceTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			exception.Should().BeException<UnauthorizedAccessException>(hResult: -2147024891);
-			FileSystem.File.Exists(sourceName).Should().BeTrue();
+			FileSystem.Should().HaveFile(sourceName);
 			FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-			FileSystem.File.Exists(destinationName).Should().BeTrue();
+			FileSystem.Should().HaveFile(destinationName);
 			FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
 			FileSystem.File.GetAttributes(destinationName)
 				.Should().NotHaveFlag(FileAttributes.ReadOnly);
-			FileSystem.File.Exists(backupName).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(backupName);
 		}
 		else
 		{
 			exception.Should().BeNull();
-			FileSystem.File.Exists(sourceName).Should().BeFalse();
-			FileSystem.File.Exists(destinationName).Should().BeTrue();
+			FileSystem.Should().NotHaveFile(sourceName);
+			FileSystem.Should().HaveFile(destinationName);
 			FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-			FileSystem.File.Exists(backupName).Should().BeTrue();
+			FileSystem.Should().HaveFile(backupName);
 			FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
 		}
 	}
@@ -147,10 +147,10 @@ public abstract partial class ReplaceTests<TFileSystem>
 
 		FileSystem.File.Replace(sourceName, destinationName, backupName);
 
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().NotHaveFile(sourceName);
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-		FileSystem.File.Exists(backupName).Should().BeTrue();
+		FileSystem.Should().HaveFile(backupName);
 		FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
 	}
 
@@ -197,20 +197,20 @@ public abstract partial class ReplaceTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			exception.Should().BeException<IOException>(hResult: -2147024864);
-			FileSystem.File.Exists(sourceName).Should().BeTrue();
+			FileSystem.Should().HaveFile(sourceName);
 			FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-			FileSystem.File.Exists(destinationName).Should().BeTrue();
+			FileSystem.Should().HaveFile(destinationName);
 			FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
 			FileSystem.File.GetAttributes(destinationName)
 				.Should().NotHaveFlag(FileAttributes.ReadOnly);
-			FileSystem.File.Exists(backupName).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(backupName);
 		}
 		else
 		{
-			FileSystem.File.Exists(sourceName).Should().BeFalse();
-			FileSystem.File.Exists(destinationName).Should().BeTrue();
+			FileSystem.Should().NotHaveFile(sourceName);
+			FileSystem.Should().HaveFile(destinationName);
 			FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-			FileSystem.File.Exists(backupName).Should().BeTrue();
+			FileSystem.Should().HaveFile(backupName);
 			FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
 		}
 	}
@@ -233,7 +233,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			// Behaviour on Linux/MacOS is uncertain
-			FileSystem.File.Exists(backupName).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(backupName);
 		}
 	}
 
@@ -253,10 +253,10 @@ public abstract partial class ReplaceTests<TFileSystem>
 
 		FileSystem.File.Replace(sourceName, destinationName, null);
 
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().NotHaveFile(sourceName);
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-		FileSystem.File.Exists(backupName).Should().BeTrue();
+		FileSystem.Should().HaveFile(backupName);
 		FileSystem.File.ReadAllText(backupName).Should().Be(backupContents);
 	}
 
@@ -273,8 +273,8 @@ public abstract partial class ReplaceTests<TFileSystem>
 
 		FileSystem.File.Replace(sourceName, destinationName, null);
 
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().NotHaveFile(sourceName);
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
@@ -84,12 +84,12 @@ public abstract partial class ReplaceTests<TFileSystem>
 		FileSystem.File.Replace(sourceName, destinationName, backupName, true);
 
 		FileSystem.Should().NotHaveFile(sourceName);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(sourceContents);
 		FileSystem.File.GetAttributes(destinationName)
 			.Should().HaveFlag(FileAttributes.ReadOnly);
-		FileSystem.Should().HaveFile(backupName);
-		FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
+		FileSystem.Should().HaveFile(backupName)
+			.Which.HasContent(destinationContents);
 	}
 
 	[SkippableTheory]
@@ -114,10 +114,10 @@ public abstract partial class ReplaceTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			exception.Should().BeException<UnauthorizedAccessException>(hResult: -2147024891);
-			FileSystem.Should().HaveFile(sourceName);
-			FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-			FileSystem.Should().HaveFile(destinationName);
-			FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
+			FileSystem.Should().HaveFile(sourceName)
+				.Which.HasContent(sourceContents);
+			FileSystem.Should().HaveFile(destinationName)
+				.Which.HasContent(destinationContents);
 			FileSystem.File.GetAttributes(destinationName)
 				.Should().NotHaveFlag(FileAttributes.ReadOnly);
 			FileSystem.Should().NotHaveFile(backupName);
@@ -126,10 +126,10 @@ public abstract partial class ReplaceTests<TFileSystem>
 		{
 			exception.Should().BeNull();
 			FileSystem.Should().NotHaveFile(sourceName);
-			FileSystem.Should().HaveFile(destinationName);
-			FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-			FileSystem.Should().HaveFile(backupName);
-			FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
+			FileSystem.Should().HaveFile(destinationName)
+				.Which.HasContent(sourceContents);
+			FileSystem.Should().HaveFile(backupName)
+				.Which.HasContent(destinationContents);
 		}
 	}
 
@@ -148,10 +148,10 @@ public abstract partial class ReplaceTests<TFileSystem>
 		FileSystem.File.Replace(sourceName, destinationName, backupName);
 
 		FileSystem.Should().NotHaveFile(sourceName);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-		FileSystem.Should().HaveFile(backupName);
-		FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(sourceContents);
+		FileSystem.Should().HaveFile(backupName)
+			.Which.HasContent(destinationContents);
 	}
 
 	[SkippableTheory]
@@ -197,10 +197,10 @@ public abstract partial class ReplaceTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			exception.Should().BeException<IOException>(hResult: -2147024864);
-			FileSystem.Should().HaveFile(sourceName);
-			FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-			FileSystem.Should().HaveFile(destinationName);
-			FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
+			FileSystem.Should().HaveFile(sourceName)
+				.Which.HasContent(sourceContents);
+			FileSystem.Should().HaveFile(destinationName)
+				.Which.HasContent(destinationContents);
 			FileSystem.File.GetAttributes(destinationName)
 				.Should().NotHaveFlag(FileAttributes.ReadOnly);
 			FileSystem.Should().NotHaveFile(backupName);
@@ -208,10 +208,10 @@ public abstract partial class ReplaceTests<TFileSystem>
 		else
 		{
 			FileSystem.Should().NotHaveFile(sourceName);
-			FileSystem.Should().HaveFile(destinationName);
-			FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-			FileSystem.Should().HaveFile(backupName);
-			FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
+			FileSystem.Should().HaveFile(destinationName)
+				.Which.HasContent(sourceContents);
+			FileSystem.Should().HaveFile(backupName)
+				.Which.HasContent(destinationContents);
 		}
 	}
 
@@ -254,10 +254,10 @@ public abstract partial class ReplaceTests<TFileSystem>
 		FileSystem.File.Replace(sourceName, destinationName, null);
 
 		FileSystem.Should().NotHaveFile(sourceName);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-		FileSystem.Should().HaveFile(backupName);
-		FileSystem.File.ReadAllText(backupName).Should().Be(backupContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(sourceContents);
+		FileSystem.Should().HaveFile(backupName)
+			.Which.HasContent(backupContents);
 	}
 
 	[SkippableTheory]
@@ -274,7 +274,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 		FileSystem.File.Replace(sourceName, destinationName, null);
 
 		FileSystem.Should().NotHaveFile(sourceName);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(sourceContents);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/SetAttributesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/SetAttributesTests.cs
@@ -47,7 +47,7 @@ public abstract partial class SetAttributesTests<TFileSystem>
 
 		FileSystem.File.SetAttributes(path, FileAttributes.Directory);
 
-		FileSystem.Directory.Exists(path).Should().BeFalse();
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().NotHaveDirectory(path);
+		FileSystem.Should().HaveFile(path);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesAsyncTests.cs
@@ -35,8 +35,8 @@ public abstract partial class WriteAllBytesAsyncTests<TFileSystem>
 
 		await FileSystem.File.WriteAllBytesAsync(path, bytes);
 
-		byte[] result = FileSystem.File.ReadAllBytes(path);
-		result.Should().BeEquivalentTo(bytes);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(bytes);
 	}
 
 	[SkippableTheory]
@@ -46,8 +46,8 @@ public abstract partial class WriteAllBytesAsyncTests<TFileSystem>
 	{
 		await FileSystem.File.WriteAllBytesAsync(path, bytes);
 
-		byte[] result = FileSystem.File.ReadAllBytes(path);
-		result.Should().BeEquivalentTo(bytes);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(bytes);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesAsyncTests.cs
@@ -78,8 +78,8 @@ public abstract partial class WriteAllBytesAsyncTests<TFileSystem>
 
 		exception.Should().BeException<UnauthorizedAccessException>(
 			hResult: -2147024891);
-		FileSystem.Directory.Exists(path).Should().BeTrue();
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(path);
+		FileSystem.Should().NotHaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesTests.cs
@@ -17,8 +17,8 @@ public abstract partial class WriteAllBytesTests<TFileSystem>
 
 		FileSystem.File.WriteAllBytes(path, bytes);
 
-		byte[] result = FileSystem.File.ReadAllBytes(path);
-		result.Should().BeEquivalentTo(bytes);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(bytes);
 	}
 
 	[SkippableTheory]
@@ -27,8 +27,8 @@ public abstract partial class WriteAllBytesTests<TFileSystem>
 	{
 		FileSystem.File.WriteAllBytes(path, bytes);
 
-		byte[] result = FileSystem.File.ReadAllBytes(path);
-		result.Should().BeEquivalentTo(bytes);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(bytes);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesTests.cs
@@ -58,8 +58,8 @@ public abstract partial class WriteAllBytesTests<TFileSystem>
 
 		exception.Should().BeException<UnauthorizedAccessException>(
 			hResult: -2147024891);
-		FileSystem.Directory.Exists(path).Should().BeTrue();
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(path);
+		FileSystem.Should().NotHaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesAsyncTests.cs
@@ -136,8 +136,8 @@ public abstract partial class WriteAllLinesAsyncTests<TFileSystem>
 
 		exception.Should().BeException<UnauthorizedAccessException>(
 			hResult: -2147024891);
-		FileSystem.Directory.Exists(path).Should().BeTrue();
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(path);
+		FileSystem.Should().NotHaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesTests.cs
@@ -82,8 +82,8 @@ public abstract partial class WriteAllLinesTests<TFileSystem>
 
 		exception.Should().BeException<UnauthorizedAccessException>(
 			hResult: -2147024891);
-		FileSystem.Directory.Exists(path).Should().BeTrue();
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(path);
+		FileSystem.Should().NotHaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextAsyncTests.cs
@@ -119,8 +119,8 @@ public abstract partial class WriteAllTextAsyncTests<TFileSystem>
 
 		exception.Should().BeException<UnauthorizedAccessException>(
 			hResult: -2147024891);
-		FileSystem.Directory.Exists(path).Should().BeTrue();
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(path);
+		FileSystem.Should().NotHaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -163,8 +163,8 @@ public abstract partial class WriteAllTextTests<TFileSystem>
 
 		exception.Should().BeException<UnauthorizedAccessException>(
 			hResult: -2147024891);
-		FileSystem.Directory.Exists(path).Should().BeTrue();
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(path);
+		FileSystem.Should().NotHaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -97,8 +97,8 @@ public abstract partial class WriteAllTextTests<TFileSystem>
 
 		FileSystem.File.WriteAllText(path, "AA", Encoding.UTF32);
 
-		FileSystem.File.ReadAllBytes(path)
-			.Should().BeEquivalentTo(expectedBytes);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(expectedBytes);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AppendTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AppendTextTests.cs
@@ -19,10 +19,8 @@ public abstract partial class AppendTextTests<TFileSystem>
 			stream.Write(appendText);
 		}
 
-		string result = FileSystem.File.ReadAllText(path);
-
-		result.Should().Be(appendText);
-		FileSystem.Should().HaveFile(path);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(appendText);
 	}
 
 	[SkippableTheory]
@@ -38,8 +36,7 @@ public abstract partial class AppendTextTests<TFileSystem>
 			stream.Write(appendText);
 		}
 
-		string result = FileSystem.File.ReadAllText(path);
-
-		result.Should().Be(contents + appendText);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(contents + appendText);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AppendTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AppendTextTests.cs
@@ -22,7 +22,7 @@ public abstract partial class AppendTextTests<TFileSystem>
 		string result = FileSystem.File.ReadAllText(path);
 
 		result.Should().Be(appendText);
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
@@ -27,9 +27,9 @@ public abstract partial class CopyToTests<TFileSystem>
 		exception.Should().BeException<IOException>(
 			hResult: Test.RunsOnWindows ? -2147024816 : 17);
 		sut.Exists.Should().BeTrue();
-		FileSystem.File.Exists(sourceName).Should().BeTrue();
+		FileSystem.Should().HaveFile(sourceName);
 		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
 	}
 
@@ -52,9 +52,9 @@ public abstract partial class CopyToTests<TFileSystem>
 		sut.FullName.Should().Be(FileSystem.Path.GetFullPath(sourceName));
 		result.Exists.Should().BeTrue();
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
-		FileSystem.File.Exists(sourceName).Should().BeTrue();
+		FileSystem.Should().HaveFile(sourceName);
 		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
 	}
 #endif
@@ -70,8 +70,8 @@ public abstract partial class CopyToTests<TFileSystem>
 
 		sut.CopyTo(destinationName);
 
-		FileSystem.File.Exists(sourceName).Should().BeTrue();
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(sourceName);
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.GetAttributes(destinationName)
 			.Should().HaveFlag(FileAttributes.ReadOnly);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
@@ -120,9 +120,9 @@ public abstract partial class CopyToTests<TFileSystem>
 		sut.Exists.Should().BeTrue();
 		result.Exists.Should().BeTrue();
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
-		FileSystem.File.Exists(sourceName).Should().BeTrue();
+		FileSystem.Should().HaveFile(sourceName);
 		FileSystem.File.ReadAllText(sourceName).Should().Be(contents);
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
 	}
 
@@ -190,8 +190,8 @@ public abstract partial class CopyToTests<TFileSystem>
 		exception.Should().BeException<UnauthorizedAccessException>(
 			$"'{FileSystem.Path.GetFullPath(sourceName)}'",
 			hResult: -2147024891);
-		FileSystem.Directory.Exists(sourceName).Should().BeTrue();
-		FileSystem.File.Exists(destinationName).Should().BeFalse();
+		FileSystem.Should().HaveDirectory(sourceName);
+		FileSystem.Should().NotHaveFile(destinationName);
 	}
 
 	[SkippableTheory]
@@ -213,12 +213,12 @@ public abstract partial class CopyToTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			exception.Should().BeException<IOException>(hResult: -2147024864);
-			FileSystem.File.Exists(destinationName).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(destinationName);
 		}
 		else
 		{
-			FileSystem.File.Exists(sourceName).Should().BeTrue();
-			FileSystem.File.Exists(destinationName).Should().BeFalse();
+			FileSystem.Should().HaveFile(sourceName);
+			FileSystem.Should().NotHaveFile(destinationName);
 		}
 	}
 
@@ -240,6 +240,6 @@ public abstract partial class CopyToTests<TFileSystem>
 			messageContains: Test.IsNetFramework
 				? null
 				: $"'{FileSystem.Path.GetFullPath(sourceName)}'");
-		FileSystem.File.Exists(destinationName).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(destinationName);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
@@ -27,10 +27,10 @@ public abstract partial class CopyToTests<TFileSystem>
 		exception.Should().BeException<IOException>(
 			hResult: Test.RunsOnWindows ? -2147024816 : 17);
 		sut.Exists.Should().BeTrue();
-		FileSystem.Should().HaveFile(sourceName);
-		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
+		FileSystem.Should().HaveFile(sourceName)
+			.Which.HasContent(sourceContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(destinationContents);
 	}
 
 #if FEATURE_FILE_MOVETO_OVERWRITE
@@ -52,10 +52,10 @@ public abstract partial class CopyToTests<TFileSystem>
 		sut.FullName.Should().Be(FileSystem.Path.GetFullPath(sourceName));
 		result.Exists.Should().BeTrue();
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
-		FileSystem.Should().HaveFile(sourceName);
-		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
+		FileSystem.Should().HaveFile(sourceName)
+			.Which.HasContent(sourceContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(sourceContents);
 	}
 #endif
 
@@ -71,10 +71,10 @@ public abstract partial class CopyToTests<TFileSystem>
 		sut.CopyTo(destinationName);
 
 		FileSystem.Should().HaveFile(sourceName);
-		FileSystem.Should().HaveFile(destinationName);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(contents);
 		FileSystem.File.GetAttributes(destinationName)
 			.Should().HaveFlag(FileAttributes.ReadOnly);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
 	}
 
 	[SkippableTheory]
@@ -120,10 +120,10 @@ public abstract partial class CopyToTests<TFileSystem>
 		sut.Exists.Should().BeTrue();
 		result.Exists.Should().BeTrue();
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
-		FileSystem.Should().HaveFile(sourceName);
-		FileSystem.File.ReadAllText(sourceName).Should().Be(contents);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
+		FileSystem.Should().HaveFile(sourceName)
+			.Which.HasContent(contents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(contents);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTests.cs
@@ -12,11 +12,11 @@ public abstract partial class CreateTests<TFileSystem>
 	public void Create_MissingFile_ShouldCreateFile(string path)
 	{
 		IFileInfo sut = FileSystem.FileInfo.New(path);
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(path);
 
 		using FileSystemStream stream = sut.Create();
 
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 	}
 
 	[SkippableTheory]
@@ -45,7 +45,7 @@ public abstract partial class CreateTests<TFileSystem>
 			sut3.Exists.Should().BeTrue();
 		}
 
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
@@ -19,10 +19,8 @@ public abstract partial class CreateTextTests<TFileSystem>
 			stream.Write(appendText);
 		}
 
-		string result = FileSystem.File.ReadAllText(path);
-
-		result.Should().Be(appendText);
-		FileSystem.Should().HaveFile(path);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(appendText);
 	}
 
 	[SkippableTheory]
@@ -55,8 +53,7 @@ public abstract partial class CreateTextTests<TFileSystem>
 			stream.Write(appendText);
 		}
 
-		string result = FileSystem.File.ReadAllText(path);
-
-		result.Should().Be(appendText);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(appendText);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
@@ -22,7 +22,7 @@ public abstract partial class CreateTextTests<TFileSystem>
 		string result = FileSystem.File.ReadAllText(path);
 
 		result.Should().Be(appendText);
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 	}
 
 	[SkippableTheory]
@@ -39,7 +39,7 @@ public abstract partial class CreateTextTests<TFileSystem>
 		}
 
 		fileInfo.Exists.Should().BeFalse();
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/DeleteTests.cs
@@ -54,7 +54,7 @@ public abstract partial class DeleteTests<TFileSystem>
 			sut.Exists.Should().BeFalse();
 		}
 
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(path);
 	}
 
 	[SkippableTheory]
@@ -84,12 +84,12 @@ public abstract partial class DeleteTests<TFileSystem>
 			exception.Should().BeException<IOException>(
 				messageContains: $"{filename}'",
 				hResult: -2147024864);
-			FileSystem.File.Exists(filename).Should().BeTrue();
+			FileSystem.Should().HaveFile(filename);
 		}
 		else
 		{
 			exception.Should().BeNull();
-			FileSystem.File.Exists(filename).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(filename);
 		}
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
@@ -28,10 +28,10 @@ public abstract partial class MoveToTests<TFileSystem>
 			hResult: Test.RunsOnWindows ? -2147024713 : 17);
 
 		sut.Exists.Should().BeTrue();
-		FileSystem.Should().HaveFile(sourceName);
-		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
+		FileSystem.Should().HaveFile(sourceName)
+			.Which.HasContent(sourceContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(destinationContents);
 	}
 
 #if FEATURE_FILE_MOVETO_OVERWRITE
@@ -53,8 +53,8 @@ public abstract partial class MoveToTests<TFileSystem>
 		sut.ToString().Should().Be(destinationName);
 		sut.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
 		FileSystem.Should().NotHaveFile(sourceName);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(sourceContents);
 	}
 #endif
 
@@ -117,8 +117,8 @@ public abstract partial class MoveToTests<TFileSystem>
 		exception.Should().BeException<DirectoryNotFoundException>(hResult: -2147024893);
 
 		sut.Exists.Should().BeTrue();
-		FileSystem.Should().HaveFile(sourceName);
-		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
+		FileSystem.Should().HaveFile(sourceName)
+			.Which.HasContent(sourceContents);
 		FileSystem.Should().NotHaveFile(destinationName);
 	}
 
@@ -134,10 +134,10 @@ public abstract partial class MoveToTests<TFileSystem>
 		sut.MoveTo(destinationName);
 
 		FileSystem.Should().NotHaveFile(sourceName);
-		FileSystem.Should().HaveFile(destinationName);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(contents);
 		FileSystem.File.GetAttributes(destinationName)
 			.Should().HaveFlag(FileAttributes.ReadOnly);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
 	}
 
 	[SkippableTheory]
@@ -204,8 +204,8 @@ public abstract partial class MoveToTests<TFileSystem>
 		sut.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
 		sut.Exists.Should().BeTrue();
 		FileSystem.Should().NotHaveFile(sourceName);
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(contents);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
@@ -28,9 +28,9 @@ public abstract partial class MoveToTests<TFileSystem>
 			hResult: Test.RunsOnWindows ? -2147024713 : 17);
 
 		sut.Exists.Should().BeTrue();
-		FileSystem.File.Exists(sourceName).Should().BeTrue();
+		FileSystem.Should().HaveFile(sourceName);
 		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
 	}
 
@@ -52,8 +52,8 @@ public abstract partial class MoveToTests<TFileSystem>
 		sut.Exists.Should().BeTrue();
 		sut.ToString().Should().Be(destinationName);
 		sut.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().NotHaveFile(sourceName);
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
 	}
 #endif
@@ -92,7 +92,7 @@ public abstract partial class MoveToTests<TFileSystem>
 			messageContains: Test.IsNetFramework
 				? null
 				: $"'{FileSystem.Path.GetFullPath(sourceName)}'");
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(sourceName);
 	}
 
 	[SkippableTheory]
@@ -117,9 +117,9 @@ public abstract partial class MoveToTests<TFileSystem>
 		exception.Should().BeException<DirectoryNotFoundException>(hResult: -2147024893);
 
 		sut.Exists.Should().BeTrue();
-		FileSystem.File.Exists(sourceName).Should().BeTrue();
+		FileSystem.Should().HaveFile(sourceName);
 		FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-		FileSystem.File.Exists(destinationName).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(destinationName);
 	}
 
 	[SkippableTheory]
@@ -133,8 +133,8 @@ public abstract partial class MoveToTests<TFileSystem>
 
 		sut.MoveTo(destinationName);
 
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().NotHaveFile(sourceName);
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.GetAttributes(destinationName)
 			.Should().HaveFlag(FileAttributes.ReadOnly);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
@@ -203,8 +203,8 @@ public abstract partial class MoveToTests<TFileSystem>
 
 		sut.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
 		sut.Exists.Should().BeTrue();
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().NotHaveFile(sourceName);
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(contents);
 	}
 
@@ -254,12 +254,12 @@ public abstract partial class MoveToTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			exception.Should().BeException<IOException>(hResult: -2147024864);
-			FileSystem.File.Exists(destinationName).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(destinationName);
 		}
 		else
 		{
-			FileSystem.File.Exists(sourceName).Should().BeFalse();
-			FileSystem.File.Exists(destinationName).Should().BeTrue();
+			FileSystem.Should().NotHaveFile(sourceName);
+			FileSystem.Should().HaveFile(destinationName);
 		}
 	}
 
@@ -281,6 +281,6 @@ public abstract partial class MoveToTests<TFileSystem>
 				? null
 				: $"'{FileSystem.Path.GetFullPath(sourceName)}'",
 			hResult: -2147024894);
-		FileSystem.File.Exists(destinationName).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(destinationName);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenTests.cs
@@ -160,7 +160,7 @@ public abstract partial class OpenTests<TFileSystem>
 
 		exception.Should().BeNull();
 		sut.Exists.Should().BeTrue();
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenWriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenWriteTests.cs
@@ -15,7 +15,7 @@ public abstract partial class OpenWriteTests<TFileSystem>
 
 		using FileSystemStream stream = sut.OpenWrite();
 
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
@@ -105,12 +105,12 @@ public abstract partial class ReplaceTests<TFileSystem>
 		sut.Exists.Should().BeFalse();
 		FileSystem.Should().NotHaveFile(sourceName);
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(sourceContents);
 		FileSystem.File.GetAttributes(destinationName)
 			.Should().HaveFlag(FileAttributes.ReadOnly);
-		FileSystem.Should().HaveFile(backupName);
-		FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
+		FileSystem.Should().HaveFile(backupName)
+			.Which.HasContent(destinationContents);
 	}
 
 	[SkippableTheory]
@@ -136,10 +136,10 @@ public abstract partial class ReplaceTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			exception.Should().BeException<UnauthorizedAccessException>(hResult: -2147024891);
-			FileSystem.Should().HaveFile(sourceName);
-			FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-			FileSystem.Should().HaveFile(destinationName);
-			FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
+			FileSystem.Should().HaveFile(sourceName)
+				.Which.HasContent(sourceContents);
+			FileSystem.Should().HaveFile(destinationName)
+				.Which.HasContent(destinationContents);
 			FileSystem.File.GetAttributes(destinationName)
 				.Should().NotHaveFlag(FileAttributes.ReadOnly);
 			FileSystem.Should().NotHaveFile(backupName);
@@ -149,10 +149,10 @@ public abstract partial class ReplaceTests<TFileSystem>
 			exception.Should().BeNull();
 			sut.Exists.Should().BeFalse();
 			FileSystem.Should().NotHaveFile(sourceName);
-			FileSystem.Should().HaveFile(destinationName);
-			FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-			FileSystem.Should().HaveFile(backupName);
-			FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
+			FileSystem.Should().HaveFile(destinationName)
+				.Which.HasContent(sourceContents);
+			FileSystem.Should().HaveFile(backupName)
+				.Which.HasContent(destinationContents);
 		}
 	}
 
@@ -265,10 +265,10 @@ public abstract partial class ReplaceTests<TFileSystem>
 		sut.Exists.Should().BeFalse();
 		FileSystem.Should().NotHaveFile(sourceName);
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-		FileSystem.Should().HaveFile(backupName);
-		FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(sourceContents);
+		FileSystem.Should().HaveFile(backupName)
+			.Which.HasContent(destinationContents);
 	}
 
 	[SkippableTheory]
@@ -336,10 +336,10 @@ public abstract partial class ReplaceTests<TFileSystem>
 		{
 			exception.Should().BeException<IOException>(hResult: -2147024864);
 			sut.Exists.Should().BeTrue();
-			FileSystem.Should().HaveFile(sourceName);
-			FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-			FileSystem.Should().HaveFile(destinationName);
-			FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
+			FileSystem.Should().HaveFile(sourceName)
+				.Which.HasContent(sourceContents);
+			FileSystem.Should().HaveFile(destinationName)
+				.Which.HasContent(destinationContents);
 			FileSystem.File.GetAttributes(destinationName)
 				.Should().NotHaveFlag(FileAttributes.ReadOnly);
 			FileSystem.Should().NotHaveFile(backupName);
@@ -348,10 +348,10 @@ public abstract partial class ReplaceTests<TFileSystem>
 		{
 			sut.Exists.Should().BeFalse();
 			FileSystem.Should().NotHaveFile(sourceName);
-			FileSystem.Should().HaveFile(destinationName);
-			FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-			FileSystem.Should().HaveFile(backupName);
-			FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
+			FileSystem.Should().HaveFile(destinationName)
+				.Which.HasContent(sourceContents);
+			FileSystem.Should().HaveFile(backupName)
+				.Which.HasContent(destinationContents);
 		}
 	}
 
@@ -398,10 +398,10 @@ public abstract partial class ReplaceTests<TFileSystem>
 		sut.Exists.Should().BeFalse();
 		FileSystem.Should().NotHaveFile(sourceName);
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-		FileSystem.Should().HaveFile(backupName);
-		FileSystem.File.ReadAllText(backupName).Should().Be(backupContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(sourceContents);
+		FileSystem.Should().HaveFile(backupName)
+			.Which.HasContent(backupContents);
 	}
 
 	[SkippableTheory]
@@ -421,7 +421,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 		sut.Exists.Should().BeFalse();
 		FileSystem.Should().NotHaveFile(sourceName);
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
-		FileSystem.Should().HaveFile(destinationName);
-		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
+		FileSystem.Should().HaveFile(destinationName)
+			.Which.HasContent(sourceContents);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
@@ -83,7 +83,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 		});
 
 		exception.Should().BeException<FileNotFoundException>(hResult: -2147024894);
-		FileSystem.File.Exists(backupName).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(backupName);
 	}
 
 	[SkippableTheory]
@@ -103,13 +103,13 @@ public abstract partial class ReplaceTests<TFileSystem>
 		IFileInfo result = sut.Replace(destinationName, backupName, true);
 
 		sut.Exists.Should().BeFalse();
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(sourceName);
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
 		FileSystem.File.GetAttributes(destinationName)
 			.Should().HaveFlag(FileAttributes.ReadOnly);
-		FileSystem.File.Exists(backupName).Should().BeTrue();
+		FileSystem.Should().HaveFile(backupName);
 		FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
 	}
 
@@ -136,22 +136,22 @@ public abstract partial class ReplaceTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			exception.Should().BeException<UnauthorizedAccessException>(hResult: -2147024891);
-			FileSystem.File.Exists(sourceName).Should().BeTrue();
+			FileSystem.Should().HaveFile(sourceName);
 			FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-			FileSystem.File.Exists(destinationName).Should().BeTrue();
+			FileSystem.Should().HaveFile(destinationName);
 			FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
 			FileSystem.File.GetAttributes(destinationName)
 				.Should().NotHaveFlag(FileAttributes.ReadOnly);
-			FileSystem.File.Exists(backupName).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(backupName);
 		}
 		else
 		{
 			exception.Should().BeNull();
 			sut.Exists.Should().BeFalse();
-			FileSystem.File.Exists(sourceName).Should().BeFalse();
-			FileSystem.File.Exists(destinationName).Should().BeTrue();
+			FileSystem.Should().NotHaveFile(sourceName);
+			FileSystem.Should().HaveFile(destinationName);
 			FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-			FileSystem.File.Exists(backupName).Should().BeTrue();
+			FileSystem.Should().HaveFile(backupName);
 			FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
 		}
 	}
@@ -263,11 +263,11 @@ public abstract partial class ReplaceTests<TFileSystem>
 		IFileInfo result = sut.Replace(destinationName, backupName);
 
 		sut.Exists.Should().BeFalse();
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(sourceName);
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-		FileSystem.File.Exists(backupName).Should().BeTrue();
+		FileSystem.Should().HaveFile(backupName);
 		FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
 	}
 
@@ -336,21 +336,21 @@ public abstract partial class ReplaceTests<TFileSystem>
 		{
 			exception.Should().BeException<IOException>(hResult: -2147024864);
 			sut.Exists.Should().BeTrue();
-			FileSystem.File.Exists(sourceName).Should().BeTrue();
+			FileSystem.Should().HaveFile(sourceName);
 			FileSystem.File.ReadAllText(sourceName).Should().Be(sourceContents);
-			FileSystem.File.Exists(destinationName).Should().BeTrue();
+			FileSystem.Should().HaveFile(destinationName);
 			FileSystem.File.ReadAllText(destinationName).Should().Be(destinationContents);
 			FileSystem.File.GetAttributes(destinationName)
 				.Should().NotHaveFlag(FileAttributes.ReadOnly);
-			FileSystem.File.Exists(backupName).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(backupName);
 		}
 		else
 		{
 			sut.Exists.Should().BeFalse();
-			FileSystem.File.Exists(sourceName).Should().BeFalse();
-			FileSystem.File.Exists(destinationName).Should().BeTrue();
+			FileSystem.Should().NotHaveFile(sourceName);
+			FileSystem.Should().HaveFile(destinationName);
 			FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-			FileSystem.File.Exists(backupName).Should().BeTrue();
+			FileSystem.Should().HaveFile(backupName);
 			FileSystem.File.ReadAllText(backupName).Should().Be(destinationContents);
 		}
 	}
@@ -374,7 +374,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			// Behaviour on Linux/MacOS is uncertain
-			FileSystem.File.Exists(backupName).Should().BeFalse();
+			FileSystem.Should().NotHaveFile(backupName);
 		}
 	}
 
@@ -396,11 +396,11 @@ public abstract partial class ReplaceTests<TFileSystem>
 		IFileInfo result = sut.Replace(destinationName, null);
 
 		sut.Exists.Should().BeFalse();
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(sourceName);
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
-		FileSystem.File.Exists(backupName).Should().BeTrue();
+		FileSystem.Should().HaveFile(backupName);
 		FileSystem.File.ReadAllText(backupName).Should().Be(backupContents);
 	}
 
@@ -419,9 +419,9 @@ public abstract partial class ReplaceTests<TFileSystem>
 		IFileInfo result = sut.Replace(destinationName, null);
 
 		sut.Exists.Should().BeFalse();
-		FileSystem.File.Exists(sourceName).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(sourceName);
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
-		FileSystem.File.Exists(destinationName).Should().BeTrue();
+		FileSystem.Should().HaveFile(destinationName);
 		FileSystem.File.ReadAllText(destinationName).Should().Be(sourceContents);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/AdjustTimesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/AdjustTimesTests.cs
@@ -12,15 +12,15 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
-	public void CopyTo_ShouldAdjustTimes(string path, byte[] contents)
+	public void CopyTo_ShouldAdjustTimes(string path, byte[] bytes)
 	{
 		Skip.If(Test.IsNetFramework && FileSystem is RealFileSystem,
 			"Works unreliable on .NET Framework");
 		Test.SkipIfLongRunningTestsShouldBeSkipped(FileSystem);
 
-		byte[] buffer = new byte[contents.Length];
+		byte[] buffer = new byte[bytes.Length];
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
-		FileSystem.File.WriteAllBytes(path, contents);
+		FileSystem.File.WriteAllBytes(path, bytes);
 		DateTime creationTimeEnd = TimeSystem.DateTime.UtcNow;
 		TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
 		using FileSystemStream stream = FileSystem.File.OpenRead(path);
@@ -58,13 +58,13 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 #if FEATURE_SPAN
 	[SkippableTheory]
 	[AutoData]
-	public void Read_AsSpan_ShouldAdjustTimes(string path, byte[] contents)
+	public void Read_AsSpan_ShouldAdjustTimes(string path, byte[] bytes)
 	{
 		Test.SkipIfLongRunningTestsShouldBeSkipped(FileSystem);
 
 		byte[] buffer = new byte[2];
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
-		FileSystem.File.WriteAllBytes(path, contents);
+		FileSystem.File.WriteAllBytes(path, bytes);
 		DateTime creationTimeEnd = TimeSystem.DateTime.UtcNow;
 		TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
 		DateTime updateTime = TimeSystem.DateTime.UtcNow;
@@ -100,7 +100,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void Read_ShouldAdjustTimes(string path, byte[] contents)
+	public void Read_ShouldAdjustTimes(string path, byte[] bytes)
 	{
 		Skip.If(Test.IsNetFramework && FileSystem is RealFileSystem,
 			"Works unreliable on .NET Framework");
@@ -108,7 +108,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 
 		byte[] buffer = new byte[2];
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
-		FileSystem.File.WriteAllBytes(path, contents);
+		FileSystem.File.WriteAllBytes(path, bytes);
 		DateTime creationTimeEnd = TimeSystem.DateTime.UtcNow;
 		TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
 		DateTime updateTime = TimeSystem.DateTime.UtcNow;
@@ -144,13 +144,13 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 #if FEATURE_SPAN
 	[SkippableTheory]
 	[AutoData]
-	public async Task ReadAsync_AsMemory_ShouldAdjustTimes(string path, byte[] contents)
+	public async Task ReadAsync_AsMemory_ShouldAdjustTimes(string path, byte[] bytes)
 	{
 		Test.SkipIfLongRunningTestsShouldBeSkipped(FileSystem);
 
 		byte[] buffer = new byte[2];
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
-		await FileSystem.File.WriteAllBytesAsync(path, contents);
+		await FileSystem.File.WriteAllBytesAsync(path, bytes);
 		DateTime creationTimeEnd = TimeSystem.DateTime.UtcNow;
 		await TimeSystem.Task.Delay(FileTestHelper.AdjustTimesDelay);
 		DateTime updateTime = TimeSystem.DateTime.UtcNow;
@@ -187,7 +187,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 #if FEATURE_FILESYSTEM_ASYNC
 	[SkippableTheory]
 	[AutoData]
-	public async Task ReadAsync_ShouldAdjustTimes(string path, byte[] contents)
+	public async Task ReadAsync_ShouldAdjustTimes(string path, byte[] bytes)
 	{
 		Skip.If(Test.IsNetFramework && FileSystem is RealFileSystem,
 			"Works unreliable on .NET Framework");
@@ -195,7 +195,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 
 		byte[] buffer = new byte[2];
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
-		await FileSystem.File.WriteAllBytesAsync(path, contents);
+		await FileSystem.File.WriteAllBytesAsync(path, bytes);
 		DateTime creationTimeEnd = TimeSystem.DateTime.UtcNow;
 		await TimeSystem.Task.Delay(FileTestHelper.AdjustTimesDelay);
 		DateTime updateTime = TimeSystem.DateTime.UtcNow;
@@ -233,14 +233,14 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void ReadByte_ShouldAdjustTimes(string path, byte[] contents)
+	public void ReadByte_ShouldAdjustTimes(string path, byte[] bytes)
 	{
 		Skip.If(Test.IsNetFramework && FileSystem is RealFileSystem,
 			"Works unreliable on .NET Framework");
 		Test.SkipIfLongRunningTestsShouldBeSkipped(FileSystem);
 
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
-		FileSystem.File.WriteAllBytes(path, contents);
+		FileSystem.File.WriteAllBytes(path, bytes);
 		DateTime creationTimeEnd = TimeSystem.DateTime.UtcNow;
 		TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
 		DateTime updateTime = TimeSystem.DateTime.UtcNow;
@@ -275,14 +275,14 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void Seek_ShouldNotAdjustTimes(string path, byte[] contents)
+	public void Seek_ShouldNotAdjustTimes(string path, byte[] bytes)
 	{
 		Skip.If(Test.IsNetFramework && FileSystem is RealFileSystem,
 			"Works unreliable on .NET Framework");
 		Test.SkipIfLongRunningTestsShouldBeSkipped(FileSystem);
 
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
-		FileSystem.File.WriteAllBytes(path, contents);
+		FileSystem.File.WriteAllBytes(path, bytes);
 		DateTime creationTimeEnd = TimeSystem.DateTime.UtcNow;
 		TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
 		using FileSystemStream stream = FileSystem.File.OpenWrite(path);
@@ -311,7 +311,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 #if FEATURE_SPAN
 	[SkippableTheory]
 	[AutoData]
-	public void Write_AsSpan_ShouldAdjustTimes(string path, byte[] contents)
+	public void Write_AsSpan_ShouldAdjustTimes(string path, byte[] bytes)
 	{
 		Test.SkipIfLongRunningTestsShouldBeSkipped(FileSystem);
 
@@ -322,7 +322,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		DateTime updateTime = TimeSystem.DateTime.UtcNow;
 		using FileSystemStream stream = FileSystem.File.OpenWrite(path);
 
-		stream.Write(contents.AsSpan());
+		stream.Write(bytes.AsSpan());
 		stream.Dispose();
 
 		DateTime lastWriteTime = WaitToBeUpdatedToAfter(
@@ -352,7 +352,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void Write_ShouldAdjustTimes(string path, byte[] contents)
+	public void Write_ShouldAdjustTimes(string path, byte[] bytes)
 	{
 		Skip.If(Test.IsNetFramework && FileSystem is RealFileSystem,
 			"Works unreliable on .NET Framework");
@@ -365,7 +365,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		DateTime updateTime = TimeSystem.DateTime.UtcNow;
 		using FileSystemStream stream = FileSystem.File.OpenWrite(path);
 
-		stream.Write(contents, 0, 2);
+		stream.Write(bytes, 0, 2);
 		stream.Dispose();
 
 		DateTime lastWriteTime = WaitToBeUpdatedToAfter(
@@ -395,7 +395,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 #if FEATURE_SPAN
 	[SkippableTheory]
 	[AutoData]
-	public async Task WriteAsync_AsMemory_ShouldAdjustTimes(string path, byte[] contents)
+	public async Task WriteAsync_AsMemory_ShouldAdjustTimes(string path, byte[] bytes)
 	{
 		Test.SkipIfLongRunningTestsShouldBeSkipped(FileSystem);
 
@@ -406,7 +406,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		DateTime updateTime = TimeSystem.DateTime.UtcNow;
 		await using FileSystemStream stream = FileSystem.File.OpenWrite(path);
 
-		await stream.WriteAsync(contents.AsMemory());
+		await stream.WriteAsync(bytes.AsMemory());
 		await stream.DisposeAsync();
 
 		DateTime lastWriteTime = WaitToBeUpdatedToAfter(
@@ -437,7 +437,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 #if FEATURE_FILESYSTEM_ASYNC
 	[SkippableTheory]
 	[AutoData]
-	public async Task WriteAsync_ShouldAdjustTimes(string path, byte[] contents)
+	public async Task WriteAsync_ShouldAdjustTimes(string path, byte[] bytes)
 	{
 		Skip.If(Test.IsNetFramework && FileSystem is RealFileSystem,
 			"Works unreliable on .NET Framework");
@@ -451,7 +451,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		await using FileSystemStream stream = FileSystem.File.OpenWrite(path);
 
 		#pragma warning disable CA1835
-		await stream.WriteAsync(contents, 0, 2);
+		await stream.WriteAsync(bytes, 0, 2);
 		#pragma warning restore CA1835
 		await stream.DisposeAsync();
 
@@ -482,20 +482,20 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void WriteByte_ShouldAdjustTimes(string path, byte[] contents, byte content)
+	public void WriteByte_ShouldAdjustTimes(string path, byte[] bytes, byte singleByte)
 	{
 		Skip.If(Test.IsNetFramework && FileSystem is RealFileSystem,
 			"Works unreliable on .NET Framework");
 		Test.SkipIfLongRunningTestsShouldBeSkipped(FileSystem);
 
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
-		FileSystem.File.WriteAllBytes(path, contents);
+		FileSystem.File.WriteAllBytes(path, bytes);
 		DateTime creationTimeEnd = TimeSystem.DateTime.UtcNow;
 		TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
 		DateTime updateTime = TimeSystem.DateTime.UtcNow;
 		using FileSystemStream stream = FileSystem.File.OpenWrite(path);
 
-		stream.WriteByte(content);
+		stream.WriteByte(singleByte);
 		stream.Dispose();
 
 		DateTime lastWriteTime = WaitToBeUpdatedToAfter(

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/DisposeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/DisposeTests.cs
@@ -24,12 +24,12 @@ public abstract partial class DisposeTests<TFileSystem>
 			FileAccess.ReadWrite, FileShare.ReadWrite, 10, FileOptions.DeleteOnClose);
 
 		stream.Dispose();
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(path);
 		FileSystem.File.WriteAllText(path, "foo");
 
 		stream.Dispose();
 
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/DisposeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/DisposeTests.cs
@@ -14,11 +14,11 @@ public abstract partial class DisposeTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public void Dispose_CalledTwiceShouldDoNothing(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
 		Test.SkipBrittleTestsOnRealFileSystem(FileSystem);
 
-		FileSystem.File.WriteAllBytes(path, contents);
+		FileSystem.File.WriteAllBytes(path, bytes);
 
 		using FileSystemStream stream = FileSystem.FileStream.New(path, FileMode.Open,
 			FileAccess.ReadWrite, FileShare.ReadWrite, 10, FileOptions.DeleteOnClose);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/OptionsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/OptionsTests.cs
@@ -17,11 +17,11 @@ public abstract partial class OptionsTests<TFileSystem>
 
 		using FileSystemStream stream = FileSystem.FileStream.New(path, FileMode.Open,
 			FileAccess.ReadWrite, FileShare.None, 10, FileOptions.DeleteOnClose);
-		FileSystem.File.Exists(path).Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
 
 		stream.Close();
 
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(path);
 	}
 
 	[SkippableTheory]
@@ -36,7 +36,7 @@ public abstract partial class OptionsTests<TFileSystem>
 
 		stream.Dispose();
 
-		FileSystem.File.Exists(path).Should().BeFalse();
+		FileSystem.Should().NotHaveFile(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -13,13 +13,13 @@ public abstract partial class ReadTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public void BeginRead_ShouldCopyContentsToBuffer(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
 		ManualResetEventSlim ms = new();
-		FileSystem.File.WriteAllBytes(path, contents);
+		FileSystem.File.WriteAllBytes(path, bytes);
 		using FileSystemStream stream = FileSystem.File.OpenRead(path);
 
-		byte[] buffer = new byte[contents.Length];
+		byte[] buffer = new byte[bytes.Length];
 		stream.BeginRead(buffer, 0, buffer.Length, ar =>
 		{
 			// ReSharper disable once AccessToDisposedClosure
@@ -28,18 +28,18 @@ public abstract partial class ReadTests<TFileSystem>
 		}, null);
 
 		ms.Wait(30000);
-		buffer.Should().BeEquivalentTo(contents);
+		buffer.Should().BeEquivalentTo(bytes);
 	}
 
 	[SkippableTheory]
 	[AutoData]
 	public void BeginRead_CanReadFalse_ShouldThrowNotSupportedException(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
-		FileSystem.File.WriteAllBytes(path, contents);
+		FileSystem.File.WriteAllBytes(path, bytes);
 		FileSystemStream stream = FileSystem.FileInfo.New(path).OpenWrite();
 
-		byte[] buffer = new byte[contents.Length];
+		byte[] buffer = new byte[bytes.Length];
 		Exception? exception = Record.Exception(() =>
 		{
 			// ReSharper disable once AccessToDisposedClosure
@@ -54,9 +54,9 @@ public abstract partial class ReadTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public void EndRead_Null_ShouldThrowArgumentNullException(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
-		FileSystem.File.WriteAllBytes(path, contents);
+		FileSystem.File.WriteAllBytes(path, bytes);
 		using FileSystemStream stream = FileSystem.File.OpenRead(path);
 
 		Exception? exception = Record.Exception(() =>
@@ -70,18 +70,18 @@ public abstract partial class ReadTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void EndRead_ShouldNotAdjustTimes(string path, byte[] contents)
+	public void EndRead_ShouldNotAdjustTimes(string path, byte[] bytes)
 	{
 		Test.SkipBrittleTestsOnRealFileSystem(FileSystem);
 
 		ManualResetEventSlim ms = new();
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
-		FileSystem.File.WriteAllBytes(path, contents);
+		FileSystem.File.WriteAllBytes(path, bytes);
 		DateTime creationTimeEnd = TimeSystem.DateTime.UtcNow;
 		using FileSystemStream stream = FileSystem.File.OpenRead(path);
 		DateTime updateTime = DateTime.MinValue;
 
-		byte[] buffer = new byte[contents.Length];
+		byte[] buffer = new byte[bytes.Length];
 		stream.BeginRead(buffer, 0, buffer.Length, ar =>
 		{
 			TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
@@ -111,16 +111,16 @@ public abstract partial class ReadTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public void Read_CanReadFalse_ShouldThrowNotSupportedException(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
-		byte[] buffer = new byte[contents.Length];
-		FileSystem.File.WriteAllBytes(path, contents);
+		byte[] buffer = new byte[bytes.Length];
+		FileSystem.File.WriteAllBytes(path, bytes);
 		using FileSystemStream stream = FileSystem.File.OpenWrite(path);
 
 		Exception? exception = Record.Exception(() =>
 		{
 			// ReSharper disable once AccessToDisposedClosure
-			_ = stream.Read(buffer, 0, contents.Length);
+			_ = stream.Read(buffer, 0, bytes.Length);
 		});
 
 		stream.Dispose();
@@ -130,24 +130,24 @@ public abstract partial class ReadTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void Read_ShouldFillBuffer(string path, byte[] contents)
+	public void Read_ShouldFillBuffer(string path, byte[] bytes)
 	{
-		byte[] buffer = new byte[contents.Length];
-		FileSystem.File.WriteAllBytes(path, contents);
+		byte[] buffer = new byte[bytes.Length];
+		FileSystem.File.WriteAllBytes(path, bytes);
 		using FileSystemStream stream = FileSystem.File.OpenRead(path);
 
-		int result = stream.Read(buffer, 0, contents.Length);
+		int result = stream.Read(buffer, 0, bytes.Length);
 
-		result.Should().Be(contents.Length);
-		buffer.Should().BeEquivalentTo(contents);
+		result.Should().Be(bytes.Length);
+		buffer.Should().BeEquivalentTo(bytes);
 	}
 
 	[SkippableTheory]
 	[AutoData]
 	public void ReadByte_CanReadFalse_ShouldThrowNotSupportedException(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
-		FileSystem.File.WriteAllBytes(path, contents);
+		FileSystem.File.WriteAllBytes(path, bytes);
 
 		using FileSystemStream stream = FileSystem.File.OpenWrite(path);
 
@@ -165,9 +165,9 @@ public abstract partial class ReadTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public void ReadByte_ShouldReadSingleByteAndAdvancePosition(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
-		FileSystem.File.WriteAllBytes(path, contents);
+		FileSystem.File.WriteAllBytes(path, bytes);
 
 		using FileSystemStream stream = FileSystem.File.OpenRead(path);
 
@@ -175,8 +175,8 @@ public abstract partial class ReadTests<TFileSystem>
 		int result2 = stream.ReadByte();
 
 		stream.Position.Should().Be(2);
-		result1.Should().Be(contents[0]);
-		result2.Should().Be(contents[1]);
+		result1.Should().Be(bytes[0]);
+		result2.Should().Be(bytes[1]);
 	}
 
 	[SkippableTheory]
@@ -198,25 +198,25 @@ public abstract partial class ReadTests<TFileSystem>
 #if FEATURE_SPAN
 	[SkippableTheory]
 	[AutoData]
-	public void Read_AsSpan_ShouldFillBuffer(string path, byte[] contents)
+	public void Read_AsSpan_ShouldFillBuffer(string path, byte[] bytes)
 	{
-		byte[] buffer = new byte[contents.Length];
-		FileSystem.File.WriteAllBytes(path, contents);
+		byte[] buffer = new byte[bytes.Length];
+		FileSystem.File.WriteAllBytes(path, bytes);
 		using FileSystemStream stream = FileSystem.File.OpenRead(path);
 
 		int result = stream.Read(buffer.AsSpan());
 
-		result.Should().Be(contents.Length);
-		buffer.Should().BeEquivalentTo(contents);
+		result.Should().Be(bytes.Length);
+		buffer.Should().BeEquivalentTo(bytes);
 	}
 
 	[SkippableTheory]
 	[AutoData]
 	public void Read_AsSpan_CanReadFalse_ShouldThrowNotSupportedException(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
-		byte[] buffer = new byte[contents.Length];
-		FileSystem.File.WriteAllBytes(path, contents);
+		byte[] buffer = new byte[bytes.Length];
+		FileSystem.File.WriteAllBytes(path, bytes);
 		using FileSystemStream stream = FileSystem.File.OpenWrite(path);
 
 		Exception? exception = Record.Exception(() =>
@@ -234,36 +234,36 @@ public abstract partial class ReadTests<TFileSystem>
 #if FEATURE_FILESYSTEM_ASYNC
 	[SkippableTheory]
 	[AutoData]
-	public async Task ReadAsync_ShouldFillBuffer(string path, byte[] contents)
+	public async Task ReadAsync_ShouldFillBuffer(string path, byte[] bytes)
 	{
 		using CancellationTokenSource cts = new(30000);
-		byte[] buffer = new byte[contents.Length];
-		await FileSystem.File.WriteAllBytesAsync(path, contents, cts.Token);
+		byte[] buffer = new byte[bytes.Length];
+		await FileSystem.File.WriteAllBytesAsync(path, bytes, cts.Token);
 		await using FileSystemStream stream = FileSystem.File.OpenRead(path);
 
 		#pragma warning disable CA1835
-		int result = await stream.ReadAsync(buffer, 0, contents.Length, cts.Token);
+		int result = await stream.ReadAsync(buffer, 0, bytes.Length, cts.Token);
 		#pragma warning restore CA1835
 
-		result.Should().Be(contents.Length);
-		buffer.Should().BeEquivalentTo(contents);
+		result.Should().Be(bytes.Length);
+		buffer.Should().BeEquivalentTo(bytes);
 	}
 
 	[SkippableTheory]
 	[AutoData]
 	public async Task ReadAsync_CanReadFalse_ShouldThrowNotSupportedException(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
 		using CancellationTokenSource cts = new(30000);
-		byte[] buffer = new byte[contents.Length];
-		await FileSystem.File.WriteAllBytesAsync(path, contents, cts.Token);
+		byte[] buffer = new byte[bytes.Length];
+		await FileSystem.File.WriteAllBytesAsync(path, bytes, cts.Token);
 		await using FileSystemStream stream = FileSystem.File.OpenWrite(path);
 
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
 			// ReSharper disable once AccessToDisposedClosure
 			#pragma warning disable CA1835
-			_ = await stream.ReadAsync(buffer, 0, contents.Length, cts.Token);
+			_ = await stream.ReadAsync(buffer, 0, bytes.Length, cts.Token);
 			#pragma warning restore CA1835
 		});
 
@@ -275,11 +275,11 @@ public abstract partial class ReadTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public async Task ReadAsync_Memory_CanReadFalse_ShouldThrowNotSupportedException(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
 		using CancellationTokenSource cts = new(30000);
-		byte[] buffer = new byte[contents.Length];
-		await FileSystem.File.WriteAllBytesAsync(path, contents, cts.Token);
+		byte[] buffer = new byte[bytes.Length];
+		await FileSystem.File.WriteAllBytesAsync(path, bytes, cts.Token);
 		await using FileSystemStream stream = FileSystem.File.OpenWrite(path);
 
 		Exception? exception = await Record.ExceptionAsync(async () =>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/Tests.cs
@@ -55,26 +55,26 @@ public abstract partial class Tests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public void CopyTo_ShouldCopyBytes(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
-		byte[] buffer = new byte[contents.Length];
-		FileSystem.File.WriteAllBytes(path, contents);
+		byte[] buffer = new byte[bytes.Length];
+		FileSystem.File.WriteAllBytes(path, bytes);
 		using FileSystemStream stream = FileSystem.File.OpenRead(path);
 		using MemoryStream destination = new(buffer);
 
 		stream.CopyTo(destination);
 
 		destination.Flush();
-		buffer.Should().BeEquivalentTo(contents);
+		buffer.Should().BeEquivalentTo(bytes);
 	}
 
 	[SkippableTheory]
 	[AutoData]
 	public void CopyTo_BufferSizeZero_ShouldThrowArgumentOutOfRangeException(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
-		byte[] buffer = new byte[contents.Length];
-		FileSystem.File.WriteAllBytes(path, contents);
+		byte[] buffer = new byte[bytes.Length];
+		FileSystem.File.WriteAllBytes(path, bytes);
 
 		Exception? exception = Record.Exception(() =>
 		{
@@ -91,26 +91,26 @@ public abstract partial class Tests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public async Task CopyToAsync_ShouldCopyBytes(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
-		byte[] buffer = new byte[contents.Length];
-		await FileSystem.File.WriteAllBytesAsync(path, contents);
+		byte[] buffer = new byte[bytes.Length];
+		await FileSystem.File.WriteAllBytesAsync(path, bytes);
 		await using FileSystemStream stream = FileSystem.File.OpenRead(path);
 		using MemoryStream destination = new(buffer);
 
 		await stream.CopyToAsync(destination);
 
 		await destination.FlushAsync();
-		buffer.Should().BeEquivalentTo(contents);
+		buffer.Should().BeEquivalentTo(bytes);
 	}
 
 	[SkippableTheory]
 	[AutoData]
 	public async Task CopyToAsync_BufferSizeZero_ShouldThrowArgumentOutOfRangeException(
-		string path, byte[] contents)
+		string path, byte[] bytes)
 	{
-		byte[] buffer = new byte[contents.Length];
-		await FileSystem.File.WriteAllBytesAsync(path, contents);
+		byte[] buffer = new byte[bytes.Length];
+		await FileSystem.File.WriteAllBytesAsync(path, bytes);
 
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
@@ -204,7 +204,8 @@ public abstract partial class Tests<TFileSystem>
 
 		stream2.Dispose();
 		stream1.Dispose();
-		FileSystem.File.ReadAllBytes(path).Should().BeEquivalentTo(bytes2);
+		FileSystem.Should().HaveFile(path)
+			.Which.HasContent(bytes2);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace Testably.Abstractions.Tests.FileSystem;
 
 // ReSharper disable once PartialTypeWithSinglePart
@@ -13,7 +15,7 @@ public abstract partial class FileSystemTests<TFileSystem>
 		FileSystem.Directory.CreateDirectory("foo\\bar");
 		FileSystem.File.WriteAllText("foo\\bar\\file.txt", "some content");
 
-		FileSystem.File.Exists("foo/bar/file.txt").Should().BeTrue();
+		FileSystem.Should().HaveFile("foo/bar/file.txt");
 		FileSystem.Directory.GetFiles("foo/bar").Length
 			.Should().Be(1);
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemTests.cs
@@ -1,5 +1,3 @@
-using System.IO;
-
 namespace Testably.Abstractions.Tests.FileSystem;
 
 // ReSharper disable once PartialTypeWithSinglePart

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
@@ -239,8 +239,10 @@ public abstract partial class Tests<TFileSystem>
 			/// <inheritdoc cref="IComponent.Site" />
 			public ISite? Site { get; set; }
 
+			#pragma warning disable CS0067 // Event is required by the interface
 			/// <inheritdoc cref="IComponent.Disposed" />
 			public event EventHandler? Disposed;
+			#pragma warning restore CS0067
 		}
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/ExceptionTests.cs
@@ -93,5 +93,5 @@ public abstract partial class ExceptionTests<TFileSystem>
 #endif
 	}
 
-#endregion
+	#endregion
 }

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/Usings.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/Usings.cs
@@ -3,6 +3,7 @@ global using FluentAssertions;
 global using System;
 global using System.IO.Abstractions;
 global using Testably.Abstractions.FileSystem;
+global using Testably.Abstractions.FluentAssertions;
 global using Testably.Abstractions.Testing;
 global using Testably.Abstractions.TestHelpers;
 global using Testably.Abstractions.Tests.TestHelpers;

--- a/Tests/Testably.Abstractions.Tests/Testably.Abstractions.Tests.csproj
+++ b/Tests/Testably.Abstractions.Tests/Testably.Abstractions.Tests.csproj
@@ -8,10 +8,11 @@
 		<ProjectReference Include="..\..\Source\Testably.Abstractions\Testably.Abstractions.csproj" />
 		<ProjectReference Include="..\..\Source\Testably.Abstractions.Testing\Testably.Abstractions.Testing.csproj" />
 		<ProjectReference Include="..\Helpers\Testably.Abstractions.TestHelpers\Testably.Abstractions.TestHelpers.csproj" />
+		<ProjectReference Include="..\Helpers\Testably.Abstractions.Tests.SourceGenerator\Testably.Abstractions.Tests.SourceGenerator.csproj" OutputItemType="Analyzer" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Helpers\Testably.Abstractions.Tests.SourceGenerator\Testably.Abstractions.Tests.SourceGenerator.csproj" OutputItemType="Analyzer" />
+		<PackageReference Include="Testably.Abstractions.FluentAssertions" />
 	</ItemGroup>
 
 	<PropertyGroup>

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -134,6 +134,7 @@ public abstract partial class TimerTests<TTimeSystem>
 			{
 				ms3.Set();
 			}
+
 			Thread.Sleep(10);
 		}, null, 0 * TimerMultiplier, 200 * TimerMultiplier);
 		ms.Wait(30000).Should().BeTrue();
@@ -152,6 +153,7 @@ public abstract partial class TimerTests<TTimeSystem>
 		{
 			triggerTimes.RemoveAt(0);
 		}
+
 		triggerTimes[0].Should()
 			.BeGreaterThan(70 * TimerMultiplier).And
 			.BeLessThan(130 * TimerMultiplier);
@@ -185,6 +187,7 @@ public abstract partial class TimerTests<TTimeSystem>
 			{
 				ms3.Set();
 			}
+
 			Thread.Sleep(10);
 		}, null, 0L * TimerMultiplier, 200L * TimerMultiplier);
 		ms.Wait(30000).Should().BeTrue();
@@ -203,6 +206,7 @@ public abstract partial class TimerTests<TTimeSystem>
 		{
 			triggerTimes.RemoveAt(0);
 		}
+
 		triggerTimes[0].Should()
 			.BeGreaterThan(70 * TimerMultiplier).And
 			.BeLessThan(130 * TimerMultiplier);
@@ -258,6 +262,7 @@ public abstract partial class TimerTests<TTimeSystem>
 		{
 			triggerTimes.RemoveAt(0);
 		}
+
 		triggerTimes[0].Should()
 			.BeGreaterThan(70 * TimerMultiplier).And
 			.BeLessThan(130 * TimerMultiplier);


### PR DESCRIPTION
Improve readability of tests by using the [FluentAssertions](https://github.com/Testably/Testably.Abstractions.FluentAssertions) extensions.