### PR TITLE
feat: enable support for .NET 8.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -74,6 +75,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
@@ -101,6 +103,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
@@ -128,6 +131,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
@@ -155,6 +159,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1
       - name: Setup VSTest
@@ -180,6 +185,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Build example solution

--- a/.github/workflows/ci-stryker.yml
+++ b/.github/workflows/ci-stryker.yml
@@ -19,6 +19,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Install .NET Stryker
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
@@ -53,6 +54,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
@@ -86,6 +88,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
@@ -153,6 +156,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Build example solution

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -85,6 +86,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
@@ -112,6 +114,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
@@ -139,6 +142,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
@@ -190,6 +194,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True
       - name: Build example solution
@@ -215,6 +220,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Install .NET Stryker
         shell: bash
         run: |
@@ -242,6 +248,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Install .NET Stryker
         shell: bash
         run: |
@@ -294,6 +301,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Prepare README.md
         shell: bash
         run: |

--- a/.github/workflows/stryker.yml
+++ b/.github/workflows/stryker.yml
@@ -21,6 +21,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Install .NET Stryker
         shell: bash
         run: |
@@ -48,6 +49,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
       - name: Install .NET Stryker
         shell: bash
         run: |

--- a/Feature.Flags.props
+++ b/Feature.Flags.props
@@ -30,6 +30,7 @@
 		<DefineConstants Condition="'$(IS_NET7_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_UNIXFILEMODE</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET7_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_GUID_FORMATPROVIDER</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET8_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_RANDOM_ITEMS</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET8_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_COMPRESSION_STREAM</DefineConstants>
 	</PropertyGroup>
 
 </Project>

--- a/Feature.Flags.props
+++ b/Feature.Flags.props
@@ -4,6 +4,7 @@
 		<IS_NET21_OR_HIGHER Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'netstandard2.1'">1</IS_NET21_OR_HIGHER>
 		<IS_NET6_OR_HIGHER Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">1</IS_NET6_OR_HIGHER>
 		<IS_NET7_OR_HIGHER Condition="'$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">1</IS_NET7_OR_HIGHER>
+		<IS_NET8_OR_HIGHER Condition="'$(TargetFramework)' == 'net8.0'">1</IS_NET8_OR_HIGHER>
 
 		<DefineConstants Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NETFRAMEWORK</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET21_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_ASYNC</DefineConstants>
@@ -28,6 +29,7 @@
 		<DefineConstants Condition="'$(IS_NET7_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_SAFEFILEHANDLE</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET7_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_UNIXFILEMODE</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET7_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_GUID_FORMATPROVIDER</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET8_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_RANDOM_ITEMS</DefineConstants>
 	</PropertyGroup>
 
 </Project>

--- a/Feature.Flags.props
+++ b/Feature.Flags.props
@@ -1,9 +1,9 @@
 <Project>
 
 	<PropertyGroup>
-		<IS_NET21_OR_HIGHER Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'netstandard2.1'">1</IS_NET21_OR_HIGHER>
-		<IS_NET6_OR_7 Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">1</IS_NET6_OR_7>
-		<IS_NET7 Condition="'$(TargetFramework)' == 'net7.0'">1</IS_NET7>
+		<IS_NET21_OR_HIGHER Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'netstandard2.1'">1</IS_NET21_OR_HIGHER>
+		<IS_NET6_OR_HIGHER Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">1</IS_NET6_OR_HIGHER>
+		<IS_NET7_OR_HIGHER Condition="'$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">1</IS_NET7_OR_HIGHER>
 
 		<DefineConstants Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NETFRAMEWORK</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET21_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_ASYNC</DefineConstants>
@@ -16,18 +16,18 @@
 		<DefineConstants Condition="'$(IS_NET21_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_COMPRESSION_OVERWRITE</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET21_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_COMPRESSION_ADVANCED</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET21_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_ASYNC_DISPOSABLE</DefineConstants>
-		<DefineConstants Condition="'$(IS_NET6_OR_7)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_STREAM_OPTIONS</DefineConstants>
-		<DefineConstants Condition="'$(IS_NET6_OR_7)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_LINK</DefineConstants>
-		<DefineConstants Condition="'$(IS_NET6_OR_7)' == '1'">$(DefineConstants);FEATURE_PATH_ADVANCED</DefineConstants>
-		<DefineConstants Condition="'$(IS_NET6_OR_7)' == '1'">$(DefineConstants);FEATURE_FILE_MOVETO_OVERWRITE</DefineConstants>
-		<DefineConstants Condition="'$(IS_NET6_OR_7)' == '1'">$(DefineConstants);FEATURE_RANDOM_ADVANCED</DefineConstants>
-		<DefineConstants Condition="'$(IS_NET6_OR_7)' == '1'">$(DefineConstants);FEATURE_FILESYSTEMWATCHER_ADVANCED</DefineConstants>
-		<DefineConstants Condition="'$(IS_NET6_OR_7)' == '1'">$(DefineConstants);FEATURE_EXCEPTION_HRESULT</DefineConstants>
-		<DefineConstants Condition="'$(IS_NET7)' == '1'">$(DefineConstants);FEATURE_ZIPFILE_NET7</DefineConstants>
-		<DefineConstants Condition="'$(IS_NET7)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_NET7</DefineConstants>
-		<DefineConstants Condition="'$(IS_NET7)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_SAFEFILEHANDLE</DefineConstants>
-		<DefineConstants Condition="'$(IS_NET7)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_UNIXFILEMODE</DefineConstants>
-		<DefineConstants Condition="'$(IS_NET7)' == '1'">$(DefineConstants);FEATURE_GUID_FORMATPROVIDER</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET6_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_STREAM_OPTIONS</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET6_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_LINK</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET6_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_PATH_ADVANCED</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET6_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILE_MOVETO_OVERWRITE</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET6_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_RANDOM_ADVANCED</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET6_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEMWATCHER_ADVANCED</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET6_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_EXCEPTION_HRESULT</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET7_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_ZIPFILE_NET7</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET7_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_NET7</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET7_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_SAFEFILEHANDLE</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET7_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_UNIXFILEMODE</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET7_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_GUID_FORMATPROVIDER</DefineConstants>
 	</PropertyGroup>
 
 </Project>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;netstandard2.1;netstandard2.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(NetFrameworkOnly)' == 'True'">netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(NetFrameworkOnly)' == 'True'">netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 

--- a/Source/Testably.Abstractions.Compression/IZipFile.cs
+++ b/Source/Testably.Abstractions.Compression/IZipFile.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Compression;
+﻿using System.IO;
+using System.IO.Compression;
 using System.Text;
 
 namespace Testably.Abstractions;
@@ -6,6 +7,17 @@ namespace Testably.Abstractions;
 /// <inheritdoc cref="ZipFile" />
 public interface IZipFile : IFileSystemEntity
 {
+#if FEATURE_COMPRESSION_STREAM
+	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, Stream)" />
+	void CreateFromDirectory(string sourceDirectoryName, Stream destination);
+
+	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, Stream, CompressionLevel, bool)" />
+	void CreateFromDirectory(string sourceDirectoryName, Stream destination, CompressionLevel compressionLevel, bool includeBaseDirectory);
+
+	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, Stream, CompressionLevel, bool, Encoding)" />
+	void CreateFromDirectory(string sourceDirectoryName, Stream destination, CompressionLevel compressionLevel, bool includeBaseDirectory, Encoding entryNameEncoding);
+#endif
+
 	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, string)" />
 	void CreateFromDirectory(string sourceDirectoryName,
 		string destinationArchiveFileName);
@@ -22,6 +34,20 @@ public interface IZipFile : IFileSystemEntity
 		CompressionLevel compressionLevel,
 		bool includeBaseDirectory,
 		Encoding entryNameEncoding);
+
+#if FEATURE_COMPRESSION_STREAM
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string)" />
+	void ExtractToDirectory(Stream source, string destinationDirectoryName);
+
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, bool)" />
+	void ExtractToDirectory(Stream source, string destinationDirectoryName, bool overwriteFiles);
+
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, Encoding)" />
+	void ExtractToDirectory(Stream source, string destinationDirectoryName, Encoding entryNameEncoding);
+
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, Encoding, bool)" />
+	void ExtractToDirectory(Stream source, string destinationDirectoryName, Encoding entryNameEncoding, bool overwriteFiles);
+#endif
 
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(string, string)" />
 	void ExtractToDirectory(string sourceArchiveFileName,

--- a/Source/Testably.Abstractions.Compression/IZipFile.cs
+++ b/Source/Testably.Abstractions.Compression/IZipFile.cs
@@ -9,27 +9,41 @@ public interface IZipFile : IFileSystemEntity
 {
 #if FEATURE_COMPRESSION_STREAM
 	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, Stream)" />
-	void CreateFromDirectory(string sourceDirectoryName, Stream destination);
+	void CreateFromDirectory(
+		string sourceDirectoryName,
+		Stream destination);
 
 	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, Stream, CompressionLevel, bool)" />
-	void CreateFromDirectory(string sourceDirectoryName, Stream destination, CompressionLevel compressionLevel, bool includeBaseDirectory);
+	void CreateFromDirectory(
+		string sourceDirectoryName,
+		Stream destination,
+		CompressionLevel compressionLevel,
+		bool includeBaseDirectory);
 
 	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, Stream, CompressionLevel, bool, Encoding)" />
-	void CreateFromDirectory(string sourceDirectoryName, Stream destination, CompressionLevel compressionLevel, bool includeBaseDirectory, Encoding entryNameEncoding);
+	void CreateFromDirectory(
+		string sourceDirectoryName,
+		Stream destination,
+		CompressionLevel compressionLevel,
+		bool includeBaseDirectory,
+		Encoding entryNameEncoding);
 #endif
 
 	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, string)" />
