### PR TITLE
fix: correctly match statistic paths

### DIFF
--- a/Source/Testably.Abstractions.Testing/Helpers/CharExtensionMethods.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/CharExtensionMethods.cs
@@ -1,0 +1,19 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Testably.Abstractions.Testing.Helpers;
+
+/// <summary>
+///     Provides extension methods on <see cref="char" />.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class CharExtensionMethods
+{
+	/// <summary>Indicates whether a character is categorized as an ASCII letter.</summary>
+	/// <param name="c">The character to evaluate.</param>
+	/// <returns>true if <paramref name="c" /> is an ASCII letter; otherwise, false.</returns>
+	/// <remarks>
+	///     This determines whether the character is in the range 'A' through 'Z', inclusive,
+	///     or 'a' through 'z', inclusive.
+	/// </remarks>
+	public static bool IsAsciiLetter(this char c) => (uint)((c | 0x20) - 'a') <= 'z' - 'a';
+}

--- a/Source/Testably.Abstractions.Testing/Statistics/CallStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/CallStatistics.cs
@@ -6,12 +6,14 @@ namespace Testably.Abstractions.Testing.Statistics;
 internal class CallStatistics : IStatistics
 {
 	private readonly ConcurrentQueue<MethodStatistic> _methods = new();
+	private readonly string _name;
 	private readonly ConcurrentQueue<PropertyStatistic> _properties = new();
 	private readonly IStatisticsGate _statisticsGate;
 
-	public CallStatistics(IStatisticsGate statisticsGate)
+	public CallStatistics(IStatisticsGate statisticsGate, string name)
 	{
 		_statisticsGate = statisticsGate;
+		_name = name;
 	}
 
 	#region IStatistics Members
@@ -23,6 +25,10 @@ internal class CallStatistics : IStatistics
 	public PropertyStatistic[] Properties => _properties.ToArray();
 
 	#endregion
+
+	/// <inheritdoc cref="object.ToString()" />
+	public override string ToString()
+		=> _name;
 
 	/// <summary>
 	///     Registers the method <paramref name="name" /> with <paramref name="parameters" />.

--- a/Source/Testably.Abstractions.Testing/Statistics/FileSystemStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/FileSystemStatistics.cs
@@ -8,22 +8,22 @@ internal sealed class FileSystemStatistics : IFileSystemStatistics, IStatisticsG
 {
 	private static readonly AsyncLocal<bool> IsDisabled = new();
 	internal readonly CallStatistics Directory;
-	internal readonly FileSystemEntryStatistics DirectoryInfo;
-	internal readonly FileSystemEntryStatistics DriveInfo;
+	internal readonly PathStatistics DirectoryInfo;
+	internal readonly PathStatistics DriveInfo;
 	internal readonly CallStatistics File;
-	internal readonly FileSystemEntryStatistics FileInfo;
-	internal readonly FileSystemEntryStatistics FileStream;
-	internal readonly FileSystemEntryStatistics FileSystemWatcher;
+	internal readonly PathStatistics FileInfo;
+	internal readonly PathStatistics FileStream;
+	internal readonly PathStatistics FileSystemWatcher;
 	internal readonly CallStatistics Path;
 	private int _counter;
 
 	public FileSystemStatistics(MockFileSystem fileSystem)
 	{
-		DirectoryInfo = new FileSystemEntryStatistics(this, fileSystem);
-		DriveInfo = new FileSystemEntryStatistics(this, fileSystem);
-		FileInfo = new FileSystemEntryStatistics(this, fileSystem);
-		FileStream = new FileSystemEntryStatistics(this, fileSystem);
-		FileSystemWatcher = new FileSystemEntryStatistics(this, fileSystem);
+		DirectoryInfo = new PathStatistics(this, fileSystem);
+		DriveInfo = new PathStatistics(this, fileSystem);
+		FileInfo = new PathStatistics(this, fileSystem);
+		FileStream = new PathStatistics(this, fileSystem);
+		FileSystemWatcher = new PathStatistics(this, fileSystem);
 		File = new CallStatistics(this);
 		Directory = new CallStatistics(this);
 		Path = new CallStatistics(this);

--- a/Source/Testably.Abstractions.Testing/Statistics/FileSystemStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/FileSystemStatistics.cs
@@ -19,14 +19,14 @@ internal sealed class FileSystemStatistics : IFileSystemStatistics, IStatisticsG
 
 	public FileSystemStatistics(MockFileSystem fileSystem)
 	{
-		DirectoryInfo = new PathStatistics(this, fileSystem);
-		DriveInfo = new PathStatistics(this, fileSystem);
-		FileInfo = new PathStatistics(this, fileSystem);
-		FileStream = new PathStatistics(this, fileSystem);
-		FileSystemWatcher = new PathStatistics(this, fileSystem);
-		File = new CallStatistics(this);
-		Directory = new CallStatistics(this);
-		Path = new CallStatistics(this);
+		DirectoryInfo = new PathStatistics(this, fileSystem, nameof(IFileSystem.DirectoryInfo));
+		DriveInfo = new PathStatistics(this, fileSystem, nameof(IFileSystem.DriveInfo));
+		FileInfo = new PathStatistics(this, fileSystem, nameof(IFileSystem.FileInfo));
+		FileStream = new PathStatistics(this, fileSystem, nameof(IFileSystem.FileStream));
+		FileSystemWatcher = new PathStatistics(this, fileSystem, nameof(IFileSystem.FileSystemWatcher));
+		File = new CallStatistics(this, nameof(IFileSystem.File));
+		Directory = new CallStatistics(this, nameof(IFileSystem.Directory));
+		Path = new CallStatistics(this, nameof(IFileSystem.Path));
 	}
 
 	#region IFileSystemStatistics Members

--- a/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
@@ -14,8 +14,9 @@ internal class PathStatistics : CallStatistics, IPathStatistics
 
 	public PathStatistics(
 		IStatisticsGate statisticsGate,
-		MockFileSystem fileSystem)
-		: base(statisticsGate)
+		MockFileSystem fileSystem,
+		string name)
+		: base(statisticsGate, name)
 	{
 		_statisticsGate = statisticsGate;
 		_fileSystem = fileSystem;
@@ -29,7 +30,8 @@ internal class PathStatistics : CallStatistics, IPathStatistics
 		get
 		{
 			string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
-			return _statistics.GetOrAdd(key, _ => new CallStatistics(_statisticsGate));
+			return _statistics.GetOrAdd(key, 
+				k => new CallStatistics(_statisticsGate, $"{ToString()}[{k}]"));
 		}
 	}
 
@@ -44,7 +46,8 @@ internal class PathStatistics : CallStatistics, IPathStatistics
 	{
 		string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
 		CallStatistics callStatistics =
-			_statistics.GetOrAdd(key, _ => new CallStatistics(_statisticsGate));
+			_statistics.GetOrAdd(key,
+				k => new CallStatistics(_statisticsGate, $"{ToString()}[{k}]"));
 		return callStatistics.RegisterMethod(name, parameters);
 	}
 
@@ -57,7 +60,8 @@ internal class PathStatistics : CallStatistics, IPathStatistics
 	{
 		string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
 		CallStatistics callStatistics =
-			_statistics.GetOrAdd(key, _ => new CallStatistics(_statisticsGate));
+			_statistics.GetOrAdd(key,
+				k => new CallStatistics(_statisticsGate, $"{ToString()}[{k}]"));
 		return callStatistics.RegisterProperty(name, access);
 	}
 

--- a/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
@@ -4,14 +4,14 @@ using System.IO;
 
 namespace Testably.Abstractions.Testing.Statistics;
 
-internal class FileSystemEntryStatistics : CallStatistics, IPathStatistics
+internal class PathStatistics : CallStatistics, IPathStatistics
 {
 	private readonly MockFileSystem _fileSystem;
 
 	private readonly ConcurrentDictionary<string, CallStatistics> _statistics = new();
 	private readonly IStatisticsGate _statisticsGate;
 
-	public FileSystemEntryStatistics(
+	public PathStatistics(
 		IStatisticsGate statisticsGate,
 		MockFileSystem fileSystem)
 		: base(statisticsGate)
@@ -64,12 +64,7 @@ internal class FileSystemEntryStatistics : CallStatistics, IPathStatistics
 	{
 		if (string.IsNullOrEmpty(path))
 		{
-			return "(empty)";
-		}
-
-		if (Path.IsPathRooted(path))
-		{
-			return path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+			return string.Empty;
 		}
 
 		return Path.GetFullPath(Path.Combine(currentDirectory, path))

--- a/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
@@ -67,9 +67,9 @@ internal class PathStatistics : CallStatistics, IPathStatistics
 			return string.Empty;
 		}
 
-		if (path.StartsWith("//") || path.StartsWith("\\"))
+		if (path.StartsWith("//") || path.StartsWith(@"\\"))
 		{
-			return path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+			return path.TrimEnd('/', '\\');
 		}
 
 		if (path.Length == 2 && path.EndsWith(":"))
@@ -77,7 +77,6 @@ internal class PathStatistics : CallStatistics, IPathStatistics
 			return path;
 		}
 
-		return Path.GetFullPath(Path.Combine(currentDirectory, path))
-			.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+		return Path.GetFullPath(Path.Combine(currentDirectory, path)).TrimEnd('/', '\\');
 	}
 }

--- a/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
@@ -67,6 +67,16 @@ internal class PathStatistics : CallStatistics, IPathStatistics
 			return string.Empty;
 		}
 
