### PR TITLE
refactor: use non-static OS selector in tests

### DIFF
--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/FileSystemTestBase.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/FileSystemTestBase.cs
@@ -17,13 +17,17 @@ public abstract class FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
 	public abstract string BasePath { get; }
+	public Test Test { get; }
 	public TFileSystem FileSystem { get; }
 	public ITimeSystem TimeSystem { get; }
 
 	// ReSharper disable once UnusedMember.Global
-	protected FileSystemTestBase(TFileSystem fileSystem,
+	protected FileSystemTestBase(
+		Test test,
+		TFileSystem fileSystem,
 		ITimeSystem timeSystem)
 	{
+		Test = test;
 		FileSystem = fileSystem;
 		TimeSystem = timeSystem;
 

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/Test.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/Test.cs
@@ -1,19 +1,17 @@
 using System.IO.Abstractions;
 using System.Runtime.InteropServices;
-using Testably.Abstractions.Testing;
 using Xunit;
 
 namespace Testably.Abstractions.TestHelpers;
 
 public class Test
 {
-	public Test()
-	{
-		RunsOnLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-		RunsOnMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-		RunsOnWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-		IsNetFramework = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
-	}
+	public static bool IsNet7OrGreater
+#if NET7_0_OR_GREATER
+		=> true;
+#else
+		=> false;
+#endif
 	public bool IsNetFramework { get; }
 
 	public bool RunsOnLinux { get; }
@@ -22,12 +20,13 @@ public class Test
 
 	public bool RunsOnWindows { get; }
 
-	public static bool IsNet7OrGreater
-#if NET7_0_OR_GREATER
-		=> true;
-#else
-		=> false;
-#endif
+	public Test()
+	{
+		RunsOnLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+		RunsOnMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+		RunsOnWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		IsNetFramework = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
+	}
 
 	public static void SkipBrittleTestsOnRealFileSystem(
 		IFileSystem fileSystem, bool condition = true)

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/Test.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/Test.cs
@@ -1,31 +1,26 @@
 using System.IO.Abstractions;
 using System.Runtime.InteropServices;
+using Testably.Abstractions.Testing;
 using Xunit;
 
 namespace Testably.Abstractions.TestHelpers;
 
-public static class Test
+public class Test
 {
-	private static bool? _isNetFramework;
-
-	public static bool IsNetFramework
+	public Test()
 	{
-		get
-		{
-			_isNetFramework ??= RuntimeInformation
-				.FrameworkDescription.StartsWith(".NET Framework");
-			return _isNetFramework.Value;
-		}
+		RunsOnLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+		RunsOnMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+		RunsOnWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		IsNetFramework = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
 	}
+	public bool IsNetFramework { get; }
 
-	public static bool RunsOnLinux
-		=> RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+	public bool RunsOnLinux { get; }
 
-	public static bool RunsOnMac
-		=> RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+	public bool RunsOnMac { get; }
 
-	public static bool RunsOnWindows
-		=> RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+	public bool RunsOnWindows { get; }
 
 	public static bool IsNet7OrGreater
 #if NET7_0_OR_GREATER

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
@@ -21,8 +21,8 @@ namespace {@class.Namespace}
 {{
 	public abstract partial class {@class.Name}<TFileSystem>
 	{{
-		protected {@class.Name}(TFileSystem fileSystem, ITimeSystem timeSystem)
-			: base(fileSystem, timeSystem)
+		protected {@class.Name}(Test test, TFileSystem fileSystem, ITimeSystem timeSystem)
+			: base(test, fileSystem, timeSystem)
 		{{
 		}}
 	}}
@@ -33,26 +33,27 @@ namespace {@class.Namespace}.{@class.Name}
 	// ReSharper disable once UnusedMember.Global
 	public sealed class MockFileSystemTests : {@class.Name}<MockFileSystem>, IDisposable
 	{{
-		/// <inheritdoc cref=""{@class.Name}{{TFileSystem}}.BasePath"" />
-		public override string BasePath => _directoryCleaner.BasePath;
+	    /// <inheritdoc cref=""{@class.Name}{{TFileSystem}}.BasePath"" />
+	    public override string BasePath => _directoryCleaner.BasePath;
 
-		private readonly IDirectoryCleaner _directoryCleaner;
+	    private readonly IDirectoryCleaner _directoryCleaner;
 
-		public MockFileSystemTests() : this(new MockFileSystem())
-		{{
-		}}
+	    public MockFileSystemTests() : this(new MockFileSystem())
+	    {{
+	    }}
 
-		private MockFileSystemTests(MockFileSystem mockFileSystem) : base(
-			mockFileSystem,
-			mockFileSystem.TimeSystem)
-		{{
-			_directoryCleaner = FileSystem
-			   .SetCurrentDirectoryToEmptyTemporaryDirectory();
-		}}
+	    private MockFileSystemTests(MockFileSystem mockFileSystem) : base(
+		    new Test(),
+		    mockFileSystem,
+		    mockFileSystem.TimeSystem)
+	    {{
+		    _directoryCleaner = FileSystem
+		       .SetCurrentDirectoryToEmptyTemporaryDirectory();
+	    }}
 
-		/// <inheritdoc cref=""IDisposable.Dispose()"" />
-		public void Dispose()
-			=> _directoryCleaner.Dispose();
+	    /// <inheritdoc cref=""IDisposable.Dispose()"" />
+	    public void Dispose()
+		    => _directoryCleaner.Dispose();
 	}}
 }}
 
@@ -70,7 +71,7 @@ namespace {@class.Namespace}.{@class.Name}
 		private readonly IDirectoryCleaner _directoryCleaner;
 
 		public RealFileSystemTests(ITestOutputHelper testOutputHelper)
-			: base(new RealFileSystem(), new RealTimeSystem())
+			: base(new Test(), new RealFileSystem(), new RealTimeSystem())
 		{{
 			_directoryCleaner = FileSystem
 			   .SetCurrentDirectoryToEmptyTemporaryDirectory($""{@class.Namespace}{{FileSystem.Path.DirectorySeparatorChar}}{@class.Name}-"", testOutputHelper.WriteLine);

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
@@ -33,27 +33,27 @@ namespace {@class.Namespace}.{@class.Name}
 	// ReSharper disable once UnusedMember.Global
 	public sealed class MockFileSystemTests : {@class.Name}<MockFileSystem>, IDisposable
 	{{
-	    /// <inheritdoc cref=""{@class.Name}{{TFileSystem}}.BasePath"" />
-	    public override string BasePath => _directoryCleaner.BasePath;
+		/// <inheritdoc cref=""{@class.Name}{{TFileSystem}}.BasePath"" />
+		public override string BasePath => _directoryCleaner.BasePath;
 
-	    private readonly IDirectoryCleaner _directoryCleaner;
+		private readonly IDirectoryCleaner _directoryCleaner;
 
-	    public MockFileSystemTests() : this(new MockFileSystem())
-	    {{
-	    }}
+		public MockFileSystemTests() : this(new MockFileSystem())
+		{{
+		}}
 
-	    private MockFileSystemTests(MockFileSystem mockFileSystem) : base(
-		    new Test(),
-		    mockFileSystem,
-		    mockFileSystem.TimeSystem)
-	    {{
-		    _directoryCleaner = FileSystem
-		       .SetCurrentDirectoryToEmptyTemporaryDirectory();
-	    }}
+		private MockFileSystemTests(MockFileSystem mockFileSystem) : base(
+			new Test(),
+			mockFileSystem,
+			mockFileSystem.TimeSystem)
+		{{
+			_directoryCleaner = FileSystem
+			   .SetCurrentDirectoryToEmptyTemporaryDirectory();
+		}}
 
-	    /// <inheritdoc cref=""IDisposable.Dispose()"" />
-	    public void Dispose()
-		    => _directoryCleaner.Dispose();
+		/// <inheritdoc cref=""IDisposable.Dispose()"" />
+		public void Dispose()
+			=> _directoryCleaner.Dispose();
 	}}
 }}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -69,7 +69,7 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 	[SkippableFact]
 	public void CreateDirectory_Root_ShouldNotThrowException()
 	{
-		string path = FileTestHelper.RootDrive();
+		string path = FileTestHelper.RootDrive(Test);
 		FileSystem.Directory.CreateDirectory(path);
 
 		Exception? exception = Record.Exception(() =>
@@ -313,9 +313,8 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 		result.Name.Should().Be(expectedName.TrimEnd(
 			FileSystem.Path.DirectorySeparatorChar,
 			FileSystem.Path.AltDirectorySeparatorChar));
-		result.FullName.Should().Be(System.IO.Path.Combine(BasePath, expectedName
-			.Replace(FileSystem.Path.AltDirectorySeparatorChar,
-				FileSystem.Path.DirectorySeparatorChar)));
+		result.FullName.Should().Be($"{BasePath}{FileSystem.Path.DirectorySeparatorChar}{expectedName}"
+			.Replace(FileSystem.Path.AltDirectorySeparatorChar, FileSystem.Path.DirectorySeparatorChar));
 		FileSystem.Should().HaveDirectory(nameWithSuffix);
 	}
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetDirectoryRootTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetDirectoryRootTests.cs
@@ -19,7 +19,7 @@ public abstract partial class GetDirectoryRootTests<TFileSystem>
 	[SkippableFact]
 	public void GetDirectoryRoot_ShouldReturnDefaultRoot()
 	{
-		string expectedRoot = FileTestHelper.RootDrive();
+		string expectedRoot = FileTestHelper.RootDrive(Test);
 
 		string result = FileSystem.Directory.GetDirectoryRoot("foo");
 
@@ -34,7 +34,7 @@ public abstract partial class GetDirectoryRootTests<TFileSystem>
 		char drive)
 	{
 		Skip.IfNot(Test.RunsOnWindows, "Linux does not support different drives.");
-		string expectedRoot = FileTestHelper.RootDrive("", drive);
+		string expectedRoot = FileTestHelper.RootDrive(Test, "", drive);
 		string path = System.IO.Path.Combine($"{drive}:\\foo", "bar");
 
 		string result = FileSystem.Directory.GetDirectoryRoot(path);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/MoveTests.cs
@@ -70,7 +70,7 @@ public abstract partial class MoveTests<TFileSystem>
 	{
 		FileSystem.InitializeIn(source)
 			.WithAFile();
-		string destination = FileTestHelper.RootDrive("not-existing/path");
+		string destination = FileTestHelper.RootDrive(Test, "not-existing/path");
 
 		Exception? exception = Record.Exception(() =>
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ResolveLinkTargetTests.cs
@@ -15,7 +15,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 	///     The maximum number of symbolic links that are followed.<br />
 	///     <see href="https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks" />
 	/// </summary>
-	private static int MaxResolveLinks =>
+	private int MaxResolveLinks =>
 		Test.RunsOnWindows ? 63 : 40;
 
 	#endregion

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.cs
@@ -30,14 +30,14 @@ public abstract partial class Tests<TFileSystem>
 	{
 		string result = FileSystem.Directory.GetCurrentDirectory();
 
-		result.Should().NotBe(FileTestHelper.RootDrive());
+		result.Should().NotBe(FileTestHelper.RootDrive(Test));
 	}
 
 	[SkippableTheory]
 	[AutoData]
 	public void GetDirectoryRoot_ShouldReturnRoot(string path)
 	{
-		string root = FileTestHelper.RootDrive();
+		string root = FileTestHelper.RootDrive(Test);
 		string rootedPath = root + path;
 
 		string result = FileSystem.Directory.GetDirectoryRoot(rootedPath);
@@ -51,7 +51,7 @@ public abstract partial class Tests<TFileSystem>
 		string[] result = FileSystem.Directory.GetLogicalDrives();
 
 		result.Should().NotBeEmpty();
-		result.Should().Contain(FileTestHelper.RootDrive());
+		result.Should().Contain(FileTestHelper.RootDrive(Test));
 	}
 
 	[SkippableTheory]
@@ -73,7 +73,7 @@ public abstract partial class Tests<TFileSystem>
 	[SkippableFact]
 	public void GetParent_Root_ShouldReturnNull()
 	{
-		string path = FileTestHelper.RootDrive();
+		string path = FileTestHelper.RootDrive(Test);
 
 		IDirectoryInfo? result = FileSystem.Directory.GetParent(path);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/Tests.cs
@@ -283,7 +283,7 @@ public abstract partial class Tests<TFileSystem>
 	public void Parent_Root_ShouldBeNull()
 	{
 		IDirectoryInfo sut =
-			FileSystem.DirectoryInfo.New(FileTestHelper.RootDrive());
+			FileSystem.DirectoryInfo.New(FileTestHelper.RootDrive(Test));
 
 		sut.Parent.Should().BeNull();
 	}
@@ -342,7 +342,7 @@ public abstract partial class Tests<TFileSystem>
 	[AutoData]
 	public void Root_Name_ShouldBeCorrect()
 	{
-		string rootName = FileTestHelper.RootDrive();
+		string rootName = FileTestHelper.RootDrive(Test);
 		IDirectoryInfo sut =
 			FileSystem.DirectoryInfo.New(rootName);
 
@@ -354,7 +354,7 @@ public abstract partial class Tests<TFileSystem>
 	[AutoData]
 	public void Root_ShouldExist(string path)
 	{
-		string expectedRoot = FileTestHelper.RootDrive();
+		string expectedRoot = FileTestHelper.RootDrive(Test);
 		IDirectoryInfo result = FileSystem.DirectoryInfo.New(path);
 
 		result.Root.Should().Exist();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/Tests.cs
@@ -11,7 +11,7 @@ public abstract partial class Tests<TFileSystem>
 		Test.SkipIfLongRunningTestsShouldBeSkipped(FileSystem);
 
 		IDriveInfo result =
-			FileSystem.DriveInfo.New(FileTestHelper.RootDrive());
+			FileSystem.DriveInfo.New(FileTestHelper.RootDrive(Test));
 		string previousVolumeLabel = result.VolumeLabel;
 
 		try
@@ -50,7 +50,7 @@ public abstract partial class Tests<TFileSystem>
 		Skip.IfNot(Test.RunsOnWindows);
 
 		IDriveInfo result =
-			FileSystem.DriveInfo.New(FileTestHelper.RootDrive());
+			FileSystem.DriveInfo.New(FileTestHelper.RootDrive(Test));
 
 		result.ToString().Should().Be("C:\\");
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/Tests.cs
@@ -63,13 +63,13 @@ public abstract partial class Tests<TFileSystem>
 	public void New_DefaultDrive_ShouldBeFixed()
 	{
 		IDriveInfo result =
-			FileSystem.DriveInfo.New(FileTestHelper.RootDrive());
+			FileSystem.DriveInfo.New(FileTestHelper.RootDrive(Test));
 
 		result.AvailableFreeSpace.Should().BeGreaterThan(0);
 		result.DriveFormat.Should().NotBeNull();
 		result.DriveType.Should().Be(DriveType.Fixed);
 		result.IsReady.Should().BeTrue();
-		result.RootDirectory.FullName.Should().Be(FileTestHelper.RootDrive());
+		result.RootDirectory.FullName.Should().Be(FileTestHelper.RootDrive(Test));
 		result.TotalFreeSpace.Should().BeGreaterThan(0);
 		result.TotalSize.Should().BeGreaterThan(0);
 		result.VolumeLabel.Should().NotBeEmpty();
@@ -111,7 +111,7 @@ public abstract partial class Tests<TFileSystem>
 	{
 		Skip.IfNot(Test.RunsOnWindows, "Linux does not support different drives.");
 
-		string rootedPath = FileTestHelper.RootDrive(path, driveLetter);
+		string rootedPath = FileTestHelper.RootDrive(Test, path, driveLetter);
 
 		IDriveInfo result = FileSystem.DriveInfo.New(rootedPath);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -15,7 +15,7 @@ public abstract partial class CopyTests<TFileSystem>
 	{
 		FileSystem.Initialize()
 			.WithFile(source);
-		string destination = FileTestHelper.RootDrive("not-existing/path/foo.txt");
+		string destination = FileTestHelper.RootDrive(Test, "not-existing/path/foo.txt");
 
 		Exception? exception = Record.Exception(() =>
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ExceptionTests.cs
@@ -15,63 +15,14 @@ public abstract partial class ExceptionTests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
 	[SkippableTheory]
-	[MemberData(nameof(GetFileCallbacks), parameters: "")]
-	public void Operations_WhenValueIsEmpty_ShouldThrowArgumentException(
-		Expression<Action<IFile>> callback, string paramName, bool ignoreParamCheck)
-	{
-		Exception? exception = Record.Exception(() =>
-		{
-			callback.Compile().Invoke(FileSystem.File);
-		});
-
-		exception.Should().BeException<ArgumentException>(
-			hResult: -2147024809,
-			paramName: ignoreParamCheck || Test.IsNetFramework ? null : paramName,
-			because:
-			$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
-	}
-
-	[SkippableTheory]
-	[MemberData(nameof(GetFileCallbacks), parameters: "  ")]
-	public void Operations_WhenValueIsWhitespace_ShouldThrowArgumentException(
-		Expression<Action<IFile>> callback, string paramName, bool ignoreParamCheck)
-	{
-		Skip.IfNot(Test.RunsOnWindows);
-
-		Exception? exception = Record.Exception(() =>
-		{
-			callback.Compile().Invoke(FileSystem.File);
-		});
-
-		exception.Should().BeException<ArgumentException>(
-			hResult: -2147024809,
-			paramName: ignoreParamCheck || Test.IsNetFramework ? null : paramName,
-			because:
-			$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
-	}
-
-	[SkippableTheory]
-	[MemberData(nameof(GetFileCallbacks), parameters: (string?)null)]
-	public void Operations_WhenValueIsNull_ShouldThrowArgumentNullException(
-		Expression<Action<IFile>> callback, string paramName, bool ignoreParamCheck)
-	{
-		Exception? exception = Record.Exception(() =>
-		{
-			callback.Compile().Invoke(FileSystem.File);
-		});
-
-		exception.Should().BeException<ArgumentNullException>(
-			paramName: ignoreParamCheck ? null : paramName,
-			because:
-			$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
-	}
-
-	[SkippableTheory]
 	[MemberData(nameof(GetFileCallbacks), parameters: "Illegal\tCharacter?InPath")]
 	public void
 		Operations_WhenValueContainsIllegalPathCharacters_ShouldThrowCorrectException_OnWindows(
-			Expression<Action<IFile>> callback, string paramName, bool ignoreParamCheck)
+			Expression<Action<IFile>> callback, string paramName, bool ignoreParamCheck,
+			Func<Test, bool> skipTest)
 	{
+		Skip.If(skipTest(Test));
+
 		Exception? exception = Record.Exception(() =>
 		{
 			callback.Compile().Invoke(FileSystem.File);
@@ -104,321 +55,536 @@ public abstract partial class ExceptionTests<TFileSystem>
 		}
 	}
 
+	[SkippableTheory]
+	[MemberData(nameof(GetFileCallbacks), parameters: "")]
+	public void Operations_WhenValueIsEmpty_ShouldThrowArgumentException(
+		Expression<Action<IFile>> callback, string paramName, bool ignoreParamCheck,
+		Func<Test, bool> skipTest)
+	{
+		Skip.If(skipTest(Test));
+
+		Exception? exception = Record.Exception(() =>
+		{
+			callback.Compile().Invoke(FileSystem.File);
+		});
+
+		exception.Should().BeException<ArgumentException>(
+			hResult: -2147024809,
+			paramName: ignoreParamCheck || Test.IsNetFramework ? null : paramName,
+			because:
+			$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
+	}
+
+	[SkippableTheory]
+	[MemberData(nameof(GetFileCallbacks), parameters: (string?)null)]
+	public void Operations_WhenValueIsNull_ShouldThrowArgumentNullException(
+		Expression<Action<IFile>> callback, string paramName, bool ignoreParamCheck,
+		Func<Test, bool> skipTest)
+	{
+		Skip.If(skipTest(Test));
+
+		Exception? exception = Record.Exception(() =>
+		{
+			callback.Compile().Invoke(FileSystem.File);
+		});
+
+		exception.Should().BeException<ArgumentNullException>(
+			paramName: ignoreParamCheck ? null : paramName,
+			because:
+			$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
+	}
+
+	[SkippableTheory]
+	[MemberData(nameof(GetFileCallbacks), parameters: "  ")]
+	public void Operations_WhenValueIsWhitespace_ShouldThrowArgumentException(
+		Expression<Action<IFile>> callback, string paramName, bool ignoreParamCheck,
+		Func<Test, bool> skipTest)
+	{
+		Skip.If(skipTest(Test));
+		Skip.IfNot(Test.RunsOnWindows);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			callback.Compile().Invoke(FileSystem.File);
+		});
+
+		exception.Should().BeException<ArgumentException>(
+			hResult: -2147024809,
+			paramName: ignoreParamCheck || Test.IsNetFramework ? null : paramName,
+			because:
+			$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
+	}
+
 	#region Helpers
 
-	public static TheoryData<Expression<Action<IFile>>, string, bool> GetFileCallbacks(string? path)
+	public static TheoryData<Expression<Action<IFile>>, string, bool, Func<Test, bool>>
+		GetFileCallbacks(string? path)
 	{
-		TheoryData<Expression<Action<IFile>>, string, bool> theoryData = new();
-		foreach (var item in GetFileCallbackTestParameters(path!)
-			.Where(item => item.TestType.HasFlag(path.ToTestType())))
+		TheoryData<Expression<Action<IFile>>, string, bool, Func<Test, bool>> theoryData = new();
+		foreach ((ExceptionTestHelper.TestTypes TestType, string ParamName,
+			Expression<Action<IFile>> Callback, Func<Test, bool>? SkipTest) item in
+			GetFileCallbackTestParameters(path!)
+				.Where(item => item.TestType.HasFlag(path.ToTestType())))
 		{
 			theoryData.Add(
 				item.Callback,
 				item.ParamName,
-				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck));
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck),
+				item.SkipTest ?? (_ => false));
 		}
+
 		return theoryData;
 	}
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string ParamName,
-			Expression<Action<IFile>> Callback)>
+			Expression<Action<IFile>> Callback, Func<Test, bool>? SkipTest)>
 		GetFileCallbackTestParameters(string value)
 	{
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.AppendAllLines(value, new[]
-			{
-				"foo"
-			}));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.AppendAllLines(value, new[]
-			{
-				"foo"
-			}, Encoding.UTF8));
-#if FEATURE_FILESYSTEM_ASYNC
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.AppendAllLinesAsync(value, new[]
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.AppendAllLines(value, new[]
 				{
 					"foo"
-				}, CancellationToken.None)
-				.GetAwaiter().GetResult());
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.AppendAllLinesAsync(value, new[]
+				}),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.AppendAllLines(value, new[]
 				{
 					"foo"
-				}, Encoding.UTF8,
-				CancellationToken.None).GetAwaiter().GetResult());
-#endif
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.AppendAllText(value, "foo"));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.AppendAllText(value, "foo", Encoding.UTF8));
+				}, Encoding.UTF8),
+			null);
 #if FEATURE_FILESYSTEM_ASYNC
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.AppendAllTextAsync(value, "foo", CancellationToken.None).GetAwaiter()
-				.GetResult());
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.AppendAllTextAsync(value, "foo", Encoding.UTF8,
-				CancellationToken.None).GetAwaiter().GetResult());
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.AppendAllLinesAsync(value, new[]
+					{
+						"foo"
+					}, CancellationToken.None)
+					.GetAwaiter().GetResult(),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.AppendAllLinesAsync(value, new[]
+					{
+						"foo"
+					}, Encoding.UTF8,
+					CancellationToken.None).GetAwaiter().GetResult(),
+			null);
 #endif
-		yield return (ExceptionTestHelper.TestTypes.NullOrInvalidPath, "path", file
-			=> file.AppendText(value));
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.AppendAllText(value, "foo"),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.AppendAllText(value, "foo", Encoding.UTF8),
+			null);
+#if FEATURE_FILESYSTEM_ASYNC
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.AppendAllTextAsync(value, "foo", CancellationToken.None)
+					.GetAwaiter().GetResult(),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.AppendAllTextAsync(value, "foo", Encoding.UTF8, CancellationToken.None)
+					.GetAwaiter().GetResult(),
+			null);
+#endif
+		yield return (ExceptionTestHelper.TestTypes.NullOrInvalidPath, "path",
+			file
+				=> file.AppendText(value),
+			null);
 		yield return (ExceptionTestHelper.TestTypes.AllExceptWhitespace, "sourceFileName",
 			file
-				=> file.Copy(value, "foo"));
-		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "destFileName", file
-			=> file.Copy("foo", value));
+				=> file.Copy(value, "foo"),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "destFileName",
+			file
+				=> file.Copy("foo", value),
+			null);
 		yield return (ExceptionTestHelper.TestTypes.AllExceptWhitespace, "sourceFileName",
 			file
-				=> file.Copy(value, "foo", false));
-		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "destFileName", file
-			=> file.Copy("foo", value, false));
+				=> file.Copy(value, "foo", false),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "destFileName",
+			file
+				=> file.Copy("foo", value, false), null);
 		yield return (
 			ExceptionTestHelper.TestTypes.Whitespace |
-			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName", file
-				=> file.Copy(value, "foo"));
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName",
+			file
+				=> file.Copy(value, "foo"),
+			null);
 		yield return (
 			ExceptionTestHelper.TestTypes.Whitespace |
-			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName", file
-				=> file.Copy("foo", value));
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName",
+			file
+				=> file.Copy("foo", value),
+			null);
 		yield return (
 			ExceptionTestHelper.TestTypes.Whitespace |
-			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName", file
-				=> file.Copy(value, "foo", false));
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName",
+			file
+				=> file.Copy(value, "foo", false),
+			null);
 		yield return (
 			ExceptionTestHelper.TestTypes.Whitespace |
-			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName", file
-				=> file.Copy("foo", value, false));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.Create(value));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.Create(value, 1023));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.Create(value, 1023, FileOptions.None));
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName",
+			file
+				=> file.Copy("foo", value, false),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.Create(value),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.Create(value, 1023),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.Create(value, 1023, FileOptions.None),
+			null);
 #if FEATURE_FILESYSTEM_LINK
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.CreateSymbolicLink(value, "foo"));
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.CreateSymbolicLink(value, "foo"),
+			null);
 #endif