-	void CreateFromDirectory(string sourceDirectoryName,
+	void CreateFromDirectory(
+		string sourceDirectoryName,
 		string destinationArchiveFileName);
 
 	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, string, CompressionLevel, bool)" />
-	void CreateFromDirectory(string sourceDirectoryName,
+	void CreateFromDirectory(
+		string sourceDirectoryName,
 		string destinationArchiveFileName,
 		CompressionLevel compressionLevel,
 		bool includeBaseDirectory);
 
 	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, string, CompressionLevel, bool, Encoding)" />
-	void CreateFromDirectory(string sourceDirectoryName,
+	void CreateFromDirectory(
+		string sourceDirectoryName,
 		string destinationArchiveFileName,
 		CompressionLevel compressionLevel,
 		bool includeBaseDirectory,
@@ -37,51 +51,70 @@ public interface IZipFile : IFileSystemEntity
 
 #if FEATURE_COMPRESSION_STREAM
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string)" />
-	void ExtractToDirectory(Stream source, string destinationDirectoryName);
+	void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName);
 
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, bool)" />
-	void ExtractToDirectory(Stream source, string destinationDirectoryName, bool overwriteFiles);
+	void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName,
+		bool overwriteFiles);
 
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, Encoding)" />
-	void ExtractToDirectory(Stream source, string destinationDirectoryName, Encoding entryNameEncoding);
+	void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName,
+		Encoding entryNameEncoding);
 
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, Encoding, bool)" />
-	void ExtractToDirectory(Stream source, string destinationDirectoryName, Encoding entryNameEncoding, bool overwriteFiles);
+	void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName,
+		Encoding entryNameEncoding,
+		bool overwriteFiles);
 #endif
 
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(string, string)" />
-	void ExtractToDirectory(string sourceArchiveFileName,
+	void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName);
 
 #if FEATURE_COMPRESSION_OVERWRITE
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(string, string, bool)" />
-	void ExtractToDirectory(string sourceArchiveFileName,
+	void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName,
 		bool overwriteFiles);
 #endif
 
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(string, string, Encoding?)" />
-	void ExtractToDirectory(string sourceArchiveFileName,
+	void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName,
 		Encoding? entryNameEncoding);
 
 #if FEATURE_COMPRESSION_OVERWRITE
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(string, string, Encoding?, bool)" />
-	void ExtractToDirectory(string sourceArchiveFileName,
+	void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName,
 		Encoding? entryNameEncoding,
 		bool overwriteFiles);
 #endif
 
 	/// <inheritdoc cref="ZipFile.Open(string, ZipArchiveMode)" />
-	IZipArchive Open(string archiveFileName,
+	IZipArchive Open(
+		string archiveFileName,
 		ZipArchiveMode mode);
 
 	/// <inheritdoc cref="IZipFile.Open(string, ZipArchiveMode, Encoding?)" />
-	IZipArchive Open(string archiveFileName,
+	IZipArchive Open(
+		string archiveFileName,
 		ZipArchiveMode mode,
 		Encoding? entryNameEncoding);
 
 	/// <inheritdoc cref="ZipFile.OpenRead(string)" />
-	IZipArchive OpenRead(string archiveFileName);
+	IZipArchive OpenRead(
+		string archiveFileName);
 }

--- a/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
+++ b/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
@@ -96,11 +96,11 @@ internal static class ZipUtilities
 					fileInfo.OpenRead().CopyTo(stream);
 				}
 				else if (file is IDirectoryInfo directoryInfo &&
-						 directoryInfo.GetFileSystemInfos().Length == 0)
+				         directoryInfo.GetFileSystemInfos().Length == 0)
 				{
-#pragma warning disable CA1845
+					#pragma warning disable CA1845
 					string entryName = file.FullName.Substring(basePath.Length + 1) + "/";
-#pragma warning restore CA1845
+					#pragma warning restore CA1845
 					archive.CreateEntry(entryName);
 				}
 			}
@@ -137,9 +137,11 @@ internal static class ZipUtilities
 				HResult = -2147024809
 			};
 		}
+
 		sourceDirectoryName = fileSystem.Path.GetFullPath(sourceDirectoryName);
 
-		using (ZipArchive archive = new ZipArchive(destination, ZipArchiveMode.Create, leaveOpen: true,
+		using (ZipArchive archive = new(destination, ZipArchiveMode.Create,
+			leaveOpen: true,
 			entryNameEncoding: entryNameEncoding))
 		{
 			bool directoryIsEmpty = true;
@@ -171,11 +173,11 @@ internal static class ZipUtilities
 					fileInfo.OpenRead().CopyTo(stream);
 				}
 				else if (file is IDirectoryInfo directoryInfo &&
-						 directoryInfo.GetFileSystemInfos().Length == 0)
+				         directoryInfo.GetFileSystemInfos().Length == 0)
 				{
-#pragma warning disable CA1845
+					#pragma warning disable CA1845
 					string entryName = file.FullName.Substring(basePath.Length + 1) + "/";
-#pragma warning restore CA1845
+					#pragma warning restore CA1845
 					archive.CreateEntry(entryName);
 				}
 			}
@@ -254,7 +256,7 @@ internal static class ZipUtilities
 
 #if FEATURE_COMPRESSION_STREAM
 	/// <summary>
-	///     Extract the archive at <paramref name="sourceArchiveFileName" /> to the
+	///     Extract the archive at <paramref name="source" /> to the
 	///     <paramref name="destinationDirectoryName" />.
 	/// </summary>
 	internal static void ExtractToDirectory(IFileSystem fileSystem,
@@ -272,7 +274,7 @@ internal static class ZipUtilities
 			};
 		}
 
-		using (ZipArchive archive = new ZipArchive(source, ZipArchiveMode.Read, leaveOpen: true, entryNameEncoding))
+		using (ZipArchive archive = new(source, ZipArchiveMode.Read, true, entryNameEncoding))
 		{
 			ZipArchiveWrapper wrappedArchive = new(fileSystem, archive);
 			foreach (ZipArchiveEntry entry in archive.Entries)

--- a/Source/Testably.Abstractions.Compression/ZipFileWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipFileWrapper.cs
@@ -1,4 +1,6 @@
-﻿using System.IO.Compression;
+﻿using System;
+using System.IO;
+using System.IO.Compression;
 using System.Text;
 using Testably.Abstractions.Internal;
 
@@ -15,6 +17,20 @@ internal sealed class ZipFileWrapper : IZipFile
 
 	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
+
+#if FEATURE_COMPRESSION_STREAM
+	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, Stream)" />
+	public void CreateFromDirectory(string sourceDirectoryName, Stream destination)
+		=> throw new NotImplementedException("Missing for .NET8.0");
+
+	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, Stream, CompressionLevel, bool)" />
+	public void CreateFromDirectory(string sourceDirectoryName, Stream destination, CompressionLevel compressionLevel, bool includeBaseDirectory)
+		=> throw new NotImplementedException("Missing for .NET8.0");
+
+	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, Stream, CompressionLevel, bool, Encoding)" />
+	public void CreateFromDirectory(string sourceDirectoryName, Stream destination, CompressionLevel compressionLevel, bool includeBaseDirectory, Encoding entryNameEncoding)
+		=> throw new NotImplementedException("Missing for .NET8.0");
+#endif
 
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, string)" />
 	public void CreateFromDirectory(string sourceDirectoryName,
@@ -66,6 +82,25 @@ internal sealed class ZipFileWrapper : IZipFile
 				compressionLevel,
 				includeBaseDirectory,
 				entryNameEncoding));
+
+
+#if FEATURE_COMPRESSION_STREAM
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string)" />
+	public void ExtractToDirectory(Stream source, string destinationDirectoryName)
+		=> throw new NotImplementedException("Missing for .NET8.0");
+
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, bool)" />
+	public void ExtractToDirectory(Stream source, string destinationDirectoryName, bool overwriteFiles)
+		=> throw new NotImplementedException("Missing for .NET8.0");
+
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, Encoding)" />
+	public void ExtractToDirectory(Stream source, string destinationDirectoryName, Encoding entryNameEncoding)
+		=> throw new NotImplementedException("Missing for .NET8.0");
+
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, Encoding, bool)" />
+	public void ExtractToDirectory(Stream source, string destinationDirectoryName, Encoding entryNameEncoding, bool overwriteFiles)
+		=> throw new NotImplementedException("Missing for .NET8.0");
+#endif
 
 	/// <inheritdoc cref="IZipFile.ExtractToDirectory(string, string)" />
 	public void ExtractToDirectory(string sourceArchiveFileName,

--- a/Source/Testably.Abstractions.Compression/ZipFileWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipFileWrapper.cs
@@ -21,15 +21,46 @@ internal sealed class ZipFileWrapper : IZipFile
 #if FEATURE_COMPRESSION_STREAM
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, Stream)" />
 	public void CreateFromDirectory(string sourceDirectoryName, Stream destination)
-		=> throw new NotImplementedException("Missing for .NET8.0");
+		=> Execute.WhenRealFileSystem(FileSystem,
+			() => ZipFile.CreateFromDirectory(
+				sourceDirectoryName,
+				destination),
+			() => ZipUtilities.CreateFromDirectory(
+				FileSystem,
+				sourceDirectoryName,
+				destination));
 
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, Stream, CompressionLevel, bool)" />
 	public void CreateFromDirectory(string sourceDirectoryName, Stream destination, CompressionLevel compressionLevel, bool includeBaseDirectory)
-		=> throw new NotImplementedException("Missing for .NET8.0");
+		=> Execute.WhenRealFileSystem(FileSystem,
+			() => ZipFile.CreateFromDirectory(
+				sourceDirectoryName,
+				destination,
+				compressionLevel,
+				includeBaseDirectory),
+			() => ZipUtilities.CreateFromDirectory(
+				FileSystem,
+				sourceDirectoryName,
+				destination,
+				compressionLevel,
+				includeBaseDirectory));
 
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, Stream, CompressionLevel, bool, Encoding)" />
 	public void CreateFromDirectory(string sourceDirectoryName, Stream destination, CompressionLevel compressionLevel, bool includeBaseDirectory, Encoding entryNameEncoding)
