### PR TITLE
fix: errors from static code analysis

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -13,6 +13,7 @@ using Testably.Abstractions.Testing.Storage;
 #if FEATURE_FILESYSTEM_ASYNC
 using System.Threading;
 using System.Threading.Tasks;
+// ReSharper disable PossibleMultipleEnumeration
 #endif
 
 namespace Testably.Abstractions.Testing.FileSystem;
@@ -1359,9 +1360,6 @@ internal sealed class FileMock : IFile
 	}
 #endif
 
-	private IDisposable Register(string name)
-		=> _fileSystem.StatisticsRegistration.File.Register(name);
-
 	private IDisposable Register<T1>(string name, T1 parameter1)
 		=> _fileSystem.StatisticsRegistration.File.Register(name,
 			ParameterDescription.FromParameter(parameter1));
@@ -1371,13 +1369,15 @@ internal sealed class FileMock : IFile
 			ParameterDescription.FromParameter(parameter1),
 			ParameterDescription.FromParameter(parameter2));
 
-	private IDisposable Register<T1, T2, T3>(string name, T1 parameter1, T2 parameter2, T3 parameter3)
+	private IDisposable Register<T1, T2, T3>(string name, T1 parameter1, T2 parameter2,
+		T3 parameter3)
 		=> _fileSystem.StatisticsRegistration.File.Register(name,
 			ParameterDescription.FromParameter(parameter1),
 			ParameterDescription.FromParameter(parameter2),
 			ParameterDescription.FromParameter(parameter3));
 
-	private IDisposable Register<T1, T2, T3, T4>(string name, T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)
+	private IDisposable Register<T1, T2, T3, T4>(string name, T1 parameter1, T2 parameter2,
+		T3 parameter3, T4 parameter4)
 		=> _fileSystem.StatisticsRegistration.File.Register(name,
 			ParameterDescription.FromParameter(parameter1),
 			ParameterDescription.FromParameter(parameter2),

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -1360,24 +1360,26 @@ internal sealed class FileMock : IFile
 	}
 #endif
 
-	private IDisposable Register<T1>(string name, T1 parameter1)
+	private IDisposable Register<T1>(string name,
+		T1 parameter1)
 		=> _fileSystem.StatisticsRegistration.File.Register(name,
 			ParameterDescription.FromParameter(parameter1));
 
-	private IDisposable Register<T1, T2>(string name, T1 parameter1, T2 parameter2)
+	private IDisposable Register<T1, T2>(string name,
+		T1 parameter1, T2 parameter2)
 		=> _fileSystem.StatisticsRegistration.File.Register(name,
 			ParameterDescription.FromParameter(parameter1),
 			ParameterDescription.FromParameter(parameter2));
 
-	private IDisposable Register<T1, T2, T3>(string name, T1 parameter1, T2 parameter2,
-		T3 parameter3)
+	private IDisposable Register<T1, T2, T3>(string name,
+		T1 parameter1, T2 parameter2, T3 parameter3)
 		=> _fileSystem.StatisticsRegistration.File.Register(name,
 			ParameterDescription.FromParameter(parameter1),
 			ParameterDescription.FromParameter(parameter2),
 			ParameterDescription.FromParameter(parameter3));
 
