### PR TITLE
refactor: use `Exist` and `NotExist` fluent assertions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,7 +37,7 @@
 	<ItemGroup>
 		<PackageVersion Include="Testably.Abstractions" Version="2.4.1" />
 		<PackageVersion Include="Testably.Abstractions.Testing" Version="2.4.1" />
-		<PackageVersion Include="Testably.Abstractions.FluentAssertions" Version="0.8.0" />
+		<PackageVersion Include="Testably.Abstractions.FluentAssertions" Version="0.10.0" />
 	</ItemGroup>
 
 </Project>

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
@@ -160,7 +160,7 @@ public class FileSystemInitializerExtensionsTests
 			MockFileSystem> result =
 			sut.Initialize().WithSubdirectory(directoryName);
 
-		result.Directory.Exists.Should().BeTrue();
+		result.Directory.Should().Exist();
 	}
 
 	[Theory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -237,9 +237,9 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 		result.Name.Should().Be(directoryLevel3);
 		result.Parent!.Name.Should().Be(directoryLevel2);
 		result.Parent.Parent!.Name.Should().Be(directoryLevel1);
-		result.Exists.Should().BeTrue();
-		result.Parent.Exists.Should().BeTrue();
-		result.Parent.Parent.Exists.Should().BeTrue();
+		result.Should().Exist();
+		result.Parent.Should().Exist();
+		result.Parent.Parent.Should().Exist();
 	}
 
 #if NETFRAMEWORK

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
@@ -43,7 +43,7 @@ public abstract partial class DeleteTests<TFileSystem>
 		FileSystem.Directory.Delete(result.FullName);
 
 		FileSystem.Should().NotHaveDirectory(directoryName);
-		result.Exists.Should().BeFalse();
+		result.Should().NotExist();
 	}
 
 	[SkippableTheory]
@@ -195,7 +195,7 @@ public abstract partial class DeleteTests<TFileSystem>
 		FileSystem.Directory.Delete(directoryName);
 
 		FileSystem.Should().NotHaveDirectory(directoryName);
-		result.Exists.Should().BeFalse();
+		result.Should().NotExist();
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ResolveLinkTargetTests.cs
@@ -1,5 +1,6 @@
 #if FEATURE_FILESYSTEM_LINK
 using System.IO;
+using Testably.Abstractions.FluentAssertions;
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 
@@ -32,7 +33,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 			FileSystem.Directory.ResolveLinkTarget(path, false);
 
 		target!.FullName.Should().Be(targetFullPath);
-		target.Exists.Should().BeTrue();
+		target.Should().Exist();
 	}
 
 	[SkippableTheory]
@@ -53,12 +54,12 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 		if (!Test.RunsOnLinux)
 		{
 			target!.FullName.Should().Be(targetFullPath);
-			target.Exists.Should().BeTrue();
+			target.Should().Exist();
 		}
 		else
 		{
 			target!.FullName.Should().Be(targetFullPath);
-			target.Exists.Should().BeFalse();
+			target.Should().NotExist();
 		}
 	}
 
@@ -174,7 +175,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 			FileSystem.Directory.ResolveLinkTarget(path, false);
 
 		target!.FullName.Should().Be(targetFullPath);
-		target.Exists.Should().BeTrue();
+		target.Should().Exist();
 	}
 
 	[SkippableTheory]
@@ -194,7 +195,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 
 		target!.FullName.Should().Be(targetFullPath);
 
-		target.Exists.Should().BeFalse();
+		target.Should().NotExist();
 	}
 }
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.cs
@@ -13,7 +13,7 @@ public abstract partial class Tests<TFileSystem>
 	{
 		IDirectoryInfo result = FileSystem.Directory.CreateTempSubdirectory();
 
-		result.Exists.Should().BeTrue();
+		result.Should().Exist();
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateSubdirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateSubdirectoryTests.cs
@@ -31,12 +31,12 @@ public abstract partial class CreateSubdirectoryTests<TFileSystem>
 		string path, string subdirectory)
 	{
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 		IDirectoryInfo result = sut.CreateSubdirectory(subdirectory);
 
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 		FileSystem.Should().HaveDirectory(sut.FullName);
-		result.Exists.Should().BeTrue();
+		result.Should().Exist();
 		FileSystem.Should().HaveDirectory(result.FullName);
 	}
 
