### PR TITLE
feat: support .NET 8.0 | Add new methods for `IZipFile`

### DIFF
--- a/Source/Testably.Abstractions.Compression/IZipFile.cs
+++ b/Source/Testably.Abstractions.Compression/IZipFile.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Compression;
+﻿using System.IO;
+using System.IO.Compression;
 using System.Text;
 
 namespace Testably.Abstractions;
@@ -6,56 +7,114 @@ namespace Testably.Abstractions;
 /// <inheritdoc cref="ZipFile" />
 public interface IZipFile : IFileSystemEntity
 {
+#if FEATURE_COMPRESSION_STREAM
+	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, Stream)" />
+	void CreateFromDirectory(
+		string sourceDirectoryName,
+		Stream destination);
+
+	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, Stream, CompressionLevel, bool)" />
+	void CreateFromDirectory(
+		string sourceDirectoryName,
+		Stream destination,
+		CompressionLevel compressionLevel,
+		bool includeBaseDirectory);
+
+	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, Stream, CompressionLevel, bool, Encoding)" />
+	void CreateFromDirectory(
+		string sourceDirectoryName,
+		Stream destination,
+		CompressionLevel compressionLevel,
+		bool includeBaseDirectory,
+		Encoding entryNameEncoding);
+#endif
+
 	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, string)" />
-	void CreateFromDirectory(string sourceDirectoryName,
+	void CreateFromDirectory(
+		string sourceDirectoryName,
 		string destinationArchiveFileName);
 
 	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, string, CompressionLevel, bool)" />
-	void CreateFromDirectory(string sourceDirectoryName,
+	void CreateFromDirectory(
+		string sourceDirectoryName,
 		string destinationArchiveFileName,
 		CompressionLevel compressionLevel,
 		bool includeBaseDirectory);
 
 	/// <inheritdoc cref="ZipFile.CreateFromDirectory(string, string, CompressionLevel, bool, Encoding)" />
-	void CreateFromDirectory(string sourceDirectoryName,
+	void CreateFromDirectory(
+		string sourceDirectoryName,
 		string destinationArchiveFileName,
 		CompressionLevel compressionLevel,
 		bool includeBaseDirectory,
 		Encoding entryNameEncoding);
 
+#if FEATURE_COMPRESSION_STREAM
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string)" />
+	void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName);
+
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, bool)" />
+	void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName,
+		bool overwriteFiles);
+
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, Encoding)" />
+	void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName,
+		Encoding entryNameEncoding);
+
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, Encoding, bool)" />
+	void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName,
+		Encoding entryNameEncoding,
+		bool overwriteFiles);
+#endif
+
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(string, string)" />
-	void ExtractToDirectory(string sourceArchiveFileName,
+	void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName);
 
 #if FEATURE_COMPRESSION_OVERWRITE
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(string, string, bool)" />
-	void ExtractToDirectory(string sourceArchiveFileName,
+	void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName,
 		bool overwriteFiles);
 #endif
 
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(string, string, Encoding?)" />
-	void ExtractToDirectory(string sourceArchiveFileName,
+	void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName,
 		Encoding? entryNameEncoding);
 
 #if FEATURE_COMPRESSION_OVERWRITE
 	/// <inheritdoc cref="ZipFile.ExtractToDirectory(string, string, Encoding?, bool)" />
-	void ExtractToDirectory(string sourceArchiveFileName,
+	void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName,
 		Encoding? entryNameEncoding,
 		bool overwriteFiles);
 #endif
 
 	/// <inheritdoc cref="ZipFile.Open(string, ZipArchiveMode)" />
-	IZipArchive Open(string archiveFileName,
+	IZipArchive Open(
+		string archiveFileName,
 		ZipArchiveMode mode);
 
 	/// <inheritdoc cref="IZipFile.Open(string, ZipArchiveMode, Encoding?)" />
-	IZipArchive Open(string archiveFileName,
+	IZipArchive Open(
+		string archiveFileName,
 		ZipArchiveMode mode,
 		Encoding? entryNameEncoding);
 
 	/// <inheritdoc cref="ZipFile.OpenRead(string)" />
-	IZipArchive OpenRead(string archiveFileName);
+	IZipArchive OpenRead(
+		string archiveFileName);
 }

--- a/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
+++ b/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
@@ -59,7 +59,6 @@ internal static class ZipUtilities
 		CompressionLevel? compressionLevel = null,
 		bool includeBaseDirectory = false,
 		Encoding? entryNameEncoding = null)
