### PR TITLE
refactor: fix sonar issues due to updated analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,17 +14,6 @@ tab_width = 4
 # New line preferences
 end_of_line = crlf
 insert_final_newline = true
-dotnet_style_operator_placement_when_wrapping = beginning_of_line
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_auto_properties = true:silent
-dotnet_style_predefined_type_for_locals_parameters_members = true:silent
-dotnet_diagnostic.CA1510.severity = none
-dotnet_diagnostic.CA1513.severity = none
-dotnet_diagnostic.CA1512.severity = none
-dotnet_diagnostic.CA1860.severity = none
-dotnet_diagnostic.CA1861.severity = none
 
 # C# files
 [*.cs]
@@ -95,36 +84,36 @@ csharp_style_var_for_built_in_types = false
 csharp_style_var_when_type_is_apparent = false
 
 # Expression-bodied members
-csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_accessors = true
 csharp_style_expression_bodied_constructors = false:none
-csharp_style_expression_bodied_indexers = true:silent
-csharp_style_expression_bodied_lambdas = true:silent
-csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_indexers = true
+csharp_style_expression_bodied_lambdas = true
+csharp_style_expression_bodied_local_functions = false
 csharp_style_expression_bodied_methods = true:suggestion
-csharp_style_expression_bodied_operators = false:silent
-csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_operators = false
+csharp_style_expression_bodied_properties = true
 
 # Pattern matching preferences
 csharp_style_pattern_matching_over_as_with_null_check = true
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true
 csharp_style_prefer_extended_property_pattern = true
 csharp_style_prefer_not_pattern = true
 csharp_style_prefer_pattern_matching = true
 csharp_style_prefer_switch_expression = true
 
 # Null-checking preferences
-csharp_style_conditional_delegate_call = true:suggestion
+csharp_style_conditional_delegate_call = true
 
 # Modifier preferences
-csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_static_local_function = true
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
 
 # Code-block preferences
-csharp_prefer_braces = true:silent
-csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true
+csharp_prefer_simple_using_statement = true
 csharp_style_namespace_declarations = file_scoped:suggestion
-csharp_style_prefer_method_group_conversion = true:silent
-csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_method_group_conversion = true
+csharp_style_prefer_top_level_statements = true
 
 # Expression-level preferences
 csharp_prefer_simple_default_expression = true
@@ -132,7 +121,7 @@ csharp_style_deconstructed_variable_declaration = true
 csharp_style_implicit_object_creation_when_type_is_apparent = true
 csharp_style_inlined_variable_declaration = true
 csharp_style_prefer_index_operator = true
-csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true
 csharp_style_prefer_null_check_over_type_check = true
 csharp_style_prefer_range_operator = true
 csharp_style_prefer_tuple_swap = true
@@ -142,7 +131,7 @@ csharp_style_unused_value_assignment_preference = discard_variable
 csharp_style_unused_value_expression_statement_preference = discard_variable
 
 # 'using' directive preferences
-csharp_using_directive_placement = outside_namespace:silent
+csharp_using_directive_placement = outside_namespace
 
 # New line preferences
 csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
@@ -240,4 +229,10 @@ dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
 # ReSharper inspection severities
 resharper_arrange_method_or_operator_body_highlighting = hint
-csharp_style_prefer_primary_constructors = true:suggestion
+
+# Diagnostics
+dotnet_diagnostic.CA1510.severity = none
+dotnet_diagnostic.CA1512.severity = none
+dotnet_diagnostic.CA1513.severity = none
+dotnet_diagnostic.CA1860.severity = none
+dotnet_diagnostic.CA1861.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -24,6 +24,7 @@ dotnet_diagnostic.CA1510.severity = none
 dotnet_diagnostic.CA1513.severity = none
 dotnet_diagnostic.CA1512.severity = none
 dotnet_diagnostic.CA1860.severity = none
+dotnet_diagnostic.CA1861.severity = none
 
 # C# files
 [*.cs]

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,15 @@ tab_width = 4
 # New line preferences
 end_of_line = crlf
 insert_final_newline = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_diagnostic.CA1510.severity = none
+dotnet_diagnostic.CA1513.severity = none
+dotnet_diagnostic.CA1512.severity = none
 
 # C# files
 [*.cs]
@@ -84,36 +93,36 @@ csharp_style_var_for_built_in_types = false
 csharp_style_var_when_type_is_apparent = false
 
 # Expression-bodied members
-csharp_style_expression_bodied_accessors = true
+csharp_style_expression_bodied_accessors = true:silent
 csharp_style_expression_bodied_constructors = false:none
-csharp_style_expression_bodied_indexers = true
-csharp_style_expression_bodied_lambdas = true
-csharp_style_expression_bodied_local_functions = false
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
 csharp_style_expression_bodied_methods = true:suggestion
-csharp_style_expression_bodied_operators = false
-csharp_style_expression_bodied_properties = true
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
 
 # Pattern matching preferences
 csharp_style_pattern_matching_over_as_with_null_check = true
-csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
 csharp_style_prefer_extended_property_pattern = true
 csharp_style_prefer_not_pattern = true
 csharp_style_prefer_pattern_matching = true
 csharp_style_prefer_switch_expression = true
 
 # Null-checking preferences