-	private IDisposable Register<T1, T2, T3, T4>(string name, T1 parameter1, T2 parameter2,
-		T3 parameter3, T4 parameter4)
+	private IDisposable Register<T1, T2, T3, T4>(string name,
+		T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)
 		=> _fileSystem.StatisticsRegistration.File.Register(name,
 			ParameterDescription.FromParameter(parameter1),
 			ParameterDescription.FromParameter(parameter2),

--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -524,7 +524,9 @@ internal sealed class PathMock : PathSystemBase
 	private IDisposable Register<T1>(string name, ReadOnlySpan<T1> parameter1)
 		=> _fileSystem.StatisticsRegistration.Path.Register(name,
 			ParameterDescription.FromParameter(parameter1));
+#endif
 
+#if FEATURE_PATH_ADVANCED
 	private IDisposable Register<T1, T2>(string name, ReadOnlySpan<T1> parameter1,
 		ReadOnlySpan<T2> parameter2)
 		=> _fileSystem.StatisticsRegistration.Path.Register(name,

--- a/Source/Testably.Abstractions.Testing/Statistics/FileSystemStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/FileSystemStatistics.cs
@@ -82,7 +82,7 @@ internal sealed class FileSystemStatistics : IFileSystemStatistics, IStatisticsG
 
 	#endregion
 
-	private class TemporaryDisable : IDisposable
+	private sealed class TemporaryDisable : IDisposable
 	{
 		public static IDisposable None { get; } = new NoOpDisposable();
 

--- a/Source/Testably.Abstractions.Testing/Statistics/ParameterDescription.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/ParameterDescription.cs
@@ -45,15 +45,6 @@ public abstract class ParameterDescription
 		       value.SequenceEqual(d.Value);
 	}
 
-	private static bool IsEqual<T>(T value1, T value2)
-	{
-		if (value1 is null)
-		{
-			return value2 is null;
-		}
-
-		return value1.Equals(value2);
-	}
 #if FEATURE_SPAN
 	/// <summary>
 	///     Checks, if the span value of the parameter equals <paramref name="value" />.
@@ -111,7 +102,17 @@ public abstract class ParameterDescription
 		return new GenericParameterDescription<T>(value, true);
 	}
 
-	private class GenericParameterDescription<T> : ParameterDescription
+	private static bool IsEqual<T>(T value1, T value2)
+	{
+		if (value1 is null)
+		{
+			return value2 is null;
+		}
+
+		return value1.Equals(value2);
+	}
+
+	private sealed class GenericParameterDescription<T> : ParameterDescription
 	{
 		public T Value { get; }
 
@@ -133,7 +134,7 @@ public abstract class ParameterDescription
 	}
 
 #if FEATURE_SPAN
-	private class SpanParameterDescription<T> : ParameterDescription
+	private sealed class SpanParameterDescription<T> : ParameterDescription
 	{
 		public T[] Value { get; }
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Polyfills/StringExtensionMethods.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Polyfills/StringExtensionMethods.cs
@@ -1,0 +1,29 @@
+﻿#if NET48
+using System.Diagnostics.CodeAnalysis;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Abstractions.Polyfills;
+
+/// <summary>
+///     Provides extension methods to simplify writing platform independent tests.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class StringExtensionMethods
+{
+	/// <summary>
+	///     Reports the zero-based index of the first occurrence of the specified string in the current
+	///     <see langword="string" /> object. A parameter specifies the type of search to use for the specified string.
+	/// </summary>
+	/// <returns>
+	///     The index position of the <paramref name="value" /> parameter if that string is found, or <c>-1</c> if it is not.
+	///     If <paramref name="value" /> is <see cref="string.Empty" />, the return value is <c>0</c>.
+	/// </returns>
+	internal static int IndexOf(
+		this string @this,
+		char value,
+		StringComparison comparison)
+	{
+		return @this.IndexOf($"{value}", comparison);
+	}
+}
+#endif

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamFactoryStatisticsTests.cs
@@ -20,7 +20,7 @@ public class FileStreamFactoryStatisticsTests
 		SafeFileHandle handle = new();
 		FileAccess access = FileAccess.ReadWrite;
 
-		sut.FileStream.New(handle, access);
+		using FileSystemStream result = sut.FileStream.New(handle, access);
 
 		sut.Statistics.FileStream.ShouldOnlyContain(nameof(IFileStreamFactory.New),
 			handle, access);
@@ -34,7 +34,7 @@ public class FileStreamFactoryStatisticsTests
 		string path = "foo";
 		FileMode mode = FileMode.OpenOrCreate;
 
-		sut.FileStream.New(path, mode);
+		using FileSystemStream result = sut.FileStream.New(path, mode);
 
 		sut.Statistics.FileStream.ShouldOnlyContain(nameof(IFileStreamFactory.New),
 			path, mode);
@@ -49,7 +49,7 @@ public class FileStreamFactoryStatisticsTests
 		string path = "foo";
 		FileStreamOptions options = new();
 
-		sut.FileStream.New(path, options);
+		using FileSystemStream result = sut.FileStream.New(path, options);
 
 		sut.Statistics.FileStream.ShouldOnlyContain(nameof(IFileStreamFactory.New),
 			path, options);
@@ -68,7 +68,7 @@ public class FileStreamFactoryStatisticsTests
 		FileAccess access = FileAccess.ReadWrite;
 		int bufferSize = 42;
 
-		sut.FileStream.New(handle, access, bufferSize);
+		using FileSystemStream result = sut.FileStream.New(handle, access, bufferSize);
 
 		sut.Statistics.FileStream.ShouldOnlyContain(nameof(IFileStreamFactory.New),
 			handle, access, bufferSize);
@@ -83,7 +83,7 @@ public class FileStreamFactoryStatisticsTests
 		FileMode mode = FileMode.OpenOrCreate;
 		FileAccess access = FileAccess.ReadWrite;
 
-		sut.FileStream.New(path, mode, access);
+		using FileSystemStream result = sut.FileStream.New(path, mode, access);
 
 		sut.Statistics.FileStream.ShouldOnlyContain(nameof(IFileStreamFactory.New),
 			path, mode, access);
@@ -102,7 +102,7 @@ public class FileStreamFactoryStatisticsTests
 		int bufferSize = 42;
 		bool isAsync = true;
 
-		sut.FileStream.New(handle, access, bufferSize, isAsync);
+		using FileSystemStream result = sut.FileStream.New(handle, access, bufferSize, isAsync);
 
 		sut.Statistics.FileStream.ShouldOnlyContain(nameof(IFileStreamFactory.New),
 			handle, access, bufferSize, isAsync);
@@ -118,7 +118,7 @@ public class FileStreamFactoryStatisticsTests
 		FileAccess access = FileAccess.ReadWrite;
 		FileShare share = FileShare.ReadWrite;
 
-		sut.FileStream.New(path, mode, access, share);
+		using FileSystemStream result = sut.FileStream.New(path, mode, access, share);
 
 		sut.Statistics.FileStream.ShouldOnlyContain(nameof(IFileStreamFactory.New),
 			path, mode, access, share);
@@ -134,7 +134,7 @@ public class FileStreamFactoryStatisticsTests
 		FileShare share = FileShare.ReadWrite;
 		int bufferSize = 42;
 
-		sut.FileStream.New(path, mode, access, share, bufferSize);
+		using FileSystemStream result = sut.FileStream.New(path, mode, access, share, bufferSize);
 
 		sut.Statistics.FileStream.ShouldOnlyContain(nameof(IFileStreamFactory.New),
 			path, mode, access, share, bufferSize);
@@ -151,7 +151,7 @@ public class FileStreamFactoryStatisticsTests
 		int bufferSize = 42;
 		bool useAsync = true;
 
-		sut.FileStream.New(path, mode, access, share, bufferSize, useAsync);
+		using FileSystemStream result = sut.FileStream.New(path, mode, access, share, bufferSize, useAsync);
 
 		sut.Statistics.FileStream.ShouldOnlyContain(nameof(IFileStreamFactory.New),
 			path, mode, access, share, bufferSize, useAsync);
@@ -168,7 +168,7 @@ public class FileStreamFactoryStatisticsTests
 		int bufferSize = 42;
 		FileOptions options = new();
 
-		sut.FileStream.New(path, mode, access, share, bufferSize, options);
+		using FileSystemStream result = sut.FileStream.New(path, mode, access, share, bufferSize, options);
 
 		sut.Statistics.FileStream.ShouldOnlyContain(nameof(IFileStreamFactory.New),
 			path, mode, access, share, bufferSize, options);
@@ -182,7 +182,7 @@ public class FileStreamFactoryStatisticsTests
 
 		try
 		{
-			sut.FileStream.Wrap(fileStream);
+			using FileSystemStream result = sut.FileStream.Wrap(fileStream);
 		}
 		catch (NotSupportedException)
 		{

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamStatisticsTests.cs
@@ -12,14 +12,14 @@ public class FileStreamStatisticsTests
 	public void BeginRead_ByteArray_Int_Int_AsyncCallback_Object_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		byte[] buffer = Encoding.UTF8.GetBytes("foo");
 		int offset = 0;
 		int count = 2;
 		AsyncCallback? callback = null;
-		object? state = new();
+		object? state = null;
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate)
-			.BeginRead(buffer, offset, count, callback, state);
+		fileStream.BeginRead(buffer, offset, count, callback, state);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.BeginRead),
 			buffer, offset, count, callback, state);