+		if (path.StartsWith("//") || path.StartsWith("\\"))
+		{
+			return path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+		}
+
+		if (path.Length == 2 && path.EndsWith(":"))
+		{
+			return path;
+		}
+
 		return Path.GetFullPath(Path.Combine(currentDirectory, path))
 			.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 	}

--- a/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.IO;
+using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.Statistics;
 
@@ -62,21 +63,23 @@ internal class PathStatistics : CallStatistics, IPathStatistics
 
 	private static string CreateKey(string currentDirectory, string path)
 	{
+		string key = string.Empty;
 		if (string.IsNullOrEmpty(path))
 		{
-			return string.Empty;
+			return key;
 		}
 
-		if (path.StartsWith("//") || path.StartsWith(@"\\"))
+		if (path.StartsWith("//") ||
+		    path.StartsWith(@"\\") ||
+		    (path.Length >= 2 && path[1] == ':' && path[0].IsAsciiLetter()))
 		{
-			return path.TrimEnd('/', '\\');
+			key = path;
 		}
-
-		if (path.Length == 2 && path.EndsWith(":"))
+		else
 		{
-			return path;
+			key = Path.GetFullPath(Path.Combine(currentDirectory, path));
 		}
 
-		return Path.GetFullPath(Path.Combine(currentDirectory, path)).TrimEnd('/', '\\');
+		return key.TrimEnd('/', '\\');
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/CharExtensionMethodsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/CharExtensionMethodsTests.cs
@@ -1,0 +1,35 @@
+﻿using Testably.Abstractions.Testing.Helpers;
+
+namespace Testably.Abstractions.Testing.Tests.Helpers;
+
+public sealed class CharExtensionMethodsTests
+{
+	[Theory]
+	[InlineData('A')]
+	[InlineData('Z')]
+	[InlineData('a')]
+	[InlineData('z')]
+	[InlineData('M')]
+	[InlineData('d')]
+	public void IsAsciiLetter_WithAsciiLetterChar_ShouldReturnTrue(char c)
+	{
+		bool result = c.IsAsciiLetter();
+
+		result.Should().BeTrue();
+	}
+
+	[Theory]
+	[InlineData((char)64)]
+	[InlineData((char)91)]
+	[InlineData((char)96)]
+	[InlineData((char)123)]
+	[InlineData((char)55)]
+	[InlineData((char)0)]
+	[InlineData((char)127)]
+	public void IsAsciiLetter_WithNonAsciiLetterChar_ShouldReturnFalse(char c)
+	{
+		bool result = c.IsAsciiLetter();
+
+		result.Should().BeFalse();
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryInfoFactoryStatisticsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 
 namespace Testably.Abstractions.Testing.Tests.Statistics.FileSystem;
@@ -27,5 +28,15 @@ public sealed class DirectoryInfoFactoryStatisticsTests
 
 		sut.Statistics.DirectoryInfo.ShouldOnlyContainMethodCall(nameof(IDirectoryInfoFactory.Wrap),
 			directoryInfo);
+	}
+
+	[SkippableFact]
+	public void ToString_ShouldBeDirectoryInfo()
+	{
+		IPathStatistics sut = new MockFileSystem().Statistics.DirectoryInfo;
+
+		string? result = sut.ToString();
+
+		result.Should().Be("DirectoryInfo");
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryInfoStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryInfoStatisticsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 
 namespace Testably.Abstractions.Testing.Tests.Statistics.FileSystem;
@@ -738,4 +739,14 @@ public sealed class DirectoryInfoStatisticsTests
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.UnixFileMode));
 	}
 #endif