-csharp_style_conditional_delegate_call = true
+csharp_style_conditional_delegate_call = true:suggestion
 
 # Modifier preferences
-csharp_prefer_static_local_function = true
+csharp_prefer_static_local_function = true:suggestion
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
 
 # Code-block preferences
-csharp_prefer_braces = true
-csharp_prefer_simple_using_statement = true
+csharp_prefer_braces = true:silent
+csharp_prefer_simple_using_statement = true:suggestion
 csharp_style_namespace_declarations = file_scoped:suggestion
-csharp_style_prefer_method_group_conversion = true
-csharp_style_prefer_top_level_statements = true
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
 
 # Expression-level preferences
 csharp_prefer_simple_default_expression = true
@@ -121,7 +130,7 @@ csharp_style_deconstructed_variable_declaration = true
 csharp_style_implicit_object_creation_when_type_is_apparent = true
 csharp_style_inlined_variable_declaration = true
 csharp_style_prefer_index_operator = true
-csharp_style_prefer_local_over_anonymous_function = true
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
 csharp_style_prefer_null_check_over_type_check = true
 csharp_style_prefer_range_operator = true
 csharp_style_prefer_tuple_swap = true
@@ -131,7 +140,7 @@ csharp_style_unused_value_assignment_preference = discard_variable
 csharp_style_unused_value_expression_statement_preference = discard_variable
 
 # 'using' directive preferences
-csharp_using_directive_placement = outside_namespace
+csharp_using_directive_placement = outside_namespace:silent
 
 # New line preferences
 csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
@@ -229,3 +238,4 @@ dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
 # ReSharper inspection severities
 resharper_arrange_method_or_operator_body_highlighting = hint
+csharp_style_prefer_primary_constructors = true:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -23,6 +23,7 @@ dotnet_style_predefined_type_for_locals_parameters_members = true:silent
 dotnet_diagnostic.CA1510.severity = none
 dotnet_diagnostic.CA1513.severity = none
 dotnet_diagnostic.CA1512.severity = none
+dotnet_diagnostic.CA1860.severity = none
 
 # C# files
 [*.cs]

--- a/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
+++ b/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
@@ -208,7 +208,7 @@ internal static class ZipUtilities
 			source.FileSystem.Directory.CreateDirectory(directoryPath);
 		}
 