@@ -29,14 +29,14 @@ public class FileStreamStatisticsTests
 	public void BeginWrite_ByteArray_Int_Int_AsyncCallback_Object_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		byte[] buffer = Encoding.UTF8.GetBytes("foo");
 		int offset = 0;
 		int count = 2;
 		AsyncCallback? callback = null;
 		object? state = null;
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate)
-			.BeginWrite(buffer, offset, count, callback, state);
+		fileStream.BeginWrite(buffer, offset, count, callback, state);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.BeginWrite),
 			buffer, offset, count, callback, state);
@@ -46,10 +46,11 @@ public class FileStreamStatisticsTests
 	public void CopyTo_Stream_Int_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		Stream destination = new MemoryStream();
 		int bufferSize = 42;
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate).CopyTo(destination, bufferSize);
+		fileStream.CopyTo(destination, bufferSize);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.CopyTo),
 			destination, bufferSize);
@@ -59,12 +60,12 @@ public class FileStreamStatisticsTests
 	public async Task CopyToAsync_Stream_Int_CancellationToken_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		Stream destination = new MemoryStream();
 		int bufferSize = 42;
 		CancellationToken cancellationToken = CancellationToken.None;
 
-		await sut.FileStream.New("foo", FileMode.OpenOrCreate)
-			.CopyToAsync(destination, bufferSize, cancellationToken);
+		await fileStream.CopyToAsync(destination, bufferSize, cancellationToken);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.CopyToAsync),
 			destination, bufferSize, cancellationToken);
