### PR TITLE
refactor: adapt ReSharper File Layout to avoid Sonar issues during cleanup

### DIFF
--- a/Source/Testably.Abstractions.Compression/ZipArchiveWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipArchiveWrapper.cs
@@ -38,10 +38,6 @@ internal sealed class ZipArchiveWrapper : IZipArchive
 	public ZipArchiveMode Mode
 		=> _instance.Mode;
 
-	/// <inheritdoc cref="IDisposable.Dispose()" />
-	public void Dispose()
-		=> _instance.Dispose();
-
 	/// <inheritdoc cref="IZipArchive.CreateEntry(string)" />
 	public IZipArchiveEntry CreateEntry(string entryName)
 		=> ZipArchiveEntryWrapper.New(FileSystem, this, _instance.CreateEntry(entryName));
@@ -76,6 +72,10 @@ internal sealed class ZipArchiveWrapper : IZipArchive
 				sourceFileName,
 				entryName,
 				compressionLevel));
+
+	/// <inheritdoc cref="IDisposable.Dispose()" />
+	public void Dispose()
+		=> _instance.Dispose();
 
 	/// <inheritdoc cref="IZipArchive.ExtractToDirectory(string)" />
 	public void ExtractToDirectory(string destinationDirectoryName)

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
@@ -110,6 +110,19 @@ internal sealed class DirectoryInfoMock
 		ResetCache(!_fileSystem.Execute.IsNetFramework);
 	}
 
+	/// <inheritdoc cref="IFileSystemInfo.Delete()" />
+	public override void Delete()
+	{
+		using IDisposable registration = RegisterMethod(nameof(Delete));
+
+		if (!_fileSystem.Storage.DeleteContainer(Location))
+		{
+			throw ExceptionFactory.DirectoryNotFound(Location.FullPath);
+		}
+
+		ResetCache(!_fileSystem.Execute.IsNetFramework);
+	}
+
 	/// <inheritdoc cref="IDirectoryInfo.EnumerateDirectories()" />
 	public IEnumerable<IDirectoryInfo> EnumerateDirectories()
 	{
@@ -392,19 +405,6 @@ internal sealed class DirectoryInfoMock
 				           .EnsureValidFormat(_fileSystem, nameof(destDirName))),
 			           recursive: true)
 		           ?? throw ExceptionFactory.DirectoryNotFound(FullName);
-	}
-
-	/// <inheritdoc cref="IFileSystemInfo.Delete()" />
-	public override void Delete()
-	{
-		using IDisposable registration = RegisterMethod(nameof(Delete));
-
-		if (!_fileSystem.Storage.DeleteContainer(Location))
-		{
-			throw ExceptionFactory.DirectoryNotFound(Location.FullPath);
-		}
-
-		ResetCache(!_fileSystem.Execute.IsNetFramework);
 	}
 
 	#endregion

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
@@ -301,6 +301,9 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 
 	#endregion
 
+	internal static FileSystemWatcherMock New(MockFileSystem fileSystem)
+		=> new(fileSystem);
+
 	/// <inheritdoc cref="Component.Dispose(bool)" />
 	protected override void Dispose(bool disposing)
 	{
@@ -311,9 +314,6 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 
 		base.Dispose(disposing);
 	}
-
-	internal static FileSystemWatcherMock New(MockFileSystem fileSystem)
-		=> new(fileSystem);
 
 	private bool MatchesFilter(ChangeDescription changeDescription)
 	{

--- a/Source/Testably.Abstractions.Testing/Notification.cs
+++ b/Source/Testably.Abstractions.Testing/Notification.cs
@@ -95,6 +95,12 @@ public static class Notification
 
 			#region IAwaitableCallback<TValue> Members
 
+			/// <inheritdoc cref="IDisposable.Dispose()" />
+			public void Dispose()
+			{
+				_factory.UnRegisterCallback(_key);
+			}
+
 			/// <inheritdoc cref="IAwaitableCallback{TValue}.Wait(Func{TValue, bool}?, int, int, Action?)" />
 			public void Wait(Func<TValue, bool>? filter = null,
 				int timeout = 30000,
@@ -115,12 +121,6 @@ public static class Notification
 				{
 					throw ExceptionFactory.TimeoutExpired(timeout);
 				}
-			}
-
-			/// <inheritdoc cref="IDisposable.Dispose()" />
-			public void Dispose()
-			{
-				_factory.UnRegisterCallback(_key);
 			}
 
 			#endregion
@@ -241,6 +241,10 @@ public static class Notification
 
 		#region IAwaitableCallback<TValue,TFunc> Members
 
+		/// <inheritdoc cref="IDisposable.Dispose()" />
+		public void Dispose()
+			=> _awaitableCallback.Dispose();
+
 		/// <inheritdoc cref="IAwaitableCallback{TValue, TFunc}.Wait(Func{TValue, bool}?,int,int, Action?)" />
 		public TFunc Wait(Func<TValue, bool>? filter = null,
 			int timeout = 30000,
@@ -268,10 +272,6 @@ public static class Notification
 				_ = _valueProvider();
 			});
 		}