-		=> throw new NotImplementedException("Missing for .NET8.0");
+		=> Execute.WhenRealFileSystem(FileSystem,
+			() => ZipFile.CreateFromDirectory(
+				sourceDirectoryName,
+				destination,
+				compressionLevel,
+				includeBaseDirectory,
+				entryNameEncoding),
+			() => ZipUtilities.CreateFromDirectory(
+				FileSystem,
+				sourceDirectoryName,
+				destination,
+				compressionLevel,
+				includeBaseDirectory,
+				entryNameEncoding));
 #endif
 
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, string)" />
@@ -87,19 +118,55 @@ internal sealed class ZipFileWrapper : IZipFile
 #if FEATURE_COMPRESSION_STREAM
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string)" />
 	public void ExtractToDirectory(Stream source, string destinationDirectoryName)
-		=> throw new NotImplementedException("Missing for .NET8.0");
+		=> Execute.WhenRealFileSystem(FileSystem,
+			() => ZipFile.ExtractToDirectory(
+				source,
+				destinationDirectoryName),
+			() => ZipUtilities.ExtractToDirectory(
+				FileSystem,
+				source,
+				destinationDirectoryName));
 
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, bool)" />
 	public void ExtractToDirectory(Stream source, string destinationDirectoryName, bool overwriteFiles)
-		=> throw new NotImplementedException("Missing for .NET8.0");
+		=> Execute.WhenRealFileSystem(FileSystem,
+			() => ZipFile.ExtractToDirectory(
+				source,
+				destinationDirectoryName,
+				overwriteFiles),
+			() => ZipUtilities.ExtractToDirectory(
+				FileSystem,
+				source,
+				destinationDirectoryName,
+				overwriteFiles: overwriteFiles));
 
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, Encoding)" />
 	public void ExtractToDirectory(Stream source, string destinationDirectoryName, Encoding entryNameEncoding)
-		=> throw new NotImplementedException("Missing for .NET8.0");
+		=> Execute.WhenRealFileSystem(FileSystem,
+			() => ZipFile.ExtractToDirectory(
+				source,
+				destinationDirectoryName,
+				entryNameEncoding),
+			() => ZipUtilities.ExtractToDirectory(
+				FileSystem,
+				source,
+				destinationDirectoryName,
+				entryNameEncoding));
 
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, Encoding, bool)" />
 	public void ExtractToDirectory(Stream source, string destinationDirectoryName, Encoding entryNameEncoding, bool overwriteFiles)
-		=> throw new NotImplementedException("Missing for .NET8.0");
+		=> Execute.WhenRealFileSystem(FileSystem,
+			() => ZipFile.ExtractToDirectory(
+				source,
+				destinationDirectoryName,
+				entryNameEncoding,
+				overwriteFiles),
+			() => ZipUtilities.ExtractToDirectory(
+				FileSystem,
+				source,
+				destinationDirectoryName,
+				entryNameEncoding,
+				overwriteFiles));
 #endif
 
 	/// <inheritdoc cref="IZipFile.ExtractToDirectory(string, string)" />

--- a/Source/Testably.Abstractions.Compression/ZipFileWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipFileWrapper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.IO.Compression;
 using System.Text;
 using Testably.Abstractions.Internal;
@@ -20,7 +19,9 @@ internal sealed class ZipFileWrapper : IZipFile
 
 #if FEATURE_COMPRESSION_STREAM
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, Stream)" />
-	public void CreateFromDirectory(string sourceDirectoryName, Stream destination)
+	public void CreateFromDirectory(
+		string sourceDirectoryName,
+		Stream destination)
 		=> Execute.WhenRealFileSystem(FileSystem,
 			() => ZipFile.CreateFromDirectory(
 				sourceDirectoryName,
@@ -31,7 +32,11 @@ internal sealed class ZipFileWrapper : IZipFile
 				destination));
 
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, Stream, CompressionLevel, bool)" />
-	public void CreateFromDirectory(string sourceDirectoryName, Stream destination, CompressionLevel compressionLevel, bool includeBaseDirectory)
+	public void CreateFromDirectory(
+		string sourceDirectoryName,
+		Stream destination,
+		CompressionLevel compressionLevel,
+		bool includeBaseDirectory)
 		=> Execute.WhenRealFileSystem(FileSystem,
 			() => ZipFile.CreateFromDirectory(
 				sourceDirectoryName,
@@ -46,7 +51,12 @@ internal sealed class ZipFileWrapper : IZipFile
 				includeBaseDirectory));
 
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, Stream, CompressionLevel, bool, Encoding)" />
-	public void CreateFromDirectory(string sourceDirectoryName, Stream destination, CompressionLevel compressionLevel, bool includeBaseDirectory, Encoding entryNameEncoding)
+	public void CreateFromDirectory(
+		string sourceDirectoryName,
+		Stream destination,
+		CompressionLevel compressionLevel,
+		bool includeBaseDirectory,
+		Encoding entryNameEncoding)
 		=> Execute.WhenRealFileSystem(FileSystem,
 			() => ZipFile.CreateFromDirectory(
 				sourceDirectoryName,
@@ -64,7 +74,8 @@ internal sealed class ZipFileWrapper : IZipFile
 #endif
 
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, string)" />
-	public void CreateFromDirectory(string sourceDirectoryName,
+	public void CreateFromDirectory(
+		string sourceDirectoryName,
 		string destinationArchiveFileName)
 		=> Execute.WhenRealFileSystem(FileSystem,
 			() => ZipFile.CreateFromDirectory(
@@ -76,7 +87,8 @@ internal sealed class ZipFileWrapper : IZipFile
 				destinationArchiveFileName));
 
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, string, CompressionLevel, bool)" />
-	public void CreateFromDirectory(string sourceDirectoryName,
+	public void CreateFromDirectory(
+		string sourceDirectoryName,
 		string destinationArchiveFileName,
 		CompressionLevel compressionLevel,
 		bool includeBaseDirectory)
@@ -94,7 +106,8 @@ internal sealed class ZipFileWrapper : IZipFile
 				includeBaseDirectory));
 
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, string, CompressionLevel, bool, Encoding)" />
-	public void CreateFromDirectory(string sourceDirectoryName,
+	public void CreateFromDirectory(
+		string sourceDirectoryName,
 		string destinationArchiveFileName,
 		CompressionLevel compressionLevel,
 		bool includeBaseDirectory,
@@ -114,10 +127,11 @@ internal sealed class ZipFileWrapper : IZipFile
 				includeBaseDirectory,
 				entryNameEncoding));
 
