### PR TITLE
refactor: avoid `Thread.Sleep` in Tests

### DIFF
--- a/Source/Testably.Abstractions.Testing/Helpers/FilePlatformIndependenceExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FilePlatformIndependenceExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.RegularExpressions;
 
@@ -10,7 +11,9 @@ namespace Testably.Abstractions.Testing.Helpers;
 internal static class FilePlatformIndependenceExtensions
 {
 	#pragma warning disable SYSLIB1045
-	private static readonly Regex PathTransformRegex = new(@"^[a-zA-Z]:(?<path>.*)$");
+	private static readonly Regex PathTransformRegex = new(@"^[a-zA-Z]:(?<path>.*)$",
+		RegexOptions.None,
+		TimeSpan.FromMilliseconds(1000));
 	#pragma warning restore SYSLIB1045
 
 	/// <summary>

--- a/Tests/Testably.Abstractions.Testing.Tests/NotificationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/NotificationTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Testing.Tests;
 
@@ -18,22 +19,22 @@ public class NotificationTests
 				}
 			});
 
-		new Thread(() =>
+		_ = Task.Run(async () =>
 		{
-			Thread.Sleep(10);
+			await Task.Delay(10);
 			for (int i = 1; i <= 10; i++)
 			{
 				timeSystem.Thread.Sleep(i);
-				Thread.Sleep(1);
+				await Task.Delay(1);
 			}
-		}).Start();
+		});
 
 		wait.Wait(count: 7);
 		receivedCount.Should().BeGreaterOrEqualTo(7);
 	}
 
 	[SkippableFact]
-	public void AwaitableCallback_Dispose_ShouldStopListening()
+	public async Task AwaitableCallback_Dispose_ShouldStopListening()
 	{
 		MockTimeSystem timeSystem = new();
 		bool isCalled = false;
@@ -46,12 +47,12 @@ public class NotificationTests
 		wait.Dispose();
 
 		timeSystem.Thread.Sleep(1);
-		Thread.Sleep(10);
+		await Task.Delay(10);
 		isCalled.Should().BeFalse();
 	}
 
 	[SkippableFact]
-	public void AwaitableCallback_DisposeFromExecuteWhileWaiting_ShouldStopListening()
+	public async Task AwaitableCallback_DisposeFromExecuteWhileWaiting_ShouldStopListening()
 	{
 		MockTimeSystem timeSystem = new();
 		bool isCalled = false;
@@ -66,7 +67,7 @@ public class NotificationTests
 		wait.Dispose();
 
 		timeSystem.Thread.Sleep(1);
-		Thread.Sleep(10);
+		await Task.Delay(10);
 		isCalled.Should().BeFalse();
 	}
 
@@ -81,15 +82,15 @@ public class NotificationTests
 				receivedCount++;
 			});
 
-		new Thread(() =>
+		_ = Task.Run(async () =>
 		{
-			Thread.Sleep(10);
+			await Task.Delay(10);
 			for (int i = 1; i <= 10; i++)
 			{
 				timeSystem.Thread.Sleep(i);
-				Thread.Sleep(1);
+				await Task.Delay(1);
 			}
-		}).Start();
+		});
 
 		wait.Wait(t => t.TotalMilliseconds > 6);
 		receivedCount.Should().BeGreaterOrEqualTo(6);
@@ -105,18 +106,18 @@ public class NotificationTests
 		{
 			receivedCount++;
 		}, t => t.TotalMilliseconds > 6);
-
-		new Thread(() =>
+		
+		_ = Task.Run(async () =>
 		{
-			Thread.Sleep(10);
+			await Task.Delay(10);
 			for (int i = 1; i <= 10; i++)
 			{
 				timeSystem.Thread.Sleep(i);
-				Thread.Sleep(1);
+				await Task.Delay(1);
 			}
 
 			ms.Set();
-		}).Start();
+		});
 
 		ms.Wait(30000);
 		receivedCount.Should().BeLessOrEqualTo(4);
@@ -136,14 +137,15 @@ public class NotificationTests
 					isCalled = true;
 				});
 
-			new Thread(() =>
+
+			_ = Task.Run(async () =>
 			{
 				while (!ms.IsSet)
 				{
 					timeSystem.Thread.Sleep(1);
-					Thread.Sleep(1);
+					await Task.Delay(1);
 				}
-			}).Start();
+			});
 
 			wait.Wait();
 			isCalled.Should().BeTrue();

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
@@ -1,10 +1,8 @@
 ﻿using System.Threading;