-
 	{
 		sourceDirectoryName = fileSystem.Path.GetFullPath(sourceDirectoryName);
 		destinationArchiveFileName =
@@ -113,6 +112,84 @@ internal static class ZipUtilities
 			}
 		}
 	}
+
+#if FEATURE_COMPRESSION_STREAM
+	/// <summary>
+	///     Create a <c>ZipArchive</c> from the files and directories in <paramref name="sourceDirectoryName" />.
+	/// </summary>
+	/// <remarks>
+	///     <see
+	///         href="https://github.com/dotnet/runtime/blob/v6.0.10/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs#L354" />
+	/// </remarks>
+	internal static void CreateFromDirectory(
+		IFileSystem fileSystem,
+		string sourceDirectoryName,
+		Stream destination,
+		CompressionLevel? compressionLevel = null,
+		bool includeBaseDirectory = false,
+		Encoding? entryNameEncoding = null)
+	{
+		ArgumentNullException.ThrowIfNull(destination);
+		if (!destination.CanWrite)
+		{
+			throw new ArgumentException("The stream is unwritable.", nameof(destination))
+			{
+				HResult = -2147024809
+			};
+		}
+
+		sourceDirectoryName = fileSystem.Path.GetFullPath(sourceDirectoryName);
+
+		using (ZipArchive archive = new(destination, ZipArchiveMode.Create,
+			leaveOpen: true,
+			entryNameEncoding: entryNameEncoding))
+		{
+			bool directoryIsEmpty = true;
+
+			IDirectoryInfo di =
+				fileSystem.DirectoryInfo.New(sourceDirectoryName);
+
+			string basePath = di.FullName;
+
+			if (includeBaseDirectory && di.Parent != null)
+			{
+				basePath = di.Parent.FullName;
+			}
+
+			foreach (IFileSystemInfo file in di
+				.EnumerateFileSystemInfos(SearchPattern, SearchOption.AllDirectories))
+			{
+				directoryIsEmpty = false;
+
+				if (file is IFileInfo fileInfo)
+				{
+					string entryName = file.FullName
+						.Substring(basePath.Length + 1)
+						.Replace("\\", "/");
+					ZipArchiveEntry entry = compressionLevel.HasValue
+						? archive.CreateEntry(entryName, compressionLevel.Value)
+						: archive.CreateEntry(entryName);
+					using Stream stream = entry.Open();
+					fileInfo.OpenRead().CopyTo(stream);
+				}
+				else if (file is IDirectoryInfo directoryInfo &&
+				         directoryInfo.GetFileSystemInfos().Length == 0)
+				{
+					#pragma warning disable CA1845
+					string entryName = file.FullName.Substring(basePath.Length + 1) + "/";
+					#pragma warning restore CA1845
+					archive.CreateEntry(entryName);
+				}
+			}
+
+			if (includeBaseDirectory && directoryIsEmpty)
+			{
+				string entryName = di.Name + "/";
+				archive.CreateEntry(entryName);
+			}
+		}
+	}
+#endif
 
 	internal static void ExtractRelativeToDirectory(this IZipArchiveEntry source,
 		string destinationDirectoryName,
@@ -176,6 +253,40 @@ internal static class ZipUtilities
 			}
 		}
 	}
