### PR TITLE
chore(deps): update dependency testableio.system.io.abstractions to v20.0.34

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
 	<ItemGroup>
 		<PackageVersion Include="System.Linq.Async" Version="6.0.1" />
 		<PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
-		<PackageVersion Include="TestableIO.System.IO.Abstractions" Version="20.0.28" />
+		<PackageVersion Include="TestableIO.System.IO.Abstractions" Version="20.0.34" />
 		<PackageVersion Include="System.IO.Compression" Version="4.3.0" />
 		<PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
 	</ItemGroup>


### PR DESCRIPTION
Use [v20.0.34](https://github.com/TestableIO/System.IO.Abstractions/releases/tag/v20.0.34)