-		if (source.FullName.EndsWith("/"))
+		if (source.FullName.EndsWith('/'))
 		{
 			if (source.Length != 0)
 			{

--- a/Source/Testably.Abstractions.Compression/Polyfills/StringExtensionMethods.cs
+++ b/Source/Testably.Abstractions.Compression/Polyfills/StringExtensionMethods.cs
@@ -18,15 +18,5 @@ internal static class StringExtensionMethods
 	{
 		return @this.EndsWith($"{value}");
 	}
-	
-	/// <summary>
-	///     Determines whether this string instance starts with the specified character.
-	/// </summary>
-	internal static bool StartsWith(
-		this string @this,
-		char value)
-	{
-		return @this.StartsWith($"{value}");
-	}
 }
 #endif

--- a/Source/Testably.Abstractions.Compression/Usings.cs
+++ b/Source/Testably.Abstractions.Compression/Usings.cs
@@ -1,1 +1,4 @@
-﻿global using System.IO.Abstractions;
+﻿#if NETSTANDARD2_0 || NETSTANDARD2_1
+global using Testably.Abstractions.Polyfills;
+# endif
+global using System.IO.Abstractions;

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
@@ -114,7 +114,7 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 	{
 		get
 		{
-			if (Location.FullPath.EndsWith(".") &&
+			if (Location.FullPath.EndsWith('.') &&
 			    !Execute.IsWindows)
 			{
 				return ".";

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/TestingException.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/TestingException.cs
@@ -6,7 +6,9 @@ namespace Testably.Abstractions.Testing.FileSystemInitializer;
 /// <summary>
 ///     Custom <see cref="TestingException" /> when using the test system incorrectly.
 /// </summary>
+#if !NET8_0_OR_GREATER
 [Serializable]
+#endif
 public class TestingException : Exception
 {
 	/// <summary>

--- a/Source/Testably.Abstractions.Testing/Helpers/RandomFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/RandomFactory.cs
@@ -20,7 +20,7 @@ internal static class RandomFactory
 	/// <summary>
 	///     <see href="https://andrewlock.net/building-a-thread-safe-random-implementation-for-dotnet-framework/" />
 	/// </summary>
-	private static IRandom CreateThreadSafeRandomWrapper()
+	private static RandomWrapper CreateThreadSafeRandomWrapper()
 	{
 		int seed;
 		lock (Global)

--- a/Source/Testably.Abstractions.Testing/RandomSystem/RandomProviderMock.cs
+++ b/Source/Testably.Abstractions.Testing/RandomSystem/RandomProviderMock.cs
@@ -6,7 +6,7 @@ namespace Testably.Abstractions.Testing.RandomSystem;
 
 internal sealed class RandomProviderMock : IRandomProvider
 {
-	[ThreadStatic] private static IRandom? _shared;
+	[ThreadStatic] private static RandomMock? _shared;
 
 	private static Generator<Guid> DefaultGuidGenerator
 		=> Generator<Guid>.FromCallback(Guid.NewGuid);
@@ -34,7 +34,7 @@ internal sealed class RandomProviderMock : IRandomProvider
 
 	#endregion
 
-	private static IRandom DefaultRandomGenerator(int seed)
+	private static RandomMock DefaultRandomGenerator(int seed)
 	{
 		if (seed == SharedSeed)
 		{

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -250,7 +250,7 @@ internal class InMemoryContainer : IStorageContainer
 
 	internal FileAttributes AdjustAttributes(FileAttributes attributes)
 	{
-		if (Path.GetFileName(_location.FullPath).StartsWith("."))
+		if (Path.GetFileName(_location.FullPath).StartsWith('.'))
 		{
 			FileAttributes attr = attributes;
 			attributes = Execute.OnLinux(

--- a/Source/Testably.Abstractions/RandomSystem/RandomFactory.cs
+++ b/Source/Testably.Abstractions/RandomSystem/RandomFactory.cs
@@ -35,7 +35,7 @@ internal sealed class RandomFactory : IRandomFactory
 	/// <summary>
 	///     <see href="https://andrewlock.net/building-a-thread-safe-random-implementation-for-dotnet-framework/" />
 	/// </summary>
-	private static IRandom CreateThreadSafeRandomWrapper()
+	private static RandomWrapper CreateThreadSafeRandomWrapper()
 	{
 		int seed;
 		lock (Global)

--- a/Tests/Testably.Abstractions.AccessControl.Tests/ExceptionMissingFileTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/ExceptionMissingFileTests.cs
@@ -162,13 +162,16 @@ public abstract partial class ExceptionMissingFileTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetFileCallbacks(int baseType)
-		=> GetFileCallbackTestParameters()
-			.Where(item => (item.BaseType & (BaseTypes)baseType) > 0)
-			.Select(item => new object?[]
-			{
-				item.Callback, item.BaseType, item.MethodType
-			});
+	public static TheoryData<Action<IFileSystem, string>, BaseTypes, MethodType> GetFileCallbacks(int baseType)
+	{
+		TheoryData<Action<IFileSystem, string>, BaseTypes, MethodType> theoryData = new();
+		foreach (var item in GetFileCallbackTestParameters()
+			.Where(item => (item.BaseType & (BaseTypes)baseType) > 0))
+		{
+			theoryData.Add(item.Callback, item.BaseType, item.MethodType);
+		}
+		return theoryData;
+	}
 
 	private static
 		IEnumerable<(

--- a/Tests/Testably.Abstractions.AccessControl.Tests/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/ExceptionTests.cs
@@ -64,13 +64,16 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetFileCallbacks(int baseType)
-		=> GetFileCallbackTestParameters()
-			.Where(item => (item.BaseType & (BaseTypes)baseType) > 0)
-			.Select(item => new object?[]
-			{
-				item.Callback, item.BaseType, item.MethodType
-			});
+	public static TheoryData<Action<IFileSystem, string>, BaseTypes, MethodType> GetFileCallbacks(int baseType)
+	{
+		TheoryData<Action<IFileSystem, string>, BaseTypes, MethodType> theoryData = new();
+		foreach (var item in GetFileCallbackTestParameters()
+			.Where(item => (item.BaseType & (BaseTypes)baseType) > 0))
+		{
+			theoryData.Add(item.Callback, item.BaseType, item.MethodType);
+		}
+		return theoryData;
+	}
 
 	private static
 		IEnumerable<(

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveFactory/Tests.cs
@@ -126,17 +126,19 @@ public abstract partial class Tests<TFileSystem>
 		}
 	}
 
-	public static IEnumerable<object[]> EntryNameEncoding()
+	#region Helpers
+
+	public static TheoryData<string, Encoding, bool> EntryNameEncoding()
 	{
 		// ReSharper disable StringLiteralTypo
-		yield return new object[]
+		TheoryData<string, Encoding, bool> theoryData = new()
 		{
-			"Dans mes rêves.mp3", Encoding.Default, true
-		};
-		yield return new object[]
-		{
-			"Dans mes rêves.mp3", Encoding.ASCII, false
+			{ "Dans mes rêves.mp3", Encoding.Default, true },
+			{ "Dans mes rêves.mp3", Encoding.ASCII, false }
 		};
 		// ReSharper restore StringLiteralTypo
+		return theoryData;
 	}
+
+	#endregion
 }

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
@@ -341,18 +341,16 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object[]> EntryNameEncoding()
+	public static TheoryData<string, Encoding, bool> EntryNameEncoding()
 	{
 		// ReSharper disable StringLiteralTypo
-		yield return new object[]
+		TheoryData<string, Encoding, bool> theoryData = new()
 		{
-			"Dans mes rêves.mp3", Encoding.Default, true
-		};
-		yield return new object[]
-		{
-			"Dans mes rêves.mp3", Encoding.ASCII, false
+			{ "Dans mes rêves.mp3", Encoding.Default, true },
+			{ "Dans mes rêves.mp3", Encoding.ASCII, false }
 		};
 		// ReSharper restore StringLiteralTypo
+		return theoryData;
 	}
 
 	#endregion

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
@@ -102,39 +102,42 @@ public class ChangeHandlerTests
 		receivedPath.Should().Be(FileSystem.Path.GetFullPath(path));
 	}
 
-	public static IEnumerable<object?[]> NotificationTriggeringMethods()
+	#region Helpers
+
+	public static TheoryData<Action<IFileSystem, string>?, Action<IFileSystem, string>, WatcherChangeTypes, FileSystemTypes, string> NotificationTriggeringMethods()
 	{
-		yield return new object?[]
+		return new TheoryData<Action<IFileSystem, string>?, Action<IFileSystem, string>, WatcherChangeTypes, FileSystemTypes, string>()
 		{
-			null,
-			new Action<IFileSystem, string>((f, p) => f.Directory.CreateDirectory(p)),
-			WatcherChangeTypes.Created,
-			FileSystemTypes.Directory,
-			$"path_{Guid.NewGuid()}"
-		};
-		yield return new object?[]
-		{
-			new Action<IFileSystem, string>((f, p) => f.Directory.CreateDirectory(p)),
-			new Action<IFileSystem, string>((f, p) => f.Directory.Delete(p)),
-			WatcherChangeTypes.Deleted,
-			FileSystemTypes.Directory,
-			$"path_{Guid.NewGuid()}"
-		};
-		yield return new object?[]
-		{
-			null,
-			new Action<IFileSystem, string>((f, p) => f.File.WriteAllText(p, null)),
-			WatcherChangeTypes.Created,
-			FileSystemTypes.File,
-			$"path_{Guid.NewGuid()}"
-		};
-		yield return new object?[]
-		{
-			new Action<IFileSystem, string>((f, p) => f.File.WriteAllText(p, null)),
-			new Action<IFileSystem, string>((f, p) => f.File.Delete(p)),
-			WatcherChangeTypes.Deleted,
-			FileSystemTypes.File,
-			$"path_{Guid.NewGuid()}"
+			{
+				null,
+				new Action<IFileSystem, string>((f, p) => f.Directory.CreateDirectory(p)),
+				WatcherChangeTypes.Created,
+				FileSystemTypes.Directory,
+				$"path_{Guid.NewGuid()}"
+			},
+			{
+				new Action<IFileSystem, string>((f, p) => f.Directory.CreateDirectory(p)),
+				new Action<IFileSystem, string>((f, p) => f.Directory.Delete(p)),
+				WatcherChangeTypes.Deleted,
+				FileSystemTypes.Directory,
+				$"path_{Guid.NewGuid()}"
+			},
+			{
+				null,
+				new Action<IFileSystem, string>((f, p) => f.File.WriteAllText(p, null)),
+				WatcherChangeTypes.Created,
+				FileSystemTypes.File,
+				$"path_{Guid.NewGuid()}"
+			},
+			{
+				new Action<IFileSystem, string>((f, p) => f.File.WriteAllText(p, null)),
+				new Action<IFileSystem, string>((f, p) => f.File.Delete(p)),
+				WatcherChangeTypes.Deleted,
+				FileSystemTypes.File,
+				$"path_{Guid.NewGuid()}"
+			}
 		};
 	}
+
+	#endregion
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
@@ -106,7 +106,7 @@ public class ChangeHandlerTests
 
 	public static TheoryData<Action<IFileSystem, string>?, Action<IFileSystem, string>, WatcherChangeTypes, FileSystemTypes, string> NotificationTriggeringMethods()
 	{
-		return new TheoryData<Action<IFileSystem, string>?, Action<IFileSystem, string>, WatcherChangeTypes, FileSystemTypes, string>()
+		return new TheoryData<Action<IFileSystem, string>?, Action<IFileSystem, string>, WatcherChangeTypes, FileSystemTypes, string>
 		{
 			{
 				null,

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DefaultAccessControlStrategyTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DefaultAccessControlStrategyTests.cs
@@ -27,7 +27,7 @@ public class DefaultAccessControlStrategyTests
 	[SkippableFact]
 	public void IsAccessGranted_ShouldUseCallback()
 	{
-		DefaultAccessControlStrategy sut = new((p, _) => p.StartsWith("a"));
+		DefaultAccessControlStrategy sut = new((p, _) => p.StartsWith('a'));
 
 		sut.IsAccessGranted("abc", new FileSystemExtensibility()).Should().BeTrue();
 		sut.IsAccessGranted("xyz", new FileSystemExtensibility()).Should().BeFalse();

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemExtensibilityTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemExtensibilityTests.cs
@@ -148,16 +148,14 @@ public class FileSystemExtensibilityTests
 		result.Should().BeSameAs(fileSystem);
 	}
 
-	public static IEnumerable<object[]> GetFileSystems =>
-		new List<object[]>
+	#region Helpers
+
+	public static TheoryData<IFileSystem> GetFileSystems
+		=> new()
 		{
-			new object[]
-			{
-				new RealFileSystem()
-			},
-			new object[]
-			{
-				new MockFileSystem()
-			},
+			new RealFileSystem(),
+			new MockFileSystem()
 		};
+
+	#endregion
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/RandomSystemExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/RandomSystemExtensionsTests.cs
@@ -62,6 +62,6 @@ public class RandomSystemExtensionsTests
 		// Check edge cases for directories
 		fileNames.Should().Contain(d => d.Contains(' '));
 		fileNames.Should().Contain(d => d.Length == 1);
-		fileNames.Should().Contain(d => d.StartsWith("."));
+		fileNames.Should().Contain(d => d.StartsWith('.'));
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -97,7 +97,7 @@ public class MockFileSystemTests
 	{
 		string? driveName = Path.GetPathRoot(Directory.GetCurrentDirectory());
 
-		Skip.If(!Test.RunsOnWindows || driveName?.StartsWith("C") != false);
+		Skip.If(!Test.RunsOnWindows || driveName?.StartsWith('C') != false);
 
 		MockFileSystem sut = new();
 

--- a/Tests/Testably.Abstractions.Testing.Tests/RandomSystem/RandomSystemExtensibilityTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/RandomSystem/RandomSystemExtensibilityTests.cs
@@ -27,16 +27,14 @@ public class RandomSystemExtensibilityTests
 		result.Should().Be(randomSystem);
 	}
 
-	public static IEnumerable<object[]> GetRandomSystems =>
-		new List<object[]>
+	#region Helpers
+
+	public static TheoryData<IRandomSystem> GetRandomSystems
+		=> new()
 		{
-			new object[]
-			{
-				new RealRandomSystem()
-			},
-			new object[]
-			{
-				new MockRandomSystem()
-			},
+			new RealRandomSystem(),
+			new MockRandomSystem()
 		};
+
+	#endregion
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryContainerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Storage/InMemoryContainerTests.cs
@@ -314,7 +314,7 @@ public class InMemoryContainerTests
 		MockFileSystem fileSystem = new();
 		string expectedPath = fileSystem.Path.GetFullPath("foo");
 		IStorageLocation location = InMemoryLocation.New(null, expectedPath);
-		IStorageContainer sut = new InMemoryContainer(FileSystemTypes.DirectoryOrFile, location,
+		InMemoryContainer sut = new InMemoryContainer(FileSystemTypes.DirectoryOrFile, location,
 			fileSystem);
 
 		string? result = sut.ToString();

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Usings.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Usings.cs
@@ -1,4 +1,7 @@
-﻿global using AutoFixture.Xunit2;
+﻿#if NET48
+global using Testably.Abstractions.Polyfills;
+# endif
+global using AutoFixture.Xunit2;
 global using FluentAssertions;
 global using System;
 global using System.IO.Abstractions;

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimeSystemExtensibilityTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimeSystemExtensibilityTests.cs
@@ -60,16 +60,14 @@ public class TimeSystemExtensibilityTests
 		result.Should().Be(timeSystem);
 	}
 
-	public static IEnumerable<object[]> GetTimeSystems =>
-		new List<object[]>
+	#region Helpers
+
+	public static TheoryData<ITimeSystem> GetTimeSystems
+		=> new()
 		{
-			new object[]
-			{
-				new RealTimeSystem()
-			},
-			new object[]
-			{
-				new MockTimeSystem()
-			},
+			new RealTimeSystem(),
+			new MockTimeSystem()
 		};
+
+	#endregion
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ExceptionTests.cs
@@ -103,16 +103,19 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetDirectoryCallbacks(string? path)
-		=> GetDirectoryCallbackTestParameters(path!)
-			.Where(item => item.TestType.HasFlag(path.ToTestType()))
-			.Select(item => new object?[]
-			{
+	public static TheoryData<Expression<Action<IDirectory>>, string, bool> GetDirectoryCallbacks(string? path)
+	{
+		TheoryData<Expression<Action<IDirectory>>, string, bool> theoryData = new();
+		foreach (var item in GetDirectoryCallbackTestParameters(path!)
+			.Where(item => item.TestType.HasFlag(path.ToTestType())))
+		{
+			theoryData.Add(
 				item.Callback,
 				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
-					.IgnoreParamNameCheck)
-			});
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck));
+		}
+		return theoryData;
+	}
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string ParamName,
 			Expression<Action<IDirectory>> Callback)>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExceptionTests.cs
@@ -116,16 +116,19 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetDirectoryInfoCallbacks(string? path)
-		=> GetDirectoryInfoCallbackTestParameters(path!)
-			.Where(item => item.TestType.HasFlag(path.ToTestType()))
-			.Select(item => new object?[]
-			{
+	public static TheoryData<Expression<Action<IDirectoryInfo>>, string?, bool> GetDirectoryInfoCallbacks(string? path)
+	{
+		TheoryData<Expression<Action<IDirectoryInfo>>, string?, bool> theoryData = new();
+		foreach (var item in GetDirectoryInfoCallbackTestParameters(path!)
+			.Where(item => item.TestType.HasFlag(path.ToTestType())))
+		{
+			theoryData.Add(
 				item.Callback,
 				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
-					.IgnoreParamNameCheck)
-			});
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck));
+		}
+		return theoryData;
+	}
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,
 			Expression<Action<IDirectoryInfo>> Callback)>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/ExceptionTests.cs
@@ -94,16 +94,19 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetDirectoryInfoFactoryCallbacks(string? path)
-		=> GetDirectoryInfoFactoryCallbackTestParameters(path!)
-			.Where(item => item.TestType.HasFlag(path.ToTestType()))
-			.Select(item => new object?[]
-			{
+	public static TheoryData<Expression<Action<IDirectoryInfoFactory>>, string?, bool> GetDirectoryInfoFactoryCallbacks(string? path)
+	{
+		TheoryData<Expression<Action<IDirectoryInfoFactory>>, string?, bool> theoryData = new();
+		foreach (var item in GetDirectoryInfoFactoryCallbackTestParameters(path!)
+			.Where(item => item.TestType.HasFlag(path.ToTestType())))
+		{
+			theoryData.Add(
 				item.Callback,
 				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
-					.IgnoreParamNameCheck)
-			});
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck));
+		}
+		return theoryData;
+	}
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,
 			Expression<Action<IDirectoryInfoFactory>> Callback)>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/ExceptionTests.cs
@@ -63,16 +63,19 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetDriveInfoFactoryCallbacks(string? path)
-		=> GetDriveInfoFactoryCallbackTestParameters(path!)
-			.Where(item => item.TestType.HasFlag(path.ToTestType()))
-			.Select(item => new object?[]
-			{
+	public static TheoryData<Expression<Action<IDriveInfoFactory>>, string?, bool> GetDriveInfoFactoryCallbacks(string? path)
+	{
+		TheoryData<Expression<Action<IDriveInfoFactory>>, string?, bool> theoryData = new();
+		foreach (var item in GetDriveInfoFactoryCallbackTestParameters(path!)
+			.Where(item => item.TestType.HasFlag(path.ToTestType())))
+		{
+			theoryData.Add(
 				item.Callback,
 				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
-					.IgnoreParamNameCheck)
-			});
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck));
+		}
+		return theoryData;
+	}
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string ParamName,
 			Expression<Action<IDriveInfoFactory>> Callback)>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionMissingFileTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionMissingFileTests.cs
@@ -81,13 +81,11 @@ public abstract partial class ExceptionMissingFileTests<TFileSystem>
 		Default,
 	}
 
-	public static IEnumerable<object?[]> GetFileCallbacks(int testCases)
-		=> GetFileCallbackTestParameters()
-			.Where(item => (item.TestCase & (MissingFileTestCase)testCases) != 0)
-			.Select(item => new object?[]
-			{
-				item.Callback
-			});
+	public static TheoryData<Expression<Action<IFile, string>>> GetFileCallbacks(int testCases)
+		=> new TheoryData<Expression<Action<IFile, string>>>(
+			GetFileCallbackTestParameters()
+				.Where(item => (item.TestCase & (MissingFileTestCase)testCases) != 0)
+				.Select(item => item.Callback));
 
 	private static IEnumerable<(MissingFileTestCase TestCase, ExpectedExceptionType ExceptionType,
 			Expression<Action<IFile, string>> Callback)>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionTests.cs
@@ -106,16 +106,19 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetFileCallbacks(string? path)
-		=> GetFileCallbackTestParameters(path!)
-			.Where(item => item.TestType.HasFlag(path.ToTestType()))
-			.Select(item => new object?[]
-			{
+	public static TheoryData<Expression<Action<IFile>>, string?, bool> GetFileCallbacks(string? path)
+	{
+		TheoryData<Expression<Action<IFile>>, string?, bool> theoryData = new();
+		foreach (var item in GetFileCallbackTestParameters(path!)
+			.Where(item => item.TestType.HasFlag(path.ToTestType())))
+		{
+			theoryData.Add(
 				item.Callback,
 				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
-					.IgnoreParamNameCheck)
-			});
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck));
+		}
+		return theoryData;
+	}
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,
 			Expression<Action<IFile>> Callback)>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadAllTextTests.cs