+
+#if FEATURE_COMPRESSION_STREAM
+	/// <summary>
+	///     Extract the archive at <paramref name="source" /> to the
+	///     <paramref name="destinationDirectoryName" />.
+	/// </summary>
+	internal static void ExtractToDirectory(IFileSystem fileSystem,
+		Stream source,
+		string destinationDirectoryName,
+		Encoding? entryNameEncoding = null,
+		bool overwriteFiles = false)
+	{
+		ArgumentNullException.ThrowIfNull(source);
+		if (!source.CanRead)
+		{
+			throw new ArgumentException("The stream is unreadable.", nameof(source))
+			{
+				HResult = -2147024809
+			};
+		}
+
+		using (ZipArchive archive = new(source, ZipArchiveMode.Read, true, entryNameEncoding))
+		{
+			ZipArchiveWrapper wrappedArchive = new(fileSystem, archive);
+			foreach (ZipArchiveEntry entry in archive.Entries)
+			{
+				IZipArchiveEntry wrappedEntry = ZipArchiveEntryWrapper.New(
+					fileSystem, wrappedArchive, entry);
+				ExtractRelativeToDirectory(wrappedEntry, destinationDirectoryName,
+					overwriteFiles);
+			}
+		}
+	}
+#endif
 
 	internal static void ExtractToFile(IZipArchiveEntry source,
 		string destinationFileName, bool overwrite)

--- a/Source/Testably.Abstractions.Compression/ZipFileWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipFileWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Compression;
+﻿using System.IO;
+using System.IO.Compression;
 using System.Text;
 using Testably.Abstractions.Internal;
 
@@ -16,8 +17,65 @@ internal sealed class ZipFileWrapper : IZipFile
 	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem { get; }
 
+#if FEATURE_COMPRESSION_STREAM
+	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, Stream)" />
+	public void CreateFromDirectory(
+		string sourceDirectoryName,
+		Stream destination)
+		=> Execute.WhenRealFileSystem(FileSystem,
+			() => ZipFile.CreateFromDirectory(
+				sourceDirectoryName,
+				destination),
+			() => ZipUtilities.CreateFromDirectory(
+				FileSystem,
+				sourceDirectoryName,
+				destination));
+
+	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, Stream, CompressionLevel, bool)" />
+	public void CreateFromDirectory(
+		string sourceDirectoryName,
+		Stream destination,
+		CompressionLevel compressionLevel,
+		bool includeBaseDirectory)
+		=> Execute.WhenRealFileSystem(FileSystem,
+			() => ZipFile.CreateFromDirectory(
+				sourceDirectoryName,
+				destination,
+				compressionLevel,
+				includeBaseDirectory),
+			() => ZipUtilities.CreateFromDirectory(
+				FileSystem,
+				sourceDirectoryName,
+				destination,
+				compressionLevel,
+				includeBaseDirectory));
+
+	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, Stream, CompressionLevel, bool, Encoding)" />
+	public void CreateFromDirectory(
+		string sourceDirectoryName,
+		Stream destination,
+		CompressionLevel compressionLevel,
+		bool includeBaseDirectory,
+		Encoding entryNameEncoding)
+		=> Execute.WhenRealFileSystem(FileSystem,
+			() => ZipFile.CreateFromDirectory(
+				sourceDirectoryName,
+				destination,
+				compressionLevel,
+				includeBaseDirectory,
+				entryNameEncoding),
+			() => ZipUtilities.CreateFromDirectory(
+				FileSystem,
+				sourceDirectoryName,
+				destination,
+				compressionLevel,
+				includeBaseDirectory,
+				entryNameEncoding));
+#endif
+
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, string)" />
-	public void CreateFromDirectory(string sourceDirectoryName,
+	public void CreateFromDirectory(
+		string sourceDirectoryName,
 		string destinationArchiveFileName)
 		=> Execute.WhenRealFileSystem(FileSystem,
 			() => ZipFile.CreateFromDirectory(
@@ -29,7 +87,8 @@ internal sealed class ZipFileWrapper : IZipFile
 				destinationArchiveFileName));
 
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, string, CompressionLevel, bool)" />
-	public void CreateFromDirectory(string sourceDirectoryName,
+	public void CreateFromDirectory(
+		string sourceDirectoryName,
 		string destinationArchiveFileName,
 		CompressionLevel compressionLevel,
 		bool includeBaseDirectory)
@@ -47,7 +106,8 @@ internal sealed class ZipFileWrapper : IZipFile
 				includeBaseDirectory));
 
 	/// <inheritdoc cref="IZipFile.CreateFromDirectory(string, string, CompressionLevel, bool, Encoding)" />