+
+	[SkippableFact]
+	public void ToString_ShouldBeDirectoryInfoWithPath()
+	{
+		IStatistics sut = new MockFileSystem().Statistics.DirectoryInfo[@"\\some\path"];
+
+		string? result = sut.ToString();
+
+		result.Should().Be(@"DirectoryInfo[\\some\path]");
+	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryStatisticsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 
 namespace Testably.Abstractions.Testing.Tests.Statistics.FileSystem;
@@ -701,5 +702,15 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.SetLastWriteTimeUtc),
 			path, lastWriteTimeUtc);
+	}
+
+	[SkippableFact]
+	public void ToString_ShouldBeDirectoryInfo()
+	{
+		IStatistics sut = new MockFileSystem().Statistics.Directory;
+
+		string? result = sut.ToString();
+
+		result.Should().Be("Directory");
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryStatisticsTests.cs
@@ -705,7 +705,7 @@ public sealed class DirectoryStatisticsTests
 	}
 
 	[SkippableFact]
-	public void ToString_ShouldBeDirectoryInfo()
+	public void ToString_ShouldBeDirectory()
 	{
 		IStatistics sut = new MockFileSystem().Statistics.Directory;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoFactoryStatisticsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
+using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 
 namespace Testably.Abstractions.Testing.Tests.Statistics.FileSystem;
@@ -38,5 +39,15 @@ public sealed class DriveInfoFactoryStatisticsTests
 
 		sut.Statistics.DriveInfo.ShouldOnlyContainMethodCall(nameof(IDriveInfoFactory.Wrap),
 			driveInfo);
+	}
+
+	[SkippableFact]
+	public void ToString_ShouldBeDirectoryInfo()
+	{
+		IPathStatistics sut = new MockFileSystem().Statistics.DriveInfo;
+
+		string? result = sut.ToString();
+
+		result.Should().Be("DriveInfo");
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoFactoryStatisticsTests.cs
@@ -42,7 +42,7 @@ public sealed class DriveInfoFactoryStatisticsTests
 	}
 
 	[SkippableFact]
