### PR TITLE
feat: support .NET 8.0 | Timer no longer throws `ObjectDisposedException`

### DIFF
--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimerFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimerFactoryMock.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.TimeSystem;
+using ITimer = Testably.Abstractions.TimeSystem.ITimer;
 
 namespace Testably.Abstractions.Testing.TimeSystem;
 

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimerMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimerMock.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.TimeSystem;
+using ITimer = Testably.Abstractions.TimeSystem.ITimer;
 
 namespace Testably.Abstractions.Testing.TimeSystem;
 
@@ -99,7 +100,11 @@ internal sealed class TimerMock : ITimerMock
 	{
 		if (_isDisposed)
 		{
+#if NET8_0_OR_GREATER
+			return false;
+#else
 			throw new ObjectDisposedException(nameof(Change), "Cannot access a disposed object.");
+#endif
 		}
 
 		if (dueTime.TotalMilliseconds < -1)

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/TimeSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/TimeSystemClassGenerator.cs
@@ -32,7 +32,7 @@ namespace {@class.Namespace}.{@class.Name}
 	// ReSharper disable once UnusedMember.Global
 	public sealed class MockTimeSystemTests : {@class.Name}<MockTimeSystem>
 	{{
-		public MockTimeSystemTests() : base(new MockTimeSystem(TimeProvider.Now()))
+		public MockTimeSystemTests() : base(new MockTimeSystem(Testing.TimeProvider.Now()))
 		{{
 		}}
 	}}

--- a/Tests/Testably.Abstractions.Parity.Tests/ParityTests.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/ParityTests.cs
@@ -141,7 +141,7 @@ public abstract class ParityTests
 		ITimerAndITimerFactory_EnsureParityWith_Timer()
 	{
 		List<string> parityErrors = Parity.Timer
-			.GetErrorsToInstanceType<ITimer, ITimerFactory>(
+			.GetErrorsToInstanceType<TimeSystem.ITimer, ITimerFactory>(
 				typeof(Timer),
 				_testOutputHelper);
 

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerFactoryMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerFactoryMockTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using Testably.Abstractions.TimeSystem;
+using ITimer = Testably.Abstractions.TimeSystem.ITimer;
 
 namespace Testably.Abstractions.Testing.Tests.TimeSystem;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Testably.Abstractions.Testing.TimeSystem;
 using Testably.Abstractions.TimeSystem;
 using Xunit.Abstractions;
+using ITimer = Testably.Abstractions.TimeSystem.ITimer;
 
 namespace Testably.Abstractions.Testing.Tests.TimeSystem;
 
@@ -68,10 +69,14 @@ public class TimerMockTests
 			timer.Change(0, 0);
 		});
 
+#if NET8_0_OR_GREATER
+		exception.Should().BeNull();
+#else
 		exception.Should().BeOfType<ObjectDisposedException>()
 			.Which.Message.Should().ContainAll(
 				"Cannot access a disposed object.",
 				nameof(ITimer.Change));
+#endif
 	}
 
 #if FEATURE_ASYNC_DISPOSABLE
@@ -89,7 +94,11 @@ public class TimerMockTests
 			timer.Change(0, 0);
 		});
 
+#if NET8_0_OR_GREATER
+		exception.Should().BeNull();
+#else
 		exception.Should().BeOfType<ObjectDisposedException>();
+#endif
 	}
 #endif
 

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerFactoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Testably.Abstractions.TimeSystem;
+using ITimer = Testably.Abstractions.TimeSystem.ITimer;
 
 namespace Testably.Abstractions.Tests.TimeSystem;
 

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Testably.Abstractions.TimeSystem;
+using ITimer = Testably.Abstractions.TimeSystem.ITimer;
 
 namespace Testably.Abstractions.Tests.TimeSystem;
 
@@ -23,14 +24,17 @@ public abstract partial class TimerTests<TTimeSystem>
 		{
 		}, null, 0, 200);
 		timer.Dispose();
-
 		Exception? exception = Record.Exception(() =>
 		{
 			// ReSharper disable once AccessToDisposedClosure
 			timer.Change(100, 200);
 		});
 
+#if NET8_0_OR_GREATER
+		exception.Should().BeNull();
+#else
 		exception.Should().BeOfType<ObjectDisposedException>();
+#endif
 	}
 
 	[SkippableFact]
@@ -320,8 +324,16 @@ public abstract partial class TimerTests<TTimeSystem>
 		waitHandle.WaitOne(1000).Should().BeTrue();
 		result.Should().BeTrue();
 		// ReSharper disable once AccessToDisposedClosure
-		Record.Exception(() => timer.Change(0, 0))
-			.Should().BeOfType<ObjectDisposedException>();
+		Exception? exception = Record.Exception(() =>
+		{
+			timer.Change(0, 0);
+		});
+
+#if NET8_0_OR_GREATER
+		exception.Should().BeNull();
+#else
+		exception.Should().BeOfType<ObjectDisposedException>();
+#endif
 	}
 
 	[SkippableFact]
@@ -336,8 +348,16 @@ public abstract partial class TimerTests<TTimeSystem>
 		waitHandle.WaitOne(1000).Should().BeTrue();
 		result.Should().BeTrue();
 		// ReSharper disable once AccessToDisposedClosure
-		Record.Exception(() => timer.Change(0, 0))
-			.Should().BeOfType<ObjectDisposedException>();
+		Exception? exception = Record.Exception(() =>
+		{
+			timer.Change(0, 0);
+		});
+
+#if NET8_0_OR_GREATER
+		exception.Should().BeNull();
+#else
+		exception.Should().BeOfType<ObjectDisposedException>();
+#endif
 	}
 
 	[SkippableFact]
@@ -352,8 +372,16 @@ public abstract partial class TimerTests<TTimeSystem>
 		waitHandle.WaitOne(1000).Should().BeTrue();
 		result.Should().BeTrue();
 		// ReSharper disable once AccessToDisposedClosure
-		Record.Exception(() => timer.Change(0, 0))
-			.Should().BeOfType<ObjectDisposedException>();
+		Exception? exception = Record.Exception(() =>
+		{
+			timer.Change(0, 0);
+		});
+
+#if NET8_0_OR_GREATER
+		exception.Should().BeNull();
+#else
+		exception.Should().BeOfType<ObjectDisposedException>();
+#endif
 	}
 
 	[SkippableFact]
@@ -380,8 +408,16 @@ public abstract partial class TimerTests<TTimeSystem>
 		await timer.DisposeAsync();
 
 		// ReSharper disable once AccessToDisposedClosure
-		Record.Exception(() => timer.Change(0, 0))
-			.Should().BeOfType<ObjectDisposedException>();
+		Exception? exception = Record.Exception(() =>
+		{
+			timer.Change(0, 0);
+		});
+
+#if NET8_0_OR_GREATER
+		exception.Should().BeNull();
+#else
+		exception.Should().BeOfType<ObjectDisposedException>();
+#endif
 	}
 #endif
 }


### PR DESCRIPTION
- #381 

Change Timer so that it no longer throws `ObjectDisposedException` after being disposed:
(see [this change](https://github.com/dotnet/runtime/commit/5d88ff404de77d78e07ad3de7fa2af270332da22#diff-ca0e15ba4d75ab4c7ce9b34d870658ec3d507a6e88739138e9751b7338b4171d) for more details)