-		yield return (ExceptionTestHelper.TestTypes.NullOrInvalidPath, "path", file
-			=> file.CreateText(value));
-
-		if (Test.RunsOnWindows)
-		{
-			#pragma warning disable CA1416
-			yield return (ExceptionTestHelper.TestTypes.AllExceptInvalidPath, "path", file
-				=> file.Decrypt(value));
-			#pragma warning restore CA1416
-		}
-
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.Delete(value));
-		if (Test.RunsOnWindows)
-		{
-			#pragma warning disable CA1416
-			yield return (ExceptionTestHelper.TestTypes.AllExceptInvalidPath, "path", file
-				=> file.Encrypt(value));
-			#pragma warning restore CA1416
-		}
-
+		yield return (ExceptionTestHelper.TestTypes.NullOrInvalidPath, "path",
+			file
+				=> file.CreateText(value),
+			null);
+		#pragma warning disable CA1416
+		yield return (ExceptionTestHelper.TestTypes.AllExceptInvalidPath, "path",
+			file
+				=> file.Decrypt(value),
+			test => !test.RunsOnWindows);
+		#pragma warning restore CA1416
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.Delete(value),
+			null);
+		#pragma warning disable CA1416
+		yield return (ExceptionTestHelper.TestTypes.AllExceptInvalidPath, "path",
+			file
+				=> file.Encrypt(value),
+			test => !test.RunsOnWindows);
+		#pragma warning restore CA1416
 		// `File.Exists` doesn't throw an exception on `null`
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.GetAttributes(value));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.GetCreationTime(value));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.GetCreationTimeUtc(value));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.GetLastAccessTime(value));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.GetLastAccessTimeUtc(value));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.GetLastWriteTime(value));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.GetLastWriteTimeUtc(value));
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.GetAttributes(value),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.GetCreationTime(value),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.GetCreationTimeUtc(value),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.GetLastAccessTime(value),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.GetLastAccessTimeUtc(value),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.GetLastWriteTime(value),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.GetLastWriteTimeUtc(value),
+			null);
 #if FEATURE_FILESYSTEM_UNIXFILEMODE