-
 #if FEATURE_COMPRESSION_STREAM
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string)" />
-	public void ExtractToDirectory(Stream source, string destinationDirectoryName)
+	public void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName)
 		=> Execute.WhenRealFileSystem(FileSystem,
 			() => ZipFile.ExtractToDirectory(
 				source,
@@ -128,7 +142,10 @@ internal sealed class ZipFileWrapper : IZipFile
 				destinationDirectoryName));
 
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, bool)" />
-	public void ExtractToDirectory(Stream source, string destinationDirectoryName, bool overwriteFiles)
+	public void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName,
+		bool overwriteFiles)
 		=> Execute.WhenRealFileSystem(FileSystem,
 			() => ZipFile.ExtractToDirectory(
 				source,
@@ -141,7 +158,10 @@ internal sealed class ZipFileWrapper : IZipFile
 				overwriteFiles: overwriteFiles));
 
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, Encoding)" />
-	public void ExtractToDirectory(Stream source, string destinationDirectoryName, Encoding entryNameEncoding)
+	public void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName,
+		Encoding entryNameEncoding)
 		=> Execute.WhenRealFileSystem(FileSystem,
 			() => ZipFile.ExtractToDirectory(
 				source,
@@ -154,7 +174,11 @@ internal sealed class ZipFileWrapper : IZipFile
 				entryNameEncoding));
 
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, Encoding, bool)" />
-	public void ExtractToDirectory(Stream source, string destinationDirectoryName, Encoding entryNameEncoding, bool overwriteFiles)
+	public void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName,
+		Encoding entryNameEncoding,
+		bool overwriteFiles)
 		=> Execute.WhenRealFileSystem(FileSystem,
 			() => ZipFile.ExtractToDirectory(
 				source,
@@ -170,7 +194,8 @@ internal sealed class ZipFileWrapper : IZipFile
 #endif
 
 	/// <inheritdoc cref="IZipFile.ExtractToDirectory(string, string)" />
-	public void ExtractToDirectory(string sourceArchiveFileName,
+	public void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName)
 		=> Execute.WhenRealFileSystem(FileSystem,
 			() => ZipFile.ExtractToDirectory(
@@ -183,7 +208,8 @@ internal sealed class ZipFileWrapper : IZipFile
 
 #if FEATURE_COMPRESSION_OVERWRITE
 	/// <inheritdoc cref="IZipFile.ExtractToDirectory(string, string, bool)" />
-	public void ExtractToDirectory(string sourceArchiveFileName,
+	public void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName,
 		bool overwriteFiles)
 		=> Execute.WhenRealFileSystem(FileSystem,
@@ -199,7 +225,8 @@ internal sealed class ZipFileWrapper : IZipFile
 #endif
 
 	/// <inheritdoc cref="IZipFile.ExtractToDirectory(string, string, Encoding?)" />
-	public void ExtractToDirectory(string sourceArchiveFileName,
+	public void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName,
 		Encoding? entryNameEncoding)
 		=> Execute.WhenRealFileSystem(FileSystem,
@@ -215,7 +242,8 @@ internal sealed class ZipFileWrapper : IZipFile
 
 #if FEATURE_COMPRESSION_OVERWRITE
 	/// <inheritdoc cref="IZipFile.ExtractToDirectory(string, string, Encoding?, bool)" />
-	public void ExtractToDirectory(string sourceArchiveFileName,
+	public void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName,
 		Encoding? entryNameEncoding,
 		bool overwriteFiles)
@@ -234,7 +262,9 @@ internal sealed class ZipFileWrapper : IZipFile
 #endif
 
 	/// <inheritdoc cref="IZipFile.Open(string, ZipArchiveMode)" />
-	public IZipArchive Open(string archiveFileName, ZipArchiveMode mode)
+	public IZipArchive Open(
+		string archiveFileName,
+		ZipArchiveMode mode)
 		=> new ZipArchiveWrapper(FileSystem,
 			Execute.WhenRealFileSystem(FileSystem,
 				() => ZipFile.Open(archiveFileName, mode),
@@ -243,7 +273,8 @@ internal sealed class ZipFileWrapper : IZipFile
 					mode)));
 
 	/// <inheritdoc cref="IZipFile.Open(string, ZipArchiveMode, Encoding?)" />
-	public IZipArchive Open(string archiveFileName,
+	public IZipArchive Open(
+		string archiveFileName,
 		ZipArchiveMode mode,
 		Encoding? entryNameEncoding)
 		=> new ZipArchiveWrapper(FileSystem,
@@ -255,7 +286,8 @@ internal sealed class ZipFileWrapper : IZipFile
 					entryNameEncoding)));
 
 	/// <inheritdoc cref="IZipFile.OpenRead(string)" />
-	public IZipArchive OpenRead(string archiveFileName)
+	public IZipArchive OpenRead(
+		string archiveFileName)
 		=> new ZipArchiveWrapper(FileSystem,
 			Execute.WhenRealFileSystem(FileSystem,
 				() => ZipFile.OpenRead(archiveFileName),

--- a/Source/Testably.Abstractions.Interface/Helpers/RandomWrapper.cs
+++ b/Source/Testably.Abstractions.Interface/Helpers/RandomWrapper.cs
@@ -26,12 +26,12 @@ public sealed class RandomWrapper : IRandom
 	public void GetItems<T>(ReadOnlySpan<T> choices, Span<T> destination)
 		=> _instance.GetItems(choices, destination);
 
-	/// <inheritdoc cref="IRandom.GetItems{T}(T[], Int32{T})" />
-	public T[] GetItems<T>(T[] choices, Int32 length)
+	/// <inheritdoc cref="IRandom.GetItems{T}(T[], int{T})" />
+	public T[] GetItems<T>(T[] choices, int length)
 		=> _instance.GetItems(choices, length);
 
-	/// <inheritdoc cref="IRandom.GetItems{T}(ReadOnlySpan{T}, Int32)" />
-	public T[] GetItems<T>(ReadOnlySpan<T> choices, Int32 length)
+	/// <inheritdoc cref="IRandom.GetItems{T}(ReadOnlySpan{T}, int)" />
+	public T[] GetItems<T>(ReadOnlySpan<T> choices, int length)
 		=> _instance.GetItems(choices, length);
 #endif
 

--- a/Source/Testably.Abstractions.Interface/Helpers/RandomWrapper.cs
+++ b/Source/Testably.Abstractions.Interface/Helpers/RandomWrapper.cs
@@ -21,6 +21,20 @@ public sealed class RandomWrapper : IRandom
 
 	#region IRandom Members
 
+#if FEATURE_RANDOM_ITEMS
+	/// <inheritdoc cref="IRandom.GetItems{T}(ReadOnlySpan{T}, Span{T})" />
+	public void GetItems<T>(ReadOnlySpan<T> choices, Span<T> destination)
+		=> _instance.GetItems(choices, destination);
+
+	/// <inheritdoc cref="IRandom.GetItems{T}(T[], Int32{T})" />
+	public T[] GetItems<T>(T[] choices, Int32 length)
+		=> _instance.GetItems(choices, length);
+
+	/// <inheritdoc cref="IRandom.GetItems{T}(ReadOnlySpan{T}, Int32)" />
+	public T[] GetItems<T>(ReadOnlySpan<T> choices, Int32 length)
+		=> _instance.GetItems(choices, length);
+#endif
+
 	/// <inheritdoc cref="IRandom.Next()" />
 	public int Next()
 		=> _instance.Next();
@@ -63,6 +77,16 @@ public sealed class RandomWrapper : IRandom
 	/// <inheritdoc cref="IRandom.NextSingle()" />
 	public float NextSingle()
 		=> _instance.NextSingle();
+#endif
+
+#if FEATURE_RANDOM_ITEMS
+	/// <inheritdoc cref="IRandom.Shuffle{T}(T[])" />
+	public void Shuffle<T>(T[] values)
+		=> _instance.Shuffle(values);
+
+	/// <inheritdoc cref="IRandom.Shuffle{T}(Span{T})" />
+	public void Shuffle<T>(Span<T> values)
+		=> _instance.Shuffle(values);
 #endif
 
 	#endregion

--- a/Source/Testably.Abstractions.Interface/Helpers/RandomWrapper.cs
+++ b/Source/Testably.Abstractions.Interface/Helpers/RandomWrapper.cs
@@ -26,7 +26,7 @@ public sealed class RandomWrapper : IRandom
 	public void GetItems<T>(ReadOnlySpan<T> choices, Span<T> destination)
 		=> _instance.GetItems(choices, destination);
 
-	/// <inheritdoc cref="IRandom.GetItems{T}(T[], int{T})" />
+	/// <inheritdoc cref="IRandom.GetItems{T}(T[], int)" />
 	public T[] GetItems<T>(T[] choices, int length)
 		=> _instance.GetItems(choices, length);
 

--- a/Source/Testably.Abstractions.Interface/RandomSystem/IRandom.cs
+++ b/Source/Testably.Abstractions.Interface/RandomSystem/IRandom.cs
@@ -7,6 +7,17 @@ namespace Testably.Abstractions.RandomSystem;
 /// </summary>
 public interface IRandom
 {
+#if FEATURE_RANDOM_ITEMS
+	/// <inheritdoc cref="Random.GetItems{T}(ReadOnlySpan{T}, Span{T})" />
+	void GetItems<T>(ReadOnlySpan<T> choices, Span<T> destination);
+
+	/// <inheritdoc cref="Random.GetItems{T}(T[], Int32)" />
+	T[] GetItems<T>(T[] choices, Int32 length);
+
+	/// <inheritdoc cref="Random.GetItems{T}(ReadOnlySpan{T}, Int32)" />
+	T[] GetItems<T>(ReadOnlySpan<T> choices, Int32 length);
+#endif
+
 	/// <inheritdoc cref="Random.Next()" />
 	int Next();
 
@@ -39,5 +50,13 @@ public interface IRandom
 
 	/// <inheritdoc cref="Random.NextSingle()" />
 	float NextSingle();
+#endif
+
+#if FEATURE_RANDOM_ITEMS
+	/// <inheritdoc cref="Random.Shuffle{T}(T[])" />
+	void Shuffle<T>(T[] values);
+
+	/// <inheritdoc cref="Random.Shuffle{T}(Span{T})" />
+	void Shuffle<T>(Span<T> values);
 #endif
 }

--- a/Source/Testably.Abstractions.Interface/RandomSystem/IRandom.cs
+++ b/Source/Testably.Abstractions.Interface/RandomSystem/IRandom.cs
@@ -11,11 +11,11 @@ public interface IRandom
 	/// <inheritdoc cref="Random.GetItems{T}(ReadOnlySpan{T}, Span{T})" />
 	void GetItems<T>(ReadOnlySpan<T> choices, Span<T> destination);
 
-	/// <inheritdoc cref="Random.GetItems{T}(T[], Int32)" />
-	T[] GetItems<T>(T[] choices, Int32 length);
+	/// <inheritdoc cref="Random.GetItems{T}(T[], int)" />
+	T[] GetItems<T>(T[] choices, int length);
 
-	/// <inheritdoc cref="Random.GetItems{T}(ReadOnlySpan{T}, Int32)" />
-	T[] GetItems<T>(ReadOnlySpan<T> choices, Int32 length);
+	/// <inheritdoc cref="Random.GetItems{T}(ReadOnlySpan{T}, int)" />
+	T[] GetItems<T>(ReadOnlySpan<T> choices, int length);
 #endif
 
 	/// <inheritdoc cref="Random.Next()" />

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
@@ -107,7 +107,13 @@ internal sealed class FileInfoMock
 
 	/// <inheritdoc cref="IFileInfo.CreateText()" />
 	public StreamWriter CreateText()
-		=> new(_fileSystem.File.Create(FullName));
+	{
+		StreamWriter streamWriter = new(_fileSystem.File.Create(FullName));
+#if NET8_0_OR_GREATER
+		Refresh();
+#endif
+		return streamWriter;
+	}
 
 	/// <inheritdoc cref="IFileInfo.Decrypt()" />
 	[SupportedOSPlatform("windows")]

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/TestingException.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/TestingException.cs
@@ -26,6 +26,7 @@ public class TestingException : Exception
 	{
 	}
 
+#if !NET8_0_OR_GREATER
 	/// <summary>
 	///     Initializes a new instance of <see cref="TestingException" /> for serialization.
 	///     <para />
@@ -35,4 +36,5 @@ public class TestingException : Exception
 		: base(info, context)
 	{
 	}
+#endif
 }

--- a/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
@@ -190,6 +190,15 @@ internal static class ExceptionFactory
 			"Unable seek backward to overwrite data that previously existed in a file opened in Append mode.",
 			-2146232800);
 
+	internal static ArgumentException SpanMayNotBeEmpty(string paramName)
+		=> new ArgumentException("Span may not be empty.", paramName)
+		{
+#if FEATURE_EXCEPTION_HRESULT
+			HResult = -2147024809
+#endif
+		};
+
+
 	internal static NotSupportedException StreamDoesNotSupportReading()
 		=> new("Stream does not support reading.")
 		{

--- a/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
@@ -191,13 +191,12 @@ internal static class ExceptionFactory
 			-2146232800);
 
 	internal static ArgumentException SpanMayNotBeEmpty(string paramName)
-		=> new ArgumentException("Span may not be empty.", paramName)
+		=> new("Span may not be empty.", paramName)
 		{
 #if FEATURE_EXCEPTION_HRESULT
 			HResult = -2147024809
 #endif
 		};
-
 
 	internal static NotSupportedException StreamDoesNotSupportReading()
 		=> new("Stream does not support reading.")

--- a/Source/Testably.Abstractions.Testing/RandomSystem/RandomMock.cs
+++ b/Source/Testably.Abstractions.Testing/RandomSystem/RandomMock.cs
@@ -77,15 +77,15 @@ internal sealed class RandomMock : IRandom
 		}
 	}
 
-	/// <inheritdoc cref="IRandom.GetItems{T}(T[], Int32)" />
-	public T[] GetItems<T>(T[] choices, Int32 length)
+	/// <inheritdoc cref="IRandom.GetItems{T}(T[], int)" />
+	public T[] GetItems<T>(T[] choices, int length)
 	{
 		ArgumentNullException.ThrowIfNull(choices);
 		return GetItems(new ReadOnlySpan<T>(choices), length);
 	}
 
-	/// <inheritdoc cref="IRandom.GetItems{T}(ReadOnlySpan{T}, Int32)" />
-	public T[] GetItems<T>(ReadOnlySpan<T> choices, Int32 length)
+	/// <inheritdoc cref="IRandom.GetItems{T}(ReadOnlySpan{T}, int)" />
+	public T[] GetItems<T>(ReadOnlySpan<T> choices, int length)
 	{
 		ArgumentOutOfRangeException.ThrowIfNegative(length);
 

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -74,8 +74,13 @@ internal sealed class InMemoryStorage : IStorage
 					() => copiedContainer.LastAccessTime.Set(
 						sourceContainer.LastAccessTime.Get(DateTimeKind.Local),
 						DateTimeKind.Local));
+#if NET8_0_OR_GREATER
 				Execute.NotOnWindows(()
 					=> sourceContainer.AdjustTimes(TimeAdjustments.LastAccessTime));
+#else
+				Execute.OnLinux(()
+					=> sourceContainer.AdjustTimes(TimeAdjustments.LastAccessTime));
+#endif
 
 				copiedContainer.Attributes = sourceContainer.Attributes;
 				Execute.OnWindowsIf(sourceContainer.Type == FileSystemTypes.File,
@@ -497,7 +502,7 @@ internal sealed class InMemoryStorage : IStorage
 		return false;
 	}
 
-	#endregion
+#endregion
 
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -75,10 +75,10 @@ internal sealed class InMemoryStorage : IStorage
 						sourceContainer.LastAccessTime.Get(DateTimeKind.Local),
 						DateTimeKind.Local));
 #if NET8_0_OR_GREATER