-
-		/// <inheritdoc cref="IDisposable.Dispose()" />
-		public void Dispose()
-			=> _awaitableCallback.Dispose();
 
 		#endregion
 	}

--- a/Source/Testably.Abstractions/FileSystem/FileSystemWatcherWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileSystemWatcherWrapper.cs
@@ -90,10 +90,6 @@ internal sealed class FileSystemWatcherWrapper : IFileSystemWatcher
 		set => _instance.SynchronizingObject = value;
 	}
 
-	/// <inheritdoc cref="IDisposable.Dispose()" />
-	public void Dispose()
-		=> _instance.Dispose();
-
 	/// <inheritdoc cref="IFileSystemWatcher.BeginInit()" />
 	public void BeginInit()
 		=> _instance.BeginInit();
@@ -118,6 +114,10 @@ internal sealed class FileSystemWatcherWrapper : IFileSystemWatcher
 		add => _instance.Deleted += value;
 		remove => _instance.Deleted -= value;
 	}
+
+	/// <inheritdoc cref="IDisposable.Dispose()" />
+	public void Dispose()
+		=> _instance.Dispose();
 
 	/// <inheritdoc cref="IFileSystemWatcher.EndInit()" />
 	public void EndInit()

--- a/Source/Testably.Abstractions/TimeSystem/TimerWrapper.cs
+++ b/Source/Testably.Abstractions/TimeSystem/TimerWrapper.cs
@@ -31,13 +31,13 @@ internal sealed class TimerWrapper : ITimer
 	public bool Change(TimeSpan dueTime, TimeSpan period)
 		=> _timer.Change(dueTime, period);
 
-	/// <inheritdoc cref="ITimer.Dispose(WaitHandle)" />
-	public bool Dispose(WaitHandle notifyObject)
-		=> _timer.Dispose(notifyObject);
-
 	/// <inheritdoc cref="IDisposable.Dispose()" />
 	public void Dispose()
 		=> _timer.Dispose();
+
+	/// <inheritdoc cref="ITimer.Dispose(WaitHandle)" />
+	public bool Dispose(WaitHandle notifyObject)
+		=> _timer.Dispose(notifyObject);
 
 #if FEATURE_ASYNC_DISPOSABLE
 	/// <inheritdoc cref="IAsyncDisposable.DisposeAsync()" />

--- a/Testably.Abstractions.sln.DotSettings
+++ b/Testably.Abstractions.sln.DotSettings
@@ -46,8 +46,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_CHAINED_METHOD_CALLS/@EntryValue">WRAP_IF_LONG</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">100</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">True</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
-&lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
+	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
   &lt;TypePattern DisplayName="Non-reorderable types"&gt;&#xD;
     &lt;TypePattern.Match&gt;&#xD;
       &lt;Or&gt;&#xD;
@@ -72,19 +71,19 @@
           &lt;Or&gt;&#xD;
             &lt;And&gt;&#xD;
               &lt;Kind Is="Method" /&gt;&#xD;
-              &lt;HasAttribute Name="Xunit.FactAttribute" Inherited="True" /&gt;&#xD;
+              &lt;HasAttribute Inherited="True" Name="Xunit.FactAttribute" /&gt;&#xD;
             &lt;/And&gt;&#xD;
             &lt;And&gt;&#xD;
               &lt;Kind Is="Method" /&gt;&#xD;
-              &lt;HasAttribute Name="Xunit.SkippableFactAttribute" Inherited="True" /&gt;&#xD;
+              &lt;HasAttribute Inherited="True" Name="Xunit.SkippableFactAttribute" /&gt;&#xD;
             &lt;/And&gt;&#xD;
             &lt;And&gt;&#xD;
               &lt;Kind Is="Method" /&gt;&#xD;