+using System.Threading.Tasks;
 using Testably.Abstractions.Testing.TimeSystem;
 using Testably.Abstractions.TimeSystem;
 using Xunit.Abstractions;
-#if FEATURE_ASYNC_DISPOSABLE
-using System.Threading.Tasks;
-#endif
 
 namespace Testably.Abstractions.Testing.Tests.TimeSystem;
 
@@ -160,7 +158,7 @@ public class TimerMockTests
 	}
 
 	[Fact]
-	public void Exception_WhenSwallowExceptionsIsNotSet_ShouldStopTimer()
+	public async Task Exception_WhenSwallowExceptionsIsNotSet_ShouldStopTimer()
 	{
 		MockTimeSystem timeSystem = new MockTimeSystem()
 			.WithTimerStrategy(new TimerStrategy(
@@ -182,13 +180,13 @@ public class TimerMockTests
 			timeSystem.TimerHandler[0].Wait();
 		});
 
-		Thread.Sleep(10);
+		await Task.Delay(10);
 		exception.Should().Be(expectedException);
 		count.Should().Be(1);
 	}
 
 	[Fact]
-	public void New_WithStartOnMockWaitMode_ShouldOnlyStartWhenCallingWait()
+	public async Task New_WithStartOnMockWaitMode_ShouldOnlyStartWhenCallingWait()
 	{
 		MockTimeSystem timeSystem = new MockTimeSystem()
 			.WithTimerStrategy(new TimerStrategy(TimerMode.StartOnMockWait));
@@ -197,7 +195,7 @@ public class TimerMockTests
 		int count = 0;
 		using ITimer timer = timeSystem.Timer.New(_ => count++, null, 0, 100);
 
-		Thread.Sleep(10);
+		await Task.Delay(10);
 		count.Should().Be(0);
 		timerHandler[0].Wait();
 		count.Should().BeGreaterThan(0);
@@ -311,7 +309,7 @@ public class TimerMockTests
 	}
 
 	[Fact]
-	public void Wait_WithExecutionCount_ShouldWaitForSpecifiedNumberOfExecutions()
+	public async Task Wait_WithExecutionCount_ShouldWaitForSpecifiedNumberOfExecutions()
 	{
 		int executionCount = 10;
 		MockTimeSystem timeSystem = new MockTimeSystem()
@@ -333,7 +331,7 @@ public class TimerMockTests
 			_testOutputHelper.WriteLine("Disposed.");
 		}, timeout: 10000);
 		_testOutputHelper.WriteLine("Waiting 100ms...");