@@ -165,26 +165,15 @@ public abstract partial class ReadAllTextTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetEncodingsForReadAllText()
+	public static TheoryData<Encoding> GetEncodingsForReadAllText()
 	{
-		// little endian
-		yield return new object?[]
+		return new TheoryData<Encoding>()
 		{
-			new UTF32Encoding(false, true, true)
-		};
-
-		// big endian
-		yield return new object?[]
-		{
-			new UTF32Encoding(true, true, true)
-		};
-		yield return new object?[]
-		{
-			new UTF8Encoding(true, true)
-		};
-
-		yield return new object?[]
-		{
+			// little endian
+			new UTF32Encoding(false, true, true),
+			// big endian
+			new UTF32Encoding(true, true, true),
+			new UTF8Encoding(true, true),
 			new ASCIIEncoding()
 		};
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadAllTextTests.cs
@@ -167,7 +167,7 @@ public abstract partial class ReadAllTextTests<TFileSystem>
 
 	public static TheoryData<Encoding> GetEncodingsForReadAllText()
 	{
-		return new TheoryData<Encoding>()
+		return new TheoryData<Encoding>
 		{
 			// little endian
 			new UTF32Encoding(false, true, true),

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExceptionTests.cs
@@ -84,16 +84,19 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetFileInfoCallbacks(string? path)
-		=> GetFileInfoCallbackTestParameters(path!)
-			.Where(item => item.TestType.HasFlag(path.ToTestType()))
-			.Select(item => new object?[]
-			{
+	public static TheoryData<Expression<Action<IFileInfo>>, string?, bool> GetFileInfoCallbacks(string? path)
+	{
+		TheoryData<Expression<Action<IFileInfo>>, string?, bool> theoryData = new();
+		foreach (var item in GetFileInfoCallbackTestParameters(path!)
+			.Where(item => item.TestType.HasFlag(path.ToTestType())))
+		{
+			theoryData.Add(
 				item.Callback,
 				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
-					.IgnoreParamNameCheck)
-			});
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck));
+		}
+		return theoryData;
+	}
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,
 			Expression<Action<IFileInfo>> Callback)>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/ExceptionTests.cs
