### PR TITLE
refactor: replace the dictionary in the statistics with an array

### DIFF
--- a/Source/Testably.Abstractions.Testing/Statistics/IStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/IStatistics.cs
@@ -10,5 +10,5 @@ public interface IStatistics
 	/// <summary>
 	///     Lists all called mocked methods.
 	/// </summary>
-	IReadOnlyDictionary<int, MethodStatistic> Methods { get; }
+	MethodStatistic[] Methods { get; }
 }

--- a/Source/Testably.Abstractions.Testing/Statistics/MethodStatistic.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/MethodStatistic.cs
@@ -8,6 +8,11 @@ namespace Testably.Abstractions.Testing.Statistics;
 public sealed class MethodStatistic
 {
 	/// <summary>
+	///     The global counter value to determine the order of calls.
+	/// </summary>
+	public int Counter { get; }
+
+	/// <summary>
 	///     The name of the called method.
 	/// </summary>
 	public string Name { get; }
@@ -17,8 +22,9 @@ public sealed class MethodStatistic
 	/// </summary>
 	public ParameterDescription[] Parameters { get; }
 
-	internal MethodStatistic(string name, ParameterDescription[] parameters)
+	internal MethodStatistic(int counter, string name, ParameterDescription[] parameters)
 	{
+		Counter = counter;
 		Name = name;
 		Parameters = parameters;
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamStatisticsTests.cs
@@ -81,8 +81,8 @@ public class FileStreamStatisticsTests
 
 		fileStream.EndRead(asyncResult);
 
-		sut.Statistics.FileStream["foo"].Methods.Count.Should().Be(2);
-		sut.Statistics.FileStream["foo"].Methods.Values.Should()
+		sut.Statistics.FileStream["foo"].Methods.Length.Should().Be(2);
+		sut.Statistics.FileStream["foo"].Methods.Should()
 			.ContainSingle(c => c.Name == nameof(FileSystemStream.EndRead) &&
 			                    c.Parameters.Length == 1 &&
 			                    c.Parameters[0].Is(asyncResult));
@@ -98,8 +98,8 @@ public class FileStreamStatisticsTests
 
 		fileStream.EndWrite(asyncResult);
 
-		sut.Statistics.FileStream["foo"].Methods.Count.Should().Be(2);
-		sut.Statistics.FileStream["foo"].Methods.Values.Should()
+		sut.Statistics.FileStream["foo"].Methods.Length.Should().Be(2);
+		sut.Statistics.FileStream["foo"].Methods.Should()
 			.ContainSingle(c => c.Name == nameof(FileSystemStream.EndWrite) &&
 			                    c.Parameters.Length == 1 &&
 			                    c.Parameters[0].Is(asyncResult));

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/MethodStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/MethodStatisticsTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Testably.Abstractions.Testing.Tests.Statistics;
+﻿using System.Linq;
+
+namespace Testably.Abstractions.Testing.Tests.Statistics;
 
 public sealed class MethodStatisticsTests
 {
@@ -8,7 +10,7 @@ public sealed class MethodStatisticsTests
 		MockFileSystem sut = new();
 		sut.Directory.CreateDirectory("foo");
 
-		string result = sut.Statistics.Directory.Methods[1].ToString();
+		string result = sut.Statistics.Directory.Methods.First().ToString();
 
 		result.Should()
 			.Contain(nameof(IDirectory.CreateDirectory)).And
@@ -22,7 +24,7 @@ public sealed class MethodStatisticsTests
 		MockFileSystem sut = new();
 		sut.File.WriteAllText("foo", "bar");
 
-		string result = sut.Statistics.File.Methods[1].ToString();
+		string result = sut.Statistics.File.Methods.First().ToString();
 
 		result.Should()
 			.Contain(nameof(IFile.WriteAllText)).And

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/StatisticsTestHelpers.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/StatisticsTestHelpers.cs
@@ -8,8 +8,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain(this IStatistics statistics, string name,
 		object?[] parameters, string because = "")
 	{
-		statistics.Methods.Count.Should().Be(1, because);
-		statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1, because);
+		statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.SequenceEqual(parameters),
 				because);
@@ -17,8 +17,8 @@ public static class StatisticsTestHelpers
 
 	public static void ShouldOnlyContain(this IStatistics statistics, string name)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 0);
 	}
@@ -26,8 +26,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain<T1>(this IStatistics statistics, string name,
 		T1 parameter1)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 1 &&
 			                    c.Parameters[0].Is(parameter1));
@@ -36,8 +36,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain<T1>(this IStatistics statistics, string name,
 		T1[] parameter1)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 1 &&
 			                    c.Parameters[0].Is(parameter1));
