### PR TITLE
refactor: extract extension methods from `Execute`

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
@@ -96,7 +96,7 @@ public static class FileSystemInitializerExtensions
 			#pragma warning restore CA2249
 
 			if (EnumerationOptionsHelper.MatchesPattern(
-				(fileSystem as MockFileSystem)?.Execute ?? new Execute(),
+				(fileSystem as MockFileSystem)?.Execute ?? Execute.Default,
 				enumerationOptions,
 				fileName,
 				searchPattern))

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace Testably.Abstractions.Testing.Helpers;
 
-[ExcludeFromCodeCoverage]
 internal class Execute
 {
 	/// <summary>
@@ -38,184 +36,27 @@ internal class Execute
 	/// <summary>
 	///     The default <see cref="StringComparison" /> used for comparing paths.
 	/// </summary>
-	public StringComparison StringComparisonMode => IsLinux
-		? StringComparison.Ordinal
-		: StringComparison.OrdinalIgnoreCase;
+	public StringComparison StringComparisonMode { get; }
 
-	public Execute()
+	internal Execute(OSPlatform osPlatform, bool isNetFramework = false)
+	{
+		IsLinux = osPlatform == OSPlatform.Linux;
+		IsMac = osPlatform == OSPlatform.OSX;
+		IsWindows = osPlatform == OSPlatform.Windows;
+		IsNetFramework = isNetFramework && IsWindows;
+		StringComparisonMode = IsLinux
+			? StringComparison.Ordinal
+			: StringComparison.OrdinalIgnoreCase;
+	}
+
+	private Execute()
 	{
 		IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 		IsMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 		IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 		IsNetFramework = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
-	}
-
-	/// <summary>
-	///     The <paramref name="callback" /> is executed when the code runs not in .NET Framework.
-	/// </summary>
-	/// <remarks>
-	///     See also: <seealso cref="IsNetFramework" />
-	/// </remarks>
-	public void NotOnNetFramework(Action callback)
-	{
-		if (!IsNetFramework)
-		{
-			callback();
-		}
-	}
-
-	/// <summary>
-	///     The <paramref name="callback" /> is executed on all operating systems except <see cref="OSPlatform.Windows" />.
-	/// </summary>
-	public void NotOnWindows(Action callback)
-	{
-		if (!IsWindows)
-		{
-			callback();
-		}
-	}
-
-	/// <summary>
-	///     The <paramref name="callback" /> is executed when the operating system is not <see cref="OSPlatform.Windows" />
-	///     and the <paramref name="predicate" /> is <see langword="true" />.
-	/// </summary>
-	public void NotOnWindowsIf(bool predicate, Action callback)
-	{
-		if (predicate && !IsWindows)
-		{
-			callback();
-		}
-	}
-
-	/// <summary>
-	///     Returns the value from <paramref name="callback" />, when the operating system is <see cref="OSPlatform.Linux" />,
-	///     otherwise the value from <paramref name="alternativeCallback" />.
-	/// </summary>
-	public T OnLinux<T>(Func<T> callback, Func<T> alternativeCallback)
-	{
-		if (IsLinux)
-		{
-			return callback();
-		}
-
-		return alternativeCallback();
-	}
-
-	/// <summary>
-	///     The <paramref name="callback" /> is executed when the operating system is <see cref="OSPlatform.Linux" />.
-	/// </summary>
-	public void OnLinux(Action callback)
-	{
-		if (IsLinux)
-		{
-			callback();
-		}
-	}
-
-	/// <summary>
-	///     The <paramref name="callback" /> is executed when the operating system is <see cref="OSPlatform.OSX" />.
-	/// </summary>
-	public void OnMac(Action callback, Action? alternativeCallback = null)
-	{
-		if (IsMac)
-		{
-			callback();
-		}
-		else
-		{
-			alternativeCallback?.Invoke();
-		}
-	}
-
-	/// <summary>
-	///     Returns the value from <paramref name="callback" />, when the code runs in .NET Framework,
-	///     otherwise the value from <paramref name="alternativeCallback" />.
-	/// </summary>
-	/// <remarks>
-	///     See also: <seealso cref="IsNetFramework" />
-	/// </remarks>
-	public T OnNetFramework<T>(Func<T> callback, Func<T> alternativeCallback)
-	{
-		if (IsNetFramework)
-		{
-			return callback();
-		}
-
-		return alternativeCallback();
-	}
-
-	/// <summary>
-	///     The <paramref name="callback" /> is executed when the code runs in .NET Framework.
-	/// </summary>
-	/// <remarks>
-	///     See also: <seealso cref="IsNetFramework" />
-	/// </remarks>
-	public void OnNetFramework(Action callback, Action? alternativeCallback = null)
-	{
-		if (IsNetFramework)
-		{
-			callback();
-		}
-		else
-		{
-			alternativeCallback?.Invoke();
-		}
-	}
-
-	/// <summary>
-	///     The <paramref name="callback" /> is executed when the code runs in .NET Framework
-	///     and the <paramref name="predicate" /> is <see langword="true" />.
-	/// </summary>
-	/// <remarks>
-	///     See also: <seealso cref="IsNetFramework" />
-	/// </remarks>
-	public void OnNetFrameworkIf(bool predicate, Action callback)
-	{
-		if (IsNetFramework && predicate)
-		{
-			callback();
-		}
-	}
-
-	/// <summary>
-	///     The <paramref name="callback" /> is executed when the operating system is <see cref="OSPlatform.Windows" />.
-	/// </summary>
-	public void OnWindows(Action callback, Action? alternativeCallback = null)
-	{
-		if (IsWindows)
-		{
-			callback();
-		}
-		else
-		{
-			alternativeCallback?.Invoke();
-		}
-	}
-
-	/// <summary>
-	///     Returns the value from <paramref name="callback" />, when the operating system is <see cref="OSPlatform.Windows" />
-	///     ,
-	///     otherwise the value from <paramref name="alternativeCallback" />.
-	/// </summary>
-	public T OnWindows<T>(Func<T> callback, Func<T> alternativeCallback)
-	{
-		if (IsWindows)
-		{
-			return callback();
-		}
-
-		return alternativeCallback();
-	}
-
-	/// <summary>
-	///     The <paramref name="callback" /> is executed when the operating system is <see cref="OSPlatform.Windows" />
-	///     and the <paramref name="predicate" /> is <see langword="true" />.
-	/// </summary>
-	public void OnWindowsIf(bool predicate, Action callback)
-	{
-		if (predicate && IsWindows)
-		{
-			callback();
-		}
+		StringComparisonMode = IsLinux
+			? StringComparison.Ordinal
+			: StringComparison.OrdinalIgnoreCase;
 	}
 }