-	public void CreateFromDirectory(string sourceDirectoryName,
+	public void CreateFromDirectory(
+		string sourceDirectoryName,
 		string destinationArchiveFileName,
 		CompressionLevel compressionLevel,
 		bool includeBaseDirectory,
@@ -67,8 +127,75 @@ internal sealed class ZipFileWrapper : IZipFile
 				includeBaseDirectory,
 				entryNameEncoding));
 
+#if FEATURE_COMPRESSION_STREAM
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string)" />
+	public void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName)
+		=> Execute.WhenRealFileSystem(FileSystem,
+			() => ZipFile.ExtractToDirectory(
+				source,
+				destinationDirectoryName),
+			() => ZipUtilities.ExtractToDirectory(
+				FileSystem,
+				source,
+				destinationDirectoryName));
+
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, bool)" />
+	public void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName,
+		bool overwriteFiles)
+		=> Execute.WhenRealFileSystem(FileSystem,
+			() => ZipFile.ExtractToDirectory(
+				source,
+				destinationDirectoryName,
+				overwriteFiles),
+			() => ZipUtilities.ExtractToDirectory(
+				FileSystem,
+				source,
+				destinationDirectoryName,
+				overwriteFiles: overwriteFiles));
+
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, Encoding)" />
+	public void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName,
+		Encoding entryNameEncoding)
+		=> Execute.WhenRealFileSystem(FileSystem,
+			() => ZipFile.ExtractToDirectory(
+				source,
+				destinationDirectoryName,
+				entryNameEncoding),
+			() => ZipUtilities.ExtractToDirectory(
+				FileSystem,
+				source,
+				destinationDirectoryName,
+				entryNameEncoding));
+
+	/// <inheritdoc cref="ZipFile.ExtractToDirectory(Stream, string, Encoding, bool)" />
+	public void ExtractToDirectory(
+		Stream source,
+		string destinationDirectoryName,
+		Encoding entryNameEncoding,
+		bool overwriteFiles)
+		=> Execute.WhenRealFileSystem(FileSystem,
+			() => ZipFile.ExtractToDirectory(
+				source,
+				destinationDirectoryName,
+				entryNameEncoding,
+				overwriteFiles),
+			() => ZipUtilities.ExtractToDirectory(
+				FileSystem,
+				source,
+				destinationDirectoryName,
+				entryNameEncoding,
+				overwriteFiles));
+#endif
+
 	/// <inheritdoc cref="IZipFile.ExtractToDirectory(string, string)" />