-	public void ToString_ShouldBeDirectoryInfo()
+	public void ToString_ShouldBeDriveInfo()
 	{
 		IPathStatistics sut = new MockFileSystem().Statistics.DriveInfo;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoStatisticsTests.cs
@@ -1,4 +1,5 @@
-﻿using Testably.Abstractions.Testing.Tests.TestHelpers;
+﻿using Testably.Abstractions.Testing.Statistics;
+using Testably.Abstractions.Testing.Tests.TestHelpers;
 
 namespace Testably.Abstractions.Testing.Tests.Statistics.FileSystem;
 
@@ -134,5 +135,15 @@ public sealed class DriveInfoStatisticsTests
 
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDriveInfo.VolumeLabel));
+	}
+
+	[SkippableFact]
+	public void ToString_ShouldBeDirectoryInfoWithPath()
+	{
+		IStatistics sut = new MockFileSystem().Statistics.DriveInfo[@"x:"];
+
+		string? result = sut.ToString();
+
+		result.Should().Be(@"DriveInfo[x:]");
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoStatisticsTests.cs
@@ -138,7 +138,7 @@ public sealed class DriveInfoStatisticsTests
 	}
 
 	[SkippableFact]
-	public void ToString_ShouldBeDirectoryInfoWithPath()
+	public void ToString_ShouldBeDriveInfoWithPath()
 	{
 		IStatistics sut = new MockFileSystem().Statistics.DriveInfo[@"x:"];
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoFactoryStatisticsTests.cs
@@ -31,7 +31,7 @@ public class FileInfoFactoryStatisticsTests
 	}
 
 	[SkippableFact]
