### PR TITLE
fix: `Directory.EnumerateDirectories` with trailing slash in `path`

### DIFF
--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -173,6 +173,7 @@ internal sealed class InMemoryStorage : IStorage
 		enumerationOptions ??= EnumerationOptionsHelper.Compatible;
 
 		string fullPath = location.FullPath;
+		string fullPathWithoutTrailingSlash = fullPath;
 #if NETSTANDARD2_0
 		if (!fullPath.EndsWith($"{_fileSystem.Path.DirectorySeparatorChar}"))
 #else
@@ -180,6 +181,10 @@ internal sealed class InMemoryStorage : IStorage
 #endif
 		{
 			fullPath += _fileSystem.Path.DirectorySeparatorChar;
+		}
+		else if (_fileSystem.Path.GetPathRoot(fullPath) != fullPath)
+		{
+			fullPathWithoutTrailingSlash = fullPathWithoutTrailingSlash.TrimEnd(_fileSystem.Path.DirectorySeparatorChar);
 		}
 
 		foreach (KeyValuePair<IStorageLocation, IStorageContainer> item in _containers
@@ -192,7 +197,7 @@ internal sealed class InMemoryStorage : IStorage
 					item.Key.FullPath.TrimEnd(_fileSystem.Path
 						.DirectorySeparatorChar));
 			if (!enumerationOptions.RecurseSubdirectories &&
-			    parentPath?.Equals(location.FullPath,
+			    parentPath?.Equals(fullPathWithoutTrailingSlash,
 				    InMemoryLocation.StringComparisonMode) != true)
 			{
 				continue;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
@@ -9,21 +9,6 @@ public abstract partial class EnumerateDirectoriesTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
-	[SkippableTheory]
-	[InlineData("Folder", @"Folder\SubFolder")]
-	[InlineData(@"Folder\", @"Folder\SubFolder")]
-	[InlineData(@"Folder\..\.\Folder", @"Folder\..\.\Folder\SubFolder")]
-	public void MockDirectory_EnumerateDirectories_ShouldReturnPathsPrefixedWithQueryPath(
-		string queryPath, string expectedPath)
-	{
-		var fileSystem = new MockFileSystem();
-		fileSystem.Directory.CreateDirectory("Folder/SubFolder");
-
-		var actualResult = fileSystem.Directory.EnumerateDirectories(queryPath);
-
-		actualResult.Should().BeEquivalentTo(new[] { expectedPath });
-	}
-
 	[SkippableFact]
 	public void EnumerateDirectories_AbsolutePath_ShouldNotIncludeTrailingSlash()
 	{
@@ -260,5 +245,17 @@ public abstract partial class EnumerateDirectoriesTests<TFileSystem>
 			.EnumerateDirectories(path, "xyz", SearchOption.AllDirectories);
 
 		result.Count().Should().Be(2);
+	}
+
+	[SkippableFact]
+	public void EnumerateDirectories_WithTrailingSlash_ShouldEnumerateSubdirectories()
+	{
+		string queryPath = @"Folder\";
+		string expectedPath = @"Folder\SubFolder";
+		FileSystem.Directory.CreateDirectory("Folder/SubFolder");
+
+		IEnumerable<string> actualResult = FileSystem.Directory.EnumerateDirectories(queryPath);
+
+		actualResult.Should().BeEquivalentTo(expectedPath);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
@@ -250,9 +250,9 @@ public abstract partial class EnumerateDirectoriesTests<TFileSystem>
 	[SkippableFact]
 	public void EnumerateDirectories_WithTrailingSlash_ShouldEnumerateSubdirectories()
 	{
-		string queryPath = @"Folder\";
-		string expectedPath = @"Folder\SubFolder";
-		FileSystem.Directory.CreateDirectory("Folder/SubFolder");
+		string queryPath = @"foo" + FileSystem.Path.DirectorySeparatorChar;
+		string expectedPath = FileSystem.Path.Combine("foo", "bar");
+		FileSystem.Directory.CreateDirectory(expectedPath);
 
 		IEnumerable<string> actualResult = FileSystem.Directory.EnumerateDirectories(queryPath);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
@@ -9,6 +9,21 @@ public abstract partial class EnumerateDirectoriesTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
+	[SkippableTheory]
+	[InlineData("Folder", @"Folder\SubFolder")]
+	[InlineData(@"Folder\", @"Folder\SubFolder")]
+	[InlineData(@"Folder\..\.\Folder", @"Folder\..\.\Folder\SubFolder")]
+	public void MockDirectory_EnumerateDirectories_ShouldReturnPathsPrefixedWithQueryPath(
+		string queryPath, string expectedPath)
+	{
+		var fileSystem = new MockFileSystem();
+		fileSystem.Directory.CreateDirectory("Folder/SubFolder");
+
+		var actualResult = fileSystem.Directory.EnumerateDirectories(queryPath);
+
+		actualResult.Should().BeEquivalentTo(new[] { expectedPath });
+	}
+
 	[SkippableFact]
 	public void EnumerateDirectories_AbsolutePath_ShouldNotIncludeTrailingSlash()
 	{


### PR DESCRIPTION
Reproduce the finding from https://github.com/TestableIO/System.IO.Abstractions/pull/1046