-	public void ExtractToDirectory(string sourceArchiveFileName,
+	public void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName)
 		=> Execute.WhenRealFileSystem(FileSystem,
 			() => ZipFile.ExtractToDirectory(
@@ -81,7 +208,8 @@ internal sealed class ZipFileWrapper : IZipFile
 
 #if FEATURE_COMPRESSION_OVERWRITE
 	/// <inheritdoc cref="IZipFile.ExtractToDirectory(string, string, bool)" />
-	public void ExtractToDirectory(string sourceArchiveFileName,
+	public void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName,
 		bool overwriteFiles)
 		=> Execute.WhenRealFileSystem(FileSystem,
@@ -97,7 +225,8 @@ internal sealed class ZipFileWrapper : IZipFile
 #endif
 
 	/// <inheritdoc cref="IZipFile.ExtractToDirectory(string, string, Encoding?)" />
-	public void ExtractToDirectory(string sourceArchiveFileName,
+	public void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName,
 		Encoding? entryNameEncoding)
 		=> Execute.WhenRealFileSystem(FileSystem,
@@ -113,7 +242,8 @@ internal sealed class ZipFileWrapper : IZipFile
 
 #if FEATURE_COMPRESSION_OVERWRITE
 	/// <inheritdoc cref="IZipFile.ExtractToDirectory(string, string, Encoding?, bool)" />
-	public void ExtractToDirectory(string sourceArchiveFileName,
+	public void ExtractToDirectory(
+		string sourceArchiveFileName,
 		string destinationDirectoryName,
 		Encoding? entryNameEncoding,
 		bool overwriteFiles)
@@ -132,7 +262,9 @@ internal sealed class ZipFileWrapper : IZipFile
 #endif
 
 	/// <inheritdoc cref="IZipFile.Open(string, ZipArchiveMode)" />
-	public IZipArchive Open(string archiveFileName, ZipArchiveMode mode)
+	public IZipArchive Open(
+		string archiveFileName,
+		ZipArchiveMode mode)
 		=> new ZipArchiveWrapper(FileSystem,
 			Execute.WhenRealFileSystem(FileSystem,
 				() => ZipFile.Open(archiveFileName, mode),
@@ -141,7 +273,8 @@ internal sealed class ZipFileWrapper : IZipFile
 					mode)));
 
 	/// <inheritdoc cref="IZipFile.Open(string, ZipArchiveMode, Encoding?)" />
-	public IZipArchive Open(string archiveFileName,
+	public IZipArchive Open(
+		string archiveFileName,
 		ZipArchiveMode mode,
 		Encoding? entryNameEncoding)
 		=> new ZipArchiveWrapper(FileSystem,
@@ -153,7 +286,8 @@ internal sealed class ZipFileWrapper : IZipFile
 					entryNameEncoding)));
 
 	/// <inheritdoc cref="IZipFile.OpenRead(string)" />
-	public IZipArchive OpenRead(string archiveFileName)
+	public IZipArchive OpenRead(
+		string archiveFileName)
 		=> new ZipArchiveWrapper(FileSystem,
 			Execute.WhenRealFileSystem(FileSystem,
 				() => ZipFile.OpenRead(archiveFileName),

--- a/Tests/Testably.Abstractions.Compression.Tests/TestHelpers/MemoryStreamMock.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/TestHelpers/MemoryStreamMock.cs
@@ -1,0 +1,16 @@
+﻿using System.IO;
+
+namespace Testably.Abstractions.Compression.Tests.TestHelpers;
+
+internal sealed class MemoryStreamMock : MemoryStream
+{
+	public MemoryStreamMock(bool canWrite = true, bool canRead = true)
+	{
+		CanWrite = canWrite;
+		CanRead = canRead;
+	}
+
+	public override bool CanRead { get; }
+
+	public override bool CanWrite { get; }
+}

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
@@ -1,6 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.IO.Compression;
 using System.Text;
+#if FEATURE_COMPRESSION_STREAM
+using System.IO;
+using Testably.Abstractions.Compression.Tests.TestHelpers;
+#endif
 
 namespace Testably.Abstractions.Compression.Tests.ZipFile;
 
@@ -156,6 +160,187 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 				FileSystem.File.ReadAllBytes("foo/bar/test.txt"));
 	}
 
+#if FEATURE_COMPRESSION_STREAM
+	[SkippableTheory]
+	[AutoData]
+	public void
+		CreateFromDirectory_WithStream_EmptyDirectory_ShouldBeIncluded(
+			CompressionLevel compressionLevel)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithSubdirectory("bar"));
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile()
+			.CreateFromDirectory("foo", stream, compressionLevel, false);
+
+		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+
+		archive.Entries.Count.Should().Be(1);
+		archive.Entries.Should().Contain(e => e.FullName.Equals("bar/"));
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateFromDirectory_WithStream_EmptySource_DoNotIncludeBaseDirectory_ShouldBeEmpty(
+		CompressionLevel compressionLevel)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("foo");
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile()
+			.CreateFromDirectory("foo", stream, compressionLevel, false);
+
+		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+
+		archive.Entries.Count.Should().Be(0);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void
+		CreateFromDirectory_WithStream_EmptySource_IncludeBaseDirectory_ShouldPrependDirectoryName(
+			CompressionLevel compressionLevel)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("foo");
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile()
+			.CreateFromDirectory("foo", stream, compressionLevel, true);
+
+		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+
+		archive.Entries.Count.Should().Be(1);
+		archive.Entries.Should().Contain(e => e.FullName.Equals("foo/"));
+	}
+
+	[SkippableTheory]
+	[MemberData(nameof(EntryNameEncoding))]
+	public void CreateFromDirectory_WithStream_EntryNameEncoding_ShouldUseEncoding(
+		string entryName, Encoding encoding, bool encodedCorrectly)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile(entryName));
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile()
+			.CreateFromDirectory("foo", stream, CompressionLevel.NoCompression,
+				false, encoding);
+
+		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+
+		archive.Entries.Count.Should().Be(1);
+		if (encodedCorrectly)
+		{
+			archive.Entries.Should().Contain(e => e.Name == entryName);
+		}
+		else
+		{
+			archive.Entries.Should().NotContain(e => e.Name == entryName);
+		}
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateFromDirectory_WithStream_IncludeBaseDirectory_ShouldPrependDirectoryName(
+		CompressionLevel compressionLevel)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile()
+			.CreateFromDirectory("foo", stream, compressionLevel, true);
+
+		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+
+		archive.Entries.Count.Should().Be(1);
+		archive.Entries.Should().Contain(e => e.FullName.Equals("foo/test.txt"));
+	}
+
+	[SkippableFact]
+	public void
+		CreateFromDirectory_WithStream_Null_ShouldThrowArgumentNullException()
+	{
+		Stream stream = null!;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		});
+
+		exception.Should().BeOfType<ArgumentNullException>()
+			.Which.ParamName.Should().Be("destination");
+	}
+
+	[SkippableFact]
+	public void
+		CreateFromDirectory_WithStream_NotWritable_ShouldThrowArgumentException()
+	{
+		Stream stream = new MemoryStreamMock(canWrite: false);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		});
+
+		exception.Should().BeException<ArgumentException>("The stream is unwritable",
+			paramName: "destination", hResult: -2147024809);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void CreateFromDirectory_WithStream_Overwrite_WithEncoding_ShouldOverwriteFile(
+		string contents, Encoding encoding)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("bar").Initialized(s => s
+				.WithFile("test.txt"))
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		FileSystem.File.WriteAllText(FileSystem.Path.Combine("foo", "test.txt"),
+			contents);
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile().CreateFromDirectory("foo", stream,
+			CompressionLevel.Optimal, false, encoding);
+
+		IZipArchive archive =
+			FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read, true, encoding);
+
+		archive.Entries.Count.Should().Be(1);
+		archive.Entries.Should().Contain(e => e.FullName.Equals("test.txt"));
+	}
+
+	[SkippableFact]
+	public void CreateFromDirectory_WithStream_ShouldZipDirectoryContent()
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("destination")
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithSubdirectory("bar").Initialized(t => t
+					.WithFile("test.txt")));
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+
+		FileSystem.ZipFile().ExtractToDirectory(stream, "destination");
+
+		FileSystem.File.Exists("destination/bar/test.txt")
+			.Should().BeTrue();
+		FileSystem.File.ReadAllBytes("destination/bar/test.txt")
+			.Should().BeEquivalentTo(
+				FileSystem.File.ReadAllBytes("foo/bar/test.txt"));
+	}
+#endif
+
+	#region Helpers
+
 	public static IEnumerable<object[]> EntryNameEncoding()
 	{
 		// ReSharper disable StringLiteralTypo
@@ -169,4 +354,6 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 		};
 		// ReSharper restore StringLiteralTypo
 	}