@@ -48,9 +48,9 @@ public abstract partial class CreateSubdirectoryTests<TFileSystem>
 		sut.Create();
 		IDirectoryInfo result = sut.CreateSubdirectory(subdirectory);
 
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 		FileSystem.Should().HaveDirectory(sut.FullName);
-		result.Exists.Should().BeTrue();
+		result.Should().Exist();
 		FileSystem.Should().HaveDirectory(result.FullName);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
@@ -29,15 +29,15 @@ public abstract partial class CreateTests<TFileSystem>
 	public void Create_ShouldCreateDirectory(string path)
 	{
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 
 		sut.Create();
 
 #if NETFRAMEWORK
 		// The DirectoryInfo is not updated in .NET Framework!
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 #else
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 #endif
 		FileSystem.Should().HaveDirectory(sut.FullName);
 	}
@@ -68,9 +68,9 @@ public abstract partial class CreateTests<TFileSystem>
 		result.Name.Should().Be(directoryLevel3);
 		result.Parent!.Name.Should().Be(directoryLevel2);
 		result.Parent.Parent!.Name.Should().Be(directoryLevel1);
-		result.Exists.Should().BeTrue();
-		result.Parent.Exists.Should().BeTrue();
-		result.Parent.Parent.Exists.Should().BeTrue();
+		result.Should().Exist();
+		result.Parent.Should().Exist();
+		result.Parent.Parent.Should().Exist();
 		result.ToString().Should().Be(path);
 	}
 
@@ -81,23 +81,23 @@ public abstract partial class CreateTests<TFileSystem>
 		IDirectoryInfo sut1 = FileSystem.DirectoryInfo.New(path);
 		IDirectoryInfo sut2 = FileSystem.DirectoryInfo.New(path);
 		IDirectoryInfo sut3 = FileSystem.DirectoryInfo.New(path);
-		sut1.Exists.Should().BeFalse();
-		sut2.Exists.Should().BeFalse();
+		sut1.Should().NotExist();
+		sut2.Should().NotExist();
 		// Do not call Exists for `sut3`
 
 		sut1.Create();
 
 		if (Test.IsNetFramework)
 		{
-			sut1.Exists.Should().BeFalse();
-			sut2.Exists.Should().BeFalse();
-			sut3.Exists.Should().BeTrue();
+			sut1.Should().NotExist();
+			sut2.Should().NotExist();
+			sut3.Should().Exist();
 		}
 		else
 		{
-			sut1.Exists.Should().BeTrue();
-			sut2.Exists.Should().BeFalse();
-			sut3.Exists.Should().BeTrue();
+			sut1.Should().Exist();
+			sut2.Should().NotExist();
+			sut3.Should().Exist();
 		}
 
 		FileSystem.Should().HaveDirectory(path);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/DeleteTests.cs