@@ -94,16 +94,19 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetFileInfoFactoryCallbacks(string? path)
-		=> GetFileInfoFactoryCallbackTestParameters(path!)
-			.Where(item => item.TestType.HasFlag(path.ToTestType()))
-			.Select(item => new object?[]
-			{
+	public static TheoryData<Expression<Action<IFileInfoFactory>>, string?, bool> GetFileInfoFactoryCallbacks(string? path)
+	{
+		TheoryData<Expression<Action<IFileInfoFactory>>, string?, bool> theoryData = new();
+		foreach (var item in GetFileInfoFactoryCallbackTestParameters(path!)
+			.Where(item => item.TestType.HasFlag(path.ToTestType())))
+		{
+			theoryData.Add(
 				item.Callback,
 				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
-					.IgnoreParamNameCheck)
-			});
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck));
+		}
+		return theoryData;
+	}
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,
 			Expression<Action<IFileInfoFactory>> Callback)>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/DisposeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/DisposeTests.cs
@@ -76,12 +76,9 @@ public abstract partial class DisposeTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetFileStreamCallbacks()
-		=> GetFileStreamCallbackTestParameters()
-			.Select(item => new object?[]
-			{
-				item
-			});
+	public static TheoryData<Expression<Action<FileSystemStream>>> GetFileStreamCallbacks()
+		=> new TheoryData<Expression<Action<FileSystemStream>>>(
+			GetFileStreamCallbackTestParameters());
 
 	private static IEnumerable<Expression<Action<FileSystemStream>>>
 		GetFileStreamCallbackTestParameters()

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStreamFactory/ExceptionTests.cs
@@ -107,16 +107,19 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetFileStreamFactoryCallbacks(string? path)
-		=> GetFileStreamFactoryCallbackTestParameters(path!)
-			.Where(item => item.TestType.HasFlag(path.ToTestType()))
-			.Select(item => new object?[]
-			{
+	public static TheoryData<Expression<Action<IFileStreamFactory>>, string?, bool> GetFileStreamFactoryCallbacks(string? path)
+	{
+		TheoryData<Expression<Action<IFileStreamFactory>>, string?, bool> theoryData = new();
+		foreach (var item in GetFileStreamFactoryCallbackTestParameters(path!)
+			.Where(item => item.TestType.HasFlag(path.ToTestType())))
+		{
+			theoryData.Add(
 				item.Callback,
 				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
-					.IgnoreParamNameCheck)
-			});
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck));
+		}
+		return theoryData;
+	}
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,
 			Expression<Action<IFileStreamFactory>> Callback)>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ExceptionTests.cs