-              &lt;HasAttribute Name="Xunit.TheoryAttribute" Inherited="True" /&gt;&#xD;
+              &lt;HasAttribute Inherited="True" Name="Xunit.TheoryAttribute" /&gt;&#xD;
             &lt;/And&gt;&#xD;
             &lt;And&gt;&#xD;
               &lt;Kind Is="Method" /&gt;&#xD;
-              &lt;HasAttribute Name="Xunit.SkippableTheoryAttribute" Inherited="True" /&gt;&#xD;
+              &lt;HasAttribute Inherited="True" Name="Xunit.SkippableTheoryAttribute" /&gt;&#xD;
             &lt;/And&gt;&#xD;
           &lt;/Or&gt;&#xD;
         &lt;/HasMember&gt;&#xD;
@@ -114,7 +113,7 @@
           &lt;/Or&gt;&#xD;
         &lt;/Entry.Match&gt;&#xD;
         &lt;Entry.SortBy&gt;&#xD;
-          &lt;Access /&gt;&#xD;
+          &lt;Access Is="0" /&gt;&#xD;
           &lt;Name /&gt;&#xD;
         &lt;/Entry.SortBy&gt;&#xD;
       &lt;/Entry&gt;&#xD;
@@ -125,7 +124,7 @@
           &lt;/Or&gt;&#xD;
         &lt;/Entry.Match&gt;&#xD;
         &lt;Entry.SortBy&gt;&#xD;
-          &lt;Access Order="Public Protected Internal Private" /&gt;&#xD;
+          &lt;Access Is="0" Order="Public Protected Internal Private" /&gt;&#xD;
           &lt;Name /&gt;&#xD;
         &lt;/Entry.SortBy&gt;&#xD;
       &lt;/Entry&gt;&#xD;
@@ -173,7 +172,7 @@
     &lt;Region Name="Helpers"&gt;&#xD;
       &lt;Entry DisplayName="All other members"&gt;&#xD;
         &lt;Entry.SortBy&gt;&#xD;
-          &lt;Access /&gt;&#xD;
+          &lt;Access Is="0" /&gt;&#xD;
           &lt;Name /&gt;&#xD;
         &lt;/Entry.SortBy&gt;&#xD;
       &lt;/Entry&gt;&#xD;
@@ -191,7 +190,7 @@
     &lt;TypePattern.Match&gt;&#xD;
       &lt;And&gt;&#xD;
         &lt;Kind Is="Class" /&gt;&#xD;
-        &lt;HasAttribute Name="Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute" Inherited="True" /&gt;&#xD;
+        &lt;HasAttribute Inherited="True" Name="Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute" /&gt;&#xD;
       &lt;/And&gt;&#xD;
     &lt;/TypePattern.Match&gt;&#xD;
     &lt;Entry DisplayName="Static Fields and Constants"&gt;&#xD;
@@ -205,7 +204,7 @@
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Kind Order="Constant Field" /&gt;&#xD;
+        &lt;Kind Is="0" Order="Constant Field" /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Properties, Indexers"&gt;&#xD;
@@ -216,7 +215,7 @@
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Access /&gt;&#xD;
+        &lt;Access Is="0" /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Fields"&gt;&#xD;
@@ -226,7 +225,7 @@
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Access Order="Public Protected Internal Private" /&gt;&#xD;
+        &lt;Access Is="0" Order="Public Protected Internal Private" /&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
@@ -236,7 +235,7 @@
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Static /&gt;&#xD;
-        &lt;Access Order="Public Protected Internal Private" /&gt;&#xD;
+        &lt;Access Is="0" Order="Public Protected Internal Private" /&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
@@ -284,7 +283,7 @@
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Kind Is="Member" /&gt;&#xD;
-        &lt;Access /&gt;&#xD;
+        &lt;Access Is="0" /&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
@@ -296,7 +295,7 @@
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Access /&gt;&#xD;
+        &lt;Access Is="0" /&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
@@ -307,7 +306,7 @@
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Access /&gt;&#xD;
+        &lt;Access Is="0" /&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
@@ -317,7 +316,7 @@
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Static /&gt;&#xD;
-        &lt;Access Order="Public Protected Internal Private" /&gt;&#xD;
+        &lt;Access Is="0" Order="Public Protected Internal Private" /&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
@@ -326,7 +325,7 @@
         &lt;Kind Is="Event" /&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Access /&gt;&#xD;