-	public void ToString_ShouldBeDirectoryInfo()
+	public void ToString_ShouldBeFileInfo()
 	{
 		IPathStatistics sut = new MockFileSystem().Statistics.FileInfo;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoFactoryStatisticsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 
 namespace Testably.Abstractions.Testing.Tests.Statistics.FileSystem;
@@ -27,5 +28,15 @@ public class FileInfoFactoryStatisticsTests
 
 		sut.Statistics.FileInfo.ShouldOnlyContainMethodCall(nameof(IFileInfoFactory.Wrap),
 			fileInfo);
+	}
+
+	[SkippableFact]
+	public void ToString_ShouldBeDirectoryInfo()
+	{
+		IPathStatistics sut = new MockFileSystem().Statistics.FileInfo;
+
+		string? result = sut.ToString();
+
+		result.Should().Be("FileInfo");
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoStatisticsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 
 namespace Testably.Abstractions.Testing.Tests.Statistics.FileSystem;
@@ -634,4 +635,14 @@ public class FileInfoStatisticsTests
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.UnixFileMode));
 	}
 #endif
+
+	[SkippableFact]
+	public void ToString_ShouldBeDirectoryInfoWithPath()
+	{
+		IStatistics sut = new MockFileSystem().Statistics.FileInfo[@"\\some\path"];
+
+		string? result = sut.ToString();
+
+		result.Should().Be(@"FileInfo[\\some\path]");
+	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoStatisticsTests.cs
@@ -637,7 +637,7 @@ public class FileInfoStatisticsTests
 #endif
 
 	[SkippableFact]
-	public void ToString_ShouldBeDirectoryInfoWithPath()
+	public void ToString_ShouldBeFileInfoWithPath()
 	{
 		IStatistics sut = new MockFileSystem().Statistics.FileInfo[@"\\some\path"];
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStatisticsTests.cs
@@ -1388,7 +1388,7 @@ public sealed class FileStatisticsTests
 #endif
 
 	[SkippableFact]
-	public void ToString_ShouldBeDirectoryInfo()
+	public void ToString_ShouldBeFile()
 	{
 		IStatistics sut = new MockFileSystem().Statistics.File;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStatisticsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 #if FEATURE_FILESYSTEM_SAFEFILEHANDLE
 using Testably.Abstractions.Testing.FileSystem;
@@ -1385,4 +1386,14 @@ public sealed class FileStatisticsTests
 			path, contents, encoding, cancellationToken);
 	}
 #endif
+
+	[SkippableFact]
+	public void ToString_ShouldBeDirectoryInfo()
+	{
+		IStatistics sut = new MockFileSystem().Statistics.File;
+
+		string? result = sut.ToString();
+
+		result.Should().Be("File");
+	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamFactoryStatisticsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 #if NET6_0_OR_GREATER
 using Microsoft.Win32.SafeHandles;
@@ -192,5 +193,15 @@ public class FileStreamFactoryStatisticsTests
 
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.Wrap),
 			fileStream);
+	}
+
+	[SkippableFact]
+	public void ToString_ShouldBeDirectoryInfo()
+	{
+		IPathStatistics sut = new MockFileSystem().Statistics.FileStream;
+
+		string? result = sut.ToString();
+
+		result.Should().Be("FileStream");
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamFactoryStatisticsTests.cs
@@ -196,7 +196,7 @@ public class FileStreamFactoryStatisticsTests
 	}
 
 	[SkippableFact]
-	public void ToString_ShouldBeDirectoryInfo()
+	public void ToString_ShouldBeFileStream()
 	{
 		IPathStatistics sut = new MockFileSystem().Statistics.FileStream;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamStatisticsTests.cs
@@ -537,7 +537,7 @@ public class FileStreamStatisticsTests
 	}
 
 	[SkippableFact]
-	public void ToString_ShouldBeDirectoryInfoWithPath()
+	public void ToString_ShouldBeFileStreamWithPath()
 	{
 		IStatistics sut = new MockFileSystem().Statistics.FileStream[@"\\some\path"];
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamStatisticsTests.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 
 namespace Testably.Abstractions.Testing.Tests.Statistics.FileSystem;
@@ -533,5 +534,15 @@ public class FileStreamStatisticsTests
 
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(FileSystemStream.WriteTimeout));
+	}
+
+	[SkippableFact]
+	public void ToString_ShouldBeDirectoryInfoWithPath()
+	{
+		IStatistics sut = new MockFileSystem().Statistics.FileStream[@"\\some\path"];
+
+		string? result = sut.ToString();
+
+		result.Should().Be(@"FileStream[\\some\path]");
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherFactoryStatisticsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 
 namespace Testably.Abstractions.Testing.Tests.Statistics.FileSystem;
@@ -57,5 +58,15 @@ public class FileSystemWatcherFactoryStatisticsTests
 		sut.Statistics.FileSystemWatcher.ShouldOnlyContainMethodCall(
 			nameof(IFileSystemWatcherFactory.Wrap),
 			fileSystemWatcher);
+	}
+
+	[SkippableFact]
+	public void ToString_ShouldBeDirectoryInfo()
+	{
+		IPathStatistics sut = new MockFileSystem().Statistics.FileSystemWatcher;
+
+		string? result = sut.ToString();
+
+		result.Should().Be("FileSystemWatcher");
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherFactoryStatisticsTests.cs
@@ -61,7 +61,7 @@ public class FileSystemWatcherFactoryStatisticsTests
 	}
 
 	[SkippableFact]