@@ -47,16 +47,19 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetFileSystemInfoCallbacks(string? path)
-		=> GetFileSystemInfoCallbackTestParameters(path!)
-			.Where(item => item.TestType.HasFlag(path.ToTestType()))
-			.Select(item => new object?[]
-			{
+	public static TheoryData<Expression<Action<IFileSystemInfo>>, string?, bool> GetFileSystemInfoCallbacks(string? path)
+	{
+		TheoryData<Expression<Action<IFileSystemInfo>>, string?, bool> theoryData = new();
+		foreach (var item in GetFileSystemInfoCallbackTestParameters(path!)
+			.Where(item => item.TestType.HasFlag(path.ToTestType())))
+		{
+			theoryData.Add(
 				item.Callback,
 				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
-					.IgnoreParamNameCheck)
-			});
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck));
+		}
+		return theoryData;
+	}
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,
 			Expression<Action<IFileSystemInfo>> Callback)>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,34 +9,6 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
-	#region Test Setup
-
-	public static TheoryData<string, Func<IFileSystemWatcher, IWaitForChangedResult>> WaitForChangedTimeoutParameters
-	{
-		get
-		{
-			TheoryData<string, Func<IFileSystemWatcher, IWaitForChangedResult>> theoryData = new()
-			{
-				{
-					"foo.dll",
-					new Func<IFileSystemWatcher, IWaitForChangedResult>(fileSystemWatcher
-						=> fileSystemWatcher.WaitForChanged(WatcherChangeTypes.Changed, 100))
-				}
-			};
-#if FEATURE_FILESYSTEM_NET7
-			theoryData.Add(
-				"bar.txt",
-				new Func<IFileSystemWatcher, IWaitForChangedResult>(fileSystemWatcher
-					=> fileSystemWatcher.WaitForChanged(WatcherChangeTypes.Changed,
-						TimeSpan.FromMilliseconds(100)))
-			);
-#endif
-			return theoryData;
-		}
-	}
-
-	#endregion
-
 	[SkippableTheory]
 	[AutoData]
 	public void WaitForChanged_ShouldBlockUntilEventHappens(string path)