-				Execute.NotOnWindows(()
+				Execute.OnLinux(()
 					=> sourceContainer.AdjustTimes(TimeAdjustments.LastAccessTime));
 #else
-				Execute.OnLinux(()
+				Execute.NotOnWindows(()
 					=> sourceContainer.AdjustTimes(TimeAdjustments.LastAccessTime));
 #endif
 

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimerFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimerFactoryMock.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.TimeSystem;
+using ITimer = Testably.Abstractions.TimeSystem.ITimer;
 
 namespace Testably.Abstractions.Testing.TimeSystem;
 

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimerMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimerMock.cs
@@ -99,7 +99,11 @@ internal sealed class TimerMock : ITimerMock
 	{
 		if (_isDisposed)
 		{
+#if NET8_0_OR_GREATER
+			return false;
+#else
 			throw new ObjectDisposedException(nameof(Change), "Cannot access a disposed object.");
+#endif
 		}
 
 		if (dueTime.TotalMilliseconds < -1)

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimerMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimerMock.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.TimeSystem;
+using ITimer = Testably.Abstractions.TimeSystem.ITimer;
 
 namespace Testably.Abstractions.Testing.TimeSystem;
 

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -5,8 +5,8 @@
 	<Import Project="$([MSBuild]::GetPathOfFileAbove('Feature.Flags.props', '$(MSBuildThisFileDirectory)/../'))" />
 
 	<PropertyGroup>
-		<TargetFrameworks Condition="'$(NetCoreOnly)' != 'True'">net6.0;net7.0;net48</TargetFrameworks>
-		<TargetFrameworks Condition="'$(NetCoreOnly)' == 'True'">net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$(NetCoreOnly)' != 'True'">net6.0;net7.0;net8.0;net48</TargetFrameworks>
+		<TargetFrameworks Condition="'$(NetCoreOnly)' == 'True'">net6.0;net7.0;net8.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(NetFrameworkOnly)' == 'True'">net48</TargetFrameworks>
 	</PropertyGroup>
 

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -5,8 +5,8 @@
 	<Import Project="$([MSBuild]::GetPathOfFileAbove('Feature.Flags.props', '$(MSBuildThisFileDirectory)/../'))" />
 
 	<PropertyGroup>
-		<TargetFrameworks Condition="'$(NetCoreOnly)' != 'True'">net6.0;net7.0;net8.0;net48</TargetFrameworks>
-		<TargetFrameworks Condition="'$(NetCoreOnly)' == 'True'">net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$(NetCoreOnly)' != 'True'">net6.0;net7.0;net48</TargetFrameworks>
+		<TargetFrameworks Condition="'$(NetCoreOnly)' == 'True'">net6.0;net7.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(NetFrameworkOnly)' == 'True'">net48</TargetFrameworks>
 	</PropertyGroup>
 

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/TimeSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/TimeSystemClassGenerator.cs
@@ -32,7 +32,7 @@ namespace {@class.Namespace}.{@class.Name}
 	// ReSharper disable once UnusedMember.Global
 	public sealed class MockTimeSystemTests : {@class.Name}<MockTimeSystem>
 	{{
-		public MockTimeSystemTests() : base(new MockTimeSystem(TimeProvider.Now()))
+		public MockTimeSystemTests() : base(new MockTimeSystem(Testing.TimeProvider.Now()))
 		{{
 		}}
 	}}

--- a/Tests/Testably.Abstractions.Compression.Tests/TestHelpers/MemoryStreamMock.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/TestHelpers/MemoryStreamMock.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Testably.Abstractions.Compression.Tests.TestHelpers;
+
+internal class MemoryStreamMock : MemoryStream
+{
+	public MemoryStreamMock(bool canWrite = true, bool canRead = true)
+	{
+		CanWrite = canWrite;
+		CanRead = canRead;
+	}
+
+	public override bool CanRead { get; }
+
+	public override bool CanWrite { get; }
+}

--- a/Tests/Testably.Abstractions.Compression.Tests/TestHelpers/MemoryStreamMock.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/TestHelpers/MemoryStreamMock.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.IO;
 
 namespace Testably.Abstractions.Compression.Tests.TestHelpers;
 
-internal class MemoryStreamMock : MemoryStream
+internal sealed class MemoryStreamMock : MemoryStream
 {
 	public MemoryStreamMock(bool canWrite = true, bool canRead = true)
 	{

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.IO.Compression;
 using System.Text;
+using Testably.Abstractions.Compression.Tests.TestHelpers;
 
 namespace Testably.Abstractions.Compression.Tests.ZipFile;
 
@@ -155,6 +157,187 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 			.Should().BeEquivalentTo(
 				FileSystem.File.ReadAllBytes("foo/bar/test.txt"));
 	}
+
+#if FEATURE_COMPRESSION_STREAM
+	[SkippableTheory]
+	[AutoData]
+	public void
+		CreateFromDirectory_WithStream_EmptyDirectory_ShouldBeIncluded(
+			CompressionLevel compressionLevel)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithSubdirectory("bar"));
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile()
+			.CreateFromDirectory("foo", stream, compressionLevel, false);
+
+		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+
+		archive.Entries.Count.Should().Be(1);
+		archive.Entries.Should().Contain(e => e.FullName.Equals("bar/"));
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateFromDirectory_WithStream_EmptySource_DoNotIncludeBaseDirectory_ShouldBeEmpty(
+		CompressionLevel compressionLevel)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("foo");
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile()
+			.CreateFromDirectory("foo", stream, compressionLevel, false);
+
+		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+
+		archive.Entries.Count.Should().Be(0);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void
+		CreateFromDirectory_WithStream_EmptySource_IncludeBaseDirectory_ShouldPrependDirectoryName(
+			CompressionLevel compressionLevel)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("foo");
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile()
+			.CreateFromDirectory("foo", stream, compressionLevel, true);
+
+		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+
+		archive.Entries.Count.Should().Be(1);
+		archive.Entries.Should().Contain(e => e.FullName.Equals("foo/"));
+	}
+
+	[SkippableTheory]
+	[MemberData(nameof(EntryNameEncoding))]
+	public void CreateFromDirectory_WithStream_EntryNameEncoding_ShouldUseEncoding(
+		string entryName, Encoding encoding, bool encodedCorrectly)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile(entryName));
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile()
+			.CreateFromDirectory("foo", stream, CompressionLevel.NoCompression,
+				false, encoding);
+
+		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+
+		archive.Entries.Count.Should().Be(1);
+		if (encodedCorrectly)
+		{
+			archive.Entries.Should().Contain(e => e.Name == entryName);
+		}
+		else
+		{
+			archive.Entries.Should().NotContain(e => e.Name == entryName);
+		}
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateFromDirectory_WithStream_IncludeBaseDirectory_ShouldPrependDirectoryName(
+		CompressionLevel compressionLevel)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile()
+			.CreateFromDirectory("foo", stream, compressionLevel, true);
+
+		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+
+		archive.Entries.Count.Should().Be(1);
+		archive.Entries.Should().Contain(e => e.FullName.Equals("foo/test.txt"));
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void
+		CreateFromDirectory_WithStream_Null_ShouldThrowArgumentNullException(
+			CompressionLevel compressionLevel)
+	{
+		Stream stream = null!;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		});
+
+		exception.Should().BeOfType<ArgumentNullException>()
+			.Which.ParamName.Should().Be("destination");
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void
+		CreateFromDirectory_WithStream_NotWritable_ShouldThrowArgumentException(
+			CompressionLevel compressionLevel)
+	{
+		Stream stream = new MemoryStreamMock(canWrite: false);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		});
+
+		exception.Should().BeException<ArgumentException>("The stream is unwritable", paramName: "destination", hResult: -2147024809);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateFromDirectory_WithStream_Overwrite_WithEncoding_ShouldOverwriteFile(
+		string contents, Encoding encoding)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("bar").Initialized(s => s
+				.WithFile("test.txt"))
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		FileSystem.File.WriteAllText(FileSystem.Path.Combine("foo", "test.txt"),
+			contents);
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile().CreateFromDirectory("foo", stream,
+			CompressionLevel.Optimal, false, encoding);
+
+		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read, true, encoding);
+
+		archive.Entries.Count.Should().Be(1);
+		archive.Entries.Should().Contain(e => e.FullName.Equals("test.txt"));
+	}
+
+	[SkippableFact]
+	public void CreateFromDirectory_WithStream_ShouldZipDirectoryContent()
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("destination")
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithSubdirectory("bar").Initialized(t => t
+					.WithFile("test.txt")));
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+
+		FileSystem.ZipFile().ExtractToDirectory(stream, "destination");
+
+		FileSystem.File.Exists("destination/bar/test.txt")
+			.Should().BeTrue();
+		FileSystem.File.ReadAllBytes("destination/bar/test.txt")
+			.Should().BeEquivalentTo(
+				FileSystem.File.ReadAllBytes("foo/bar/test.txt"));
+	}
+#endif
 
 	public static IEnumerable<object[]> EntryNameEncoding()
 	{

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
@@ -261,11 +261,9 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 		archive.Entries.Should().Contain(e => e.FullName.Equals("foo/test.txt"));
 	}
 