@@ -12,7 +12,7 @@ public abstract partial class DeleteTests<TFileSystem>
 	public void Delete_MissingDirectory_ShouldThrowDirectoryNotFoundException(string path)
 	{
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 
 		Exception? exception = Record.Exception(() =>
 		{
@@ -69,15 +69,15 @@ public abstract partial class DeleteTests<TFileSystem>
 		string subdirectoryPath = FileSystem.Path.Combine(path, subdirectory);
 		FileSystem.Directory.CreateDirectory(subdirectoryPath);
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 
 		sut.Delete(true);
 
 #if NETFRAMEWORK
 		// The DirectoryInfo is not updated in .NET Framework!
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 #else
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 #endif
 		FileSystem.Should().NotHaveDirectory(sut.FullName);
 		FileSystem.Should().NotHaveDirectory(subdirectoryPath);
@@ -89,15 +89,15 @@ public abstract partial class DeleteTests<TFileSystem>
 	{
 		FileSystem.Directory.CreateDirectory(path);
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 
 		sut.Delete();
 
 #if NETFRAMEWORK
 		// The DirectoryInfo is not updated in .NET Framework!
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 #else
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 #endif
 		FileSystem.Should().NotHaveDirectory(sut.FullName);
 	}
@@ -109,7 +109,7 @@ public abstract partial class DeleteTests<TFileSystem>
 	{
 		FileSystem.Directory.CreateDirectory(FileSystem.Path.Combine(path, subdirectory));
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 
 		Exception? exception = Record.Exception(() =>
 		{
@@ -123,7 +123,7 @@ public abstract partial class DeleteTests<TFileSystem>
 				? null
 				: $"'{sut.FullName}'");
 
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 		FileSystem.Should().HaveDirectory(sut.FullName);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExistsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExistsTests.cs
@@ -11,7 +11,7 @@ public abstract partial class ExistsTests<TFileSystem>
 	{
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
 
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 		FileSystem.Should().NotHaveDirectory(sut.FullName);
 	}
 
@@ -21,10 +21,10 @@ public abstract partial class ExistsTests<TFileSystem>
 	{
 		FileSystem.Directory.CreateDirectory(path);
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 		FileSystem.Directory.Delete(path);
 
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 		FileSystem.Should().NotHaveDirectory(sut.FullName);
 	}
 
@@ -35,7 +35,7 @@ public abstract partial class ExistsTests<TFileSystem>
 		FileSystem.File.WriteAllText(path, null);
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
 
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 	}
 
 	[SkippableTheory]
@@ -43,10 +43,10 @@ public abstract partial class ExistsTests<TFileSystem>
 	public void Exists_NotExistedPreviously_ShouldOnlyUpdateOnInitialization(string path)
 	{
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 		FileSystem.Directory.CreateDirectory(path);
 
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 		FileSystem.Should().HaveDirectory(sut.FullName);
 	}
 
@@ -56,11 +56,11 @@ public abstract partial class ExistsTests<TFileSystem>
 	{
 		FileSystem.Directory.CreateDirectory(path);
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 
 		sut.MoveTo(destination);
 
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 	}
 
 	[SkippableTheory]
@@ -68,7 +68,7 @@ public abstract partial class ExistsTests<TFileSystem>
 	public void Exists_ShouldUpdateOnCreateWhenNotNetFramework(string path)
 	{
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 
 		sut.Create();
 
@@ -81,7 +81,7 @@ public abstract partial class ExistsTests<TFileSystem>
 	{
 		FileSystem.Directory.CreateDirectory(path);
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 
 		sut.Delete();
 
@@ -94,7 +94,7 @@ public abstract partial class ExistsTests<TFileSystem>
 	{
 		FileSystem.Directory.CreateDirectory(path);
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 
 		sut.Delete(true);
 
@@ -107,12 +107,12 @@ public abstract partial class ExistsTests<TFileSystem>
 	{
 		FileSystem.Directory.CreateDirectory(path);
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 		FileSystem.Directory.Delete(path);
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 
 		sut.Refresh();
 
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/Tests.cs
@@ -273,9 +273,9 @@ public abstract partial class Tests<TFileSystem>
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
 
 		sut.Parent.Should().NotBeNull();
-		sut.Parent!.Exists.Should().BeFalse();
+		sut.Parent!.Should().NotExist();
 		sut.Parent.Parent.Should().NotBeNull();
-		sut.Parent.Parent!.Exists.Should().BeFalse();
+		sut.Parent.Parent!.Should().NotExist();
 	}
 
 	[SkippableFact]
@@ -357,7 +357,7 @@ public abstract partial class Tests<TFileSystem>
 		string expectedRoot = FileTestHelper.RootDrive();
 		IDirectoryInfo result = FileSystem.DirectoryInfo.New(path);
 
-		result.Root.Exists.Should().BeTrue();
+		result.Root.Should().Exist();
 		result.Root.FullName.Should().Be(expectedRoot);
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/Tests.cs
@@ -29,7 +29,7 @@ public abstract partial class Tests<TFileSystem>
 		IDirectoryInfo result = FileSystem.DirectoryInfo.New(path);
 
 		result.ToString().Should().Be(path);
-		result.Exists.Should().BeFalse();
+		result.Should().NotExist();
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ResolveLinkTargetTests.cs
@@ -32,7 +32,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 			FileSystem.File.ResolveLinkTarget(path, false);
 
 		target!.FullName.Should().Be(targetFullPath);
-		target.Exists.Should().BeTrue();
+		target.Should().Exist();
 	}
 
 	[SkippableTheory]
@@ -52,13 +52,13 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 		if (!Test.RunsOnLinux)
 		{
 			target!.FullName.Should().Be(targetFullPath);
-			target.Exists.Should().BeTrue();
+			target.Should().Exist();
 			FileSystem.File.ReadAllText(target.FullName).Should().Be(contents);
 		}
 		else
 		{
 			target!.FullName.Should().Be(targetFullPath);
-			target.Exists.Should().BeFalse();
+			target.Should().NotExist();
 		}
 	}
 
@@ -214,7 +214,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 			FileSystem.File.ResolveLinkTarget(path, false);
 
 		target!.FullName.Should().Be(targetFullPath);
-		target.Exists.Should().BeTrue();
+		target.Should().Exist();
 	}
 
 	[SkippableTheory]
@@ -232,7 +232,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 
 		target!.FullName.Should().Be(targetFullPath);
 
-		target.Exists.Should().BeFalse();
+		target.Should().NotExist();
 	}
 }
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
@@ -26,7 +26,7 @@ public abstract partial class CopyToTests<TFileSystem>
 
 		exception.Should().BeException<IOException>(
 			hResult: Test.RunsOnWindows ? -2147024816 : 17);
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 		FileSystem.Should().HaveFile(sourceName)
 			.Which.HasContent(sourceContents);
 		FileSystem.Should().HaveFile(destinationName)
@@ -48,9 +48,9 @@ public abstract partial class CopyToTests<TFileSystem>
 
 		IFileInfo result = sut.CopyTo(destinationName, true);
 
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 		sut.FullName.Should().Be(FileSystem.Path.GetFullPath(sourceName));
-		result.Exists.Should().BeTrue();
+		result.Should().Exist();
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
 		FileSystem.Should().HaveFile(sourceName)
 			.Which.HasContent(sourceContents);
@@ -116,8 +116,8 @@ public abstract partial class CopyToTests<TFileSystem>
 		IFileInfo result = sut.CopyTo(destinationName);
 
 		sut.FullName.Should().Be(FileSystem.Path.GetFullPath(sourceName));
-		sut.Exists.Should().BeTrue();
-		result.Exists.Should().BeTrue();
+		sut.Should().Exist();
+		result.Should().Exist();
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
 		FileSystem.Should().HaveFile(sourceName)
 			.Which.HasContent(contents);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTests.cs
@@ -26,23 +26,23 @@ public abstract partial class CreateTests<TFileSystem>
 		IFileInfo sut1 = FileSystem.FileInfo.New(path);
 		IFileInfo sut2 = FileSystem.FileInfo.New(path);
 		IFileInfo sut3 = FileSystem.FileInfo.New(path);
-		sut1.Exists.Should().BeFalse();
-		sut2.Exists.Should().BeFalse();
+		sut1.Should().NotExist();
+		sut2.Should().NotExist();
 		// Do not call Exists for `sut3`
 
 		using FileSystemStream stream = sut1.Create();
 
 		if (Test.IsNetFramework)
 		{
-			sut1.Exists.Should().BeFalse();
-			sut2.Exists.Should().BeFalse();
-			sut3.Exists.Should().BeTrue();
+			sut1.Should().NotExist();
+			sut2.Should().NotExist();
+			sut3.Should().Exist();
 		}
 		else
 		{
-			sut1.Exists.Should().BeTrue();
-			sut2.Exists.Should().BeFalse();
-			sut3.Exists.Should().BeTrue();
+			sut1.Should().Exist();
+			sut2.Should().NotExist();
+			sut3.Should().Exist();
 		}
 
 		FileSystem.Should().HaveFile(path);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
@@ -30,14 +30,14 @@ public abstract partial class CreateTextTests<TFileSystem>
 		string path, string appendText)
 	{
 		IFileInfo fileInfo = FileSystem.FileInfo.New(path);
-		fileInfo.Exists.Should().BeFalse();
+		fileInfo.Should().NotExist();
 
 		using (StreamWriter stream = fileInfo.CreateText())
 		{
 			stream.Write(appendText);
 		}
 
-		fileInfo.Exists.Should().BeTrue();
+		fileInfo.Should().Exist();
 		FileSystem.Should().HaveFile(path);
 	}
 #else
@@ -47,14 +47,14 @@ public abstract partial class CreateTextTests<TFileSystem>
 		string path, string appendText)
 	{
 		IFileInfo fileInfo = FileSystem.FileInfo.New(path);
-		fileInfo.Exists.Should().BeFalse();
+		fileInfo.Should().NotExist();
 
 		using (StreamWriter stream = fileInfo.CreateText())
 		{
 			stream.Write(appendText);
 		}
 
-		fileInfo.Exists.Should().BeFalse();
+		fileInfo.Should().NotExist();
 		FileSystem.Should().HaveFile(path);
 	}
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/DeleteTests.cs
@@ -41,17 +41,17 @@ public abstract partial class DeleteTests<TFileSystem>
 	{
 		FileSystem.File.WriteAllText(path, "some content");
 		IFileInfo sut = FileSystem.FileInfo.New(path);
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 
 		sut.Delete();
 
 		if (Test.IsNetFramework)
 		{
-			sut.Exists.Should().BeTrue();
+			sut.Should().Exist();
 		}
 		else
 		{
-			sut.Exists.Should().BeFalse();
+			sut.Should().NotExist();
 		}
 
 		FileSystem.Should().NotHaveFile(path);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExistsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExistsTests.cs
@@ -12,7 +12,7 @@ public abstract partial class ExistsTests<TFileSystem>
 		FileSystem.Directory.CreateDirectory(path);
 		IFileInfo sut = FileSystem.FileInfo.New(path);
 
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 	}
 
 	[SkippableTheory]
