### PR TITLE
chore: Limit "renovate" to run only weekly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,6 @@
 			"groupName": [ "Testably.Abstractions packages" ]
 		}
 	],
-	"ignoreDeps": [ "actions/download-artifact", "actions/upload-artifact" ]
+	"ignoreDeps": [ "actions/download-artifact", "actions/upload-artifact" ],
+	"schedule": ["before 4am on monday"]
 }


### PR DESCRIPTION
Limit renovate to [earlyMondays](https://docs.renovatebot.com/presets-schedule/#scheduleearlymondays).
This affects #236 