### PR TITLE
fix: explicitly specify `FileAttributes` in tests

### DIFF
--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/AttributesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/AttributesTests.cs
@@ -22,9 +22,10 @@ public abstract partial class AttributesTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[AutoData]
+	[InlineAutoData(FileAttributes.ReadOnly)]
+	[InlineAutoData(FileAttributes.Normal)]
 	public void Attributes_WhenFileIsExisting_SetterShouldChangeAttributesOnFileSystem(
-		string path, FileAttributes attributes)
+		FileAttributes attributes, string path)
 	{
 		FileSystem.Directory.CreateDirectory(path);
 		IDirectoryInfo sut1 = FileSystem.DirectoryInfo.New(path);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/GetAttributesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/GetAttributesTests.cs
@@ -8,9 +8,10 @@ public abstract partial class GetAttributesTests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
 	[SkippableTheory]
-	[AutoData]
+	[InlineAutoData(FileAttributes.ReadOnly)]
+	[InlineAutoData(FileAttributes.Normal)]
 	public void GetAttributes_ShouldReturnAttributes(
-		string path, FileAttributes attributes)
+		FileAttributes attributes, string path)
 	{
 		FileSystem.File.WriteAllText(path, null);
 		FileSystem.File.SetAttributes(path, attributes);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/SetAttributesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/SetAttributesTests.cs
@@ -8,8 +8,9 @@ public abstract partial class SetAttributesTests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
 	[SkippableTheory]
-	[AutoData]
-	public void SetAttributes_ShouldNotAdjustTimes(string path, FileAttributes attributes)
+	[InlineAutoData(FileAttributes.ReadOnly)]
+	[InlineAutoData(FileAttributes.Normal)]
+	public void SetAttributes_ShouldNotAdjustTimes(FileAttributes attributes, string path)
 	{
 		Test.SkipIfLongRunningTestsShouldBeSkipped(FileSystem);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
@@ -77,12 +77,13 @@ public abstract partial class CopyToTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[AutoData]
+	[InlineAutoData(FileAttributes.ReadOnly)]
+	[InlineAutoData(FileAttributes.System)]
 	public void CopyTo_ShouldAddArchiveAttribute_OnWindows(
+		FileAttributes fileAttributes,
 		string sourceName,
 		string destinationName,
-		string contents,
-		FileAttributes fileAttributes)
+		string contents)
 	{
 		FileSystem.File.WriteAllText(sourceName, contents);
 		FileSystem.File.SetAttributes(sourceName, fileAttributes);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
@@ -140,12 +140,13 @@ public abstract partial class MoveToTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[AutoData]
+	[InlineAutoData(FileAttributes.ReadOnly)]
+	[InlineAutoData(FileAttributes.System)]
 	public void MoveTo_ShouldAddArchiveAttribute_OnWindows(
+		FileAttributes fileAttributes,
 		string sourceName,
 		string destinationName,
-		string contents,
-		FileAttributes fileAttributes)
+		string contents)
 	{
 		FileSystem.File.WriteAllText(sourceName, contents);
 		FileSystem.File.SetAttributes(sourceName, fileAttributes);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
@@ -156,8 +156,8 @@ public abstract partial class ReplaceTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[InlineAutoData(FileAttributes.ReadOnly, FileAttributes.System)]
-	[InlineAutoData(FileAttributes.System, FileAttributes.ReadOnly)]
+	[InlineAutoData(FileAttributes.Hidden, FileAttributes.System)]
+	[InlineAutoData(FileAttributes.System, FileAttributes.Hidden)]
 	public void Replace_ShouldAddArchiveAttribute_OnWindows(
 		FileAttributes sourceFileAttributes,
 		FileAttributes destinationFileAttributes,

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
@@ -197,30 +197,6 @@ public abstract partial class ReplaceTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void Replace_WhenFileIsReadOnly_ShouldThrowUnauthorizedAccessException(
-		string sourceName,
-		string destinationName,
-		string backupName,
-		string sourceContents,
-		string destinationContents)
-	{
-		FileSystem.File.WriteAllText(sourceName, sourceContents);
-
-		FileSystem.File.WriteAllText(destinationName, destinationContents);
-		FileSystem.File.SetAttributes(destinationName, FileAttributes.ReadOnly);
-
-		IFileInfo sut = FileSystem.FileInfo.New(sourceName);
-
-		Exception? exception = Record.Exception(() =>
-		{
-			sut.Replace(destinationName, backupName, true);
-		});
-
-		exception.Should().BeException<UnauthorizedAccessException>(hResult: -2147024891);
-	}
-
-	[SkippableTheory]
-	[AutoData]
 	public void Replace_ShouldKeepMetadata(
 		string sourceName,
 		string destinationName,

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
@@ -156,15 +156,16 @@ public abstract partial class ReplaceTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[AutoData]
+	[InlineAutoData(FileAttributes.ReadOnly, FileAttributes.System)]
+	[InlineAutoData(FileAttributes.System, FileAttributes.ReadOnly)]
 	public void Replace_ShouldAddArchiveAttribute_OnWindows(
+		FileAttributes sourceFileAttributes,
+		FileAttributes destinationFileAttributes,
 		string sourceName,
 		string destinationName,
 		string backupName,
 		string sourceContents,
-		string destinationContents,
-		FileAttributes sourceFileAttributes,
-		FileAttributes destinationFileAttributes)
+		string destinationContents)
 	{
 		FileSystem.File.WriteAllText(sourceName, sourceContents);
 		FileSystem.File.SetAttributes(sourceName, sourceFileAttributes);


### PR DESCRIPTION
In .NET 8 a new flag was added to [`FileAttributes`](https://learn.microsoft.com/en-us/dotnet/api/system.io.fileattributes?view=net-8.0): `FileAttributes.None`.
When this attribute is used in the `GetAttributes_ShouldReturnAttributes` test, the test fails.

Now the tested attributes are explicitly specified, so that the tests with FileAttributes as parameter always succeed.

*See [this test run](https://github.com/Testably/Testably.Abstractions/actions/runs/6380040873/job/17313688446?pr=389) in #389.*