-	public void ToString_ShouldBeDirectoryInfo()
+	public void ToString_ShouldBeFileSystemWatcher()
 	{
 		IPathStatistics sut = new MockFileSystem().Statistics.FileSystemWatcher;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
@@ -337,7 +337,7 @@ public class FileSystemWatcherStatisticsTests
 	}
 
 	[SkippableFact]
-	public void ToString_ShouldBeDirectoryInfoWithPath()
+	public void ToString_ShouldBeFileSystemWatcherWithPath()
 	{
 		IStatistics sut = new MockFileSystem().Statistics.FileSystemWatcher[@"\\some\path"];
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 
 namespace Testably.Abstractions.Testing.Tests.Statistics.FileSystem;
@@ -333,5 +334,15 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.SynchronizingObject));
+	}
+
+	[SkippableFact]
+	public void ToString_ShouldBeDirectoryInfoWithPath()
+	{
+		IStatistics sut = new MockFileSystem().Statistics.FileSystemWatcher[@"\\some\path"];
+
+		string? result = sut.ToString();
+
+		result.Should().Be(@"FileSystemWatcher[\\some\path]");
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/PathStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/PathStatisticsTests.cs
@@ -1,4 +1,5 @@
-﻿using Testably.Abstractions.Testing.Tests.TestHelpers;
+﻿using Testably.Abstractions.Testing.Statistics;
+using Testably.Abstractions.Testing.Tests.TestHelpers;
 #if FEATURE_PATH_RELATIVE
 using System.IO;
 #endif
@@ -632,5 +633,15 @@ public class PathStatisticsTests
 		_ = sut.Path.VolumeSeparatorChar;
 
 		sut.Statistics.Path.ShouldOnlyContainPropertyGetAccess(nameof(IPath.VolumeSeparatorChar));
+	}
+
+	[SkippableFact]
+	public void ToString_ShouldBeDirectoryInfo()
+	{
+		IStatistics sut = new MockFileSystem().Statistics.Path;
+
+		string? result = sut.ToString();
+
+		result.Should().Be("Path");
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/PathStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/PathStatisticsTests.cs
@@ -636,7 +636,7 @@ public class PathStatisticsTests
 	}
 
 	[SkippableFact]