@@ -80,7 +50,7 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[MemberData(nameof(WaitForChangedTimeoutParameters))]
+	[MemberData(nameof(GetWaitForChangedTimeoutParameters))]
 	public void WaitForChanged_Timeout_ShouldReturnTimedOut(string path,
 		Func<IFileSystemWatcher, IWaitForChangedResult> callback)
 	{
@@ -115,4 +85,29 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 			ms.Set();
 		}
 	}
+
+	#region Helpers
+
+	public static TheoryData<string, Func<IFileSystemWatcher, IWaitForChangedResult>> GetWaitForChangedTimeoutParameters()
+	{
+		TheoryData<string, Func<IFileSystemWatcher, IWaitForChangedResult>> theoryData = new()
+			{
+				{
+					"foo.dll",
+					new Func<IFileSystemWatcher, IWaitForChangedResult>(fileSystemWatcher
+						=> fileSystemWatcher.WaitForChanged(WatcherChangeTypes.Changed, 100))
+				}
+			};
+#if FEATURE_FILESYSTEM_NET7
+		theoryData.Add(
+			"bar.txt",
+			new Func<IFileSystemWatcher, IWaitForChangedResult>(fileSystemWatcher
+				=> fileSystemWatcher.WaitForChanged(WatcherChangeTypes.Changed,
+					TimeSpan.FromMilliseconds(100)))
+		);
+#endif
+		return theoryData;
+	}
+
+	#endregion
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,25 +13,27 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 {
 	#region Test Setup
 
-	public static IEnumerable<object?[]> WaitForChangedTimeoutParameters
+	public static TheoryData<string, Func<IFileSystemWatcher, IWaitForChangedResult>> WaitForChangedTimeoutParameters
 	{
 		get
 		{
-			yield return new object?[]
+			TheoryData<string, Func<IFileSystemWatcher, IWaitForChangedResult>> theoryData = new()
 			{
-				"foo.dll",
-				new Func<IFileSystemWatcher, IWaitForChangedResult>(fileSystemWatcher
-					=> fileSystemWatcher.WaitForChanged(WatcherChangeTypes.Changed, 100))
+				{
+					"foo.dll",
+					new Func<IFileSystemWatcher, IWaitForChangedResult>(fileSystemWatcher
+						=> fileSystemWatcher.WaitForChanged(WatcherChangeTypes.Changed, 100))
+				}
 			};
 #if FEATURE_FILESYSTEM_NET7
-			yield return new object?[]
-			{
+			theoryData.Add(
 				"bar.txt",
 				new Func<IFileSystemWatcher, IWaitForChangedResult>(fileSystemWatcher
 					=> fileSystemWatcher.WaitForChanged(WatcherChangeTypes.Changed,
 						TimeSpan.FromMilliseconds(100)))
-			};
+			);
 #endif
+			return theoryData;
 		}
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcherFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcherFactory/ExceptionTests.cs
@@ -97,16 +97,19 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetFileSystemWatcherFactoryCallbacks(
-		string? path)
-		=> GetFileSystemWatcherFactoryCallbackTestParameters(path!)
-			.Where(item => item.TestType.HasFlag(path.ToTestType()))
-			.Select(item => new object?[]
-			{
+	public static TheoryData<Expression<Action<IFileSystemWatcherFactory>>, string?, bool> GetFileSystemWatcherFactoryCallbacks(string? path)
+	{
+		TheoryData<Expression<Action<IFileSystemWatcherFactory>>, string?, bool> theoryData = new();
+		foreach (var item in GetFileSystemWatcherFactoryCallbackTestParameters(path!)
+			.Where(item => item.TestType.HasFlag(path.ToTestType())))
+		{
+			theoryData.Add(
 				item.Callback,
 				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck)
-			});
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck));
+		}
+		return theoryData;
+	}
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,
 			Expression<Action<IFileSystemWatcherFactory>> Callback)>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/ExceptionTests.cs