@@ -75,10 +76,10 @@ public class FileStreamStatisticsTests
 	{
 		MockFileSystem sut = new();
 		sut.Initialize().WithFile("foo");
-		FileSystemStream stream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
-		IAsyncResult asyncResult = stream.BeginRead(new byte[10], 0, 10, null, null);
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
+		IAsyncResult asyncResult = fileStream.BeginRead(new byte[10], 0, 10, null, null);
 
-		stream.EndRead(asyncResult);
+		fileStream.EndRead(asyncResult);
 
 		sut.Statistics.FileStream["foo"].Methods.Count.Should().Be(2);
 		sut.Statistics.FileStream["foo"].Methods.Values.Should()
@@ -92,10 +93,10 @@ public class FileStreamStatisticsTests
 	{
 		MockFileSystem sut = new();
 		sut.Initialize().WithFile("foo");
-		FileSystemStream stream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
-		IAsyncResult asyncResult = stream.BeginWrite(new byte[10], 0, 10, null, null);
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
+		IAsyncResult asyncResult = fileStream.BeginWrite(new byte[10], 0, 10, null, null);
 
-		stream.EndWrite(asyncResult);
+		fileStream.EndWrite(asyncResult);
 
 		sut.Statistics.FileStream["foo"].Methods.Count.Should().Be(2);
 		sut.Statistics.FileStream["foo"].Methods.Values.Should()
@@ -108,8 +109,9 @@ public class FileStreamStatisticsTests
 	public void Flush_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate).Flush();
+		fileStream.Flush();
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.Flush));
 	}
@@ -118,9 +120,10 @@ public class FileStreamStatisticsTests
 	public void Flush_Bool_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		bool flushToDisk = true;
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate).Flush(flushToDisk);
+		fileStream.Flush(flushToDisk);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.Flush),
 			flushToDisk);
@@ -130,9 +133,10 @@ public class FileStreamStatisticsTests
 	public async Task FlushAsync_CancellationToken_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		CancellationToken cancellationToken = CancellationToken.None;
 
-		await sut.FileStream.New("foo", FileMode.OpenOrCreate).FlushAsync(cancellationToken);
+		await fileStream.FlushAsync(cancellationToken);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.FlushAsync),
 			cancellationToken);
@@ -143,9 +147,10 @@ public class FileStreamStatisticsTests
 	public void Read_SpanByte_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		Span<byte> buffer = new();
 
-		_ = sut.FileStream.New("foo", FileMode.OpenOrCreate).Read(buffer);
+		_ = fileStream.Read(buffer);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.Read),
 			buffer);
@@ -156,11 +161,12 @@ public class FileStreamStatisticsTests
 	public void Read_ByteArray_Int_Int_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		byte[] buffer = Encoding.UTF8.GetBytes("foo");
 		int offset = 0;
 		int count = 2;
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate).Read(buffer, offset, count);
+		_ = fileStream.Read(buffer, offset, count);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.Read),
 			buffer, offset, count);
@@ -168,13 +174,14 @@ public class FileStreamStatisticsTests
 
 #if FEATURE_SPAN
 	[SkippableFact]
-	public void ReadAsync_MemoryByte_CancellationToken_ShouldRegisterCall()
+	public async Task ReadAsync_MemoryByte_CancellationToken_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		await using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		Memory<byte> buffer = new();
 		CancellationToken cancellationToken = CancellationToken.None;
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate).ReadAsync(buffer, cancellationToken);
+		_ = await fileStream.ReadAsync(buffer, cancellationToken);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.ReadAsync),
 			buffer, cancellationToken);
@@ -185,13 +192,13 @@ public class FileStreamStatisticsTests
 	public async Task ReadAsync_ByteArray_Int_Int_CancellationToken_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		byte[] buffer = Encoding.UTF8.GetBytes("foo");
 		int offset = 0;
 		int count = 2;
 		CancellationToken cancellationToken = CancellationToken.None;
 