-	[SkippableTheory]
-	[AutoData]
+	[SkippableFact]
 	public void
-		CreateFromDirectory_WithStream_Null_ShouldThrowArgumentNullException(
-			CompressionLevel compressionLevel)
+		CreateFromDirectory_WithStream_Null_ShouldThrowArgumentNullException()
 	{
 		Stream stream = null!;
 
@@ -278,11 +276,9 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 			.Which.ParamName.Should().Be("destination");
 	}
 
-	[SkippableTheory]
-	[AutoData]
+	[SkippableFact]
 	public void
-		CreateFromDirectory_WithStream_NotWritable_ShouldThrowArgumentException(
-			CompressionLevel compressionLevel)
+		CreateFromDirectory_WithStream_NotWritable_ShouldThrowArgumentException()
 	{
 		Stream stream = new MemoryStreamMock(canWrite: false);
 

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 using System.IO.Compression;
 using System.Text;
+#if FEATURE_COMPRESSION_STREAM
+using System.IO;
 using Testably.Abstractions.Compression.Tests.TestHelpers;
+#endif
 
 namespace Testably.Abstractions.Compression.Tests.ZipFile;
 
@@ -287,7 +289,8 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 			FileSystem.ZipFile().CreateFromDirectory("foo", stream);
 		});
 
-		exception.Should().BeException<ArgumentException>("The stream is unwritable", paramName: "destination", hResult: -2147024809);
+		exception.Should().BeException<ArgumentException>("The stream is unwritable",
+			paramName: "destination", hResult: -2147024809);
 	}
 
 	[SkippableTheory]
@@ -307,7 +310,8 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 		FileSystem.ZipFile().CreateFromDirectory("foo", stream,
 			CompressionLevel.Optimal, false, encoding);
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read, true, encoding);
+		IZipArchive archive =
+			FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read, true, encoding);
 
 		archive.Entries.Count.Should().Be(1);
 		archive.Entries.Should().Contain(e => e.FullName.Equals("test.txt"));
@@ -335,6 +339,8 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 	}
 #endif
 
+	#region Helpers
+
 	public static IEnumerable<object[]> EntryNameEncoding()
 	{
 		// ReSharper disable StringLiteralTypo
@@ -348,4 +354,6 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 		};
 		// ReSharper restore StringLiteralTypo
 	}
+
+	#endregion
 }

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.IO.Compression;
 using System.Text;
+using Testably.Abstractions.Compression.Tests.TestHelpers;
 
 namespace Testably.Abstractions.Compression.Tests.ZipFile;
 
@@ -49,10 +50,11 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 		ExtractToDirectory_NullAsSourceFileName_ShouldThrowArgumentNullException()
 	{
 		FileSystem.Initialize();
+		string sourceArchiveFileName = null!;
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.ZipFile().ExtractToDirectory(null!, "bar");
+			FileSystem.ZipFile().ExtractToDirectory(sourceArchiveFileName, "bar");
 		});
 
 		exception.Should().BeOfType<ArgumentNullException>()
@@ -133,4 +135,133 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 		FileSystem.File.ReadAllText(destinationPath)
 			.Should().NotBe(contents);
 	}
+
+#if FEATURE_COMPRESSION_STREAM
+	[SkippableFact]
+	public void ExtractToDirectory_WithStream_MissingDestinationDirectory_ShouldCreateDirectory()
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+
+		FileSystem.ZipFile().ExtractToDirectory(stream, "bar");
+
+		FileSystem.File.Exists("bar/test.txt")
+			.Should().BeTrue();
+		FileSystem.File.ReadAllBytes("bar/test.txt")
+			.Should().BeEquivalentTo(
+				FileSystem.File.ReadAllBytes("foo/test.txt"));
+	}
+
+	[SkippableFact]
+	public void
+		ExtractToDirectory_WithStream_Null_ShouldThrowArgumentNullException()
+	{
+		FileSystem.Initialize();
+		Stream source = null!;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.ZipFile().ExtractToDirectory(source, "bar");
+		});
+
+		exception.Should().BeOfType<ArgumentNullException>()
+			.Which.ParamName.Should().Be("source");
+	}
+
+	[SkippableFact]
+	public void
+		ExtractToDirectory_WithStream_NotReadable_ShouldThrowArgumentNullException()
+	{
+		FileSystem.Initialize();
+		Stream source = new MemoryStreamMock(canRead: false);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.ZipFile().ExtractToDirectory(source, "bar");
+		});
+
+		exception.Should().BeException<ArgumentException>(
+			"The stream is unreadable", paramName: "source", hResult: -2147024809);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void ExtractToDirectory_WithStream_Overwrite_ShouldOverwriteFile(
+		string contents)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("bar").Initialized(s => s
+				.WithFile("test.txt"))
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		FileSystem.File.WriteAllText(FileSystem.Path.Combine("foo", "test.txt"),
+			contents);
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+
+		FileSystem.ZipFile().ExtractToDirectory(stream, "bar", true);
+
+		FileSystem.File.Exists(FileSystem.Path.Combine("bar", "test.txt"))
+			.Should().BeTrue();
+		FileSystem.File.ReadAllText(FileSystem.Path.Combine("bar", "test.txt"))
+			.Should().Be(contents);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void ExtractToDirectory_WithStream_WithEncoding_ShouldZipDirectoryContent(
+		Encoding encoding)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("bar")
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile().CreateFromDirectory("foo", stream,
+			CompressionLevel.Fastest, false, encoding);
+
+		FileSystem.ZipFile().ExtractToDirectory(stream, "bar", encoding);
+
+		FileSystem.File.Exists(FileSystem.Path.Combine("bar", "test.txt"))
+			.Should().BeTrue();
+		FileSystem.File.ReadAllBytes(FileSystem.Path.Combine("bar", "test.txt"))
+			.Should().BeEquivalentTo(
+				FileSystem.File.ReadAllBytes(FileSystem.Path.Combine("foo", "test.txt")));
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void ExtractToDirectory_WithStream_WithoutOverwriteAndExistingFile_ShouldOverwriteFile(
+		string contents)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("bar").Initialized(s => s
+				.WithFile("test.txt"))
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		FileSystem.File.WriteAllText(FileSystem.Path.Combine("foo", "test.txt"),
+			contents);
+		string destinationPath =
+			FileSystem.Path.Combine(FileSystem.Path.GetFullPath("bar"), "test.txt");
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.ZipFile().ExtractToDirectory(stream, "bar");
+		});
+
+		exception.Should().BeOfType<IOException>()
+			.Which.Message.Should().Contain($"'{destinationPath}'");
+		FileSystem.File.ReadAllText(destinationPath)
+			.Should().NotBe(contents);
+	}
+#endif
 }

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
@@ -1,7 +1,9 @@
 ﻿using System.IO;
 using System.IO.Compression;
 using System.Text;
+#if FEATURE_COMPRESSION_STREAM
 using Testably.Abstractions.Compression.Tests.TestHelpers;
+#endif
 
 namespace Testably.Abstractions.Compression.Tests.ZipFile;
 