@@ -20,15 +20,15 @@ public abstract partial class ExistsTests<TFileSystem>
 	public void Exists_ShouldReturnCachedValueUntilRefresh(string path)
 	{
 		IFileInfo sut = FileSystem.FileInfo.New(path);
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 
 		FileSystem.File.WriteAllText(path, "some content");
 
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 
 		sut.Refresh();
 
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
@@ -27,7 +27,7 @@ public abstract partial class MoveToTests<TFileSystem>
 		exception.Should().BeException<IOException>(
 			hResult: Test.RunsOnWindows ? -2147024713 : 17);
 
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 		FileSystem.Should().HaveFile(sourceName)
 			.Which.HasContent(sourceContents);
 		FileSystem.Should().HaveFile(destinationName)
@@ -49,7 +49,7 @@ public abstract partial class MoveToTests<TFileSystem>
 
 		sut.MoveTo(destinationName, true);
 
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 		sut.ToString().Should().Be(destinationName);
 		sut.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
 		FileSystem.Should().NotHaveFile(sourceName);
@@ -116,7 +116,7 @@ public abstract partial class MoveToTests<TFileSystem>
 
 		exception.Should().BeException<DirectoryNotFoundException>(hResult: -2147024893);
 
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 		FileSystem.Should().HaveFile(sourceName)
 			.Which.HasContent(sourceContents);
 		FileSystem.Should().NotHaveFile(destinationName);
@@ -201,7 +201,7 @@ public abstract partial class MoveToTests<TFileSystem>
 		sut.MoveTo(destinationName);
 
 		sut.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 		FileSystem.Should().NotHaveFile(sourceName);
 		FileSystem.Should().HaveFile(destinationName)
 			.Which.HasContent(contents);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/OpenTests.cs
@@ -159,7 +159,7 @@ public abstract partial class OpenTests<TFileSystem>
 		});
 
 		exception.Should().BeNull();