-		await sut.FileStream.New("foo", FileMode.OpenOrCreate)
-			.ReadAsync(buffer, offset, count, cancellationToken);
+		_ = await fileStream.ReadAsync(buffer, offset, count, cancellationToken);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.ReadAsync),
 			buffer, offset, count, cancellationToken);
@@ -201,8 +208,9 @@ public class FileStreamStatisticsTests
 	public void ReadByte_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate).ReadByte();
+		fileStream.ReadByte();
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.ReadByte));
 	}
@@ -211,10 +219,11 @@ public class FileStreamStatisticsTests
 	public void Seek_Int64_SeekOrigin_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		long offset = new();
 		SeekOrigin origin = new();
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate).Seek(offset, origin);
+		fileStream.Seek(offset, origin);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.Seek),
 			offset, origin);
@@ -224,9 +233,10 @@ public class FileStreamStatisticsTests
 	public void SetLength_Int64_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		long value = new();
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate).SetLength(value);
+		fileStream.SetLength(value);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.SetLength),
 			value);
@@ -236,8 +246,9 @@ public class FileStreamStatisticsTests
 	public void ToString_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate).ToString();
+		_ = fileStream.ToString();
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.ToString));
 	}
@@ -247,9 +258,10 @@ public class FileStreamStatisticsTests
 	public void Write_ReadOnlySpanByte_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		ReadOnlySpan<byte> buffer = new();
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate).Write(buffer);
+		fileStream.Write(buffer);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.Write),
 			buffer);
@@ -260,11 +272,12 @@ public class FileStreamStatisticsTests
 	public void Write_ByteArray_Int_Int_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		byte[] buffer = Encoding.UTF8.GetBytes("foo");
 		int offset = 0;
 		int count = 2;
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate).Write(buffer, offset, count);
+		fileStream.Write(buffer, offset, count);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.Write),
 			buffer, offset, count);
@@ -272,13 +285,14 @@ public class FileStreamStatisticsTests
 
 #if FEATURE_SPAN
 	[SkippableFact]
-	public void WriteAsync_ReadOnlyMemoryByte_CancellationToken_ShouldRegisterCall()
+	public async Task WriteAsync_ReadOnlyMemoryByte_CancellationToken_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		await using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		ReadOnlyMemory<byte> buffer = new();
 		CancellationToken cancellationToken = CancellationToken.None;
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate).WriteAsync(buffer, cancellationToken);
+		await fileStream.WriteAsync(buffer, cancellationToken);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.WriteAsync),
 			buffer, cancellationToken);
@@ -289,13 +303,13 @@ public class FileStreamStatisticsTests
 	public async Task WriteAsync_ByteArray_Int_Int_CancellationToken_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		byte[] buffer = Encoding.UTF8.GetBytes("foo");
 		int offset = 0;
 		int count = 2;
 		CancellationToken cancellationToken = CancellationToken.None;
 
-		await sut.FileStream.New("foo", FileMode.OpenOrCreate)
-			.WriteAsync(buffer, offset, count, cancellationToken);
+		await fileStream.WriteAsync(buffer, offset, count, cancellationToken);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.WriteAsync),
 			buffer, offset, count, cancellationToken);
@@ -305,9 +319,10 @@ public class FileStreamStatisticsTests
 	public void WriteByte_Byte_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
+		using FileSystemStream fileStream = sut.FileStream.New("foo", FileMode.OpenOrCreate);
 		byte value = new();
 
-		sut.FileStream.New("foo", FileMode.OpenOrCreate).WriteByte(value);
+		fileStream.WriteByte(value);
 
 		sut.Statistics.FileStream["foo"].ShouldOnlyContain(nameof(FileSystemStream.WriteByte),
 			value);

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherFactoryStatisticsTests.cs
@@ -10,7 +10,7 @@ public class FileSystemWatcherFactoryStatisticsTests
 	{
 		MockFileSystem sut = new();
 
-		sut.FileSystemWatcher.New();
+		using IFileSystemWatcher result = sut.FileSystemWatcher.New();
 
 		sut.Statistics.FileSystemWatcher.ShouldOnlyContain(nameof(IFileSystemWatcherFactory.New));
 	}
@@ -22,7 +22,7 @@ public class FileSystemWatcherFactoryStatisticsTests
 		sut.Initialize().WithSubdirectory("foo");
 		string path = "foo";
 
-		sut.FileSystemWatcher.New(path);
+		using IFileSystemWatcher result = sut.FileSystemWatcher.New(path);
 
 		sut.Statistics.FileSystemWatcher.ShouldOnlyContain(nameof(IFileSystemWatcherFactory.New),
 			path);