+        &lt;Access Is="0" /&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
@@ -338,7 +337,18 @@
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Access Order="Public Protected Internal Private" /&gt;&#xD;
+        &lt;Access Is="0" Order="Public Protected Internal Private" /&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Public Enums" Priority="100"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Access Is="Public" /&gt;&#xD;
+          &lt;Kind Is="Enum" /&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
@@ -368,7 +378,7 @@
           &lt;/And&gt;&#xD;
         &lt;/Entry.Match&gt;&#xD;
         &lt;Entry.SortBy&gt;&#xD;
-          &lt;Access /&gt;&#xD;
+          &lt;Access Is="0" /&gt;&#xD;
           &lt;Name /&gt;&#xD;
         &lt;/Entry.SortBy&gt;&#xD;
       &lt;/Entry&gt;&#xD;
@@ -380,24 +390,36 @@
           &lt;/And&gt;&#xD;
         &lt;/Entry.Match&gt;&#xD;
         &lt;Entry.SortBy&gt;&#xD;
-          &lt;ImplementsInterface /&gt;&#xD;
+          &lt;Access Is="0" /&gt;&#xD;
           &lt;Name /&gt;&#xD;
         &lt;/Entry.SortBy&gt;&#xD;
       &lt;/Entry&gt;&#xD;
     &lt;/Region&gt;&#xD;
-    &lt;Entry DisplayName="All other members"&gt;&#xD;
-      &lt;Entry.SortBy&gt;&#xD;
-        &lt;Access /&gt;&#xD;
-        &lt;Name /&gt;&#xD;
-      &lt;/Entry.SortBy&gt;&#xD;
-    &lt;/Entry&gt;&#xD;
-    &lt;Entry DisplayName="Public Enums" Priority="100"&gt;&#xD;
+    &lt;Entry DisplayName="Public Methods"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Access Is="Public" /&gt;&#xD;
-          &lt;Kind Is="Enum" /&gt;&#xD;
+          &lt;Kind Is="Method" /&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Access Is="0" /&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="Internal Methods"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Access Is="Internal" /&gt;&#xD;
+          &lt;Kind Is="Method" /&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Access Is="0" /&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+    &lt;Entry DisplayName="All other members"&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
@@ -432,6 +454,10 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
+	<s:String x:Key="/Default/Housekeeping/DiskCleanup/LastRunTime/@EntryValue">03/16/2024 16:02:02</s:String>
+	<s:Boolean x:Key="/Default/Housekeeping/GlobalSettingsUpgraded/IsUpgraded/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/Housekeeping/Layout/DialogWindows/OptionsDialogView/Position/@EntryValue">[-1903,11](1024,768)</s:String>
+	<s:String x:Key="/Default/Housekeeping/OptionsDialog/SelectedPageId/@EntryValue">CsharpFileLayout</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=decryptor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=encryptor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=endian/@EntryIndexedValue">True</s:Boolean>

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGeneratorBase.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGeneratorBase.cs
@@ -25,12 +25,6 @@ internal abstract class ClassGeneratorBase
 			SourceText.From(sourceBuilder.ToString(), Encoding.UTF8));
 	}
 
-	/// <summary>
-	///     Append the source necessary for the <paramref name="class" /> to the <paramref name="sourceBuilder" />.
-	/// </summary>
-	protected abstract void GenerateSource(
-		StringBuilder sourceBuilder, ClassModel @class);
-
 	private string CreateFileName(ClassModel classToGenerate)
 	{
 		string? fileNamePrefix = ExtractFileNamePrefixFromMarker(Marker);
@@ -70,6 +64,12 @@ internal abstract class ClassGeneratorBase
 
 		return $"{marker}.";
 	}
