### PR TITLE
feat: support .NET 8.0 | `LastAccessTime` is no longer updated for the source file when copying it on OSX

### DIFF
--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -74,8 +74,13 @@ internal sealed class InMemoryStorage : IStorage
 					() => copiedContainer.LastAccessTime.Set(
 						sourceContainer.LastAccessTime.Get(DateTimeKind.Local),
 						DateTimeKind.Local));
+#if NET8_0_OR_GREATER
+				Execute.OnLinux(()
+					=> sourceContainer.AdjustTimes(TimeAdjustments.LastAccessTime));
+#else
 				Execute.NotOnWindows(()
 					=> sourceContainer.AdjustTimes(TimeAdjustments.LastAccessTime));
+#endif
 
 				copiedContainer.Attributes = sourceContainer.Attributes;
 				Execute.OnWindowsIf(sourceContainer.Type == FileSystemTypes.File,
@@ -497,7 +502,7 @@ internal sealed class InMemoryStorage : IStorage
 		return false;
 	}
 
-	#endregion
+#endregion
 
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -156,7 +156,18 @@ public abstract partial class CopyTests<TFileSystem>
 		sourceCreationTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);
-		if (Test.RunsOnWindows)
+		if (Test.RunsOnMac)
+		{
+#if NET8_0_OR_GREATER
+			sourceLastAccessTime.Should()
+				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
+				.BeOnOrBefore(creationTimeEnd);
+#else
+			sourceLastAccessTime.Should()
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
+#endif
+		}
+		else if (Test.RunsOnWindows)
 		{
 			sourceLastAccessTime.Should()
 				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And


### PR DESCRIPTION
- #381 

`LastAccessTime` is no longer updated for the source file when copying it on OSX.
(see https://github.com/dotnet/runtime/pull/79243 for more details)