@@ -36,7 +36,7 @@ public class FileSystemWatcherFactoryStatisticsTests
 		string path = "foo";
 		string filter = "bar";
 
-		sut.FileSystemWatcher.New(path, filter);
+		using IFileSystemWatcher result = sut.FileSystemWatcher.New(path, filter);
 
 		sut.Statistics.FileSystemWatcher.ShouldOnlyContain(nameof(IFileSystemWatcherFactory.New),
 			path, filter);
@@ -48,10 +48,9 @@ public class FileSystemWatcherFactoryStatisticsTests
 		MockFileSystem sut = new();
 		FileSystemWatcher fileSystemWatcher = new();
 
-		sut.FileSystemWatcher.Wrap(fileSystemWatcher);
+		using IFileSystemWatcher result = sut.FileSystemWatcher.Wrap(fileSystemWatcher);
 
 		sut.Statistics.FileSystemWatcher.ShouldOnlyContain(nameof(IFileSystemWatcherFactory.Wrap),
 			fileSystemWatcher);
 	}
-
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
@@ -54,9 +54,8 @@ public class FileSystemWatcherStatisticsTests
 
 		fileSystemWatcher.WaitForChanged(changeType);
 
-		sut.Statistics.FileSystemWatcher["foo"].ShouldOnlyContain(
-			nameof(IFileSystemWatcher.WaitForChanged),
-			changeType);
+		sut.Statistics.FileSystemWatcher["foo"]
+			.ShouldOnlyContain(nameof(IFileSystemWatcher.WaitForChanged), changeType);
 	}
 
 	[SkippableFact]
@@ -81,9 +80,8 @@ public class FileSystemWatcherStatisticsTests
 
 		fileSystemWatcher.WaitForChanged(changeType, timeout);
 
-		sut.Statistics.FileSystemWatcher["foo"].ShouldOnlyContain(
-			nameof(IFileSystemWatcher.WaitForChanged),
-			changeType, timeout);
+		sut.Statistics.FileSystemWatcher["foo"]
+			.ShouldOnlyContain(nameof(IFileSystemWatcher.WaitForChanged), changeType, timeout);
 	}
 
 #if FEATURE_FILESYSTEM_NET7
@@ -109,8 +107,8 @@ public class FileSystemWatcherStatisticsTests
 
 		fileSystemWatcher.WaitForChanged(changeType, timeout);
 
-		sut.Statistics.FileSystemWatcher["foo"].ShouldOnlyContain(nameof(IFileSystemWatcher.WaitForChanged),
-			changeType, timeout);
+		sut.Statistics.FileSystemWatcher["foo"]
+			.ShouldOnlyContain(nameof(IFileSystemWatcher.WaitForChanged), changeType, timeout);
 	}
 #endif
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
-using System.Threading.Tasks;
 using System.Threading;
+using System.Threading.Tasks;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 
 namespace Testably.Abstractions.Testing.Tests.Statistics.FileSystem;
@@ -12,10 +12,12 @@ public class FileSystemWatcherStatisticsTests
 	{
 		MockFileSystem sut = new();
 		sut.Initialize().WithSubdirectory("foo");
+		using IFileSystemWatcher fileSystemWatcher = sut.FileSystemWatcher.New("foo");
 
-		sut.FileSystemWatcher.New("foo").BeginInit();
+		fileSystemWatcher.BeginInit();
 
-		sut.Statistics.FileSystemWatcher["foo"].ShouldOnlyContain(nameof(IFileSystemWatcher.BeginInit));
+		sut.Statistics.FileSystemWatcher["foo"]
+			.ShouldOnlyContain(nameof(IFileSystemWatcher.BeginInit));
 	}
 
 	[SkippableFact]
@@ -23,10 +25,12 @@ public class FileSystemWatcherStatisticsTests
 	{
 		MockFileSystem sut = new();
 		sut.Initialize().WithSubdirectory("foo");
+		using IFileSystemWatcher fileSystemWatcher = sut.FileSystemWatcher.New("foo");
 
-		sut.FileSystemWatcher.New("foo").EndInit();
+		fileSystemWatcher.EndInit();
 
-		sut.Statistics.FileSystemWatcher["foo"].ShouldOnlyContain(nameof(IFileSystemWatcher.EndInit));
+		sut.Statistics.FileSystemWatcher["foo"]
+			.ShouldOnlyContain(nameof(IFileSystemWatcher.EndInit));
 	}
 
 	[SkippableFact]