+
+	#endregion
 }

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
@@ -1,6 +1,9 @@
 ﻿using System.IO;
 using System.IO.Compression;
 using System.Text;
+#if FEATURE_COMPRESSION_STREAM
+using Testably.Abstractions.Compression.Tests.TestHelpers;
+#endif
 
 namespace Testably.Abstractions.Compression.Tests.ZipFile;
 
@@ -49,10 +52,11 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 		ExtractToDirectory_NullAsSourceFileName_ShouldThrowArgumentNullException()
 	{
 		FileSystem.Initialize();
+		string sourceArchiveFileName = null!;
 
 		Exception? exception = Record.Exception(() =>
 		{
-			FileSystem.ZipFile().ExtractToDirectory(null!, "bar");
+			FileSystem.ZipFile().ExtractToDirectory(sourceArchiveFileName, "bar");
 		});
 
 		exception.Should().BeOfType<ArgumentNullException>()
@@ -133,4 +137,133 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 		FileSystem.File.ReadAllText(destinationPath)
 			.Should().NotBe(contents);
 	}
+
+#if FEATURE_COMPRESSION_STREAM
+	[SkippableFact]
+	public void ExtractToDirectory_WithStream_MissingDestinationDirectory_ShouldCreateDirectory()
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+
+		FileSystem.ZipFile().ExtractToDirectory(stream, "bar");
+
+		FileSystem.File.Exists("bar/test.txt")
+			.Should().BeTrue();
+		FileSystem.File.ReadAllBytes("bar/test.txt")
+			.Should().BeEquivalentTo(
+				FileSystem.File.ReadAllBytes("foo/test.txt"));
+	}
+
+	[SkippableFact]
+	public void
+		ExtractToDirectory_WithStream_Null_ShouldThrowArgumentNullException()
+	{
+		FileSystem.Initialize();
+		Stream source = null!;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.ZipFile().ExtractToDirectory(source, "bar");
+		});
+
+		exception.Should().BeOfType<ArgumentNullException>()
+			.Which.ParamName.Should().Be("source");
+	}
+
+	[SkippableFact]
+	public void
+		ExtractToDirectory_WithStream_NotReadable_ShouldThrowArgumentNullException()
+	{
+		FileSystem.Initialize();
+		Stream source = new MemoryStreamMock(canRead: false);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.ZipFile().ExtractToDirectory(source, "bar");
+		});
+
+		exception.Should().BeException<ArgumentException>(
+			"The stream is unreadable", paramName: "source", hResult: -2147024809);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void ExtractToDirectory_WithStream_Overwrite_ShouldOverwriteFile(
+		string contents)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("bar").Initialized(s => s
+				.WithFile("test.txt"))
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		FileSystem.File.WriteAllText(FileSystem.Path.Combine("foo", "test.txt"),
+			contents);
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+
+		FileSystem.ZipFile().ExtractToDirectory(stream, "bar", true);
+
+		FileSystem.File.Exists(FileSystem.Path.Combine("bar", "test.txt"))
+			.Should().BeTrue();
+		FileSystem.File.ReadAllText(FileSystem.Path.Combine("bar", "test.txt"))
+			.Should().Be(contents);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void ExtractToDirectory_WithStream_WithEncoding_ShouldZipDirectoryContent(
+		Encoding encoding)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("bar")
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile().CreateFromDirectory("foo", stream,
+			CompressionLevel.Fastest, false, encoding);
+
+		FileSystem.ZipFile().ExtractToDirectory(stream, "bar", encoding);
+
+		FileSystem.File.Exists(FileSystem.Path.Combine("bar", "test.txt"))
+			.Should().BeTrue();
+		FileSystem.File.ReadAllBytes(FileSystem.Path.Combine("bar", "test.txt"))
+			.Should().BeEquivalentTo(
+				FileSystem.File.ReadAllBytes(FileSystem.Path.Combine("foo", "test.txt")));
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void ExtractToDirectory_WithStream_WithoutOverwriteAndExistingFile_ShouldOverwriteFile(
+		string contents)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("bar").Initialized(s => s
+				.WithFile("test.txt"))
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		FileSystem.File.WriteAllText(FileSystem.Path.Combine("foo", "test.txt"),
+			contents);
+		string destinationPath =
+			FileSystem.Path.Combine(FileSystem.Path.GetFullPath("bar"), "test.txt");
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.ZipFile().ExtractToDirectory(stream, "bar");
+		});
+
+		exception.Should().BeOfType<IOException>()
+			.Which.Message.Should().Contain($"'{destinationPath}'");
+		FileSystem.File.ReadAllText(destinationPath)
+			.Should().NotBe(contents);
+	}
+#endif
 }


### PR DESCRIPTION
- #381 

Add new methods for `IZipFile`:
`CreateFromDirectory` and `ExtractToDirectory` now also work with a `Stream`