### PR TITLE
feat: support .NET 8.0 | Refresh cache on `IFileInfo.CreateText`

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
@@ -107,7 +107,13 @@ internal sealed class FileInfoMock
 
 	/// <inheritdoc cref="IFileInfo.CreateText()" />
 	public StreamWriter CreateText()
-		=> new(_fileSystem.File.Create(FullName));
+	{
+		StreamWriter streamWriter = new(_fileSystem.File.Create(FullName));
+#if NET8_0_OR_GREATER
+		Refresh();
+#endif
+		return streamWriter;
+	}
 
 	/// <inheritdoc cref="IFileInfo.Decrypt()" />
 	[SupportedOSPlatform("windows")]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
@@ -23,6 +23,24 @@ public abstract partial class CreateTextTests<TFileSystem>
 			.Which.HasContent(appendText);
 	}
 
+#if NET8_0_OR_GREATER
+	[SkippableTheory]
+	[AutoData]
+	public void CreateText_ShouldRefreshExistsCache(
+		string path, string appendText)
+	{
+		IFileInfo fileInfo = FileSystem.FileInfo.New(path);
+		fileInfo.Exists.Should().BeFalse();
+
+		using (StreamWriter stream = fileInfo.CreateText())
+		{
+			stream.Write(appendText);
+		}
+
+		fileInfo.Exists.Should().BeTrue();
+		FileSystem.Should().HaveFile(path);
+	}
+#else
 	[SkippableTheory]
 	[AutoData]
 	public void CreateText_ShouldNotRefreshExistsCache(
@@ -39,6 +57,7 @@ public abstract partial class CreateTextTests<TFileSystem>
 		fileInfo.Exists.Should().BeFalse();
 		FileSystem.Should().HaveFile(path);
 	}
+#endif
 
 	[SkippableTheory]
 	[AutoData]


### PR DESCRIPTION
- #381 

`IFileInfo.CreateText` now refreshes the internal cache of the `FileInfo`