@@ -47,8 +47,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain<T1>(this IStatistics statistics, string name,
 		ReadOnlySpan<T1> parameter1)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		ParameterDescription parameter = statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		ParameterDescription parameter = statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 1).Which.Parameters[0];
 		parameter.Is(parameter1).Should().BeTrue();
@@ -57,8 +57,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain<T1, T2>(this IStatistics statistics, string name,
 		ReadOnlySpan<T1> parameter1, ReadOnlySpan<T2> parameter2)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		MethodStatistic? statistic = statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		MethodStatistic? statistic = statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 2).Which;
 		statistic.Parameters[0].Is(parameter1).Should().BeTrue();
@@ -68,8 +68,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain<T1, T2, T3>(this IStatistics statistics, string name,
 		ReadOnlySpan<T1> parameter1, ReadOnlySpan<T2> parameter2, ReadOnlySpan<T3> parameter3)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		MethodStatistic? statistic = statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		MethodStatistic? statistic = statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 3).Which;
 		statistic.Parameters[0].Is(parameter1).Should().BeTrue();
@@ -80,8 +80,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain<T1, T2, T3, T4>(this IStatistics statistics, string name,
 		ReadOnlySpan<T1> parameter1, ReadOnlySpan<T2> parameter2, ReadOnlySpan<T3> parameter3, ReadOnlySpan<T4> parameter4)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		MethodStatistic? statistic = statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		MethodStatistic? statistic = statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 4).Which;
 		statistic.Parameters[0].Is(parameter1).Should().BeTrue();
@@ -93,8 +93,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain<T1, T2, T3, T4>(this IStatistics statistics, string name,
 		ReadOnlySpan<T1> parameter1, ReadOnlySpan<T2> parameter2, T3 parameter3, T4 parameter4)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		MethodStatistic? statistic = statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		MethodStatistic? statistic = statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 4).Which;
 		statistic.Parameters[0].Is(parameter1).Should().BeTrue();
@@ -106,8 +106,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain<T1, T2, T3, T4>(this IStatistics statistics, string name,
 		ReadOnlySpan<T1> parameter1, ReadOnlySpan<T2> parameter2, Span<T3> parameter3, T4 parameter4)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		MethodStatistic? statistic = statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		MethodStatistic? statistic = statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 4).Which;
 		statistic.Parameters[0].Is(parameter1).Should().BeTrue();
@@ -119,8 +119,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain<T1, T2, T3, T4, T5>(this IStatistics statistics, string name,
 		ReadOnlySpan<T1> parameter1, ReadOnlySpan<T2> parameter2, ReadOnlySpan<T3> parameter3, Span<T4> parameter4, T5 parameter5)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		MethodStatistic? statistic = statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		MethodStatistic? statistic = statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 5).Which;
 		statistic.Parameters[0].Is(parameter1).Should().BeTrue();
@@ -133,8 +133,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain<T1>(this IStatistics statistics, string name,
 		Span<T1> parameter1)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		ParameterDescription parameter = statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		ParameterDescription parameter = statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 1).Which.Parameters[0];
 		parameter.Is(parameter1).Should().BeTrue();
@@ -144,8 +144,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain<T1, T2>(this IStatistics statistics, string name,
 		T1 parameter1, T2 parameter2)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 2 &&
 			                    c.Parameters[0].Is(parameter1) &&
@@ -155,8 +155,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain<T1, T2, T3>(this IStatistics statistics, string name,
 		T1 parameter1, T2 parameter2, T3 parameter3)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 3 &&
 			                    c.Parameters[0].Is(parameter1) &&
@@ -167,8 +167,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain<T1, T2, T3, T4>(this IStatistics statistics, string name,
 		T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 4 &&
 			                    c.Parameters[0].Is(parameter1) &&
@@ -180,8 +180,8 @@ public static class StatisticsTestHelpers
 	public static void ShouldOnlyContain<T1, T2, T3, T4, T5>(this IStatistics statistics,
 		string name, T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4, T5 parameter5)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 5 &&
 			                    c.Parameters[0].Is(parameter1) &&
@@ -195,8 +195,8 @@ public static class StatisticsTestHelpers
 		string name, T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4, T5 parameter5,
 		T6 parameter6)
 	{
-		statistics.Methods.Count.Should().Be(1);
-		statistics.Methods.Values.Should()
+		statistics.Methods.Length.Should().Be(1);
+		statistics.Methods.Should()
 			.ContainSingle(c => c.Name == name &&
 			                    c.Parameters.Length == 6 &&
 			                    c.Parameters[0].Is(parameter1) &&


### PR DESCRIPTION
The global counter should not be treated as an index!

Therefore replace the dictionary in the statistics with an array and move the counter information into the `MethodStatistic` itself.
