### PR TITLE
fix: throw UnauthorizedAccessException when replacing a read-only file on Windows

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
@@ -252,7 +252,8 @@ internal sealed class FileInfoMock
 								}
 
 								throw ExceptionFactory.DirectoryNotFound(FullName);
-							}))
+							}),
+					!Execute.IsWindows)
 			?? throw ExceptionFactory.FileNotFound(FullName);
 		return _fileSystem.FileInfo.New(location.FullPath);
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
@@ -169,6 +169,12 @@ public abstract partial class ReplaceTests<TFileSystem>
 	{
 		FileSystem.File.WriteAllText(sourceName, sourceContents);
 		FileSystem.File.SetAttributes(sourceName, sourceFileAttributes);
+		FileAttributes expectedSourceAttributes =
+			FileSystem.File.GetAttributes(sourceName);
+		if (Test.RunsOnWindows)
+		{
+			expectedSourceAttributes |= FileAttributes.Archive;
+		}
 
 		FileSystem.File.WriteAllText(destinationName, destinationContents);
 		FileSystem.File.SetAttributes(destinationName, destinationFileAttributes);
@@ -183,8 +189,16 @@ public abstract partial class ReplaceTests<TFileSystem>
 
 		sut.Replace(destinationName, backupName);
 
-		FileSystem.File.GetAttributes(destinationName)
-			.Should().Be(expectedDestinationAttributes);
+		if (Test.RunsOnMac)
+		{
+			FileSystem.File.GetAttributes(destinationName)
+				.Should().Be(expectedSourceAttributes);
+		}
+		else
+		{
+			FileSystem.File.GetAttributes(destinationName)
+				.Should().Be(expectedDestinationAttributes);
+		}
 		FileSystem.File.GetAttributes(backupName)
 			.Should().Be(expectedDestinationAttributes);
 	}


### PR DESCRIPTION
When replacing a read-only file on Windows, it should throw an UnauthorizedAccessException.