-		if (!Test.RunsOnWindows)
-		{
-			#pragma warning disable CA1416
-			yield return (ExceptionTestHelper.TestTypes.All, "path", file
-				=> file.GetUnixFileMode(value));
-			#pragma warning restore CA1416
-		}
+		#pragma warning disable CA1416
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.GetUnixFileMode(value),
+			test => test.RunsOnWindows);
+		#pragma warning restore CA1416
 #endif
-		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "sourceFileName", file
-			=> file.Move(value, "foo"));
-		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "destFileName", file
-			=> file.Move("foo", value));
+		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "sourceFileName",
+			file
+				=> file.Move(value, "foo"),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "destFileName",
+			file
+				=> file.Move("foo", value),
+			null);
 		yield return (
 			ExceptionTestHelper.TestTypes.Whitespace |
-			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName", file
-				=> file.Move(value, "foo"));
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName",
+			file
+				=> file.Move(value, "foo"),
+			null);
 		yield return (
 			ExceptionTestHelper.TestTypes.Whitespace |
-			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName", file
-				=> file.Move("foo", value));
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName",
+			file
+				=> file.Move("foo", value),
+			null);
 #if FEATURE_FILE_MOVETO_OVERWRITE
-		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "sourceFileName", file
-			=> file.Move(value, "foo", false));
-		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "destFileName", file
-			=> file.Move("foo", value, false));
+		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "sourceFileName",
+			file
+				=> file.Move(value, "foo", false),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.NullOrEmpty, "destFileName",
+			file
+				=> file.Move("foo", value, false),
+			null);
 		yield return (
 			ExceptionTestHelper.TestTypes.Whitespace |
-			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName", file
-				=> file.Move(value, "foo", false));
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName",
+			file
+				=> file.Move(value, "foo", false),
+			null);
 		yield return (
 			ExceptionTestHelper.TestTypes.Whitespace |
-			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName", file
-				=> file.Move("foo", value, false));
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destFileName",
+			file
+				=> file.Move("foo", value, false),
+			null);
 #endif
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.Open(value, FileMode.Open));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.Open(value, FileMode.Open, FileAccess.ReadWrite));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.Open(value, FileMode.Open, FileAccess.ReadWrite, FileShare.None));
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.Open(value, FileMode.Open),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.Open(value, FileMode.Open, FileAccess.ReadWrite),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.Open(value, FileMode.Open, FileAccess.ReadWrite, FileShare.None),
+			null);
 #if FEATURE_FILESYSTEM_STREAM_OPTIONS
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.Open(value, new FileStreamOptions()));
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.Open(value, new FileStreamOptions()),
+			null);
 #endif
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.OpenRead(value));
-		yield return (ExceptionTestHelper.TestTypes.NullOrInvalidPath, "path", file
-			=> file.OpenText(value));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.OpenWrite(value));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllBytes(value));
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.OpenRead(value),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.NullOrInvalidPath, "path",
+			file
+				=> file.OpenText(value),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.OpenWrite(value),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.ReadAllBytes(value),
+			null);
 #if FEATURE_FILESYSTEM_ASYNC
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllBytesAsync(value, CancellationToken.None).GetAwaiter()
-				.GetResult());
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.ReadAllBytesAsync(value, CancellationToken.None)
+					.GetAwaiter().GetResult(),
+			null);
 #endif
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllLines(value));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllLines(value, Encoding.UTF8));
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.ReadAllLines(value),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.ReadAllLines(value, Encoding.UTF8),
+			null);
 #if FEATURE_FILESYSTEM_ASYNC
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllLinesAsync(value, CancellationToken.None).GetAwaiter()
-				.GetResult());
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllLinesAsync(value, Encoding.UTF8, CancellationToken.None)
-				.GetAwaiter().GetResult());
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.ReadAllLinesAsync(value, CancellationToken.None)
+					.GetAwaiter().GetResult(),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.ReadAllLinesAsync(value, Encoding.UTF8, CancellationToken.None)
+					.GetAwaiter().GetResult(),
+			null);
 #endif
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllText(value));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllText(value, Encoding.UTF8));
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.ReadAllText(value),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.ReadAllText(value, Encoding.UTF8),
+			null);
 #if FEATURE_FILESYSTEM_ASYNC
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllTextAsync(value, CancellationToken.None).GetAwaiter()
-				.GetResult());
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadAllTextAsync(value, Encoding.UTF8, CancellationToken.None)
-				.GetAwaiter().GetResult());
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.ReadAllTextAsync(value, CancellationToken.None)
+					.GetAwaiter().GetResult(),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.ReadAllTextAsync(value, Encoding.UTF8, CancellationToken.None)
+					.GetAwaiter().GetResult(),
+			null);
 #endif
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadLines(value));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadLines(value, Encoding.UTF8));
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.ReadLines(value),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.ReadLines(value, Encoding.UTF8),
+			null);
 #if FEATURE_FILESYSTEM_NET7
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadLinesAsync(value, CancellationToken.None));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.ReadLinesAsync(value, Encoding.UTF8, CancellationToken.None));
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.ReadLinesAsync(value, CancellationToken.None),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.ReadLinesAsync(value, Encoding.UTF8, CancellationToken.None),
+			null);
 #endif
 		yield return (
 			ExceptionTestHelper.TestTypes.AllExceptInvalidPath |
-			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName", file
-				=> file.Replace(value, "foo", "bar"));
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName",
+			file
+				=> file.Replace(value, "foo", "bar"),
+			null);
 		yield return (
 			ExceptionTestHelper.TestTypes.All |
 			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destinationFileName",
 			file
-				=> file.Replace("foo", value, "bar"));
+				=> file.Replace("foo", value, "bar"),
+			null);
 		yield return (
 			ExceptionTestHelper.TestTypes.AllExceptInvalidPath |
-			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName", file
-				=> file.Replace(value, "foo", "bar", false));
+			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "sourceFileName",
+			file
+				=> file.Replace(value, "foo", "bar", false),
+			null);
 		yield return (
 			ExceptionTestHelper.TestTypes.All |
 			ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "destinationFileName",
 			file
-				=> file.Replace("foo", value, "bar", false));
+				=> file.Replace("foo", value, "bar", false),
+			null);
 #if FEATURE_FILESYSTEM_LINK
