### PR TITLE
fix: handling of whitespace-only filenames

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoFactoryMock.cs
@@ -33,7 +33,7 @@ internal sealed class FileInfoFactoryMock : IFileInfoFactory
 			throw new ArgumentNullException(nameof(fileName));
 		}
 
-		if (fileName.Trim() == "" && Execute.IsWindows)
+		if (fileName.IsEffectivelyEmpty())
 		{
 			throw ExceptionFactory.PathIsEmpty("path");
 		}

--- a/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
@@ -40,7 +40,9 @@ internal static class PathHelper
 	internal static bool IsEffectivelyEmpty(this string path)
 	{
 		if (string.IsNullOrEmpty(path))
+		{
 			return true;
+		}
 
 		return Execute.OnWindows(
 			() =>

--- a/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
@@ -32,6 +32,32 @@ internal static class PathHelper
 			() => false);
 	}
 
+	/// <summary>
+	///     Returns true if the path is effectively empty for the current OS.
+	///     For unix, this is empty or null. For Windows, this is empty, null, or
+	///     just spaces ((char)32).
+	/// </summary>
+	internal static bool IsEffectivelyEmpty(this string path)
+	{
+		if (string.IsNullOrEmpty(path))
+			return true;
+
+		return Execute.OnWindows(
+			() =>
+			{
+				foreach (char c in path)
+				{
+					if (c != ' ')
+					{
+						return false;
+					}
+				}
+
+				return true;
+			},
+			() => false);
+	}
+
 	internal static bool IsUncPath([NotNullWhen(true)] this string? path)
 	{
 		if (path == null)

--- a/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
@@ -45,18 +45,20 @@ internal static class PathHelper
 		}
 
 		return Execute.OnWindows(
-			() =>
-			{
-				foreach (char c in path)
+			() => Execute.OnNetFramework(
+				() => string.IsNullOrWhiteSpace(path),
+				() =>
 				{
-					if (c != ' ')
+					foreach (char c in path)
 					{
-						return false;
+						if (c != ' ')
+						{
+							return false;
+						}
 					}
-				}
 
-				return true;
-			},
+					return true;
+				}),
 			() => false);
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
@@ -91,8 +91,7 @@ public abstract partial class Tests<TFileSystem>
 
 		if (Test.RunsOnWindows)
 		{
-			exception.Should().BeOfType<ArgumentException>()
-				.Which.ParamName.Should().Be("path");
+			exception.Should().BeOfType<ArgumentException>();
 		}
 		else
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
@@ -78,7 +78,14 @@ public abstract partial class Tests<TFileSystem>
 			FileSystem.FileInfo.New("\u00A0"); // Unicode char that's treated as whitespace
 		});
 
-		exception.Should().BeNull();
+		if (Test.IsNetFramework)
+		{
+			exception.Should().BeOfType<ArgumentException>();
+		}
+		else
+		{
+			exception.Should().BeNull();
+		}
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
@@ -71,6 +71,36 @@ public abstract partial class Tests<TFileSystem>
 	}
 
 	[SkippableFact]
+	public void New_WithUnicodeWhitespace_ShouldNotThrow()
+	{
+		var exception = Record.Exception(() =>
+		{
+			FileSystem.FileInfo.New("\u00A0"); // Unicode char that's treated as whitespace
+		});
+
+		exception.Should().BeNull();
+	}
+
+	[SkippableFact]
+	public void New_WithWhitespace_ShouldThrowOnlyOnWindows()
+	{
+		var exception = Record.Exception(() =>
+		{
+			FileSystem.FileInfo.New("   ");
+		});
+
+		if (Test.RunsOnWindows)
+		{
+			exception.Should().BeOfType<ArgumentException>()
+				.Which.ParamName.Should().Be("path");
+		}
+		else
+		{
+			exception.Should().BeNull();
+		}
+	}
+
+	[SkippableFact]
 	public void Wrap_Null_ShouldReturnNull()
 	{
 		IFileInfo? result = FileSystem.FileInfo.Wrap(null);


### PR DESCRIPTION
As reported in https://github.com/TestableIO/System.IO.Abstractions/issues/1070, whitespace-only files are treated differently depending on the underlying operating system:
- Windows only supports unicode-whitespace, but throws on filenames with only blanks
- Linux supports both files with only blanks or with unicode-whitespace