-	public void ToString_ShouldBeDirectoryInfo()
+	public void ToString_ShouldBePath()
 	{
 		IStatistics sut = new MockFileSystem().Statistics.Path;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/MethodStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/MethodStatisticsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Testably.Abstractions.Testing.Statistics;
 
 namespace Testably.Abstractions.Testing.Tests.Statistics;
 
@@ -7,10 +8,11 @@ public sealed class MethodStatisticsTests
 	[Fact]
 	public void ToString_ShouldContainName()
 	{
-		MockFileSystem sut = new();
-		sut.Directory.CreateDirectory("foo");
+		MockFileSystem fileSystem = new();
+		fileSystem.Directory.CreateDirectory("foo");
+		MethodStatistic sut = fileSystem.Statistics.Directory.Methods.First();
 
-		string result = sut.Statistics.Directory.Methods.First().ToString();
+		string result = sut.ToString();
 
 		result.Should()
 			.Contain(nameof(IDirectory.CreateDirectory)).And
@@ -21,10 +23,11 @@ public sealed class MethodStatisticsTests
 	[Fact]
 	public void ToString_ShouldContainParameters()
 	{
-		MockFileSystem sut = new();
-		sut.File.WriteAllText("foo", "bar");
+		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "bar");
+		MethodStatistic sut = fileSystem.Statistics.File.Methods.First();
 
-		string result = sut.Statistics.File.Methods.First().ToString();
+		string result = sut.ToString();
 
 		result.Should()
 			.Contain(nameof(IFile.WriteAllText)).And

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/PathStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/PathStatisticsTests.cs
@@ -18,6 +18,30 @@ public sealed class PathStatisticsTests
 	}
 
 	[Fact]
+	public void Key_DifferentDrives_ShouldBeConsideredDifferent()
+	{
+		MockFileSystem fileSystem = new();
+		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+
+		IStatistics result1 = sut[@"C:\"];
+		IStatistics result2 = sut[@"D:\"];
+
+		result1.Should().NotBe(result2);
+	}
+
+	[Fact]
+	public void Key_DifferentUncRootPaths_ShouldBeConsideredDifferent()
+	{
+		MockFileSystem fileSystem = new();
+		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+
+		IStatistics result1 = sut[@"\\foo1"];
+		IStatistics result2 = sut[@"\\foo2"];
+
+		result1.Should().NotBe(result2);
+	}
+
+	[Fact]
 	public void Key_NullShouldBeSameAsEmptyKey()
 	{
 		MockFileSystem fileSystem = new();
@@ -40,6 +64,42 @@ public sealed class PathStatisticsTests
 		IStatistics relativePath = sut[".."];
 
 		absolutPath.Should().Be(relativePath);
+	}
+
+	[Fact]
+	public void Key_WithDrives_ShouldIgnoreTrailingSlash()
+	{
+		MockFileSystem fileSystem = new();
+		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+
+		IStatistics result1 = sut[@"C:"];
+		IStatistics result2 = sut[@"C:\"];
+
+		result1.Should().Be(result2);
+	}
+
+	[Fact]
+	public void Key_WithFolderInDrives_ShouldIgnoreTrailingSlash()
+	{
+		MockFileSystem fileSystem = new();
+		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+
+		IStatistics result1 = sut[@"C:\foo"];
+		IStatistics result2 = sut[@"C:\foo\"];
+
+		result1.Should().Be(result2);
+	}
+
+	[Fact]
+	public void Key_WithFolderInUncRootPaths_ShouldIgnoreTrailingSlash()
+	{
+		MockFileSystem fileSystem = new();
+		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+
+		IStatistics result1 = sut[@"\\server1\foo"];
+		IStatistics result2 = sut[@"\\server1\foo\"];
+
+		result1.Should().Be(result2);
 	}
 
 	[Fact]

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/PathStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/PathStatisticsTests.cs
@@ -57,7 +57,7 @@ public sealed class PathStatisticsTests
 	public void Key_ShouldSimplifyRelativePaths()
 	{
 		MockFileSystem fileSystem = new();
-		fileSystem.InitializeIn("foo/bar");
+		fileSystem.InitializeIn("/foo/bar");
 		IPathStatistics sut = fileSystem.Statistics.FileInfo;
 
 		IStatistics absolutPath = sut["/foo"];

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/PathStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/PathStatisticsTests.cs
@@ -66,38 +66,47 @@ public sealed class PathStatisticsTests
 		absolutPath.Should().Be(relativePath);
 	}
 
-	[Fact]
-	public void Key_WithDrives_ShouldIgnoreTrailingSlash()
+	[Theory]
+	[InlineData("/")]
+	[InlineData("\\")]
+	public void Key_WithDrives_ShouldIgnoreTrailingSeparator(string separator)
 	{
+		const string key = @"C:";
 		MockFileSystem fileSystem = new();
 		IPathStatistics sut = fileSystem.Statistics.FileInfo;
 
-		IStatistics result1 = sut[@"C:"];
-		IStatistics result2 = sut[@"C:\"];
+		IStatistics result1 = sut[key];
+		IStatistics result2 = sut[key + separator];
 
 		result1.Should().Be(result2);
 	}
 
-	[Fact]
-	public void Key_WithFolderInDrives_ShouldIgnoreTrailingSlash()
+	[Theory]
+	[InlineData("/")]
+	[InlineData("\\")]
+	public void Key_WithFolderInDrives_ShouldIgnoreTrailingSeparator(string separator)
 	{
+		const string key = @"C:\foo";
 		MockFileSystem fileSystem = new();
 		IPathStatistics sut = fileSystem.Statistics.FileInfo;
 
-		IStatistics result1 = sut[@"C:\foo"];
-		IStatistics result2 = sut[@"C:\foo\"];
+		IStatistics result1 = sut[key];
+		IStatistics result2 = sut[key + separator];
 
 		result1.Should().Be(result2);
 	}
 
-	[Fact]
-	public void Key_WithFolderInUncRootPaths_ShouldIgnoreTrailingSlash()
+	[Theory]
+	[InlineData("/")]
+	[InlineData("\\")]
+	public void Key_WithFolderInUncRootPaths_ShouldIgnoreTrailingSeparator(string separator)
 	{
+		const string key = @"\\server1\foo";
 		MockFileSystem fileSystem = new();
 		IPathStatistics sut = fileSystem.Statistics.FileInfo;
 
-		IStatistics result1 = sut[@"\\server1\foo"];
-		IStatistics result2 = sut[@"\\server1\foo\"];
+		IStatistics result1 = sut[key];
+		IStatistics result2 = sut[key + separator];
 
 		result1.Should().Be(result2);
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/PathStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/PathStatisticsTests.cs
@@ -1,0 +1,55 @@
+﻿using Testably.Abstractions.Testing.Statistics;
+
+namespace Testably.Abstractions.Testing.Tests.Statistics;
+
+public sealed class PathStatisticsTests
+{
+	[Fact]
+	public void Key_AbsoluteAndRelativePathsShouldMatch()
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.InitializeIn("/foo");
+		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+
+		IStatistics absolutPath = sut["/foo"];
+		IStatistics relativePath = sut["."];
+
+		absolutPath.Should().Be(relativePath);
+	}
+
+	[Fact]
+	public void Key_NullShouldBeSameAsEmptyKey()
+	{
+		MockFileSystem fileSystem = new();
+		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+
+		IStatistics nullKey = sut[null!];
+		IStatistics emptyKey = sut[""];
+
+		nullKey.Should().Be(emptyKey);
+	}
+
+	[Fact]
+	public void Key_ShouldSimplifyRelativePaths()
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.InitializeIn("foo/bar");
+		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+
+		IStatistics absolutPath = sut["/foo"];
+		IStatistics relativePath = sut[".."];
+
+		absolutPath.Should().Be(relativePath);
+	}
+
+	[Fact]
+	public void Key_WithNull_ShouldNotThrow()
+	{
+		MockFileSystem fileSystem = new();
+		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+
+		Exception? exception = Record.Exception(() => _ = sut[null!]);
+
+		exception.Should().BeNull();
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/PropertyStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/PropertyStatisticsTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq;
+using Testably.Abstractions.Testing.Statistics;
+
+namespace Testably.Abstractions.Testing.Tests.Statistics;
+
+public sealed class PropertyStatisticsTests
+{
+	[Fact]
+	public void ToString_Get_ShouldContainNameAndGet()
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize().WithFile("foo");
+		IFileInfo fileInfo = fileSystem.FileInfo.New("foo");
+		_ = fileInfo.IsReadOnly;
+		PropertyStatistic sut = fileSystem.Statistics.FileInfo["foo"].Properties.First();
+
+		string result = sut.ToString();
+
+		result.Should()
+			.Contain(nameof(IFileInfo.IsReadOnly)).And
+			.Contain("{get;}");
+	}
+
+	[Fact]
+	public void ToString_Set_ShouldContainNameAndSet()
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize().WithFile("foo");
+		IFileInfo fileInfo = fileSystem.FileInfo.New("foo");
+		fileInfo.IsReadOnly = false;
+		PropertyStatistic sut = fileSystem.Statistics.FileInfo["foo"].Properties.First();
+
+		string result = sut.ToString();
+
+		result.Should()
+			.Contain(nameof(IFileInfo.IsReadOnly)).And
+			.Contain("{set;}");
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/StatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/StatisticsTests.cs
@@ -50,7 +50,7 @@ public sealed partial class StatisticsTests
 	[InlineData(nameof(MockFileSystem.FileSystemWatcher), true,
 		typeof(IFileSystemWatcher), typeof(FileSystemWatcherStatisticsTests))]
 	[InlineData(nameof(MockFileSystem.Path), false,
-		typeof(IPath), typeof(PathStatisticsTests))]
+		typeof(IPath), typeof(FileSystem.PathStatisticsTests))]
 	public void ShouldHaveTestedAllFileSystemMethods(string className, bool requireInstance,
 		Type mockType, Type testType)
 	{


### PR DESCRIPTION
The statistics key was sometimes not correct (e.g. when mixing absolute and relative paths).