--- a/Tests/Testably.Abstractions.Parity.Tests/Net8ParityTests.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/Net8ParityTests.cs
@@ -1,0 +1,18 @@
+﻿#if NET8_0
+using System.IO;
+using Xunit.Abstractions;
+
+namespace Testably.Abstractions.Parity.Tests;
+
+// ReSharper disable once UnusedMember.Global
+public class Net8ParityTests : ParityTests
+{
+	public Net8ParityTests(ITestOutputHelper testOutputHelper)
+		: base(new TestHelpers.Parity(), testOutputHelper)
+	{
+		Parity.File.MissingMethods.Add(
+			typeof(File).GetMethod(nameof(File.OpenHandle)));
+	}
+}
+
+#endif

--- a/Tests/Testably.Abstractions.Parity.Tests/ParityTests.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/ParityTests.cs
@@ -141,7 +141,7 @@ public abstract class ParityTests
 		ITimerAndITimerFactory_EnsureParityWith_Timer()
 	{
 		List<string> parityErrors = Parity.Timer
-			.GetErrorsToInstanceType<ITimer, ITimerFactory>(
+			.GetErrorsToInstanceType<TimeSystem.ITimer, ITimerFactory>(
 				typeof(Timer),
 				_testOutputHelper);
 

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/TestingExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/TestingExceptionTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿#if !NET8_0_OR_GREATER
+using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using Testably.Abstractions.Testing.FileSystemInitializer;
 
@@ -18,15 +19,16 @@ public class TestingExceptionTests
 		byte[] buffer = new byte[4096];
 		using MemoryStream ms = new(buffer);
 		using MemoryStream ms2 = new(buffer);
+#pragma warning disable SYSLIB0011 //BinaryFormatter serialization is obsolete - only used in unit test
 		BinaryFormatter formatter = new();
-		#pragma warning disable SYSLIB0011 //BinaryFormatter serialization is obsolete - only used in unit test
 		formatter.Serialize(ms, originalException);
 		TestingException deserializedException =
 			(TestingException)formatter.Deserialize(ms2);
-		#pragma warning restore SYSLIB0011
+#pragma warning restore SYSLIB0011
 
 		Assert.Equal(originalException.InnerException?.Message,
 			deserializedException.InnerException?.Message);
 		Assert.Equal(originalException.Message, deserializedException.Message);
 	}
 }
+#endif

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerFactoryMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerFactoryMockTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using Testably.Abstractions.TimeSystem;
+using ITimer = Testably.Abstractions.TimeSystem.ITimer;
 
 namespace Testably.Abstractions.Testing.Tests.TimeSystem;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Testably.Abstractions.Testing.TimeSystem;
 using Testably.Abstractions.TimeSystem;
 using Xunit.Abstractions;
+using ITimer = Testably.Abstractions.TimeSystem.ITimer;
 
 namespace Testably.Abstractions.Testing.Tests.TimeSystem;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
@@ -69,10 +69,14 @@ public class TimerMockTests
 			timer.Change(0, 0);
 		});
 
+#if NET8_0_OR_GREATER
+		exception.Should().BeNull();
+#else
 		exception.Should().BeOfType<ObjectDisposedException>()
 			.Which.Message.Should().ContainAll(
 				"Cannot access a disposed object.",
 				nameof(ITimer.Change));
+#endif
 	}
 
 #if FEATURE_ASYNC_DISPOSABLE
@@ -90,7 +94,11 @@ public class TimerMockTests
 			timer.Change(0, 0);
 		});
 
+#if NET8_0_OR_GREATER
+		exception.Should().BeNull();
+#else
 		exception.Should().BeOfType<ObjectDisposedException>();
+#endif
 	}
 #endif
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/Tests.cs
@@ -10,7 +10,11 @@ public abstract partial class Tests<TFileSystem>
 	[InlineData("foo\0bar")]
 	public void New_NullCharacter_ShouldThrowArgumentException(string path)
 	{
+#if NET8_0_OR_GREATER
+		string expectedMessage = "Null character in path.";
+#else
 		string expectedMessage = "Illegal characters in path.";
+#endif
 		Exception? exception =
 			Record.Exception(() => FileSystem.DirectoryInfo.New(path));
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -156,7 +156,11 @@ public abstract partial class CopyTests<TFileSystem>
 		sourceCreationTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);
+#if NET8_0_OR_GREATER
 		if (Test.RunsOnWindows)
+#else
+		if (!Test.RunsOnLinux)
+#endif
 		{
 			sourceLastAccessTime.Should()
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -156,11 +156,18 @@ public abstract partial class CopyTests<TFileSystem>
 		sourceCreationTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);
+		if (Test.RunsOnMac)
+		{
 #if NET8_0_OR_GREATER
-		if (Test.RunsOnWindows)
+			sourceLastAccessTime.Should()
+				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
+				.BeOnOrBefore(creationTimeEnd);
 #else
-		if (!Test.RunsOnLinux)
+			sourceLastAccessTime.Should()
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 #endif
+		}
+		else if (Test.RunsOnWindows)
 		{
 			sourceLastAccessTime.Should()
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
@@ -23,6 +23,24 @@ public abstract partial class CreateTextTests<TFileSystem>
 			.Which.HasContent(appendText);
 	}
 
+#if NET8_0_OR_GREATER
+	[SkippableTheory]
+	[AutoData]
+	public void CreateText_ShouldRefreshExistsCache(
+		string path, string appendText)
+	{
+		IFileInfo fileInfo = FileSystem.FileInfo.New(path);
+		fileInfo.Exists.Should().BeFalse();
+
+		using (StreamWriter stream = fileInfo.CreateText())
+		{
+			stream.Write(appendText);
+		}
+
+		fileInfo.Exists.Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
+	}
+#else
 	[SkippableTheory]
 	[AutoData]
 	public void CreateText_ShouldNotRefreshExistsCache(
@@ -39,6 +57,7 @@ public abstract partial class CreateTextTests<TFileSystem>
 		fileInfo.Exists.Should().BeFalse();
 		FileSystem.Should().HaveFile(path);
 	}
+#endif
 
 	[SkippableTheory]
 	[AutoData]

--- a/Tests/Testably.Abstractions.Tests/RandomSystem/RandomTests.cs
+++ b/Tests/Testably.Abstractions.Tests/RandomSystem/RandomTests.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
-using System.Linq;
 using System.Threading.Tasks;
+#if FEATURE_RANDOM_ITEMS
+using System.Linq;
+#endif
 
 namespace Testably.Abstractions.Tests.RandomSystem;
 
@@ -61,7 +63,9 @@ public abstract partial class RandomTests<TRandomSystem>
 		});
 
 		exception.Should().BeOfType<ArgumentOutOfRangeException>()
-			.Which.Message.Should().Be($"length ('{length}') must be a non-negative value. (Parameter 'length')\r\nActual value was {length}.");
+			.Which.Message.Should()
+			.Be(
+				$"length ('{length}') must be a non-negative value. (Parameter 'length')\r\nActual value was {length}.");
 	}
 
 	[Fact]

--- a/Tests/Testably.Abstractions.Tests/RandomSystem/RandomTests.cs
+++ b/Tests/Testably.Abstractions.Tests/RandomSystem/RandomTests.cs
@@ -65,7 +65,7 @@ public abstract partial class RandomTests<TRandomSystem>
 		exception.Should().BeOfType<ArgumentOutOfRangeException>()
 			.Which.Message.Should()
 			.Be(
-				$"length ('{length}') must be a non-negative value. (Parameter 'length')\r\nActual value was {length}.");
+				$"length ('{length}') must be a non-negative value. (Parameter 'length'){Environment.NewLine}Actual value was {length}.");
 	}
 
 	[Fact]