@@ -34,6 +38,7 @@ public class FileSystemWatcherStatisticsTests
 	{
 		MockFileSystem sut = new();
 		sut.Initialize().WithSubdirectory("foo");
+		using IFileSystemWatcher fileSystemWatcher = sut.FileSystemWatcher.New("foo");
 		// Changes in the background are necessary, so that FileSystemWatcher.WaitForChanged returns.
 		CancellationTokenSource cts = new(TimeSpan.FromSeconds(1));
 		_ = Task.Run(async () =>
@@ -47,9 +52,10 @@ public class FileSystemWatcherStatisticsTests
 		}, cts.Token);
 		WatcherChangeTypes changeType = WatcherChangeTypes.Created;
 
-		sut.FileSystemWatcher.New("foo").WaitForChanged(changeType);
+		fileSystemWatcher.WaitForChanged(changeType);
 
-		sut.Statistics.FileSystemWatcher["foo"].ShouldOnlyContain(nameof(IFileSystemWatcher.WaitForChanged),
+		sut.Statistics.FileSystemWatcher["foo"].ShouldOnlyContain(
+			nameof(IFileSystemWatcher.WaitForChanged),
 			changeType);
 	}
 
@@ -58,6 +64,7 @@ public class FileSystemWatcherStatisticsTests
 	{
 		MockFileSystem sut = new();
 		sut.Initialize().WithSubdirectory("foo");
+		using IFileSystemWatcher fileSystemWatcher = sut.FileSystemWatcher.New("foo");
 		// Changes in the background are necessary, so that FileSystemWatcher.WaitForChanged returns.
 		CancellationTokenSource cts = new(TimeSpan.FromSeconds(1));
 		_ = Task.Run(async () =>
@@ -72,9 +79,10 @@ public class FileSystemWatcherStatisticsTests
 		WatcherChangeTypes changeType = WatcherChangeTypes.Created;
 		int timeout = 42;
 
-		sut.FileSystemWatcher.New("foo").WaitForChanged(changeType, timeout);
+		fileSystemWatcher.WaitForChanged(changeType, timeout);
 
-		sut.Statistics.FileSystemWatcher["foo"].ShouldOnlyContain(nameof(IFileSystemWatcher.WaitForChanged),
+		sut.Statistics.FileSystemWatcher["foo"].ShouldOnlyContain(
+			nameof(IFileSystemWatcher.WaitForChanged),
 			changeType, timeout);
 	}
 
@@ -84,6 +92,7 @@ public class FileSystemWatcherStatisticsTests
 	{
 		MockFileSystem sut = new();
 		sut.Initialize().WithSubdirectory("foo");
+		using IFileSystemWatcher fileSystemWatcher = sut.FileSystemWatcher.New("foo");
 		// Changes in the background are necessary, so that FileSystemWatcher.WaitForChanged returns.
 		CancellationTokenSource cts = new(TimeSpan.FromSeconds(1));
 		_ = Task.Run(async () =>
@@ -98,7 +107,7 @@ public class FileSystemWatcherStatisticsTests
 		WatcherChangeTypes changeType = WatcherChangeTypes.Created;
 		TimeSpan timeout = TimeSpan.FromSeconds(2);
 
-		sut.FileSystemWatcher.New("foo").WaitForChanged(changeType, timeout);
+		fileSystemWatcher.WaitForChanged(changeType, timeout);
 
 		sut.Statistics.FileSystemWatcher["foo"].ShouldOnlyContain(nameof(IFileSystemWatcher.WaitForChanged),
 			changeType, timeout);

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/MethodStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/MethodStatisticsTests.cs
@@ -1,0 +1,31 @@
+﻿namespace Testably.Abstractions.Testing.Tests.Statistics;
+
+public sealed class MethodStatisticsTests
+{
+	[Fact]
+	public void ToString_ShouldContainName()
+	{
+		MockFileSystem sut = new();
+		sut.Directory.CreateDirectory("foo");
+
+		string result = sut.Statistics.Directory.Methods[1].ToString();
+
+		result.Should()
+			.Contain(nameof(IDirectory.CreateDirectory)).And
+			.Contain("\"foo\"").And
+			.NotContain(",");
+	}
+
+	[Fact]
+	public void ToString_ShouldContainParameters()
+	{
+		MockFileSystem sut = new();
+		sut.File.WriteAllText("foo", "bar");
+
+		string result = sut.Statistics.File.Methods[1].ToString();
+
+		result.Should()
+			.Contain(nameof(IFile.WriteAllText)).And
+			.Contain("\"foo\",\"bar\"");
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/ParameterDescriptionTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/ParameterDescriptionTests.cs
@@ -1,0 +1,120 @@
+﻿using Testably.Abstractions.Testing.Statistics;
+
+namespace Testably.Abstractions.Testing.Tests.Statistics;
+
+public sealed class ParameterDescriptionTests
+{
+	[Theory]
+	[AutoData]
+	public void FromOutParameter_ShouldSetIsOutParameterToTrue(int value)
+	{
+		ParameterDescription sut = ParameterDescription.FromOutParameter(value);
+
+		sut.IsOutParameter.Should().BeTrue();
+	}
+
+	[Theory]
+	[AutoData]
+	public void FromParameter_ShouldSetIsOutParameterToFalse(int value)
+	{
+		ParameterDescription sut = ParameterDescription.FromParameter(value);
+
+		sut.IsOutParameter.Should().BeFalse();
+	}
+
+#if FEATURE_SPAN
+	[Theory]
+	[AutoData]
+	public void FromParameter_WithSpan_ShouldSetIsOutParameterToFalse(int[] buffer)
+	{
+		Span<int> value = buffer.AsSpan();
+
+		ParameterDescription sut = ParameterDescription.FromParameter(value);
+
+		sut.IsOutParameter.Should().BeFalse();
+	}
+
+	[Theory]
+	[AutoData]
+	public void FromParameter_WithReadOnlySpan_ShouldSetIsOutParameterToFalse(string buffer)
+	{
+		ReadOnlySpan<char> value = buffer.AsSpan();
+
+		ParameterDescription sut = ParameterDescription.FromParameter(value);
+
+		sut.IsOutParameter.Should().BeFalse();
+	}
+#endif
+
+	[Theory]
+	[AutoData]
+	public void Is_WithFromOutParameter_ShouldCheckForMatchingValue(int value)
+	{
+		ParameterDescription sut = ParameterDescription.FromOutParameter(value);
+
+		sut.Is(value).Should().BeTrue();
+		sut.Is(value + 1).Should().BeFalse();
+		sut.Is("foo").Should().BeFalse();
+	}
+
+	[Theory]
+	[AutoData]
+	public void Is_WithFromParameter_ShouldCheckForMatchingValue(string value)
+	{
+		ParameterDescription sut = ParameterDescription.FromParameter(value);
+
+		sut.Is(value).Should().BeTrue();
+		sut.Is($"other_{value}").Should().BeFalse();
+		sut.Is(42).Should().BeFalse();
+	}
+
+	[Theory]
+	[AutoData]
+	public void ToString_ShouldReturnValue(int value)
+	{
+		ParameterDescription sut = ParameterDescription.FromParameter(value);
+
+		string? result = sut.ToString();
+
+		result.Should().Be(value.ToString());
+	}
+
+	[Theory]
+	[AutoData]
+	public void ToString_WithStringValue_ShouldReturnValueEnclosedInQuotationMarks(string value)
+	{
+		ParameterDescription sut = ParameterDescription.FromOutParameter(value);
+
+		string? result = sut.ToString();
+
+		result.Should().Be($"\"{value}\"");
+	}
+
+#if FEATURE_SPAN
+	[Theory]
+	[AutoData]
+	public void ToString_WithSpan_ShouldSetIsOutParameterToFalse(int[] buffer)
+	{
+		Span<int> value = buffer.AsSpan();
+		ParameterDescription sut = ParameterDescription.FromParameter(value);
+		string expectedString = $"[{string.Join(",", buffer)}]";
+
+		string? result = sut.ToString();
+
+		result.Should().Be(expectedString);
+	}
+
+	[Theory]
+	[AutoData]
+	public void ToString_WithReadOnlySpan_ShouldSetIsOutParameterToFalse(string buffer)
+	{
+		ReadOnlySpan<char> value = buffer.AsSpan();
+		ParameterDescription sut = ParameterDescription.FromParameter(value);
+		string expectedString = $"[{string.Join(",", buffer.ToCharArray())}]";
+
+		string? result = sut.ToString();
+
+		result.Should().Be(expectedString);
+	}
+#endif
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/StatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/StatisticsTests.cs
@@ -183,7 +183,7 @@ public sealed class StatisticsTests
 
 			if (type.IsGenericType)
 			{
-				int idx = type.Name.IndexOf("`", StringComparison.Ordinal);
+				int idx = type.Name.IndexOf('`', StringComparison.Ordinal);
 				if (idx > 0)
 				{
 					return


### PR DESCRIPTION
Fix the errors from the [sonar cloud static code analysis](https://github.com/Testably/Testably.Abstractions/runs/22481531017).