### PR TITLE
fix: Delete directory recursive should delete files in subfolders

### DIFF
--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -124,7 +124,7 @@ internal sealed class InMemoryStorage : IStorage
 			{
 				foreach (IStorageLocation key in children)
 				{
-					DeleteContainer(key);
+					DeleteContainer(key, recursive);
 				}
 			}
 			else if (children.Any())

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
@@ -135,6 +135,21 @@ public abstract partial class DeleteTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public void Delete_Recursive_WithSubdirectory_ShouldDeleteDirectoryWithContent(
+		string path, string subdirectory)
+	{
+		string subdirectoryPath = FileSystem.Path.Combine(path, subdirectory);
+		FileSystem.Directory.CreateDirectory(subdirectoryPath);
+		FileSystem.Should().HaveDirectory(path);
+
+		FileSystem.Directory.Delete(path, true);
+
+		FileSystem.Should().NotHaveDirectory(path);
+		FileSystem.Should().NotHaveDirectory(subdirectoryPath);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void Delete_Recursive_WithFileInSubdirectory_ShouldDeleteDirectoryWithContent(
 		string path, string subdirectory, string fileName, string fileContent)
 	{
 		FileSystem.Directory.CreateDirectory(path);
@@ -145,7 +160,7 @@ public abstract partial class DeleteTests<TFileSystem>
 		FileSystem.Directory.CreateDirectory(subdirectoryPath);
 		string subdirectoryFilePath = FileSystem.Path.Combine(path, subdirectory, fileName);
 		FileSystem.File.WriteAllText(subdirectoryFilePath, fileContent);
-		
+
 		FileSystem.Should().HaveDirectory(path);
 
 		FileSystem.Directory.Delete(path, true);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
@@ -166,7 +166,9 @@ public abstract partial class DeleteTests<TFileSystem>
 		FileSystem.Directory.Delete(path, true);
 
 		FileSystem.Should().NotHaveDirectory(path);
+		FileSystem.Should().NotHaveFile(filePath);
 		FileSystem.Should().NotHaveDirectory(subdirectoryPath);
+		FileSystem.Should().NotHaveFile(subdirectoryFilePath);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
@@ -135,10 +135,17 @@ public abstract partial class DeleteTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public void Delete_Recursive_WithSubdirectory_ShouldDeleteDirectoryWithContent(
-		string path, string subdirectory)
+		string path, string subdirectory, string fileName, string fileContent)
 	{
+		FileSystem.Directory.CreateDirectory(path);
+		string filePath = FileSystem.Path.Combine(path, fileName);
+		FileSystem.File.WriteAllText(filePath, fileContent);
+
 		string subdirectoryPath = FileSystem.Path.Combine(path, subdirectory);
 		FileSystem.Directory.CreateDirectory(subdirectoryPath);
+		string subdirectoryFilePath = FileSystem.Path.Combine(path, subdirectory, fileName);
+		FileSystem.File.WriteAllText(subdirectoryFilePath, fileContent);
+		
 		FileSystem.Should().HaveDirectory(path);
 
 		FileSystem.Directory.Delete(path, true);


### PR DESCRIPTION
Calling `MockFileSystem.Directory.Delete` with `recursive: true` throws a `DirectoryNotEmptyException` when trying to delete a directory with files in it.

As the documentation of [`Directory.Delete(String, Boolean)`](https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.delete?view=net-8.0#system-io-directory-delete(system-string-system-boolean)) indicates, the method should actually try to delete all files and subfolders instead.