@@ -66,16 +66,19 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	#region Helpers
 
-	public static IEnumerable<object?[]> GetPathCallbacks(string? path)
-		=> GetPathCallbackTestParameters(path!)
-			.Where(item => item.TestType.HasFlag(path.ToTestType()))
-			.Select(item => new object?[]
-			{
+	public static TheoryData<Expression<Action<IPath>>, string?, bool> GetPathCallbacks(string? path)
+	{
+		TheoryData<Expression<Action<IPath>>, string?, bool> theoryData = new();
+		foreach (var item in GetPathCallbackTestParameters(path!)
+			.Where(item => item.TestType.HasFlag(path.ToTestType())))
+		{
+			theoryData.Add(
 				item.Callback,
 				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes
-					.IgnoreParamNameCheck)
-			});
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck));
+		}
+		return theoryData;
+	}
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string? ParamName,
 			Expression<Action<IPath>> Callback)>


### PR DESCRIPTION
- Make `TestingException` only serializable when using an older Framework than .NET 8
- Fix [CA1859](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1859) Use concrete types when possible for improved performance
- Fix [CA1866](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1865-ca1867) The char overload is a better performing overload than a string with a single char.
- Fix [xUnit1042](https://xunit.net/xunit.analyzers/rules/xUnit1042) The member referenced by the MemberData attribute returns untyped data rows
- Disable the following rules:
  - [CA1510](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1510) Use ArgumentNullException throw helper
  - [CA1512](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1512) Use ArgumentOutOfRangeException throw helper
  - [CA1513](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1513) Use ObjectDisposedException throw helper
  - [CA1860](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1860) Avoid using 'Enumerable.Any()' extension method
  - [CA1861](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1861) Avoid constant arrays as arguments