### PR TITLE
fix: use correct empty name for `IFileInfo` with trailing directory separator char

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
@@ -70,7 +70,7 @@ internal sealed class FileInfoMock
 		}
 	}
 
-	/// <inheritdoc cref="IFileInfo.Name" />
+	/// <inheritdoc cref="IFileSystemInfo.Name" />
 	public override string Name
 	{
 		get

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
@@ -70,6 +70,20 @@ internal sealed class FileInfoMock
 		}
 	}
 
+	/// <inheritdoc cref="IFileInfo.Name" />
+	public override string Name
+	{
+		get
+		{
+			if (Location.FullPath.EndsWith(FileSystem.Path.DirectorySeparatorChar))
+			{
+				return string.Empty;
+			}
+
+			return base.Name;
+		}
+	}
+
 	/// <inheritdoc cref="IFileInfo.AppendText()" />
 	public StreamWriter AppendText()
 		=> new(Open(FileMode.Append, FileAccess.Write));

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
@@ -166,7 +166,7 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 #endif
 
 	/// <inheritdoc cref="IFileSystemInfo.Name" />
-	public string Name
+	public virtual string Name
 		=> _fileSystem.Path.GetPathRoot(Location.FullPath) == Location.FullPath
 			? Location.FullPath
 			: _fileSystem.Path.GetFileName(Location.FullPath.TrimEnd(

--- a/Source/Testably.Abstractions.Testing/Polyfills/StringExtensionMethods.cs
+++ b/Source/Testably.Abstractions.Testing/Polyfills/StringExtensionMethods.cs
@@ -1,0 +1,22 @@
+﻿#if NETSTANDARD2_0
+using System.Diagnostics.CodeAnalysis;
+
+namespace Testably.Abstractions.Polyfills;
+
+/// <summary>
+///     Provides extension methods to simplify writing platform independent tests.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class StringExtensionMethods
+{
+	/// <summary>
+	///     Determines whether the end of this string instance matches the specified character.
+	/// </summary>
+	internal static bool EndsWith(
+		this string @this,
+		char value)
+	{
+		return @this.EndsWith($"{value}");
+	}
+}
+#endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/Tests.cs
@@ -42,6 +42,15 @@ public abstract partial class Tests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void New_WithTrailingDirectorySeparatorChar_ShouldHaveEmptyName(string path)
+	{
+		var fi = FileSystem.DirectoryInfo.New($"{path}{FileSystem.Path.DirectorySeparatorChar}");
+
+		fi.Name.Should().Be(path);
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void Wrap_ShouldWrapFromDirectoryInfo(string path)
 	{
 		System.IO.DirectoryInfo directoryInfo = new("S:\\" + path);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/Tests.cs
@@ -32,21 +32,21 @@ public abstract partial class Tests<TFileSystem>
 		result.Should().NotExist();
 	}
 
+	[SkippableTheory]
+	[AutoData]
+	public void New_WithTrailingDirectorySeparatorChar_ShouldHaveEmptyName(string path)
+	{
+		IDirectoryInfo result = FileSystem.DirectoryInfo.New($"{path}{FileSystem.Path.DirectorySeparatorChar}");
+
+		result.Name.Should().Be(path);
+	}
+
 	[SkippableFact]
 	public void Wrap_Null_ShouldReturnNull()
 	{
 		IDirectoryInfo? result = FileSystem.DirectoryInfo.Wrap(null);
 
 		result.Should().BeNull();
-	}
-
-	[SkippableTheory]
-	[AutoData]
-	public void New_WithTrailingDirectorySeparatorChar_ShouldHaveEmptyName(string path)
-	{
-		var fi = FileSystem.DirectoryInfo.New($"{path}{FileSystem.Path.DirectorySeparatorChar}");
-
-		fi.Name.Should().Be(path);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/Tests.cs
@@ -34,7 +34,7 @@ public abstract partial class Tests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void New_WithTrailingDirectorySeparatorChar_ShouldHaveEmptyName(string path)
+	public void New_WithTrailingDirectorySeparatorChar_ShouldHavePathAsName(string path)
 	{
 		IDirectoryInfo result = FileSystem.DirectoryInfo.New($"{path}{FileSystem.Path.DirectorySeparatorChar}");
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
@@ -74,9 +74,9 @@ public abstract partial class Tests<TFileSystem>
 	[AutoData]
 	public void New_WithTrailingDirectorySeparatorChar_ShouldHaveEmptyName(string path)
 	{
-		var fi = FileSystem.FileInfo.New($"{path}{FileSystem.Path.DirectorySeparatorChar}");
+		IFileInfo result = FileSystem.FileInfo.New($"{path}{FileSystem.Path.DirectorySeparatorChar}");
 
-		fi.Name.Should().Be(string.Empty);
+		result.Name.Should().Be(string.Empty);
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
@@ -70,6 +70,15 @@ public abstract partial class Tests<TFileSystem>
 		result.Should().Be(bytes.Length);
 	}
 
+	[SkippableTheory]
+	[AutoData]
+	public void New_WithTrailingDirectorySeparatorChar_ShouldHaveEmptyName(string path)
+	{
+		var fi = FileSystem.FileInfo.New($"{path}{FileSystem.Path.DirectorySeparatorChar}");
+
+		fi.Name.Should().Be(string.Empty);
+	}
+
 	[SkippableFact]
 	public void New_WithUnicodeWhitespace_ShouldNotThrow()
 	{


### PR DESCRIPTION
The `FileInfo.Name` property should be empty when created from a path with a trailing `Path.DirectorySeparatorChar`.