+
+	/// <summary>
+	///     Append the source necessary for the <paramref name="class" /> to the <paramref name="sourceBuilder" />.
+	/// </summary>
+	protected abstract void GenerateSource(
+		StringBuilder sourceBuilder, ClassModel @class);
 
 	private StringBuilder GetSourceBuilder()
 		=> new(

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
@@ -123,32 +123,20 @@ public class ChangeHandlerTests
 			string>
 		{
 			{
-				null,
-				(f, p) => f.Directory.CreateDirectory(p),
-				WatcherChangeTypes.Created,
-				FileSystemTypes.Directory,
-				$"path_{Guid.NewGuid()}"
+				null, (f, p) => f.Directory.CreateDirectory(p), WatcherChangeTypes.Created,
+				FileSystemTypes.Directory, $"path_{Guid.NewGuid()}"
 			},
 			{
-				(f, p) => f.Directory.CreateDirectory(p),
-				(f, p) => f.Directory.Delete(p),
-				WatcherChangeTypes.Deleted,
-				FileSystemTypes.Directory,
-				$"path_{Guid.NewGuid()}"
+				(f, p) => f.Directory.CreateDirectory(p), (f, p) => f.Directory.Delete(p),
+				WatcherChangeTypes.Deleted, FileSystemTypes.Directory, $"path_{Guid.NewGuid()}"
 			},
 			{
-				null,
-				(f, p) => f.File.WriteAllText(p, null),
-				WatcherChangeTypes.Created,
-				FileSystemTypes.File,
-				$"path_{Guid.NewGuid()}"
+				null, (f, p) => f.File.WriteAllText(p, null), WatcherChangeTypes.Created,
+				FileSystemTypes.File, $"path_{Guid.NewGuid()}"
 			},
 			{
-				(f, p) => f.File.WriteAllText(p, null),
-				(f, p) => f.File.Delete(p),
-				WatcherChangeTypes.Deleted,
-				FileSystemTypes.File,
-				$"path_{Guid.NewGuid()}"
+				(f, p) => f.File.WriteAllText(p, null), (f, p) => f.File.Delete(p),
+				WatcherChangeTypes.Deleted, FileSystemTypes.File, $"path_{Guid.NewGuid()}"
 			}
 		};
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/RandomProvider.GeneratorTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/RandomProvider.GeneratorTests.cs
@@ -217,13 +217,13 @@ public partial class RandomProviderTests
 
 			#region IEnumerable<int> Members
 
-			/// <inheritdoc cref="IEnumerable.GetEnumerator()" />
-			IEnumerator IEnumerable.GetEnumerator()
-				=> GetEnumerator();
-
 			/// <inheritdoc cref="IEnumerable{T}.GetEnumerator()" />
 			public IEnumerator<int> GetEnumerator()
 				=> Enumerator;
+
+			/// <inheritdoc cref="IEnumerable.GetEnumerator()" />
+			IEnumerator IEnumerable.GetEnumerator()
+				=> GetEnumerator();
 
 			#endregion
 		}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/TestDataGetEncodingDifference.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/TestDataGetEncodingDifference.cs
@@ -10,8 +10,6 @@ public class TestDataGetEncodingDifference : IEnumerable<object[]>
 
 	#region IEnumerable<object[]> Members
 
-	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
 	public IEnumerator<object[]> GetEnumerator()
 	{
 		yield return new object[]
@@ -19,6 +17,8 @@ public class TestDataGetEncodingDifference : IEnumerable<object[]>
 			SpecialCharactersContent, Encoding.ASCII, Encoding.UTF8
 		};
 	}
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
 	#endregion
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
@@ -212,14 +212,14 @@ public abstract partial class Tests<TFileSystem>
 				// Ignore any call in tests
 			}
 
-			/// <inheritdoc cref="IContainer.Remove(IComponent?)" />
-			public void Remove(IComponent? component)
+			/// <inheritdoc cref="IDisposable.Dispose()" />
+			public void Dispose()
 			{
 				// Ignore any call in tests
 			}
 
-			/// <inheritdoc cref="IDisposable.Dispose()" />
-			public void Dispose()
+			/// <inheritdoc cref="IContainer.Remove(IComponent?)" />
+			public void Remove(IComponent? component)
 			{
 				// Ignore any call in tests
 			}
@@ -239,16 +239,16 @@ public abstract partial class Tests<TFileSystem>
 			/// <inheritdoc cref="IComponent.Site" />
 			public ISite? Site { get; set; }
 
-			#pragma warning disable CS0067 // Event is required by the interface
-			/// <inheritdoc cref="IComponent.Disposed" />
-			public event EventHandler? Disposed;
-			#pragma warning restore CS0067
-
 			/// <inheritdoc cref="IDisposable.Dispose()" />
 			public void Dispose()
 			{
 				// Ignore any call in tests
 			}
+
+			#pragma warning disable CS0067 // Event is required by the interface
+			/// <inheritdoc cref="IComponent.Disposed" />
+			public event EventHandler? Disposed;
+			#pragma warning restore CS0067
 
 			#endregion
 		}


### PR DESCRIPTION
Adapt ReSharper File Layout to avoid Sonar issues due to method overloads that are not adjacent.