-		Thread.Sleep(1000);
+		await Task.Delay(1000);
 		_testOutputHelper.WriteLine("Waiting completed.");
 		count.Should().Be(executionCount);
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/FileAccessTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/FileAccessTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using System.IO;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
@@ -190,7 +189,7 @@ public abstract partial class FileAccessTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void MultipleParallelReads_ShouldBeAllowed(string path, string contents)
+	public async Task MultipleParallelReads_ShouldBeAllowed(string path, string contents)
 	{
 		FileSystem.File.WriteAllText(path, contents);
 		ConcurrentBag<string> results = new();
@@ -205,7 +204,7 @@ public abstract partial class FileAccessTests<TFileSystem>
 
 		while (!wait.IsCompleted)
 		{
-			Thread.Sleep(10);
+			await Task.Delay(10);
 		}
 
 		results.Should().HaveCount(100);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
@@ -29,11 +29,11 @@ public abstract partial class Tests<TFileSystem>
 		fileSystemWatcher.EnableRaisingEvents.Should().BeTrue();
 		try
 		{
-			Task.Run(() =>
+			_ = Task.Run(async () =>
 			{
 				while (!ms.IsSet)
 				{
-					Thread.Sleep(10);
+					await Task.Delay(10);
 					FileSystem.Directory.CreateDirectory(path);
 					FileSystem.Directory.Delete(path);
 				}
@@ -81,11 +81,11 @@ public abstract partial class Tests<TFileSystem>
 		fileSystemWatcher.EnableRaisingEvents.Should().BeTrue();
 		try
 		{
-			Task.Run(() =>
+			_ = Task.Run(async () =>
 			{
 				while (!ms.IsSet)
 				{
-					Thread.Sleep(10);
+					await Task.Delay(10);
 					FileSystem.Directory.CreateDirectory(path);
 					FileSystem.Directory.Delete(path);
 				}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
@@ -48,11 +48,11 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		try
 		{
-			Task.Run(() =>
+			_ = Task.Run(async () =>
 			{
 				while (!ms.IsSet)
 				{
-					Thread.Sleep(10);
+					await Task.Delay(10);
 					FileSystem.Directory.CreateDirectory(path);
 					FileSystem.Directory.Delete(path);
 				}
@@ -90,11 +90,11 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 		try
 		{
 			fileSystemWatcher.EnableRaisingEvents = true;
-			Task.Run(() =>
+			_ = Task.Run(async () =>
 			{
 				while (!ms.IsSet)
 				{
-					Thread.Sleep(10);
+					await Task.Delay(10);
 					FileSystem.Directory.CreateDirectory(path);
 					FileSystem.Directory.Delete(path);
 				}

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerFactoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using System.Threading.Tasks;
 using Testably.Abstractions.TimeSystem;
 
 namespace Testably.Abstractions.Tests.TimeSystem;
@@ -131,7 +132,7 @@ public abstract partial class TimerFactoryTests<TTimeSystem>
 	}
 
 	[SkippableFact]
-	public void New_WithDueTime_ShouldStartTimerOnce()
+	public async Task New_WithDueTime_ShouldStartTimerOnce()
 	{
 		int count = 0;
 		ManualResetEventSlim ms = new();
@@ -142,7 +143,7 @@ public abstract partial class TimerFactoryTests<TTimeSystem>
 		}, null, 5, 0);
 
 		ms.Wait(30000).Should().BeTrue();
-		Thread.Sleep(100);
+		await Task.Delay(100);
 		count.Should().Be(1);
 	}
 

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -123,20 +123,21 @@ public abstract partial class TimerTests<TTimeSystem>
 		ManualResetEventSlim ms2 = new();
 		ManualResetEventSlim ms3 = new();
 		using ITimer timer1 = TimeSystem.Timer.New(_ =>
-		{
-			DateTime now = TimeSystem.DateTime.Now;
-			double diff = (now - previousTime).TotalMilliseconds;
-			previousTime = now;
-			ms.Set();
-			triggerTimes.Add((int)diff);
-			ms2.Wait(30000);
-			if (triggerTimes.Count > 3)
 			{
-				ms3.Set();
-			}
+				DateTime now = TimeSystem.DateTime.Now;
+				double diff = (now - previousTime).TotalMilliseconds;
+				previousTime = now;
+				ms.Set();
+				triggerTimes.Add((int)diff);
+				ms2.Wait(30000);
+				if (triggerTimes.Count > 3)
+				{
+					ms3.Set();
+				}
 
-			Thread.Sleep(10);
-		}, null, 0 * TimerMultiplier, 200 * TimerMultiplier);
+				Thread.Sleep(10);
+			},
+			null, 0 * TimerMultiplier, 200 * TimerMultiplier);
 		ms.Wait(30000).Should().BeTrue();
 		using ITimer timer2 = TimeSystem.Timer.New(_ =>
 		{
@@ -176,20 +177,21 @@ public abstract partial class TimerTests<TTimeSystem>
 		ManualResetEventSlim ms2 = new();
 		ManualResetEventSlim ms3 = new();
 		using ITimer timer1 = TimeSystem.Timer.New(_ =>
-		{
-			DateTime now = TimeSystem.DateTime.Now;
-			double diff = (now - previousTime).TotalMilliseconds;
-			previousTime = now;
-			ms.Set();
-			triggerTimes.Add((int)diff);
-			ms2.Wait(30000);
-			if (triggerTimes.Count > 3)
 			{
-				ms3.Set();
-			}
+				DateTime now = TimeSystem.DateTime.Now;
+				double diff = (now - previousTime).TotalMilliseconds;
+				previousTime = now;
+				ms.Set();
+				triggerTimes.Add((int)diff);
+				ms2.Wait(30000);
+				if (triggerTimes.Count > 3)
+				{
+					ms3.Set();
+				}
 
-			Thread.Sleep(10);
-		}, null, 0L * TimerMultiplier, 200L * TimerMultiplier);
+				Thread.Sleep(10);
+			},
+			null, 0L * TimerMultiplier, 200L * TimerMultiplier);
 		ms.Wait(30000).Should().BeTrue();
 		using ITimer timer2 = TimeSystem.Timer.New(_ =>
 		{

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Testably.Abstractions.TimeSystem;
 
 namespace Testably.Abstractions.Tests.TimeSystem;
@@ -122,7 +123,8 @@ public abstract partial class TimerTests<TTimeSystem>
 		ManualResetEventSlim ms = new();
 		ManualResetEventSlim ms2 = new();
 		ManualResetEventSlim ms3 = new();
-		using ITimer timer1 = TimeSystem.Timer.New(_ =>
+		// ReSharper disable once AsyncVoidLambda
+		using ITimer timer1 = TimeSystem.Timer.New(async _ =>
 			{
 				DateTime now = TimeSystem.DateTime.Now;
 				double diff = (now - previousTime).TotalMilliseconds;
@@ -135,7 +137,7 @@ public abstract partial class TimerTests<TTimeSystem>
 					ms3.Set();
 				}
 
-				Thread.Sleep(10);
+				await Task.Delay(10);
 			},
 			null, 0 * TimerMultiplier, 200 * TimerMultiplier);
 		ms.Wait(30000).Should().BeTrue();
@@ -176,7 +178,8 @@ public abstract partial class TimerTests<TTimeSystem>
 		ManualResetEventSlim ms = new();
 		ManualResetEventSlim ms2 = new();
 		ManualResetEventSlim ms3 = new();
-		using ITimer timer1 = TimeSystem.Timer.New(_ =>
+		// ReSharper disable once AsyncVoidLambda
+		using ITimer timer1 = TimeSystem.Timer.New(async _ =>
 			{
 				DateTime now = TimeSystem.DateTime.Now;
 				double diff = (now - previousTime).TotalMilliseconds;
@@ -189,7 +192,7 @@ public abstract partial class TimerTests<TTimeSystem>
 					ms3.Set();
 				}
 
-				Thread.Sleep(10);
+				await Task.Delay(10);
 			},
 			null, 0L * TimerMultiplier, 200L * TimerMultiplier);
 		ms.Wait(30000).Should().BeTrue();
@@ -230,7 +233,8 @@ public abstract partial class TimerTests<TTimeSystem>
 		ManualResetEventSlim ms = new();
 		ManualResetEventSlim ms2 = new();
 		ManualResetEventSlim ms3 = new();
-		using ITimer timer1 = TimeSystem.Timer.New(_ =>
+		// ReSharper disable once AsyncVoidLambda
+		using ITimer timer1 = TimeSystem.Timer.New(async _ =>
 			{
 				DateTime now = TimeSystem.DateTime.Now;
 				double diff = (now - previousTime).TotalMilliseconds;
@@ -243,7 +247,7 @@ public abstract partial class TimerTests<TTimeSystem>
 					ms3.Set();
 				}
 
-				Thread.Sleep(10);
+				await Task.Delay(10);
 			}, null, TimeSpan.FromMilliseconds(0 * TimerMultiplier),
 			TimeSpan.FromMilliseconds(200 * TimerMultiplier));
 		ms.Wait(30000).Should().BeTrue();


### PR DESCRIPTION
Fixes [S2925 Do not use 'Thread.Sleep()' in a test](https://sonarcloud.io/organizations/testably/rules?open=csharpsquid%3AS2925&rule_key=csharpsquid%3AS2925)
*Using `Thread.Sleep` in a test might introduce unpredictable and inconsistent results depending on the environment. Furthermore, it will block the [thread](https://en.wikipedia.org/wiki/Thread_%28computing%29), which means the system resources are not being fully used.*

Fix [S6444 Not specifying a timeout for regular expressions is security-sensitive](https://sonarcloud.io/organizations/testably/rules?open=csharpsquid%3AS6444&rule_key=csharpsquid%3AS6444)
*Not specifying a timeout for regular expressions can lead to a Denial-of-Service attack. Pass a timeout when using `System.Text.RegularExpressions` to process untrusted input because a malicious user might craft a value for which the evaluation lasts excessively long.*
by applying a timeout of 1 second to the path transformation regex.