### PR TITLE
fix: `FileSystemInitializer` supports nested directories

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryInitializer.cs
@@ -9,7 +9,7 @@ internal sealed class DirectoryInitializer<TFileSystem>
 {
 	public DirectoryInitializer(FileSystemInitializer<TFileSystem> initializer,
 		IDirectoryInfo directory)
-		: base(initializer, directory)
+		: base(initializer)
 	{
 		Directory = directory;
 	}

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryInitializer.cs
@@ -9,7 +9,7 @@ internal sealed class DirectoryInitializer<TFileSystem>
 {
 	public DirectoryInitializer(FileSystemInitializer<TFileSystem> initializer,
 		IDirectoryInfo directory)
-		: base(initializer)
+		: base(initializer, directory)
 	{
 		Directory = directory;
 	}

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInitializer.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/FileSystemInitializer.cs
@@ -145,7 +145,7 @@ internal class FileSystemInitializer<TFileSystem>
 
 		if (directory.Children.Length > 0)
 		{
-			DirectoryInitializer<TFileSystem> subdirectoryInitializer = new(this, directoryInfo);
+			FileSystemInitializer<TFileSystem> subdirectoryInitializer = new(this, directoryInfo);
 			foreach (FileSystemInfoDescription children in directory.Children)
 			{
 				subdirectoryInitializer.WithFileOrDirectory(children);

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
 namespace Testably.Abstractions.Testing.Tests.FileSystemInitializer;
@@ -18,6 +19,24 @@ public class FileSystemInitializerTests
 		foreach (DirectoryDescription directory in directories)
 		{
 			fileSystem.Should().HaveDirectory(directory.Name);
+		}
+	}
+
+	[Theory]
+	[AutoData]
+	public void With_DirectoryDescriptions_WithSubdirectories_ShouldCreateDirectories(
+		string parent, DirectoryDescription[] directories)
+	{
+		DirectoryDescription directoryDescription = new(parent,
+			directories.Cast<FileSystemInfoDescription>().ToArray());
+		MockFileSystem fileSystem = new();
+		IFileSystemInitializer<MockFileSystem> sut = fileSystem.Initialize();
+
+		sut.With(directoryDescription);
+
+		foreach (DirectoryDescription directory in directories)
+		{
+			fileSystem.Should().HaveDirectory(Path.Combine(parent, directory.Name));
 		}
 	}
 


### PR DESCRIPTION
Initializing the file system with nested `DirectoryDescriptions` now creates the correct nested path.