### PR TITLE
fix: failing build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
           command: dotnet test --no-build --collect:"XPlat Code Coverage"
           attempt_limit: 2
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Code coverage (MacOS)
           path: "**/coverage.cobertura.xml"
@@ -112,7 +112,7 @@ jobs:
           command: dotnet test --no-build --collect:"XPlat Code Coverage"
           attempt_limit: 2
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Code coverage (Ubuntu)
           path: "**/coverage.cobertura.xml"
@@ -140,7 +140,7 @@ jobs:
           command: dotnet test --no-build --collect:"XPlat Code Coverage"
           attempt_limit: 2
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Code coverage (Windows)
           path: "**/coverage.cobertura.xml"
@@ -206,17 +206,17 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download code coverage files (MacOS)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: Code coverage (MacOS)
           path: Coverage/MacOS
       - name: Download code coverage files (Ubuntu)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: Code coverage (Ubuntu)
           path: Coverage/Ubuntu
       - name: Download code coverage files (Windows)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: Code coverage (Windows)
           path: Coverage/Windows

--- a/.github/workflows/ci-stryker.yml
+++ b/.github/workflows/ci-stryker.yml
@@ -61,7 +61,7 @@ jobs:
           ../../tools/dotnet-stryker -f ../.github/stryker/Stryker.Config.Testing.json -v "${GITHUB_HEAD_REF}" -r "html" -r "cleartext" --since:main
           mv ./StrykerOutput/**/reports/*.html ./StrykerOutput/Reports/Testably.Abstractions.Testing-report.html
       - name: Upload Stryker reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Stryker
           path: Tests/StrykerOutput/Reports/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,12 @@ jobs:
           attempt_limit: 2
       - name: Upload test results (MacOS)
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Test results (MacOS)
           path: TestResults
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Code coverage (MacOS)
           path: "**/coverage.cobertura.xml"
@@ -64,12 +64,12 @@ jobs:
           attempt_limit: 2
       - name: Upload test results (Ubuntu)
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Test results (Ubuntu)
           path: TestResults
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Code coverage (Ubuntu)
           path: "**/coverage.cobertura.xml"
@@ -98,12 +98,12 @@ jobs:
           attempt_limit: 2
       - name: Upload test results (Windows)
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Test results (Windows)
           path: TestResults
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Code coverage (Windows)
           path: "**/coverage.cobertura.xml"
@@ -128,7 +128,7 @@ jobs:
         run: vstest.console.exe .\Build\Tests\Testably.Abstractions.Tests\net48\Testably.Abstractions.Tests.dll .\Build\Tests\Testably.Abstractions.Parity.Tests\net48\Testably.Abstractions.Parity.Tests.dll .\Build\Tests\Testably.Abstractions.Testing.Tests\net48\Testably.Abstractions.Testing.Tests.dll /Logger:trx /ResultsDirectory:TestResults
       - name: Upload test results (.NET Framework)
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Test results (.NET Framework)
           path: TestResults
@@ -146,7 +146,7 @@ jobs:
         run: echo ${{ github.event.number }} > PR_NUMBER.txt
       - name: Archive PR number
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: PR_NUMBER
           path: PR_NUMBER.txt

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,42 @@
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows: ['CI']
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dorny/test-reporter@v1
+      if: success() || failure()
+      with:
+        artifact: Test results (MacOS)
+        name: MacOS Tests
+        path: '*.trx'
+        reporter: dotnet-trx
+        fail-on-error: 'false'
+    - uses: dorny/test-reporter@v1
+      if: success() || failure()
+      with:
+        artifact: Test results (Ubuntu)
+        name: Ubuntu Tests
+        path: '*.trx'
+        reporter: dotnet-trx
+        fail-on-error: 'false'
+    - uses: dorny/test-reporter@v1
+      if: success() || failure()
+      with:
+        artifact: Test results (Windows)
+        name: Windows Tests
+        path: '*.trx'
+        reporter: dotnet-trx
+        fail-on-error: 'false'
+    - uses: dorny/test-reporter@v1
+      if: success() || failure()
+      with:
+        artifact: Test results (.NET Framework)
+        name: .NET Framework Tests
+        path: '*.trx'
+        reporter: dotnet-trx
+        fail-on-error: 'false'

--- a/Testably.Abstractions.sln
+++ b/Testably.Abstractions.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{94F99274-3518-45
 		LICENSE = LICENSE
 		nuget.config = nuget.config
 		README.md = README.md
+		renovate.json = renovate.json
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{61F335A6-9CE0-4040-A34F-E70B1A55077D}"

--- a/Testably.Abstractions.sln
+++ b/Testably.Abstractions.sln
@@ -43,6 +43,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{5E35E265-7110-47A0-9E3E-B5180BBB5AA6}"
 	ProjectSection(SolutionItems) = preProject
 		coverage-settings.xml = coverage-settings.xml
+		.github\mergify.yml = .github\mergify.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "stryker", "stryker", "{4D8D7391-1E7B-4051-AD7E-4086AFD4E024}"
@@ -61,6 +62,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\pr.yml = .github\workflows\pr.yml
 		.github\workflows\release.yml = .github\workflows\release.yml
 		.github\workflows\stryker.yml = .github\workflows\stryker.yml
+		.github\workflows\test-report.yml = .github\workflows\test-report.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Testably.Abstractions.Parity.Tests", "Tests\Testably.Abstractions.Parity.Tests\Testably.Abstractions.Parity.Tests.csproj", "{E9A42D82-0609-4D6B-B270-A30176B4FCF2}"

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
 	"packageRules": [
 		{
 			"matchPackagePatterns": "^Testably.Abstractions",
-			"groupName": ["Testably.Abstractions packages"]
+			"groupName": [ "Testably.Abstractions packages" ]
 		}
-	]
+	],
+	"ignoreDeps": [ "actions/download-artifact", "actions/upload-artifact" ]
 }


### PR DESCRIPTION
Fix the failing build after #444:
- Add the `test-report.yml` pipeline again
- Downgrade the `upload-artifact` and `download-artifact` actions from v4 to v3
- Exclude the two actions from `renovate.json`