--- a/Source/Testably.Abstractions.Testing/Helpers/ExecuteExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ExecuteExtensions.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Testably.Abstractions.Testing.Helpers;
+
+internal static class ExecuteExtensions
+{
+	/// <summary>
+	///     The <paramref name="callback" /> is executed when the code runs not in .NET Framework.
+	/// </summary>
+	/// <remarks>
+	///     See also: <seealso cref="Execute.IsNetFramework" />
+	/// </remarks>
+	public static void NotOnNetFramework(this Execute execute, Action callback)
+	{
+		if (!execute.IsNetFramework)
+		{
+			callback();
+		}
+	}
+
+	/// <summary>
+	///     The <paramref name="callback" /> is executed on all operating systems except <see cref="OSPlatform.Windows" />.
+	/// </summary>
+	public static void NotOnWindows(this Execute execute, Action callback)
+	{
+		if (!execute.IsWindows)
+		{
+			callback();
+		}
+	}
+
+	/// <summary>
+	///     The <paramref name="callback" /> is executed when the operating system is not <see cref="OSPlatform.Windows" />
+	///     and the <paramref name="predicate" /> is <see langword="true" />.
+	/// </summary>
+	public static void NotOnWindowsIf(this Execute execute, bool predicate, Action callback)
+	{
+		if (predicate && !execute.IsWindows)
+		{
+			callback();
+		}
+	}
+
+	/// <summary>
+	///     Returns the value from <paramref name="callback" />, when the operating system is <see cref="OSPlatform.Linux" />,
+	///     otherwise the value from <paramref name="alternativeCallback" />.
+	/// </summary>
+	public static T OnLinux<T>(this Execute execute, Func<T> callback, Func<T> alternativeCallback)
+	{
+		if (execute.IsLinux)
+		{
+			return callback();
+		}
+
+		return alternativeCallback();
+	}
+
+	/// <summary>
+	///     The <paramref name="callback" /> is executed when the operating system is <see cref="OSPlatform.Linux" />.
+	/// </summary>
+	public static void OnLinux(this Execute execute, Action callback)
+	{
+		if (execute.IsLinux)
+		{
+			callback();
+		}
+	}
+
+	/// <summary>
+	///     The <paramref name="callback" /> is executed when the operating system is <see cref="OSPlatform.OSX" />.
+	/// </summary>
+	public static void OnMac(this Execute execute, Action callback,
+		Action? alternativeCallback = null)
+	{
+		if (execute.IsMac)
+		{
+			callback();
+		}
+		else
+		{
+			alternativeCallback?.Invoke();
+		}
+	}
+
+	/// <summary>
+	///     Returns the value from <paramref name="callback" />, when the code runs in .NET Framework,
+	///     otherwise the value from <paramref name="alternativeCallback" />.
+	/// </summary>
+	/// <remarks>
+	///     See also: <seealso cref="Execute.IsNetFramework" />
+	/// </remarks>
+	public static T OnNetFramework<T>(this Execute execute, Func<T> callback,
+		Func<T> alternativeCallback)
+	{
+		if (execute.IsNetFramework)
+		{
+			return callback();
+		}
+
+		return alternativeCallback();
+	}
+
+	/// <summary>
+	///     The <paramref name="callback" /> is executed when the code runs in .NET Framework.
+	/// </summary>
+	/// <remarks>
+	///     See also: <seealso cref="Execute.IsNetFramework" />
+	/// </remarks>
+	public static void OnNetFramework(this Execute execute, Action callback,
+		Action? alternativeCallback = null)
+	{
+		if (execute.IsNetFramework)
+		{
+			callback();
+		}
+		else
+		{
+			alternativeCallback?.Invoke();
+		}
+	}
+
+	/// <summary>
+	///     The <paramref name="callback" /> is executed when the code runs in .NET Framework
+	///     and the <paramref name="predicate" /> is <see langword="true" />.
+	/// </summary>
+	/// <remarks>
+	///     See also: <seealso cref="Execute.IsNetFramework" />
+	/// </remarks>
+	public static void OnNetFrameworkIf(this Execute execute, bool predicate, Action callback)
+	{
+		if (execute.IsNetFramework && predicate)
+		{
+			callback();
+		}
+	}
+
+	/// <summary>
+	///     The <paramref name="callback" /> is executed when the operating system is <see cref="OSPlatform.Windows" />.
+	/// </summary>
+	public static void OnWindows(this Execute execute, Action callback,
+		Action? alternativeCallback = null)
+	{
+		if (execute.IsWindows)
+		{
+			callback();
+		}
+		else
+		{
+			alternativeCallback?.Invoke();
+		}
+	}
+
+	/// <summary>
+	///     Returns the value from <paramref name="callback" />, when the operating system is <see cref="OSPlatform.Windows" />
+	///     ,
+	///     otherwise the value from <paramref name="alternativeCallback" />.
+	/// </summary>
+	public static T OnWindows<T>(this Execute execute, Func<T> callback,
+		Func<T> alternativeCallback)
+	{
+		if (execute.IsWindows)
+		{
+			return callback();
+		}
+
+		return alternativeCallback();
+	}
+
+	/// <summary>
+	///     The <paramref name="callback" /> is executed when the operating system is <see cref="OSPlatform.Windows" />
+	///     and the <paramref name="predicate" /> is <see langword="true" />.
+	/// </summary>
+	public static void OnWindowsIf(this Execute execute, bool predicate, Action callback)
+	{
+		if (predicate && execute.IsWindows)
+		{
+			callback();
+		}
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteExtensionsTests.cs
@@ -1,0 +1,230 @@
+﻿using System.Runtime.InteropServices;
+using Testably.Abstractions.Testing.Helpers;
+
+namespace Testably.Abstractions.Testing.Tests.Helpers;
+
+public sealed class ExecuteExtensionsTests
+{
+	[Theory]
+	[InlineData(ExecuteType.Linux, true)]
+	[InlineData(ExecuteType.Mac, true)]
+	[InlineData(ExecuteType.NetFramework, false)]
+	[InlineData(ExecuteType.Windows, true)]
+	public void NotOnNetFramework_ShouldExecuteDependingOnOperatingSystem(
+		ExecuteType type, bool shouldExecute)
+	{
+		bool isExecuted = false;
+		Execute sut = FromType(type);
+
+		sut.NotOnNetFramework(() => { isExecuted = true; });
+
+		isExecuted.Should().Be(shouldExecute);
+	}
+
+	[Theory]
+	[InlineData(ExecuteType.Linux, true)]
+	[InlineData(ExecuteType.Mac, true)]
+	[InlineData(ExecuteType.NetFramework, false)]
+	[InlineData(ExecuteType.Windows, false)]
+	public void NotOnWindows_ShouldExecuteDependingOnOperatingSystem(
+		ExecuteType type, bool shouldExecute)
+	{
+		bool isExecuted = false;
+		Execute sut = FromType(type);
+
+		sut.NotOnWindows(() => { isExecuted = true; });
+
+		isExecuted.Should().Be(shouldExecute);
+	}
+
+	[Theory]
+	[InlineData(ExecuteType.Linux, false, false)]
+	[InlineData(ExecuteType.Linux, true, true)]
+	[InlineData(ExecuteType.Mac, false, false)]
+	[InlineData(ExecuteType.Mac, true, true)]
+	[InlineData(ExecuteType.NetFramework, false, false)]
+	[InlineData(ExecuteType.NetFramework, true, false)]
+	[InlineData(ExecuteType.Windows, false, false)]
+	[InlineData(ExecuteType.Windows, true, false)]
+	public void NotOnWindowsIf_ShouldExecuteDependingOnOperatingSystem(
+		ExecuteType type, bool predicate, bool shouldExecute)
+	{
+		bool isExecuted = false;
+		Execute sut = FromType(type);
+
+		sut.NotOnWindowsIf(predicate, () => { isExecuted = true; });
+
+		isExecuted.Should().Be(shouldExecute);
+	}
+
+	[Theory]
+	[InlineData(ExecuteType.Linux, true)]
+	[InlineData(ExecuteType.Mac, false)]
+	[InlineData(ExecuteType.NetFramework, false)]
+	[InlineData(ExecuteType.Windows, false)]
+	public void OnLinux_ShouldExecuteDependingOnOperatingSystem(
+		ExecuteType type, bool shouldExecute)
+	{
+		bool isExecuted = false;
+		Execute sut = FromType(type);
+
+		sut.OnLinux(() => { isExecuted = true; });
+
+		isExecuted.Should().Be(shouldExecute);
+	}
+
+	[Theory]
+	[InlineData(ExecuteType.Linux, 3, 4, 3)]
+	[InlineData(ExecuteType.Mac, 5, 6, 6)]
+	[InlineData(ExecuteType.NetFramework, 7, 8, 8)]
+	[InlineData(ExecuteType.Windows, 1, 2, 2)]
+	public void OnLinux_WithValue_ShouldExecuteDependingOnOperatingSystem(
+		ExecuteType type, int value, int alternativeValue, int expectedValue)
+	{
+		Execute sut = FromType(type);
+
+		int result = sut.OnLinux(() => value, () => alternativeValue);
+
+		result.Should().Be(expectedValue);
+	}
+
+	[Theory]
+	[InlineData(ExecuteType.Linux, false)]
+	[InlineData(ExecuteType.Mac, true)]
+	[InlineData(ExecuteType.NetFramework, false)]
+	[InlineData(ExecuteType.Windows, false)]
+	public void OnMac_ShouldExecuteDependingOnOperatingSystem(
+		ExecuteType type, bool shouldExecute)
+	{
+		bool isExecuted = false;
+		Execute sut = FromType(type);
+
+		sut.OnMac(() => { isExecuted = true; });
+
+		isExecuted.Should().Be(shouldExecute);
+	}
+
+	[Theory]
+	[InlineData(ExecuteType.Linux, false)]
+	[InlineData(ExecuteType.Mac, false)]
+	[InlineData(ExecuteType.NetFramework, true)]
+	[InlineData(ExecuteType.Windows, false)]
+	public void OnNetFramework_ShouldExecuteDependingOnOperatingSystem(
+		ExecuteType type, bool shouldExecute)
+	{
+		bool isExecuted = false;
+		Execute sut = FromType(type);
+
+		sut.OnNetFramework(() => { isExecuted = true; });
+
+		isExecuted.Should().Be(shouldExecute);
+	}
+
+	[Theory]
+	[InlineData(ExecuteType.Linux, 3, 4, 4)]
+	[InlineData(ExecuteType.Mac, 5, 6, 6)]
+	[InlineData(ExecuteType.NetFramework, 7, 8, 7)]
+	[InlineData(ExecuteType.Windows, 1, 2, 2)]
+	public void OnNetFramework_WithValue_ShouldExecuteDependingOnOperatingSystem(
+		ExecuteType type, int value, int alternativeValue, int expectedValue)
+	{
+		Execute sut = FromType(type);
+
+		int result = sut.OnNetFramework(() => value, () => alternativeValue);
+
+		result.Should().Be(expectedValue);
+	}
+
+	[Theory]
+	[InlineData(ExecuteType.Linux, false, false)]
+	[InlineData(ExecuteType.Linux, true, false)]
+	[InlineData(ExecuteType.Mac, false, false)]
+	[InlineData(ExecuteType.Mac, true, false)]
+	[InlineData(ExecuteType.NetFramework, false, false)]
+	[InlineData(ExecuteType.NetFramework, true, true)]
+	[InlineData(ExecuteType.Windows, false, false)]
+	[InlineData(ExecuteType.Windows, true, false)]
+	public void OnNetFrameworkIf_ShouldExecuteDependingOnOperatingSystem(
+		ExecuteType type, bool predicate, bool shouldExecute)
+	{
+		bool isExecuted = false;
+		Execute sut = FromType(type);
+
+		sut.OnNetFrameworkIf(predicate, () => { isExecuted = true; });
+
+		isExecuted.Should().Be(shouldExecute);
+	}
+
+	[Theory]
+	[InlineData(ExecuteType.Linux, false)]
+	[InlineData(ExecuteType.Mac, false)]
+	[InlineData(ExecuteType.NetFramework, true)]
+	[InlineData(ExecuteType.Windows, true)]
+	public void OnWindows_ShouldExecuteDependingOnOperatingSystem(
+		ExecuteType type, bool shouldExecute)
+	{
+		bool isExecuted = false;
+		Execute sut = FromType(type);
+
+		sut.OnWindows(() => { isExecuted = true; });
+
+		isExecuted.Should().Be(shouldExecute);
+	}
+
+	[Theory]
+	[InlineData(ExecuteType.Linux, 3, 4, 4)]
+	[InlineData(ExecuteType.Mac, 5, 6, 6)]
+	[InlineData(ExecuteType.NetFramework, 7, 8, 7)]
+	[InlineData(ExecuteType.Windows, 1, 2, 1)]
+	public void OnWindows_WithValue_ShouldExecuteDependingOnOperatingSystem(
+		ExecuteType type, int value, int alternativeValue, int expectedValue)
+	{
+		Execute sut = FromType(type);
+
+		int result = sut.OnWindows(() => value, () => alternativeValue);
+
+		result.Should().Be(expectedValue);
+	}
+
+	[Theory]
+	[InlineData(ExecuteType.Linux, false, false)]
+	[InlineData(ExecuteType.Linux, true, false)]
+	[InlineData(ExecuteType.Mac, false, false)]
+	[InlineData(ExecuteType.Mac, true, false)]
+	[InlineData(ExecuteType.NetFramework, false, false)]
+	[InlineData(ExecuteType.NetFramework, true, true)]
+	[InlineData(ExecuteType.Windows, false, false)]
+	[InlineData(ExecuteType.Windows, true, true)]
+	public void OnWindowsIf_ShouldExecuteDependingOnOperatingSystem(
+		ExecuteType type, bool predicate, bool shouldExecute)
+	{
+		bool isExecuted = false;
+		Execute sut = FromType(type);
+
+		sut.OnWindowsIf(predicate, () => { isExecuted = true; });
+
+		isExecuted.Should().Be(shouldExecute);
+	}
+
+	#region Helpers
+
+	private static Execute FromType(ExecuteType type)
+		=> type switch
+		{
+			ExecuteType.Windows => new Execute(OSPlatform.Windows),
+			ExecuteType.Linux => new Execute(OSPlatform.Linux),
+			ExecuteType.Mac => new Execute(OSPlatform.OSX),
+			ExecuteType.NetFramework => new Execute(OSPlatform.Windows, true),
+			_ => throw new NotSupportedException()
+		};
+
+	#endregion
+
+	public enum ExecuteType
+	{
+		Windows,
+		Linux,
+		Mac,
+		NetFramework
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteTests.cs
@@ -1,0 +1,79 @@
+﻿using System.Runtime.InteropServices;
+using Testably.Abstractions.Testing.Helpers;
+
+namespace Testably.Abstractions.Testing.Tests.Helpers;
+
+public sealed class ExecuteTests
+{
+	[Fact]
+	public void Constructor_ForLinux_ShouldInitializeAccordingly()
+	{
+		Execute sut = new(OSPlatform.Linux);
+
+		sut.IsLinux.Should().BeTrue();
+		sut.IsMac.Should().BeFalse();
+		sut.IsNetFramework.Should().BeFalse();
+		sut.IsWindows.Should().BeFalse();
+		sut.StringComparisonMode.Should().Be(StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void Constructor_ForNetFramework_ShouldInitializeAccordingly()
+	{
+		Execute sut = new(OSPlatform.Windows, true);
+
+		sut.IsLinux.Should().BeFalse();
+		sut.IsMac.Should().BeFalse();
+		sut.IsNetFramework.Should().BeTrue();
+		sut.IsWindows.Should().BeTrue();
+		sut.StringComparisonMode.Should().Be(StringComparison.OrdinalIgnoreCase);
+	}
+
+	[Fact]
+	public void Constructor_ForNetFramework_WithLinux_ShouldInitializeLinux()
+	{
+		Execute sut = new(OSPlatform.Linux, true);
+
+		sut.IsLinux.Should().BeTrue();
+		sut.IsMac.Should().BeFalse();
+		sut.IsNetFramework.Should().BeFalse();
+		sut.IsWindows.Should().BeFalse();
+		sut.StringComparisonMode.Should().Be(StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void Constructor_ForNetFramework_WithOSX_ShouldInitializeMac()
+	{
+		Execute sut = new(OSPlatform.OSX, true);
+
+		sut.IsLinux.Should().BeFalse();
+		sut.IsMac.Should().BeTrue();
+		sut.IsNetFramework.Should().BeFalse();
+		sut.IsWindows.Should().BeFalse();
+		sut.StringComparisonMode.Should().Be(StringComparison.OrdinalIgnoreCase);
+	}
+
+	[Fact]
+	public void Constructor_ForOSX_ShouldInitializeAccordingly()
+	{
+		Execute sut = new(OSPlatform.OSX);
+
+		sut.IsLinux.Should().BeFalse();
+		sut.IsMac.Should().BeTrue();
+		sut.IsNetFramework.Should().BeFalse();
+		sut.IsWindows.Should().BeFalse();
+		sut.StringComparisonMode.Should().Be(StringComparison.OrdinalIgnoreCase);
+	}
+
+	[Fact]
+	public void Constructor_ForWindows_ShouldInitializeAccordingly()
+	{
+		Execute sut = new(OSPlatform.Windows);
+
+		sut.IsLinux.Should().BeFalse();
+		sut.IsMac.Should().BeFalse();
+		sut.IsNetFramework.Should().BeFalse();
+		sut.IsWindows.Should().BeTrue();
+		sut.StringComparisonMode.Should().Be(StringComparison.OrdinalIgnoreCase);
+	}
+}


### PR DESCRIPTION
This enables testing of the OS dependent methods.