### PR TITLE
fix: support relative path with drive information in `Path.GetFullPath`

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -41,7 +41,7 @@ internal sealed class PathMock : PathSystemBase
 		string? directoryRoot = Path.GetPathRoot(_fileSystem.Storage.CurrentDirectory);
 		if (!string.IsNullOrEmpty(pathRoot) && !string.IsNullOrEmpty(directoryRoot))
 		{
-			if (pathRoot[0] != directoryRoot[0])
+			if (char.ToUpperInvariant(pathRoot[0]) != char.ToUpperInvariant(directoryRoot[0]))
 			{
 				return Path.GetFullPath(path);
 			}

--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -37,6 +37,21 @@ internal sealed class PathMock : PathSystemBase
 	{
 		path.EnsureValidArgument(FileSystem, nameof(path));
 
+		string? pathRoot = Path.GetPathRoot(path);
+		string? directoryRoot = Path.GetPathRoot(_fileSystem.Storage.CurrentDirectory);
+		if (pathRoot != null && directoryRoot != null)
+		{
+			if (pathRoot[0] != directoryRoot[0])
+			{
+				return Path.GetFullPath(path);
+			}
+
+			if (pathRoot.Length < directoryRoot.Length)
+			{
+				path = path.Substring(pathRoot.Length);
+			}
+		}
+
 		return Path.GetFullPath(Path.Combine(
 			_fileSystem.Storage.CurrentDirectory,
 			path));

--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -39,7 +39,7 @@ internal sealed class PathMock : PathSystemBase
 
 		string? pathRoot = Path.GetPathRoot(path);
 		string? directoryRoot = Path.GetPathRoot(_fileSystem.Storage.CurrentDirectory);
-		if (pathRoot != null && directoryRoot != null)
+		if (!string.IsNullOrEmpty(pathRoot) && !string.IsNullOrEmpty(directoryRoot))
 		{
 			if (pathRoot[0] != directoryRoot[0])
 			{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetFullPathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetFullPathTests.cs
@@ -37,7 +37,9 @@ public abstract partial class GetFullPathTests<TFileSystem>
 		Skip.IfNot(Test.RunsOnWindows);
 
 		string currentDirectory = FileSystem.Directory.GetCurrentDirectory();
-		string otherDrive = currentDirectory.Substring(0, 1) == "C" ? "D" : "C";
+		string otherDrive = currentDirectory
+			.Substring(0,1)
+			.Equals("c", StringComparison.OrdinalIgnoreCase) ? "D" : "C";
 		string input = $"{otherDrive}:test.txt";
 		string expectedFullPath = $@"{otherDrive}:\test.txt";
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetFullPathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetFullPathTests.cs
@@ -35,6 +35,16 @@ public abstract partial class GetFullPathTests<TFileSystem>
 	}
 
 	[SkippableFact]
+	public void GetFullPath_Dot_ShouldReturnToCurrentDirectory()
+	{
+		string expectedFullPath = FileSystem.Directory.GetCurrentDirectory();
+
+		string result = FileSystem.Path.GetFullPath(".");
+
+		result.Should().Be(expectedFullPath);
+	}
+
+	[SkippableFact]
 	public void
 		GetFullPath_RelativePathWithDrive_WhenCurrentDirectoryIsDifferent_ShouldReturnExpectedValue()
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetFullPathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetFullPathTests.cs
@@ -39,7 +39,7 @@ public abstract partial class GetFullPathTests<TFileSystem>
 		string currentDirectory = FileSystem.Directory.GetCurrentDirectory();
 		string otherDrive = currentDirectory
 			.Substring(0,1)
-			.Equals("c", StringComparison.OrdinalIgnoreCase) ? "D" : "C";
+			.Equals("x", StringComparison.OrdinalIgnoreCase) ? "Y" : "X";
 		string input = $"{otherDrive}:test.txt";
 		string expectedFullPath = $@"{otherDrive}:\test.txt";
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetFullPathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetFullPathTests.cs
@@ -5,18 +5,14 @@ public abstract partial class GetFullPathTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
-	[SkippableTheory]
-	[InlineData(@"top/../most/file", @"most/file")]
-	[InlineData(@"top/../most/../dir/file", @"dir/file")]
-	[InlineData(@"top/../../most/file", @"most/file")]
-	public void GetFullPath_ShouldNormalizeProvidedPath(string input, string expected)
+	[SkippableFact]
+	public void GetFullPath_Dot_ShouldReturnToCurrentDirectory()
 	{
-		string expectedRootedPath = FileTestHelper.RootDrive(
-			expected.Replace('/', FileSystem.Path.DirectorySeparatorChar));
+		string expectedFullPath = FileSystem.Directory.GetCurrentDirectory();
 
-		string result = FileSystem.Path.GetFullPath(FileTestHelper.RootDrive(input));
+		string result = FileSystem.Path.GetFullPath(".");
 
-		result.Should().Be(expectedRootedPath);
+		result.Should().Be(expectedFullPath);
 	}
 
 	[SkippableFact]
@@ -35,16 +31,6 @@ public abstract partial class GetFullPathTests<TFileSystem>
 	}
 
 	[SkippableFact]
-	public void GetFullPath_Dot_ShouldReturnToCurrentDirectory()
-	{
-		string expectedFullPath = FileSystem.Directory.GetCurrentDirectory();
-
-		string result = FileSystem.Path.GetFullPath(".");
-
-		result.Should().Be(expectedFullPath);
-	}
-
-	[SkippableFact]
 	public void
 		GetFullPath_RelativePathWithDrive_WhenCurrentDirectoryIsDifferent_ShouldReturnExpectedValue()
 	{
@@ -58,6 +44,20 @@ public abstract partial class GetFullPathTests<TFileSystem>
 		string result = FileSystem.Path.GetFullPath(input);
 
 		result.Should().Be(expectedFullPath);
+	}
+
+	[SkippableTheory]
+	[InlineData(@"top/../most/file", @"most/file")]
+	[InlineData(@"top/../most/../dir/file", @"dir/file")]
+	[InlineData(@"top/../../most/file", @"most/file")]
+	public void GetFullPath_ShouldNormalizeProvidedPath(string input, string expected)
+	{
+		string expectedRootedPath = FileTestHelper.RootDrive(
+			expected.Replace('/', FileSystem.Path.DirectorySeparatorChar));
+
+		string result = FileSystem.Path.GetFullPath(FileTestHelper.RootDrive(input));
+
+		result.Should().Be(expectedRootedPath);
 	}
 
 #if FEATURE_PATH_RELATIVE

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetFullPathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetFullPathTests.cs
@@ -19,6 +19,37 @@ public abstract partial class GetFullPathTests<TFileSystem>
 		result.Should().Be(expectedRootedPath);
 	}
 
+	[SkippableFact]
+	public void GetFullPath_RelativePathWithDrive_ShouldReturnExpectedValue()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		string currentDirectory = FileSystem.Directory.GetCurrentDirectory();
+		string drive = currentDirectory.Substring(0, 1);
+		string input = $"{drive}:test.txt";
+		string expectedFullPath = FileSystem.Path.Combine(currentDirectory, "test.txt");
+
+		string result = FileSystem.Path.GetFullPath(input);
+
+		result.Should().Be(expectedFullPath);
+	}
+
+	[SkippableFact]
+	public void
+		GetFullPath_RelativePathWithDrive_WhenCurrentDirectoryIsDifferent_ShouldReturnExpectedValue()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		string currentDirectory = FileSystem.Directory.GetCurrentDirectory();
+		string otherDrive = currentDirectory.Substring(0, 1) == "C" ? "D" : "C";
+		string input = $"{otherDrive}:test.txt";
+		string expectedFullPath = $@"{otherDrive}:\test.txt";
+
+		string result = FileSystem.Path.GetFullPath(input);
+
+		result.Should().Be(expectedFullPath);
+	}
+
 #if FEATURE_PATH_RELATIVE
 	[SkippableTheory]
 	[InlineData(@"top/../most/file", "foo/bar", @"foo/bar/most/file")]


### PR DESCRIPTION
Support relative paths with drive information in `Path.GetFullPath` as described in https://github.com/TestableIO/System.IO.Abstractions/issues/1044.