-		sut.Exists.Should().BeTrue();
+		sut.Should().Exist();
 		FileSystem.Should().HaveFile(path);
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
@@ -102,7 +102,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 
 		IFileInfo result = sut.Replace(destinationName, backupName, true);
 
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 		FileSystem.Should().NotHaveFile(sourceName);
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
 		FileSystem.Should().HaveFile(destinationName)
@@ -146,7 +146,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 		else
 		{
 			exception.Should().BeNull();
-			sut.Exists.Should().BeFalse();
+			sut.Should().NotExist();
 			FileSystem.Should().NotHaveFile(sourceName);
 			FileSystem.Should().HaveFile(destinationName)
 				.Which.HasContent(sourceContents);
@@ -261,7 +261,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 
 		IFileInfo result = sut.Replace(destinationName, backupName);
 
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 		FileSystem.Should().NotHaveFile(sourceName);
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
 		FileSystem.Should().HaveFile(destinationName)
@@ -334,7 +334,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			exception.Should().BeException<IOException>(hResult: -2147024864);
-			sut.Exists.Should().BeTrue();
+			sut.Should().Exist();
 			FileSystem.Should().HaveFile(sourceName)
 				.Which.HasContent(sourceContents);
 			FileSystem.Should().HaveFile(destinationName)
@@ -345,7 +345,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 		}
 		else
 		{
-			sut.Exists.Should().BeFalse();
+			sut.Should().NotExist();
 			FileSystem.Should().NotHaveFile(sourceName);
 			FileSystem.Should().HaveFile(destinationName)
 				.Which.HasContent(sourceContents);
@@ -394,7 +394,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 
 		IFileInfo result = sut.Replace(destinationName, null);
 
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 		FileSystem.Should().NotHaveFile(sourceName);
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
 		FileSystem.Should().HaveFile(destinationName)
@@ -417,7 +417,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 
 		IFileInfo result = sut.Replace(destinationName, null);
 
-		sut.Exists.Should().BeFalse();
+		sut.Should().NotExist();
 		FileSystem.Should().NotHaveFile(sourceName);
 		result.FullName.Should().Be(FileSystem.Path.GetFullPath(destinationName));
 		FileSystem.Should().HaveFile(destinationName)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
@@ -37,7 +37,7 @@ public abstract partial class Tests<TFileSystem>
 		IFileInfo result = FileSystem.FileInfo.New(path);
 
 		result.ToString().Should().Be(path);
-		result.Exists.Should().BeFalse();
+		result.Should().NotExist();
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ResolveLinkTargetTests.cs
@@ -36,12 +36,12 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 		target!.FullName.Should().Be(targetFullPath);
 		if (!Test.RunsOnLinux)
 		{
-			target.Exists.Should().BeTrue();
+			target.Should().Exist();
 			FileSystem.File.ReadAllText(target.FullName).Should().Be(contents);
 		}
 		else
 		{
-			target.Exists.Should().BeFalse();
+			target.Should().NotExist();
 		}
 	}
 
@@ -153,7 +153,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 		IFileSystemInfo? target = fileInfo.ResolveLinkTarget(false);
 
 		target!.FullName.Should().Be(targetFullPath);
-		target.Exists.Should().BeTrue();
+		target.Should().Exist();
 	}
 
 	[SkippableTheory]
@@ -170,7 +170,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 		IFileSystemInfo? target = fileInfo.ResolveLinkTarget(false);
 
 		target!.FullName.Should().Be(targetFullPath);
-		target.Exists.Should().BeFalse();
+		target.Should().NotExist();
 	}
 }
 #endif


### PR DESCRIPTION
Use the `Exist`/`NotExist` fluent assertions for checking if `IFileInfo` or `IDirectoryInfo` exists in the file system.