--- a/Tests/Testably.Abstractions.Tests/RandomSystem/RandomTests.cs
+++ b/Tests/Testably.Abstractions.Tests/RandomSystem/RandomTests.cs
@@ -27,7 +27,7 @@ public abstract partial class RandomTests<TRandomSystem>
 	[Fact]
 	public void GetItems_Array_NullChoices_ShouldThrowArgumentNullException()
 	{
-		int[]? choices = null;
+		int[] choices = null!;
 
 		Exception? exception = Record.Exception(() =>
 		{
@@ -285,7 +285,7 @@ public abstract partial class RandomTests<TRandomSystem>
 	[Fact]
 	public void Shuffle_Array_Null_ShouldThrowArgumentNullException()
 	{
-		int[]? values = null;
+		int[] values = null!;
 
 		Exception? exception = Record.Exception(() =>
 		{

--- a/Tests/Testably.Abstractions.Tests/RandomSystem/RandomTests.cs
+++ b/Tests/Testably.Abstractions.Tests/RandomSystem/RandomTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.RandomSystem;
@@ -8,6 +9,121 @@ public abstract partial class RandomTests<TRandomSystem>
 	: RandomSystemTestBase<TRandomSystem>
 	where TRandomSystem : IRandomSystem
 {
+#if FEATURE_RANDOM_ITEMS
+	[Fact]
+	public void GetItems_Array_EmptyChoices_ShouldThrowArgumentNullException()
+	{
+		int[] choices = Array.Empty<int>();
+
+		Exception? exception = Record.Exception(() =>
+		{
+			RandomSystem.Random.Shared.GetItems(choices, 1);
+		});
+
+		exception.Should().BeException<ArgumentException>("Span may not be empty",
+			hResult: -2147024809, paramName: nameof(choices));
+	}
+
+	[Fact]
+	public void GetItems_Array_NullChoices_ShouldThrowArgumentNullException()
+	{
+		int[]? choices = null;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			RandomSystem.Random.Shared.GetItems(choices, -1);
+		});
+
+		exception.Should().BeOfType<ArgumentNullException>();
+	}
+
+	[Fact]
+	public void GetItems_Array_LengthLargerThanChoices_ShouldIncludeDuplicateValues()
+	{
+		int[] choices = Enumerable.Range(0, 10).ToArray();
+
+		int[] result = RandomSystem.Random.Shared.GetItems(choices, 100);
+
+		result.Length.Should().Be(100);
+		result.Should().OnlyContain(r => choices.Contains(r));
+	}
+
+	[Theory]
+	[InlineData(-1)]
+	[InlineData(-200)]
+	public void GetItems_Array_NegativeLength_ShouldThrowArgumentOutOfRangeException(int length)
+	{
+		int[] choices = Enumerable.Range(0, 10).ToArray();
+
+		Exception? exception = Record.Exception(() =>
+		{
+			RandomSystem.Random.Shared.GetItems(choices, length);
+		});
+
+		exception.Should().BeOfType<ArgumentOutOfRangeException>()
+			.Which.Message.Should().Be($"length ('{length}') must be a non-negative value. (Parameter 'length')\r\nActual value was {length}.");
+	}
+
+	[Fact]
+	public void GetItems_Array_ShouldSelectRandomElements()
+	{
+		int[] choices = Enumerable.Range(0, 100).ToArray();
+
+		int[] result = RandomSystem.Random.Shared.GetItems(choices, 10);
+
+		result.Length.Should().Be(10);
+		result.Should().OnlyContain(r => choices.Contains(r));
+	}
+
+	[Fact]
+	public void GetItems_ReadOnlySpan_LengthLargerThanChoices_ShouldIncludeDuplicateValues()
+	{
+		ReadOnlySpan<int> choices = Enumerable.Range(0, 10).ToArray().AsSpan();
+
+		int[] result = RandomSystem.Random.Shared.GetItems(choices, 100);
+
+		result.Length.Should().Be(100);
+		result.Should().OnlyContain(r => r >= 0 && r < 10);
+	}
+
+	[Fact]
+	public void GetItems_ReadOnlySpan_ShouldSelectRandomElements()
+	{
+		ReadOnlySpan<int> choices = Enumerable.Range(0, 100).ToArray().AsSpan();
+
+		int[] result = RandomSystem.Random.Shared.GetItems(choices, 10);
+
+		result.Length.Should().Be(10);
+		result.Should().OnlyContain(r => r >= 0 && r < 100);
+	}
+
+	[Fact]
+	public void GetItems_SpanDestination_LengthLargerThanChoices_ShouldIncludeDuplicateValues()
+	{
+		int[] buffer = new int[100];
+		Span<int> destination = new(buffer);
+		ReadOnlySpan<int> choices = Enumerable.Range(0, 10).ToArray().AsSpan();
+
+		RandomSystem.Random.Shared.GetItems(choices, destination);
+
+		destination.Length.Should().Be(100);
+		destination.ToArray().Should().OnlyContain(r => r >= 0 && r < 10);
+	}
+
+	[Fact]
+	public void GetItems_SpanDestination_ShouldSelectRandomElements()
+	{
+		int[] buffer = new int[10];
+		Span<int> destination = new(buffer);
+		ReadOnlySpan<int> choices = Enumerable.Range(0, 100).ToArray().AsSpan();
+
+		RandomSystem.Random.Shared.GetItems(choices, destination);
+
+		destination.Length.Should().Be(10);
+		destination.ToArray().Should().OnlyContain(r => r >= 0 && r < 100);
+	}
+#endif
+
 	[SkippableFact]
 	public void Next_MaxValue_ShouldOnlyReturnValidValues()
 	{
@@ -149,6 +265,50 @@ public abstract partial class RandomTests<TRandomSystem>
 		});
 
 		results.Should().OnlyHaveUniqueItems();
+	}
+#endif
+
+#if FEATURE_RANDOM_ITEMS
+	[Fact]
+	public void Shuffle_Array_ShouldShuffleItemsInPlace()
+	{
+		int[] originalValues = Enumerable.Range(0, 100).ToArray();
+		int[] values = originalValues.ToArray();
+
+		RandomSystem.Random.Shared.Shuffle(values);
+
+		values.Should().OnlyHaveUniqueItems();
+		values.Should().NotContainInOrder(originalValues);
+		values.OrderBy(x => x).Should().ContainInOrder(originalValues);
+	}
+
+	[Fact]
+	public void Shuffle_Array_Null_ShouldThrowArgumentNullException()
+	{
+		int[]? values = null;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			RandomSystem.Random.Shared.Shuffle(values);
+		});
+
+		exception.Should().BeOfType<ArgumentNullException>()
+			.Which.ParamName.Should().Be(nameof(values));
+	}
+
+	[Fact]
+	public void Shuffle_Span_ShouldShuffleItemsInPlace()
+	{
+		int[] originalValues = Enumerable.Range(0, 100).ToArray();
+		int[] buffer = originalValues.ToArray();
+		Span<int> values = new(buffer);
+
+		RandomSystem.Random.Shared.Shuffle(values);
+
+		int[] result = values.ToArray();
+		result.Should().OnlyHaveUniqueItems();
+		result.Should().NotContainInOrder(originalValues);
+		result.OrderBy(x => x).Should().ContainInOrder(originalValues);
 	}
 #endif
 }

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerFactoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Testably.Abstractions.TimeSystem;
+using ITimer = Testably.Abstractions.TimeSystem.ITimer;
 
 namespace Testably.Abstractions.Tests.TimeSystem;
 

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -30,7 +30,11 @@ public abstract partial class TimerTests<TTimeSystem>
 			timer.Change(100, 200);
 		});
 
+#if NET8_0_OR_GREATER
+		exception.Should().BeNull();
+#else
 		exception.Should().BeOfType<ObjectDisposedException>();
+#endif
 	}
 
 	[SkippableFact]
@@ -320,8 +324,16 @@ public abstract partial class TimerTests<TTimeSystem>
 		waitHandle.WaitOne(1000).Should().BeTrue();
 		result.Should().BeTrue();
 		// ReSharper disable once AccessToDisposedClosure
-		Record.Exception(() => timer.Change(0, 0))
-			.Should().BeOfType<ObjectDisposedException>();
+		Exception? exception = Record.Exception(() =>
+		{
+			timer.Change(0, 0);
+		});
+
+#if NET8_0_OR_GREATER
+		exception.Should().BeNull();
+#else
+		exception.Should().BeOfType<ObjectDisposedException>();
+#endif
 	}
 
 	[SkippableFact]
@@ -336,8 +348,16 @@ public abstract partial class TimerTests<TTimeSystem>
 		waitHandle.WaitOne(1000).Should().BeTrue();
 		result.Should().BeTrue();
 		// ReSharper disable once AccessToDisposedClosure
-		Record.Exception(() => timer.Change(0, 0))
-			.Should().BeOfType<ObjectDisposedException>();
+		Exception? exception = Record.Exception(() =>
+		{
+			timer.Change(0, 0);
+		});
+
+#if NET8_0_OR_GREATER
+		exception.Should().BeNull();
+#else
+		exception.Should().BeOfType<ObjectDisposedException>();
+#endif
 	}
 
 	[SkippableFact]
@@ -352,8 +372,16 @@ public abstract partial class TimerTests<TTimeSystem>
 		waitHandle.WaitOne(1000).Should().BeTrue();
 		result.Should().BeTrue();
 		// ReSharper disable once AccessToDisposedClosure
-		Record.Exception(() => timer.Change(0, 0))
-			.Should().BeOfType<ObjectDisposedException>();
+		Exception? exception = Record.Exception(() =>
+		{
+			timer.Change(0, 0);
+		});
+
+#if NET8_0_OR_GREATER
+		exception.Should().BeNull();
+#else
+		exception.Should().BeOfType<ObjectDisposedException>();
+#endif
 	}
 
 	[SkippableFact]
@@ -380,8 +408,16 @@ public abstract partial class TimerTests<TTimeSystem>
 		await timer.DisposeAsync();
 
 		// ReSharper disable once AccessToDisposedClosure
-		Record.Exception(() => timer.Change(0, 0))
-			.Should().BeOfType<ObjectDisposedException>();
+		Exception? exception = Record.Exception(() =>
+		{
+			timer.Change(0, 0);
+		});
+
+#if NET8_0_OR_GREATER
+		exception.Should().BeNull();
+#else
+		exception.Should().BeOfType<ObjectDisposedException>();
+#endif
 	}
 #endif
 }

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Testably.Abstractions.TimeSystem;
+using ITimer = Testably.Abstractions.TimeSystem.ITimer;
 
 namespace Testably.Abstractions.Tests.TimeSystem;
 
@@ -23,7 +24,6 @@ public abstract partial class TimerTests<TTimeSystem>
 		{
 		}, null, 0, 200);
 		timer.Dispose();
-
 		Exception? exception = Record.Exception(() =>
 		{
 			// ReSharper disable once AccessToDisposedClosure


### PR DESCRIPTION
Adapt **Testably.Abstractions** to support .NET 8.0 with the following changes:

1. Add new methods for `IRandom`:
   - [`GetItems`](https://learn.microsoft.com/en-us/dotnet/api/system.random.getitems?view=net-8.0)
   - [`Shuffle`](https://learn.microsoft.com/en-us/dotnet/api/system.random.shuffle?view=net-8.0)

2. Add new methods for `IZipFile`:
   `CreateFromDirectory` and `ExtractToDirectory` now also work with a `Stream`

3. Change Timer so that it no longer throws `ObjectDisposedException` after being disposed:
    *see [this change](https://github.com/dotnet/runtime/commit/5d88ff404de77d78e07ad3de7fa2af270332da22#diff-ca0e15ba4d75ab4c7ce9b34d870658ec3d507a6e88739138e9751b7338b4171d) for more details*

4. `IFileInfo.CreateText` now refreshes the internal cache of the `FileInfo`

5. Remove `BinaryFormatter` and serialization support for `TestingException` as the [`BinaryFormatter` becomes obsolete](https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md)

6. `LastAccessTime` is no longer updated for the source file when copying it on OSX.
   (see https://github.com/dotnet/runtime/pull/79243 for more details)