-		yield return (ExceptionTestHelper.TestTypes.AllExceptWhitespace, "linkPath", file
-			=> file.ResolveLinkTarget(value, false));
+		yield return (ExceptionTestHelper.TestTypes.AllExceptWhitespace, "linkPath",
+			file
+				=> file.ResolveLinkTarget(value, false),
+			null);
 #endif
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.SetAttributes(value, FileAttributes.ReadOnly));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.SetCreationTime(value, DateTime.Now));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.SetCreationTimeUtc(value, DateTime.Now));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.SetLastAccessTime(value, DateTime.Now));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.SetLastAccessTimeUtc(value, DateTime.Now));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.SetLastWriteTime(value, DateTime.Now));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.SetLastWriteTimeUtc(value, DateTime.Now));
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.SetAttributes(value, FileAttributes.ReadOnly),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.SetCreationTime(value, DateTime.Now),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.SetCreationTimeUtc(value, DateTime.Now),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.SetLastAccessTime(value, DateTime.Now),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.SetLastAccessTimeUtc(value, DateTime.Now),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.SetLastWriteTime(value, DateTime.Now),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.SetLastWriteTimeUtc(value, DateTime.Now),
+			null);
 #if FEATURE_FILESYSTEM_UNIXFILEMODE
-		if (!Test.RunsOnWindows)
-		{
-			#pragma warning disable CA1416
-			yield return (ExceptionTestHelper.TestTypes.All, "path", file
-				=> file.SetUnixFileMode(value, UnixFileMode.None));
-			#pragma warning restore CA1416
-		}
+		#pragma warning disable CA1416
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.SetUnixFileMode(value, UnixFileMode.None),
+			test => test.RunsOnWindows);
+		#pragma warning restore CA1416
 #endif
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.WriteAllBytes(value, new byte[]
-			{
-				0, 1
-			}));
-#if FEATURE_FILESYSTEM_ASYNC
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.WriteAllBytesAsync(value, new byte[]
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.WriteAllBytes(value, new byte[]
 				{
 					0, 1
-				},
-				CancellationToken.None).GetAwaiter().GetResult());
-#endif
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.WriteAllLines(value, new[]
-			{
-				"foo"
-			}));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.WriteAllLines(value, new[]
-			{
-				"foo"
-			}, Encoding.UTF8));
+				}),
+			null);
 #if FEATURE_FILESYSTEM_ASYNC
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.WriteAllLinesAsync(value, new[]
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.WriteAllBytesAsync(value, new byte[]
+					{
+						0, 1
+					},
+					CancellationToken.None).GetAwaiter().GetResult(),
+			null);
+#endif
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.WriteAllLines(value, new[]
 				{
 					"foo"
-				}, CancellationToken.None)
-				.GetAwaiter().GetResult());
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.WriteAllLinesAsync(value, new[]
+				}),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.WriteAllLines(value, new[]
 				{
 					"foo"
-				}, Encoding.UTF8,
-				CancellationToken.None).GetAwaiter().GetResult());
-#endif
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.WriteAllText(value, "foo"));
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.WriteAllText(value, "foo", Encoding.UTF8));
+				}, Encoding.UTF8),
+			null);
 #if FEATURE_FILESYSTEM_ASYNC
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.WriteAllTextAsync(value, "foo", CancellationToken.None).GetAwaiter()
-				.GetResult());
-		yield return (ExceptionTestHelper.TestTypes.All, "path", file
-			=> file.WriteAllTextAsync(value, "foo", Encoding.UTF8,
-				CancellationToken.None).GetAwaiter().GetResult());
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.WriteAllLinesAsync(value, new[]
+					{
+						"foo"
+					}, CancellationToken.None)
+					.GetAwaiter().GetResult(),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.WriteAllLinesAsync(value, new[]
+					{
+						"foo"
+					}, Encoding.UTF8,
+					CancellationToken.None).GetAwaiter().GetResult(),
+			null);
+#endif
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.WriteAllText(value, "foo"),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.WriteAllText(value, "foo", Encoding.UTF8),
+			null);
+#if FEATURE_FILESYSTEM_ASYNC
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.WriteAllTextAsync(value, "foo", CancellationToken.None)
+					.GetAwaiter().GetResult(),
+			null);
+		yield return (ExceptionTestHelper.TestTypes.All, "path",
+			file
+				=> file.WriteAllTextAsync(value, "foo", Encoding.UTF8, CancellationToken.None)
+					.GetAwaiter().GetResult(),
+			null);
 #endif
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
@@ -36,7 +36,7 @@ public abstract partial class MoveTests<TFileSystem>
 	{
 		FileSystem.Initialize()
 			.WithFile(source);
-		string destination = FileTestHelper.RootDrive("not-existing/path");
+		string destination = FileTestHelper.RootDrive(Test, "not-existing/path");
 
 		Exception? exception = Record.Exception(() =>
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
@@ -15,7 +15,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 	{
 		FileSystem.Initialize()
 			.WithFile(source);
-		string destination = FileTestHelper.RootDrive("not-existing/path/foo.txt");
+		string destination = FileTestHelper.RootDrive(Test, "not-existing/path/foo.txt");
 
 		Exception? exception = Record.Exception(() =>
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ResolveLinkTargetTests.cs
@@ -14,7 +14,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 	///     The maximum number of symbolic links that are followed.<br />
 	///     <see href="https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks" />
 	/// </summary>
-	private static int MaxResolveLinks =>
+	private int MaxResolveLinks =>
 		Test.RunsOnWindows ? 63 : 40;
 
 	#endregion

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfoFactory/Tests.cs
@@ -13,7 +13,7 @@ public abstract partial class Tests<TFileSystem>
 	public void New_PathTooLong_ShouldThrowPathTooLongException_OnNetFramework(
 		int maxLength)
 	{
-		string rootDrive = FileTestHelper.RootDrive();
+		string rootDrive = FileTestHelper.RootDrive(Test);
 		string path = new('a', maxLength - rootDrive.Length);
 		Exception? exception = Record.Exception(() =>
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemInfo/ResolveLinkTargetTests.cs
@@ -14,7 +14,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 	///     The maximum number of symbolic links that are followed.<br />
 	///     <see href="https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks" />
 	/// </summary>
-	private static int MaxResolveLinks =>
+	private int MaxResolveLinks =>
 		Test.RunsOnWindows ? 63 : 40;
 
 	#endregion

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetFullPathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetFullPathTests.cs
@@ -54,10 +54,10 @@ public abstract partial class GetFullPathTests<TFileSystem>
 	[InlineData(@"top/../../most/file", @"most/file")]
 	public void GetFullPath_ShouldNormalizeProvidedPath(string input, string expected)
 	{
-		string expectedRootedPath = FileTestHelper.RootDrive(
+		string expectedRootedPath = FileTestHelper.RootDrive(Test, 
 			expected.Replace('/', FileSystem.Path.DirectorySeparatorChar));
 
-		string result = FileSystem.Path.GetFullPath(FileTestHelper.RootDrive(input));
+		string result = FileSystem.Path.GetFullPath(FileTestHelper.RootDrive(Test, input));
 
 		result.Should().Be(expectedRootedPath);
 	}
@@ -70,10 +70,10 @@ public abstract partial class GetFullPathTests<TFileSystem>
 	public void GetFullPath_Relative_ShouldNormalizeProvidedPath(string input, string basePath,
 		string expected)
 	{
-		string expectedRootedPath = FileTestHelper.RootDrive(
+		string expectedRootedPath = FileTestHelper.RootDrive(Test, 
 			expected.Replace('/', FileSystem.Path.DirectorySeparatorChar));
 
-		string result = FileSystem.Path.GetFullPath(input, FileTestHelper.RootDrive(basePath));
+		string result = FileSystem.Path.GetFullPath(input, FileTestHelper.RootDrive(Test, basePath));
 
 		result.Should().Be(expectedRootedPath);
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetRelativePathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetRelativePathTests.cs
@@ -27,8 +27,8 @@ public abstract partial class GetRelativePathTests<TFileSystem>
 	{
 		Skip.IfNot(Test.RunsOnWindows, "Different drives are only supported on Windows");
 
-		path1 = FileTestHelper.RootDrive(path1, 'A');
-		path2 = FileTestHelper.RootDrive(path2, 'B');
+		path1 = FileTestHelper.RootDrive(Test, path1, 'A');
+		path2 = FileTestHelper.RootDrive(Test, path2, 'B');
 		string result = FileSystem.Path.GetRelativePath(path1, path2);
 
 		result.Should().Be(path2);
@@ -51,7 +51,7 @@ public abstract partial class GetRelativePathTests<TFileSystem>
 	public void GetRelativePath_RootedPath_ShouldReturnAbsolutePath(
 		string baseDirectory, string directory1, string directory2)
 	{
-		baseDirectory = FileTestHelper.RootDrive(baseDirectory);
+		baseDirectory = FileTestHelper.RootDrive(Test, baseDirectory);
 		string path1 = FileSystem.Path.Combine(baseDirectory, directory1);
 		string path2 = FileSystem.Path.Combine(baseDirectory, directory2);
 		string expectedRelativePath = FileSystem.Path.Combine("..", directory2);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/IsPathFullyQualifiedTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/IsPathFullyQualifiedTests.cs
@@ -11,7 +11,7 @@ public abstract partial class IsPathFullyQualifiedTests<TFileSystem>
 	public void IsPathFullyQualified_PrefixedRoot_ShouldReturnTrue(
 		string directory)
 	{
-		string path = FileTestHelper.RootDrive(directory);
+		string path = FileTestHelper.RootDrive(Test, directory);
 		bool result = FileSystem.Path.IsPathFullyQualified(path);
 
 		result.Should().BeTrue();
@@ -33,7 +33,7 @@ public abstract partial class IsPathFullyQualifiedTests<TFileSystem>
 	public void IsPathFullyQualified_Span_PrefixedRoot_ShouldReturnTrue(
 		string directory)
 	{
-		string path = FileTestHelper.RootDrive(directory);
+		string path = FileTestHelper.RootDrive(Test, directory);
 		bool result = FileSystem.Path.IsPathFullyQualified(path.AsSpan());
 
 		result.Should().BeTrue();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/TrimEndingDirectorySeparatorTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/TrimEndingDirectorySeparatorTests.cs
@@ -21,7 +21,7 @@ public abstract partial class TrimEndingDirectorySeparatorTests<TFileSystem>
 	[SkippableFact]
 	public void TrimEndingDirectorySeparator_Root_ShouldReturnUnchanged()
 	{
-		string path = FileTestHelper.RootDrive();
+		string path = FileTestHelper.RootDrive(Test);
 
 		string result = FileSystem.Path.TrimEndingDirectorySeparator(path);
 
@@ -44,7 +44,7 @@ public abstract partial class TrimEndingDirectorySeparatorTests<TFileSystem>
 	[SkippableFact]
 	public void TrimEndingDirectorySeparator_Span_Root_ShouldReturnUnchanged()
 	{
-		string path = FileTestHelper.RootDrive();
+		string path = FileTestHelper.RootDrive(Test);
 
 		ReadOnlySpan<char> result =
 			FileSystem.Path.TrimEndingDirectorySeparator(path.AsSpan());

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/FileTestHelper.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/FileTestHelper.cs
@@ -68,9 +68,9 @@ public static class FileTestHelper
 		return fileShare;
 	}
 
-	public static string RootDrive(string path = "", char driveLetter = 'C')
+	public static string RootDrive(Test test, string path = "", char driveLetter = 'C')
 	{
-		if (Test.RunsOnWindows)
+		if (test.RunsOnWindows)
 		{
 			return $"{driveLetter}:\\{path}";
 		}


### PR DESCRIPTION
As a prerequisite to #460 refactor how to handle OS-specific use cases in tests:
- Make the `Test` class non-static and a property of the source-generated test classes
- Replace all calls to the `Test` methods to use the property instead