### PR TITLE
feat: avoid arbitrary statistic calls

### DIFF
--- a/Source/Testably.Abstractions.Interface/Helpers/PathSystemBase.cs
+++ b/Source/Testably.Abstractions.Interface/Helpers/PathSystemBase.cs
@@ -1,9 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Abstractions;
-#if !NETSTANDARD2_0
-using System;
-#endif
 
 namespace Testably.Abstractions.Helpers;
 
@@ -12,6 +10,11 @@ namespace Testably.Abstractions.Helpers;
 ///     <para />
 ///     Implements <seealso cref="IPath" />
 /// </summary>
+#if NETSTANDARD2_0
+[Obsolete]
+#else
+[Obsolete("Will be removed in a future version!")]
+#endif
 public abstract class PathSystemBase : IPath
 {
 	/// <summary>

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
@@ -87,7 +87,7 @@ internal sealed class DirectoryInfoMock
 
 		DirectoryInfoMock directory = New(
 			_fileSystem.Storage.GetLocation(
-				_fileSystem.Path.Combine(FullName, path
+				_fileSystem.Execute.Path.Combine(FullName, path
 					.EnsureValidFormat(_fileSystem, nameof(path),
 						_fileSystem.Execute.IsWindows && !_fileSystem.Execute.IsNetFramework))),
 			_fileSystem);

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
@@ -82,10 +82,10 @@ internal sealed class DirectoryMock : IDirectory
 
 		do
 		{
-			string localBasePath = _fileSystem.Path.Combine(
-				_fileSystem.Path.GetTempPath(),
-				(prefix ?? "") + _fileSystem.Path.GetFileNameWithoutExtension(
-					_fileSystem.Path.GetRandomFileName()));
+			string localBasePath = _fileSystem.Execute.Path.Combine(
+				_fileSystem.Execute.Path.GetTempPath(),
+				(prefix ?? "") + _fileSystem.Execute.Path.GetFileNameWithoutExtension(
+					_fileSystem.Execute.Path.GetRandomFileName()));
 			_fileSystem.Execute.OnMac(() => localBasePath = "/private" + localBasePath);
 			basePath = localBasePath;
 		} while (_fileSystem.Directory.Exists(basePath));
@@ -361,8 +361,8 @@ internal sealed class DirectoryMock : IDirectory
 		using IDisposable registration = RegisterMethod(nameof(GetDirectoryRoot),
 			path);
 
-		return _fileSystem.Path.GetPathRoot(
-			       _fileSystem.Path.GetFullPath(path)) ??
+		return _fileSystem.Execute.Path.GetPathRoot(
+			       _fileSystem.Execute.Path.GetFullPath(path)) ??
 		       throw ExceptionFactory.PathIsEmpty(nameof(path));
 	}
 
@@ -584,7 +584,7 @@ internal sealed class DirectoryMock : IDirectory
 		if (!directoryInfo.Exists)
 		{
 			throw ExceptionFactory.DirectoryNotFound(
-				FileSystem.Path.GetFullPath(path));
+				_fileSystem.Execute.Path.GetFullPath(path));
 		}
 
 		_fileSystem.Storage.CurrentDirectory = directoryInfo.FullName;
@@ -692,18 +692,18 @@ internal sealed class DirectoryMock : IDirectory
 		fileSystem.Execute.OnMac(
 			() =>
 				throw ExceptionFactory.DirectoryNotFound(
-					fileSystem.Path.GetFullPath(path)),
+					fileSystem.Execute.Path.GetFullPath(path)),
 			() =>
 				throw ExceptionFactory.FileNotFound(
-					fileSystem.Path.GetFullPath(path)));
+					fileSystem.Execute.Path.GetFullPath(path)));
 #else
 		fileSystem.Execute.OnWindows(
 			() =>
 				throw ExceptionFactory.FileNotFound(
-					fileSystem.Path.GetFullPath(path)),
+					fileSystem.Execute.Path.GetFullPath(path)),
 			() =>
 				throw ExceptionFactory.DirectoryNotFound(
-					fileSystem.Path.GetFullPath(path)));
+					fileSystem.Execute.Path.GetFullPath(path)));
 #endif
 	}
 
@@ -713,15 +713,15 @@ internal sealed class DirectoryMock : IDirectory
 	{
 #if NET7_0_OR_GREATER
 		throw ExceptionFactory.FileNotFound(
-			fileSystem.Path.GetFullPath(path));
+			fileSystem.Execute.Path.GetFullPath(path));
 #else
 		fileSystem.Execute.OnWindows(
 			() =>
 				throw ExceptionFactory.FileNotFound(
-					fileSystem.Path.GetFullPath(path)),
+					fileSystem.Execute.Path.GetFullPath(path)),
 			() =>
 				throw ExceptionFactory.DirectoryNotFound(
-					fileSystem.Path.GetFullPath(path)));
+					fileSystem.Execute.Path.GetFullPath(path)));
 #endif
 	}
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
@@ -46,7 +46,7 @@ internal sealed class DriveInfoMock : IStorageDrive
 		if (driveName.IsUncPath(_fileSystem))
 		{
 			IsUncPath = true;
-			driveName = new string(fileSystem.Path.DirectorySeparatorChar, 2) +
+			driveName = new string(fileSystem.Execute.Path.DirectorySeparatorChar, 2) +
 			            GetTopmostParentDirectory(driveName.Substring(2));
 		}
 		else
@@ -259,7 +259,7 @@ internal sealed class DriveInfoMock : IStorageDrive
 	{
 		while (true)
 		{
-			string? child = FileSystem.Path.GetDirectoryName(path);
+			string? child = _fileSystem.Execute.Path.GetDirectoryName(path);
 			if (string.IsNullOrEmpty(child))
 			{
 				break;
@@ -283,14 +283,14 @@ internal sealed class DriveInfoMock : IStorageDrive
 			return $"{driveName.ToUpperInvariant()}:\\";
 		}
 
-		if (fileSystem.Path.IsPathRooted(driveName))
+		if (fileSystem.Execute.Path.IsPathRooted(driveName))
 		{
 			return fileSystem.Execute.OnWindows(() =>
 				{
-					string rootedPath = fileSystem.Path.GetPathRoot(driveName)!;
+					string rootedPath = fileSystem.Execute.Path.GetPathRoot(driveName)!;
 					return $"{rootedPath.TrimEnd('\\')}\\";
 				},
-				() => fileSystem.Path.GetPathRoot(driveName)!);
+				() => fileSystem.Execute.Path.GetPathRoot(driveName)!);
 		}
 
 		throw ExceptionFactory.InvalidDriveName();

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
@@ -113,7 +113,7 @@ internal sealed class FileInfoMock
 		{
 			using IDisposable registration = RegisterProperty(nameof(Name), PropertyAccess.Get);
 
-			if (Location.FullPath.EndsWith(FileSystem.Path.DirectorySeparatorChar))
+			if (Location.FullPath.EndsWith(_fileSystem.Execute.Path.DirectorySeparatorChar))
 			{
 				return string.Empty;
 			}

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -188,7 +188,7 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 		FileOptions options)
 		: base(
 			stream,
-			path == null ? "" : fileSystem.Path.GetFullPath(path),
+			path == null ? "" : fileSystem.Execute.Path.GetFullPath(path),
 			(options & FileOptions.Asynchronous) != 0)
 	{
 		ThrowIfInvalidModeAccess(mode, access);
@@ -210,7 +210,7 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 			    _mode.Equals(FileMode.Truncate))
 			{
 				throw ExceptionFactory.FileNotFound(
-					_fileSystem.Path.GetFullPath(base.Name));
+					_fileSystem.Execute.Path.GetFullPath(base.Name));
 			}
 
 			file = _fileSystem.Storage.GetOrCreateContainer(_location,
@@ -222,15 +222,15 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 			_fileSystem.Execute.OnWindows(
 				() =>
 					throw ExceptionFactory.AccessToPathDenied(
-						_fileSystem.Path.GetFullPath(base.Name)),
+						_fileSystem.Execute.Path.GetFullPath(base.Name)),
 				() =>
 					throw ExceptionFactory.FileAlreadyExists(
-						_fileSystem.Path.GetFullPath(base.Name), 17));
+						_fileSystem.Execute.Path.GetFullPath(base.Name), 17));
 		}
 		else if (_mode.Equals(FileMode.CreateNew))
 		{
 			throw ExceptionFactory.FileAlreadyExists(
-				_fileSystem.Path.GetFullPath(Name),
+				_fileSystem.Execute.Path.GetFullPath(Name),
 				_fileSystem.Execute.IsWindows ? -2147024816 : 17);
 		}
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
@@ -166,7 +166,7 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 				return ".";
 			}
 
-			return _fileSystem.Path.GetExtension(Location.FullPath);
+			return _fileSystem.Execute.Path.GetExtension(Location.FullPath);
 		}
 	}
 
@@ -282,11 +282,11 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 		{
 			using IDisposable registration = RegisterProperty(nameof(Name), PropertyAccess.Get);
 
-			return _fileSystem.Path.GetPathRoot(Location.FullPath) == Location.FullPath
+			return _fileSystem.Execute.Path.GetPathRoot(Location.FullPath) == Location.FullPath
 				? Location.FullPath
-				: _fileSystem.Path.GetFileName(Location.FullPath.TrimEnd(
-					_fileSystem.Path.DirectorySeparatorChar,
-					_fileSystem.Path.AltDirectorySeparatorChar));
+				: _fileSystem.Execute.Path.GetFileName(Location.FullPath.TrimEnd(
+					_fileSystem.Execute.Path.DirectorySeparatorChar,
+					_fileSystem.Execute.Path.AltDirectorySeparatorChar));
 		}
 	}
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
@@ -317,7 +317,7 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 
 	private bool MatchesFilter(ChangeDescription changeDescription)
 	{
-		string fullPath = _fileSystem.Path.GetFullPath(Path);
+		string fullPath = _fileSystem.Execute.Path.GetFullPath(Path);
 		if (IncludeSubdirectories)
 		{
 			if (!changeDescription.Path.StartsWith(fullPath))
@@ -325,7 +325,7 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 				return false;
 			}
 		}
-		else if (FileSystem.Path.GetDirectoryName(changeDescription.Path) != fullPath)
+		else if (_fileSystem.Execute.Path.GetDirectoryName(changeDescription.Path) != fullPath)
 		{
 			return false;
 		}
@@ -344,7 +344,7 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 			EnumerationOptionsHelper.MatchesPattern(
 				_fileSystem.Execute,
 				EnumerationOptionsHelper.Compatible,
-				_fileSystem.Path.GetFileName(changeDescription.Path),
+				_fileSystem.Execute.Path.GetFileName(changeDescription.Path),
 				filter));
 	}
 
@@ -501,10 +501,10 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 		string? transformedName = changeDescriptionName;
 		string? path = changeDescriptionPath;
 		if (transformedName == null ||
-		    _fileSystem.Path.IsPathRooted(changeDescriptionName))
+		    _fileSystem.Execute.Path.IsPathRooted(changeDescriptionName))
 		{
-			transformedName = _fileSystem.Path.GetFileName(changeDescriptionPath);
-			path = _fileSystem.Path.GetDirectoryName(path);
+			transformedName = _fileSystem.Execute.Path.GetFileName(changeDescriptionPath);
+			path = _fileSystem.Execute.Path.GetDirectoryName(path);
 		}
 		else if (path.EndsWith(transformedName))
 		{

--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -143,13 +143,7 @@ internal sealed class PathMock : IPath
 		using IDisposable register = RegisterMethod(nameof(Exists),
 			path);
 
-		if (string.IsNullOrEmpty(path))
-		{
-			return false;
-		}
-
-		return _fileSystem.Storage.GetContainer(_fileSystem.Storage.GetLocation(path))
-			is not NullContainer;
+		return _fileSystem.Execute.Path.Exists(path);
 	}
 #endif
 
@@ -242,26 +236,7 @@ internal sealed class PathMock : IPath
 		using IDisposable register = RegisterMethod(nameof(GetFullPath),
 			path);
 
-		path.EnsureValidArgument(_fileSystem, nameof(path));
-
-		string? pathRoot = Path.GetPathRoot(path);
-		string? directoryRoot = Path.GetPathRoot(_fileSystem.Storage.CurrentDirectory);
-		if (!string.IsNullOrEmpty(pathRoot) && !string.IsNullOrEmpty(directoryRoot))
-		{
-			if (char.ToUpperInvariant(pathRoot[0]) != char.ToUpperInvariant(directoryRoot[0]))
-			{
-				return Path.GetFullPath(path);
-			}
-
-			if (pathRoot.Length < directoryRoot.Length)
-			{
-				path = path.Substring(pathRoot.Length);
-			}
-		}
-
-		return Path.GetFullPath(Path.Combine(
-			_fileSystem.Storage.CurrentDirectory,
-			path));
+		return _fileSystem.Execute.Path.GetFullPath(path);
 	}
 
 #if FEATURE_PATH_RELATIVE
@@ -326,13 +301,7 @@ internal sealed class PathMock : IPath
 		using IDisposable register = RegisterMethod(nameof(GetRelativePath),
 			relativeTo, path);
 
-		relativeTo.EnsureValidArgument(_fileSystem, nameof(relativeTo));
-		path.EnsureValidArgument(_fileSystem, nameof(path));
-
-		relativeTo = _fileSystem.Path.GetFullPath(relativeTo);
-		path = _fileSystem.Path.GetFullPath(path);
-
-		return Path.GetRelativePath(relativeTo, path);
+		return _fileSystem.Execute.Path.GetRelativePath(relativeTo, path);
 	}
 #endif
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Statistics;
-#if FEATURE_FILESYSTEM_NET7
-using Testably.Abstractions.Testing.Storage;
-#endif
 
 namespace Testably.Abstractions.Testing.FileSystem;
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using Testably.Abstractions.Helpers;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Statistics;
 #if FEATURE_FILESYSTEM_NET7
@@ -10,131 +9,136 @@ using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.FileSystem;
 
-internal sealed class PathMock : PathSystemBase
+internal sealed class PathMock : IPath
 {
+	private readonly MockFileSystem _fileSystem;
+
+	internal PathMock(MockFileSystem fileSystem)
+	{
+		_fileSystem = fileSystem;
+	}
+
+	#region IPath Members
+
 	/// <inheritdoc cref="IPath.AltDirectorySeparatorChar" />
-	public override char AltDirectorySeparatorChar
+	public char AltDirectorySeparatorChar
 	{
 		get
 		{
 			using IDisposable register = RegisterProperty(nameof(AltDirectorySeparatorChar));
 
-			return base.AltDirectorySeparatorChar;
+			return _fileSystem.Execute.Path.AltDirectorySeparatorChar;
 		}
 	}
 
 	/// <inheritdoc cref="IPath.DirectorySeparatorChar" />
-	public override char DirectorySeparatorChar
+	public char DirectorySeparatorChar
 	{
 		get
 		{
 			using IDisposable register = RegisterProperty(nameof(DirectorySeparatorChar));
 
-			return base.DirectorySeparatorChar;
+			return _fileSystem.Execute.Path.DirectorySeparatorChar;
 		}
 	}
 
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
+	public IFileSystem FileSystem
+		=> _fileSystem;
+
 	/// <inheritdoc cref="IPath.PathSeparator" />
-	public override char PathSeparator
+	public char PathSeparator
 	{
 		get
 		{
 			using IDisposable register = RegisterProperty(nameof(PathSeparator));
 
-			return base.PathSeparator;
+			return _fileSystem.Execute.Path.PathSeparator;
 		}
 	}
 
 	/// <inheritdoc cref="IPath.VolumeSeparatorChar" />
-	public override char VolumeSeparatorChar
+	public char VolumeSeparatorChar
 	{
 		get
 		{
 			using IDisposable register = RegisterProperty(nameof(VolumeSeparatorChar));
 
-			return base.VolumeSeparatorChar;
+			return _fileSystem.Execute.Path.VolumeSeparatorChar;
 		}
-	}
-
-	private readonly MockFileSystem _fileSystem;
-
-	internal PathMock(MockFileSystem fileSystem)
-		: base(fileSystem)
-	{
-		_fileSystem = fileSystem;
 	}
 
 	/// <inheritdoc cref="IPath.ChangeExtension(string, string)" />
 	[return: NotNullIfNotNull("path")]
-	public override string? ChangeExtension(string? path, string? extension)
+	public string? ChangeExtension(string? path, string? extension)
 	{
 		using IDisposable register = RegisterMethod(nameof(ChangeExtension),
 			path, extension);
 
-		return base.ChangeExtension(path, extension);
+		return _fileSystem.Execute.Path.ChangeExtension(path, extension);
 	}
 
 	/// <inheritdoc cref="IPath.Combine(string, string)" />
-	public override string Combine(string path1, string path2)
+	public string Combine(string path1, string path2)
 	{
 		using IDisposable register = RegisterMethod(nameof(Combine),
 			path1, path2);
 
-		return base.Combine(path1, path2);
+		return _fileSystem.Execute.Path.Combine(path1, path2);
 	}
 
 	/// <inheritdoc cref="IPath.Combine(string, string, string)" />
-	public override string Combine(string path1, string path2, string path3)
+	public string Combine(string path1, string path2, string path3)
 	{
 		using IDisposable register = RegisterMethod(nameof(Combine),
 			path1, path2, path3);
 
-		return base.Combine(path1, path2, path3);
+		return _fileSystem.Execute.Path.Combine(path1, path2, path3);
 	}
 
 	/// <inheritdoc cref="IPath.Combine(string, string, string, string)" />
-	public override string Combine(string path1, string path2, string path3, string path4)
+	public string Combine(string path1, string path2, string path3, string path4)
 	{
 		using IDisposable register = RegisterMethod(nameof(Combine),
 			path1, path2, path3, path4);
 
-		return base.Combine(path1, path2, path3, path4);
+		return _fileSystem.Execute.Path.Combine(path1, path2, path3, path4);
 	}
 
 	/// <inheritdoc cref="IPath.Combine(string[])" />
-	public override string Combine(params string[] paths)
+	public string Combine(params string[] paths)
 	{
 		using IDisposable register = RegisterMethod(nameof(Combine),
 			paths);
 
-		return base.Combine(paths);
+		return _fileSystem.Execute.Path.Combine(paths);
 	}
 
 #if FEATURE_PATH_ADVANCED
 	/// <inheritdoc cref="IPath.EndsInDirectorySeparator(ReadOnlySpan{char})" />
-	public override bool EndsInDirectorySeparator(ReadOnlySpan<char> path)
+	public bool EndsInDirectorySeparator(ReadOnlySpan<char> path)
 	{
 		using IDisposable register = RegisterMethod(nameof(EndsInDirectorySeparator),
 			path);
 
-		return base.EndsInDirectorySeparator(path);
+		return _fileSystem.Execute.Path.EndsInDirectorySeparator(path);
 	}
 #endif
 
 #if FEATURE_PATH_ADVANCED
 	/// <inheritdoc cref="IPath.EndsInDirectorySeparator(string)" />
-	public override bool EndsInDirectorySeparator(string path)
+	public bool EndsInDirectorySeparator(string path)
 	{
 		using IDisposable register = RegisterMethod(nameof(EndsInDirectorySeparator),
 			path);
 
-		return base.EndsInDirectorySeparator(path);
+		return _fileSystem.Execute.Path.EndsInDirectorySeparator(path);
 	}
 #endif
 
 #if FEATURE_FILESYSTEM_NET7
 	/// <inheritdoc cref="IPath.Exists(string)" />
-	public override bool Exists([NotNullWhen(true)] string? path)
+	public bool Exists([NotNullWhen(true)] string? path)
 	{
 		using IDisposable register = RegisterMethod(nameof(Exists),
 			path);
@@ -151,89 +155,89 @@ internal sealed class PathMock : PathSystemBase
 
 #if FEATURE_SPAN
 	/// <inheritdoc cref="IPath.GetDirectoryName(ReadOnlySpan{char})" />
-	public override ReadOnlySpan<char> GetDirectoryName(ReadOnlySpan<char> path)
+	public ReadOnlySpan<char> GetDirectoryName(ReadOnlySpan<char> path)
 	{
 		using IDisposable register = RegisterMethod(nameof(GetDirectoryName),
 			path);
 
-		return base.GetDirectoryName(path);
+		return _fileSystem.Execute.Path.GetDirectoryName(path);
 	}
 #endif
 
 	/// <inheritdoc cref="IPath.GetDirectoryName(string)" />
-	public override string? GetDirectoryName(string? path)
+	public string? GetDirectoryName(string? path)
 	{
 		using IDisposable register = RegisterMethod(nameof(GetDirectoryName),
 			path);
 
-		return base.GetDirectoryName(path);
+		return _fileSystem.Execute.Path.GetDirectoryName(path);
 	}
 
 #if FEATURE_SPAN
 	/// <inheritdoc cref="IPath.GetExtension(ReadOnlySpan{char})" />
-	public override ReadOnlySpan<char> GetExtension(ReadOnlySpan<char> path)
+	public ReadOnlySpan<char> GetExtension(ReadOnlySpan<char> path)
 	{
 		using IDisposable register = RegisterMethod(nameof(GetExtension),
 			path);
 
-		return base.GetExtension(path);
+		return _fileSystem.Execute.Path.GetExtension(path);
 	}
 #endif
 
 	/// <inheritdoc cref="IPath.GetExtension(string)" />
 	[return: NotNullIfNotNull("path")]
-	public override string? GetExtension(string? path)
+	public string? GetExtension(string? path)
 	{
 		using IDisposable register = RegisterMethod(nameof(GetExtension),
 			path);
 
-		return base.GetExtension(path);
+		return _fileSystem.Execute.Path.GetExtension(path);
 	}
 
 #if FEATURE_SPAN
 	/// <inheritdoc cref="IPath.GetFileName(ReadOnlySpan{char})" />
-	public override ReadOnlySpan<char> GetFileName(ReadOnlySpan<char> path)
+	public ReadOnlySpan<char> GetFileName(ReadOnlySpan<char> path)
 	{
 		using IDisposable register = RegisterMethod(nameof(GetFileName),
 			path);
 
-		return base.GetFileName(path);
+		return _fileSystem.Execute.Path.GetFileName(path);
 	}
 #endif
 
 	/// <inheritdoc cref="IPath.GetFileName(string)" />
 	[return: NotNullIfNotNull("path")]
-	public override string? GetFileName(string? path)
+	public string? GetFileName(string? path)
 	{
 		using IDisposable register = RegisterMethod(nameof(GetFileName),
 			path);
 
-		return base.GetFileName(path);
+		return _fileSystem.Execute.Path.GetFileName(path);
 	}
 
 #if FEATURE_SPAN
 	/// <inheritdoc cref="IPath.GetFileNameWithoutExtension(ReadOnlySpan{char})" />
-	public override ReadOnlySpan<char> GetFileNameWithoutExtension(ReadOnlySpan<char> path)
+	public ReadOnlySpan<char> GetFileNameWithoutExtension(ReadOnlySpan<char> path)
 	{
 		using IDisposable register = RegisterMethod(nameof(GetFileNameWithoutExtension),
 			path);
 
-		return base.GetFileNameWithoutExtension(path);
+		return _fileSystem.Execute.Path.GetFileNameWithoutExtension(path);
 	}
 #endif
 
 	/// <inheritdoc cref="IPath.GetFileNameWithoutExtension(string)" />
 	[return: NotNullIfNotNull("path")]
-	public override string? GetFileNameWithoutExtension(string? path)
+	public string? GetFileNameWithoutExtension(string? path)
 	{
 		using IDisposable register = RegisterMethod(nameof(GetFileNameWithoutExtension),
 			path);
 
-		return base.GetFileNameWithoutExtension(path);
+		return _fileSystem.Execute.Path.GetFileNameWithoutExtension(path);
 	}
 
 	/// <inheritdoc cref="IPath.GetFullPath(string)" />
-	public override string GetFullPath(string path)
+	public string GetFullPath(string path)
 	{
 		using IDisposable register = RegisterMethod(nameof(GetFullPath),
 			path);
@@ -262,62 +266,62 @@ internal sealed class PathMock : PathSystemBase
 
 #if FEATURE_PATH_RELATIVE
 	/// <inheritdoc cref="IPath.GetFullPath(string, string)" />
-	public override string GetFullPath(string path, string basePath)
+	public string GetFullPath(string path, string basePath)
 	{
 		using IDisposable register = RegisterMethod(nameof(GetFullPath),
 			path, basePath);
 
-		return base.GetFullPath(path, basePath);
+		return _fileSystem.Execute.Path.GetFullPath(path, basePath);
 	}
 #endif
 
 	/// <inheritdoc cref="IPath.GetInvalidFileNameChars()" />
-	public override char[] GetInvalidFileNameChars()
+	public char[] GetInvalidFileNameChars()
 	{
 		using IDisposable register = RegisterMethod(nameof(GetInvalidFileNameChars));
 
-		return base.GetInvalidFileNameChars();
+		return _fileSystem.Execute.Path.GetInvalidFileNameChars();
 	}
 
 	/// <inheritdoc cref="IPath.GetInvalidPathChars()" />
-	public override char[] GetInvalidPathChars()
+	public char[] GetInvalidPathChars()
 	{
 		using IDisposable register = RegisterMethod(nameof(GetInvalidPathChars));
 
-		return base.GetInvalidPathChars();
+		return _fileSystem.Execute.Path.GetInvalidPathChars();
 	}
 
 #if FEATURE_SPAN
 	/// <inheritdoc cref="IPath.GetPathRoot(ReadOnlySpan{char})" />
-	public override ReadOnlySpan<char> GetPathRoot(ReadOnlySpan<char> path)
+	public ReadOnlySpan<char> GetPathRoot(ReadOnlySpan<char> path)
 	{
 		using IDisposable register = RegisterMethod(nameof(GetPathRoot),
 			path);
 
-		return base.GetPathRoot(path);
+		return _fileSystem.Execute.Path.GetPathRoot(path);
 	}
 #endif
 
 	/// <inheritdoc cref="IPath.GetPathRoot(string?)" />
-	public override string? GetPathRoot(string? path)
+	public string? GetPathRoot(string? path)
 	{
 		using IDisposable register = RegisterMethod(nameof(GetPathRoot),
 			path);
 
-		return base.GetPathRoot(path);
+		return _fileSystem.Execute.Path.GetPathRoot(path);
 	}
 
 	/// <inheritdoc cref="IPath.GetRandomFileName()" />
-	public override string GetRandomFileName()
+	public string GetRandomFileName()
 	{
 		using IDisposable register = RegisterMethod(nameof(GetRandomFileName));
 
-		return base.GetRandomFileName();
+		return _fileSystem.Execute.Path.GetRandomFileName();
 	}
 
 #if FEATURE_PATH_RELATIVE
 	/// <inheritdoc cref="IPath.GetRelativePath(string, string)" />
-	public override string GetRelativePath(string relativeTo, string path)
+	public string GetRelativePath(string relativeTo, string path)
 	{
 		using IDisposable register = RegisterMethod(nameof(GetRelativePath),
 			relativeTo, path);
@@ -337,97 +341,97 @@ internal sealed class PathMock : PathSystemBase
 	[Obsolete(
 		"Insecure temporary file creation methods should not be used. Use `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())` instead.")]
 #endif
-	public override string GetTempFileName()
+	public string GetTempFileName()
 	{
 		using IDisposable register = RegisterMethod(nameof(GetTempFileName));
 
-		return base.GetTempFileName();
+		return _fileSystem.Execute.Path.GetTempFileName();
 	}
 
 	/// <inheritdoc cref="IPath.GetTempPath()" />
-	public override string GetTempPath()
+	public string GetTempPath()
 	{
 		using IDisposable register = RegisterMethod(nameof(GetTempPath));
 
-		return base.GetTempPath();
+		return _fileSystem.Execute.Path.GetTempPath();
 	}
 
 #if FEATURE_SPAN
 	/// <inheritdoc cref="IPath.HasExtension(ReadOnlySpan{char})" />
-	public override bool HasExtension(ReadOnlySpan<char> path)
+	public bool HasExtension(ReadOnlySpan<char> path)
 	{
 		using IDisposable register = RegisterMethod(nameof(HasExtension),
 			path);
 
-		return base.HasExtension(path);
+		return _fileSystem.Execute.Path.HasExtension(path);
 	}
 #endif
 
 	/// <inheritdoc cref="IPath.HasExtension(string)" />
-	public override bool HasExtension([NotNullWhen(true)] string? path)
+	public bool HasExtension([NotNullWhen(true)] string? path)
 	{
 		using IDisposable register = RegisterMethod(nameof(HasExtension),
 			path);
 
-		return base.HasExtension(path);
+		return _fileSystem.Execute.Path.HasExtension(path);
 	}
 
 #if FEATURE_SPAN
 	/// <inheritdoc cref="IPath.IsPathFullyQualified(ReadOnlySpan{char})" />
-	public override bool IsPathFullyQualified(ReadOnlySpan<char> path)
+	public bool IsPathFullyQualified(ReadOnlySpan<char> path)
 	{
 		using IDisposable register = RegisterMethod(nameof(IsPathFullyQualified),
 			path);
 
-		return base.IsPathFullyQualified(path);
+		return _fileSystem.Execute.Path.IsPathFullyQualified(path);
 	}
 #endif
 
 #if FEATURE_PATH_RELATIVE
 	/// <inheritdoc cref="IPath.IsPathFullyQualified(string)" />
-	public override bool IsPathFullyQualified(string path)
+	public bool IsPathFullyQualified(string path)
 	{
 		using IDisposable register = RegisterMethod(nameof(IsPathFullyQualified),
 			path);
 
-		return base.IsPathFullyQualified(path);
+		return _fileSystem.Execute.Path.IsPathFullyQualified(path);
 	}
 #endif
 
 #if FEATURE_SPAN
 	/// <inheritdoc cref="IPath.IsPathRooted(ReadOnlySpan{char})" />
-	public override bool IsPathRooted(ReadOnlySpan<char> path)
+	public bool IsPathRooted(ReadOnlySpan<char> path)
 	{
 		using IDisposable register = RegisterMethod(nameof(IsPathRooted),
 			path);
 
-		return base.IsPathRooted(path);
+		return _fileSystem.Execute.Path.IsPathRooted(path);
 	}
 #endif
 
 	/// <inheritdoc cref="IPath.IsPathRooted(string)" />
-	public override bool IsPathRooted(string? path)
+	public bool IsPathRooted(string? path)
 	{
 		using IDisposable register = RegisterMethod(nameof(IsPathRooted),
 			path);
 
-		return base.IsPathRooted(path);
+		return _fileSystem.Execute.Path.IsPathRooted(path);
 	}
 
-#if FEATURE_PATH_ADVANCED
+#if FEATURE_PATH_JOIN
 	/// <inheritdoc cref="IPath.Join(ReadOnlySpan{char}, ReadOnlySpan{char})" />
-	public override string Join(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2)
+	public string Join(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2)
 	{
 		using IDisposable register = RegisterMethod(nameof(Join),
 			path1, path2);
 
-		return base.Join(path1, path2);
+		return _fileSystem.Execute.Path.Join(path1, path2);
 	}
 #endif
 
-#if FEATURE_PATH_ADVANCED
+#if FEATURE_PATH_JOIN
 	/// <inheritdoc cref="IPath.Join(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char})" />
-	public override string Join(ReadOnlySpan<char> path1,
+	public string Join(ReadOnlySpan<char> path1,
 		ReadOnlySpan<char> path2,
 		ReadOnlySpan<char> path3)
 	{
@@ -436,13 +440,13 @@ internal sealed class PathMock : PathSystemBase
 			path2,
 			path3);
 
-		return base.Join(path1, path2, path3);
+		return _fileSystem.Execute.Path.Join(path1, path2, path3);
 	}
 #endif
 
 #if FEATURE_PATH_ADVANCED
 	/// <inheritdoc cref="IPath.Join(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char})" />
-	public override string Join(ReadOnlySpan<char> path1,
+	public string Join(ReadOnlySpan<char> path1,
 		ReadOnlySpan<char> path2,
 		ReadOnlySpan<char> path3,
 		ReadOnlySpan<char> path4)
@@ -453,79 +457,79 @@ internal sealed class PathMock : PathSystemBase
 			path3,
 			path4);
 
-		return base.Join(path1, path2, path3, path4);
+		return _fileSystem.Execute.Path.Join(path1, path2, path3, path4);
 	}
 #endif
 
 #if FEATURE_PATH_ADVANCED
 	/// <inheritdoc cref="IPath.Join(string, string)" />
-	public override string Join(string? path1, string? path2)
+	public string Join(string? path1, string? path2)
 	{
 		using IDisposable register = RegisterMethod(nameof(Join),
 			path1, path2);
 
-		return base.Join(path1, path2);
+		return _fileSystem.Execute.Path.Join(path1, path2);
 	}
 #endif
 
 #if FEATURE_PATH_ADVANCED
 	/// <inheritdoc cref="IPath.Join(string, string, string)" />
-	public override string Join(string? path1, string? path2, string? path3)
+	public string Join(string? path1, string? path2, string? path3)
 	{
 		using IDisposable register = RegisterMethod(nameof(Join),
 			path1, path2, path3);
 
-		return base.Join(path1, path2, path3);
+		return _fileSystem.Execute.Path.Join(path1, path2, path3);
 	}
 #endif
 
 #if FEATURE_PATH_ADVANCED
 	/// <inheritdoc cref="IPath.Join(string, string, string, string)" />
-	public override string Join(string? path1, string? path2, string? path3, string? path4)
+	public string Join(string? path1, string? path2, string? path3, string? path4)
 	{
 		using IDisposable register = RegisterMethod(nameof(Join),
 			path1, path2, path3, path4);
 
-		return base.Join(path1, path2, path3, path4);
+		return _fileSystem.Execute.Path.Join(path1, path2, path3, path4);
 	}
 #endif
 
 #if FEATURE_PATH_ADVANCED
 	/// <inheritdoc cref="IPath.Join(string[])" />
-	public override string Join(params string?[] paths)
+	public string Join(params string?[] paths)
 	{
 		using IDisposable register = RegisterMethod(nameof(Join),
 			paths);
 
-		return base.Join(paths);
+		return _fileSystem.Execute.Path.Join(paths);
 	}
 #endif
 
 #if FEATURE_PATH_ADVANCED
 	/// <inheritdoc cref="IPath.TrimEndingDirectorySeparator(ReadOnlySpan{char})" />
-	public override ReadOnlySpan<char> TrimEndingDirectorySeparator(ReadOnlySpan<char> path)
+	public ReadOnlySpan<char> TrimEndingDirectorySeparator(ReadOnlySpan<char> path)
 	{
 		using IDisposable register = RegisterMethod(nameof(TrimEndingDirectorySeparator),
 			path);
 
-		return base.TrimEndingDirectorySeparator(path);
+		return _fileSystem.Execute.Path.TrimEndingDirectorySeparator(path);
 	}
 #endif
 
 #if FEATURE_PATH_ADVANCED
 	/// <inheritdoc cref="IPath.TrimEndingDirectorySeparator(string)" />
-	public override string TrimEndingDirectorySeparator(string path)
+	public string TrimEndingDirectorySeparator(string path)
 	{
 		using IDisposable register = RegisterMethod(nameof(TrimEndingDirectorySeparator),
 			path);
 
-		return base.TrimEndingDirectorySeparator(path);
+		return _fileSystem.Execute.Path.TrimEndingDirectorySeparator(path);
 	}
 #endif
 
 #if FEATURE_PATH_JOIN
 	/// <inheritdoc cref="IPath.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
-	public override bool TryJoin(ReadOnlySpan<char> path1,
+	public bool TryJoin(ReadOnlySpan<char> path1,
 		ReadOnlySpan<char> path2,
 		Span<char> destination,
 		out int charsWritten)
@@ -533,7 +537,8 @@ internal sealed class PathMock : PathSystemBase
 		int registerCharsWritten = 0;
 		try
 		{
-			bool result = base.TryJoin(path1, path2, destination, out charsWritten);
+			bool result =
+				_fileSystem.Execute.Path.TryJoin(path1, path2, destination, out charsWritten);
 			registerCharsWritten = charsWritten;
 			return result;
 		}
@@ -550,7 +555,7 @@ internal sealed class PathMock : PathSystemBase
 
 #if FEATURE_PATH_JOIN
 	/// <inheritdoc cref="IPath.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
-	public override bool TryJoin(ReadOnlySpan<char> path1,
+	public bool TryJoin(ReadOnlySpan<char> path1,
 		ReadOnlySpan<char> path2,
 		ReadOnlySpan<char> path3,
 		Span<char> destination,
@@ -559,7 +564,9 @@ internal sealed class PathMock : PathSystemBase
 		int registerCharsWritten = 0;
 		try
 		{
-			bool result = base.TryJoin(path1, path2, path3, destination, out charsWritten);
+			bool result =
+				_fileSystem.Execute.Path.TryJoin(path1, path2, path3, destination,
+					out charsWritten);
 			registerCharsWritten = charsWritten;
 			return result;
 		}
@@ -575,6 +582,8 @@ internal sealed class PathMock : PathSystemBase
 	}
 #endif
 
+	#endregion
+
 	private IDisposable RegisterMethod(string name)
 		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name);
 
@@ -588,7 +597,7 @@ internal sealed class PathMock : PathSystemBase
 			ParameterDescription.FromParameter(parameter1));
 #endif
 
-#if FEATURE_PATH_ADVANCED
+#if FEATURE_PATH_JOIN
 	private IDisposable RegisterMethod<T1, T2>(string name, ReadOnlySpan<T1> parameter1,
 		ReadOnlySpan<T2> parameter2)
 		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name,
@@ -596,7 +605,7 @@ internal sealed class PathMock : PathSystemBase
 			ParameterDescription.FromParameter(parameter2));
 #endif
 
-#if FEATURE_PATH_ADVANCED
+#if FEATURE_PATH_JOIN
 	private IDisposable RegisterMethod<T1, T2, T3>(string name, ReadOnlySpan<T1> parameter1,
 		ReadOnlySpan<T2> parameter2, ReadOnlySpan<T3> parameter3)
 		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name,

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryCleaner.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryCleaner.cs
@@ -17,7 +17,7 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 		_fileSystem = fileSystem;
 		_logger = logger;
 		BasePath = InitializeBasePath(
-			(fileSystem as MockFileSystem)?.Execute ?? Execute.Default,
+			fileSystem.ExecuteOrDefault(),
 			prefix ?? "");
 	}
 

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
@@ -96,7 +96,7 @@ public static class FileSystemInitializerExtensions
 			#pragma warning restore CA2249
 
 			if (EnumerationOptionsHelper.MatchesPattern(
-				(fileSystem as MockFileSystem)?.Execute ?? Execute.Default,
+				fileSystem.ExecuteOrDefault(),
 				enumerationOptions,
 				fileName,
 				searchPattern))

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.NativePath.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.NativePath.cs
@@ -1,0 +1,292 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using Testably.Abstractions.Testing.Storage;
+
+namespace Testably.Abstractions.Testing.Helpers;
+
+internal partial class Execute
+{
+	private class NativePath : IPath
+	{
+		private readonly MockFileSystem _mockFileSystem;
+
+		public NativePath(MockFileSystem mockFileSystem)
+		{
+			_mockFileSystem = mockFileSystem;
+		}
+
+		#region IPath Members
+
+		/// <inheritdoc cref="Path.AltDirectorySeparatorChar" />
+		public char AltDirectorySeparatorChar
+			=> System.IO.Path.AltDirectorySeparatorChar;
+
+		/// <inheritdoc cref="Path.DirectorySeparatorChar" />
+		public char DirectorySeparatorChar
+			=> System.IO.Path.DirectorySeparatorChar;
+
+		/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
+		public IFileSystem FileSystem => _mockFileSystem;
+
+		/// <inheritdoc cref="Path.PathSeparator" />
+		public char PathSeparator
+			=> System.IO.Path.PathSeparator;
+
+		/// <inheritdoc cref="Path.VolumeSeparatorChar" />
+		public char VolumeSeparatorChar
+			=> System.IO.Path.VolumeSeparatorChar;
+
+		/// <inheritdoc cref="Path.ChangeExtension(string, string)" />
+		[return: NotNullIfNotNull("path")]
+		public string? ChangeExtension(string? path, string? extension)
+			=> System.IO.Path.ChangeExtension(path, extension);
+
+		/// <inheritdoc cref="Path.Combine(string, string)" />
+		public string Combine(string path1, string path2)
+			=> System.IO.Path.Combine(path1, path2);
+
+		/// <inheritdoc cref="Path.Combine(string, string, string)" />
+		public string Combine(string path1, string path2, string path3)
+			=> System.IO.Path.Combine(path1, path2, path3);
+
+		/// <inheritdoc cref="Path.Combine(string, string, string, string)" />
+		public string Combine(string path1, string path2, string path3, string path4)
+			=> System.IO.Path.Combine(path1, path2, path3, path4);
+
+		/// <inheritdoc cref="Path.Combine(string[])" />
+		public string Combine(params string[] paths)
+			=> System.IO.Path.Combine(paths);
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.EndsInDirectorySeparator(ReadOnlySpan{char})" />
+	public bool EndsInDirectorySeparator(ReadOnlySpan<char> path)
+		=> System.IO.Path.EndsInDirectorySeparator(path);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.EndsInDirectorySeparator(string)" />
+	public bool EndsInDirectorySeparator(string path)
+		=> System.IO.Path.EndsInDirectorySeparator(path);
+#endif
+
+#if FEATURE_FILESYSTEM_NET7
+		/// <inheritdoc cref="Path.Exists(string)" />
+		public bool Exists([NotNullWhen(true)] string? path)
+		{
+			if (string.IsNullOrEmpty(path))
+			{
+				return false;
+			}
+
+			return _mockFileSystem.Storage.GetContainer(_mockFileSystem.Storage.GetLocation(path))
+				is not NullContainer;
+		}
+#endif
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.GetDirectoryName(ReadOnlySpan{char})" />
+	public ReadOnlySpan<char> GetDirectoryName(ReadOnlySpan<char> path)
+		=> System.IO.Path.GetDirectoryName(path);
+#endif
+
+		/// <inheritdoc cref="Path.GetDirectoryName(string)" />
+		public string? GetDirectoryName(string? path)
+			=> System.IO.Path.GetDirectoryName(path);
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.GetExtension(ReadOnlySpan{char})" />
+	public ReadOnlySpan<char> GetExtension(ReadOnlySpan<char> path)
+		=> System.IO.Path.GetExtension(path);
+#endif
+
+		/// <inheritdoc cref="Path.GetExtension(string)" />
+		[return: NotNullIfNotNull("path")]
+		public string? GetExtension(string? path)
+			=> System.IO.Path.GetExtension(path);
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.GetFileName(ReadOnlySpan{char})" />
+	public ReadOnlySpan<char> GetFileName(ReadOnlySpan<char> path)
+		=> System.IO.Path.GetFileName(path);
+#endif
+
+		/// <inheritdoc cref="Path.GetFileName(string)" />
+		[return: NotNullIfNotNull("path")]
+		public string? GetFileName(string? path)
+			=> System.IO.Path.GetFileName(path);
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.GetFileNameWithoutExtension(ReadOnlySpan{char})" />
+	public ReadOnlySpan<char> GetFileNameWithoutExtension(ReadOnlySpan<char> path)
+		=> System.IO.Path.GetFileNameWithoutExtension(path);
+#endif
+
+		/// <inheritdoc cref="Path.GetFileNameWithoutExtension(string)" />
+		[return: NotNullIfNotNull("path")]
+		public string? GetFileNameWithoutExtension(string? path)
+			=> System.IO.Path.GetFileNameWithoutExtension(path);
+
+		/// <inheritdoc cref="Path.GetFullPath(string)" />
+		public string GetFullPath(string path)
+			=> System.IO.Path.GetFullPath(path);
+
+#if FEATURE_PATH_RELATIVE
+	/// <inheritdoc cref="Path.GetFullPath(string, string)" />
+	public string GetFullPath(string path, string basePath)
+		=> System.IO.Path.GetFullPath(path, basePath);
+#endif
+
+		/// <inheritdoc cref="Path.GetInvalidFileNameChars()" />
+		public char[] GetInvalidFileNameChars()
+			=> System.IO.Path.GetInvalidFileNameChars();
+
+		/// <inheritdoc cref="Path.GetInvalidPathChars()" />
+		public char[] GetInvalidPathChars()
+			=> System.IO.Path.GetInvalidPathChars();
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.GetPathRoot(ReadOnlySpan{char})" />
+	public ReadOnlySpan<char> GetPathRoot(ReadOnlySpan<char> path)
+		=> System.IO.Path.GetPathRoot(path);
+#endif
+
+		/// <inheritdoc cref="Path.GetPathRoot(string?)" />
+		public string? GetPathRoot(string? path)
+			=> System.IO.Path.GetPathRoot(path);
+
+		/// <inheritdoc cref="Path.GetRandomFileName()" />
+		public string GetRandomFileName()
+			=> System.IO.Path.GetRandomFileName();
+
+#if FEATURE_PATH_RELATIVE
+	/// <inheritdoc cref="Path.GetRelativePath(string, string)" />
+	public string GetRelativePath(string relativeTo, string path)
+		=> System.IO.Path.GetRelativePath(relativeTo, path);
+#endif
+
+		/// <inheritdoc cref="Path.GetTempFileName()" />
+#if !NETSTANDARD2_0
+	[Obsolete(
+		"Insecure temporary file creation methods should not be used. Use `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())` instead.")]
+#endif
+		public string GetTempFileName()
+			=> System.IO.Path.GetTempFileName();
+
+		/// <inheritdoc cref="Path.GetTempPath()" />
+		public string GetTempPath()
+			=> System.IO.Path.GetTempPath();
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.HasExtension(ReadOnlySpan{char})" />
+	public bool HasExtension(ReadOnlySpan<char> path)
+		=> System.IO.Path.HasExtension(path);
+#endif
+
+		/// <inheritdoc cref="Path.HasExtension(string)" />
+		public bool HasExtension([NotNullWhen(true)] string? path)
+			=> System.IO.Path.HasExtension(path);
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.IsPathFullyQualified(ReadOnlySpan{char})" />
+	public bool IsPathFullyQualified(ReadOnlySpan<char> path)
+		=> System.IO.Path.IsPathFullyQualified(path);
+#endif
+
+#if FEATURE_PATH_RELATIVE
+	/// <inheritdoc cref="Path.IsPathFullyQualified(string)" />
+	public bool IsPathFullyQualified(string path)
+		=> System.IO.Path.IsPathFullyQualified(path);
+#endif
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.IsPathRooted(ReadOnlySpan{char})" />
+	public bool IsPathRooted(ReadOnlySpan<char> path)
+		=> System.IO.Path.IsPathRooted(path);
+#endif
+
+		/// <inheritdoc cref="Path.IsPathRooted(string)" />
+		public bool IsPathRooted(string? path)
+			=> System.IO.Path.IsPathRooted(path);
+
+#if FEATURE_PATH_JOIN
+	/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char})" />
+	public string Join(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2)
+		=> System.IO.Path.Join(path1, path2);
+#endif
+
+#if FEATURE_PATH_JOIN
+	/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char})" />
+	public string Join(ReadOnlySpan<char> path1,
+		ReadOnlySpan<char> path2,
+		ReadOnlySpan<char> path3)
+		=> System.IO.Path.Join(path1, path2, path3);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char})" />
+	public string Join(ReadOnlySpan<char> path1,
+		ReadOnlySpan<char> path2,
+		ReadOnlySpan<char> path3,
+		ReadOnlySpan<char> path4)
+		=> System.IO.Path.Join(path1, path2, path3, path4);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.Join(string, string)" />
+	public string Join(string? path1, string? path2)
+		=> System.IO.Path.Join(path1, path2);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.Join(string, string, string)" />
+	public string Join(string? path1, string? path2, string? path3)
+		=> System.IO.Path.Join(path1, path2, path3);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.Join(string, string, string, string)" />
+	public string Join(string? path1, string? path2, string? path3, string? path4)
+		=> System.IO.Path.Join(path1, path2, path3, path4);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.Join(string[])" />
+	public string Join(params string?[] paths)
+		=> System.IO.Path.Join(paths);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.TrimEndingDirectorySeparator(ReadOnlySpan{char})" />
+	public ReadOnlySpan<char> TrimEndingDirectorySeparator(ReadOnlySpan<char> path)
+		=> System.IO.Path.TrimEndingDirectorySeparator(path);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.TrimEndingDirectorySeparator(string)" />
+	public string TrimEndingDirectorySeparator(string path)
+		=> System.IO.Path.TrimEndingDirectorySeparator(path);
+#endif
+
+#if FEATURE_PATH_JOIN
+	/// <inheritdoc cref="Path.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
+	public bool TryJoin(ReadOnlySpan<char> path1,
+		ReadOnlySpan<char> path2,
+		Span<char> destination,
+		out int charsWritten)
+		=> System.IO.Path.TryJoin(path1, path2, destination, out charsWritten);
+#endif
+
+#if FEATURE_PATH_JOIN
+	/// <inheritdoc cref="Path.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
+	public bool TryJoin(ReadOnlySpan<char> path1,
+		ReadOnlySpan<char> path2,
+		ReadOnlySpan<char> path3,
+		Span<char> destination,
+		out int charsWritten)
+		=> System.IO.Path.TryJoin(path1, path2, path3, destination, out charsWritten);
+#endif
+
+		#endregion
+	}
+}

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.NativePath.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.NativePath.cs
@@ -9,11 +9,11 @@ internal partial class Execute
 {
 	private class NativePath : IPath
 	{
-		private readonly MockFileSystem _mockFileSystem;
+		private readonly MockFileSystem _fileSystem;
 
-		public NativePath(MockFileSystem mockFileSystem)
+		public NativePath(MockFileSystem fileSystem)
 		{
-			_mockFileSystem = mockFileSystem;
+			_fileSystem = fileSystem;
 		}
 
 		#region IPath Members
@@ -27,7 +27,7 @@ internal partial class Execute
 			=> System.IO.Path.DirectorySeparatorChar;
 
 		/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
-		public IFileSystem FileSystem => _mockFileSystem;
+		public IFileSystem FileSystem => _fileSystem;
 
 		/// <inheritdoc cref="Path.PathSeparator" />
 		public char PathSeparator
@@ -59,15 +59,15 @@ internal partial class Execute
 			=> System.IO.Path.Combine(paths);
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.EndsInDirectorySeparator(ReadOnlySpan{char})" />
-	public bool EndsInDirectorySeparator(ReadOnlySpan<char> path)
-		=> System.IO.Path.EndsInDirectorySeparator(path);
+		/// <inheritdoc cref="Path.EndsInDirectorySeparator(ReadOnlySpan{char})" />
+		public bool EndsInDirectorySeparator(ReadOnlySpan<char> path)
+			=> System.IO.Path.EndsInDirectorySeparator(path);
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.EndsInDirectorySeparator(string)" />
-	public bool EndsInDirectorySeparator(string path)
-		=> System.IO.Path.EndsInDirectorySeparator(path);
+		/// <inheritdoc cref="Path.EndsInDirectorySeparator(string)" />
+		public bool EndsInDirectorySeparator(string path)
+			=> System.IO.Path.EndsInDirectorySeparator(path);
 #endif
 
 #if FEATURE_FILESYSTEM_NET7
@@ -79,15 +79,15 @@ internal partial class Execute
 				return false;
 			}
 
-			return _mockFileSystem.Storage.GetContainer(_mockFileSystem.Storage.GetLocation(path))
+			return _fileSystem.Storage.GetContainer(_fileSystem.Storage.GetLocation(path))
 				is not NullContainer;
 		}
 #endif
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.GetDirectoryName(ReadOnlySpan{char})" />
-	public ReadOnlySpan<char> GetDirectoryName(ReadOnlySpan<char> path)
-		=> System.IO.Path.GetDirectoryName(path);
+		/// <inheritdoc cref="Path.GetDirectoryName(ReadOnlySpan{char})" />
+		public ReadOnlySpan<char> GetDirectoryName(ReadOnlySpan<char> path)
+			=> System.IO.Path.GetDirectoryName(path);
 #endif
 
 		/// <inheritdoc cref="Path.GetDirectoryName(string)" />
@@ -95,9 +95,9 @@ internal partial class Execute
 			=> System.IO.Path.GetDirectoryName(path);
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.GetExtension(ReadOnlySpan{char})" />
-	public ReadOnlySpan<char> GetExtension(ReadOnlySpan<char> path)
-		=> System.IO.Path.GetExtension(path);
+		/// <inheritdoc cref="Path.GetExtension(ReadOnlySpan{char})" />
+		public ReadOnlySpan<char> GetExtension(ReadOnlySpan<char> path)
+			=> System.IO.Path.GetExtension(path);
 #endif
 
 		/// <inheritdoc cref="Path.GetExtension(string)" />
@@ -106,9 +106,9 @@ internal partial class Execute
 			=> System.IO.Path.GetExtension(path);
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.GetFileName(ReadOnlySpan{char})" />
-	public ReadOnlySpan<char> GetFileName(ReadOnlySpan<char> path)
-		=> System.IO.Path.GetFileName(path);
+		/// <inheritdoc cref="Path.GetFileName(ReadOnlySpan{char})" />
+		public ReadOnlySpan<char> GetFileName(ReadOnlySpan<char> path)
+			=> System.IO.Path.GetFileName(path);
 #endif
 
 		/// <inheritdoc cref="Path.GetFileName(string)" />
@@ -117,9 +117,9 @@ internal partial class Execute
 			=> System.IO.Path.GetFileName(path);
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.GetFileNameWithoutExtension(ReadOnlySpan{char})" />
-	public ReadOnlySpan<char> GetFileNameWithoutExtension(ReadOnlySpan<char> path)
-		=> System.IO.Path.GetFileNameWithoutExtension(path);
+		/// <inheritdoc cref="Path.GetFileNameWithoutExtension(ReadOnlySpan{char})" />
+		public ReadOnlySpan<char> GetFileNameWithoutExtension(ReadOnlySpan<char> path)
+			=> System.IO.Path.GetFileNameWithoutExtension(path);
 #endif
 
 		/// <inheritdoc cref="Path.GetFileNameWithoutExtension(string)" />
@@ -129,12 +129,34 @@ internal partial class Execute
 
 		/// <inheritdoc cref="Path.GetFullPath(string)" />
 		public string GetFullPath(string path)
-			=> System.IO.Path.GetFullPath(path);
+		{
+			path.EnsureValidArgument(_fileSystem, nameof(path));
+
+			string? pathRoot = System.IO.Path.GetPathRoot(path);
+			string? directoryRoot =
+				System.IO.Path.GetPathRoot(_fileSystem.Storage.CurrentDirectory);
+			if (!string.IsNullOrEmpty(pathRoot) && !string.IsNullOrEmpty(directoryRoot))
+			{
+				if (char.ToUpperInvariant(pathRoot[0]) != char.ToUpperInvariant(directoryRoot[0]))
+				{
+					return System.IO.Path.GetFullPath(path);
+				}
+
+				if (pathRoot.Length < directoryRoot.Length)
+				{
+					path = path.Substring(pathRoot.Length);
+				}
+			}
+
+			return System.IO.Path.GetFullPath(System.IO.Path.Combine(
+				_fileSystem.Storage.CurrentDirectory,
+				path));
+		}
 
 #if FEATURE_PATH_RELATIVE
-	/// <inheritdoc cref="Path.GetFullPath(string, string)" />
-	public string GetFullPath(string path, string basePath)
-		=> System.IO.Path.GetFullPath(path, basePath);
+		/// <inheritdoc cref="Path.GetFullPath(string, string)" />
+		public string GetFullPath(string path, string basePath)
+			=> System.IO.Path.GetFullPath(path, basePath);
 #endif
 
 		/// <inheritdoc cref="Path.GetInvalidFileNameChars()" />
@@ -146,9 +168,9 @@ internal partial class Execute
 			=> System.IO.Path.GetInvalidPathChars();
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.GetPathRoot(ReadOnlySpan{char})" />
-	public ReadOnlySpan<char> GetPathRoot(ReadOnlySpan<char> path)
-		=> System.IO.Path.GetPathRoot(path);
+		/// <inheritdoc cref="Path.GetPathRoot(ReadOnlySpan{char})" />
+		public ReadOnlySpan<char> GetPathRoot(ReadOnlySpan<char> path)
+			=> System.IO.Path.GetPathRoot(path);
 #endif
 
 		/// <inheritdoc cref="Path.GetPathRoot(string?)" />
@@ -160,15 +182,23 @@ internal partial class Execute
 			=> System.IO.Path.GetRandomFileName();
 
 #if FEATURE_PATH_RELATIVE
-	/// <inheritdoc cref="Path.GetRelativePath(string, string)" />
-	public string GetRelativePath(string relativeTo, string path)
-		=> System.IO.Path.GetRelativePath(relativeTo, path);
+		/// <inheritdoc cref="Path.GetRelativePath(string, string)" />
+		public string GetRelativePath(string relativeTo, string path)
+		{
+			relativeTo.EnsureValidArgument(_fileSystem, nameof(relativeTo));
+			path.EnsureValidArgument(_fileSystem, nameof(path));
+
+			relativeTo = _fileSystem.Execute.Path.GetFullPath(relativeTo);
+			path = _fileSystem.Execute.Path.GetFullPath(path);
+
+			return System.IO.Path.GetRelativePath(relativeTo, path);
+		}
 #endif
 
 		/// <inheritdoc cref="Path.GetTempFileName()" />
 #if !NETSTANDARD2_0
-	[Obsolete(
-		"Insecure temporary file creation methods should not be used. Use `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())` instead.")]
+		[Obsolete(
+			"Insecure temporary file creation methods should not be used. Use `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())` instead.")]
 #endif
 		public string GetTempFileName()
 			=> System.IO.Path.GetTempFileName();
@@ -178,9 +208,9 @@ internal partial class Execute
 			=> System.IO.Path.GetTempPath();
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.HasExtension(ReadOnlySpan{char})" />
-	public bool HasExtension(ReadOnlySpan<char> path)
-		=> System.IO.Path.HasExtension(path);
+		/// <inheritdoc cref="Path.HasExtension(ReadOnlySpan{char})" />
+		public bool HasExtension(ReadOnlySpan<char> path)
+			=> System.IO.Path.HasExtension(path);
 #endif
 
 		/// <inheritdoc cref="Path.HasExtension(string)" />
@@ -188,21 +218,21 @@ internal partial class Execute
 			=> System.IO.Path.HasExtension(path);
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.IsPathFullyQualified(ReadOnlySpan{char})" />
-	public bool IsPathFullyQualified(ReadOnlySpan<char> path)
-		=> System.IO.Path.IsPathFullyQualified(path);
+		/// <inheritdoc cref="Path.IsPathFullyQualified(ReadOnlySpan{char})" />
+		public bool IsPathFullyQualified(ReadOnlySpan<char> path)
+			=> System.IO.Path.IsPathFullyQualified(path);
 #endif
 
 #if FEATURE_PATH_RELATIVE
-	/// <inheritdoc cref="Path.IsPathFullyQualified(string)" />
-	public bool IsPathFullyQualified(string path)
-		=> System.IO.Path.IsPathFullyQualified(path);
+		/// <inheritdoc cref="Path.IsPathFullyQualified(string)" />
+		public bool IsPathFullyQualified(string path)
+			=> System.IO.Path.IsPathFullyQualified(path);
 #endif
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.IsPathRooted(ReadOnlySpan{char})" />
-	public bool IsPathRooted(ReadOnlySpan<char> path)
-		=> System.IO.Path.IsPathRooted(path);
+		/// <inheritdoc cref="Path.IsPathRooted(ReadOnlySpan{char})" />
+		public bool IsPathRooted(ReadOnlySpan<char> path)
+			=> System.IO.Path.IsPathRooted(path);
 #endif
 
 		/// <inheritdoc cref="Path.IsPathRooted(string)" />
@@ -210,81 +240,81 @@ internal partial class Execute
 			=> System.IO.Path.IsPathRooted(path);
 
 #if FEATURE_PATH_JOIN
-	/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char})" />
-	public string Join(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2)
-		=> System.IO.Path.Join(path1, path2);
+		/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char})" />
+		public string Join(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2)
+			=> System.IO.Path.Join(path1, path2);
 #endif
 
 #if FEATURE_PATH_JOIN
-	/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char})" />
-	public string Join(ReadOnlySpan<char> path1,
-		ReadOnlySpan<char> path2,
-		ReadOnlySpan<char> path3)
-		=> System.IO.Path.Join(path1, path2, path3);
+		/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char})" />
+		public string Join(ReadOnlySpan<char> path1,
+			ReadOnlySpan<char> path2,
+			ReadOnlySpan<char> path3)
+			=> System.IO.Path.Join(path1, path2, path3);
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char})" />
-	public string Join(ReadOnlySpan<char> path1,
-		ReadOnlySpan<char> path2,
-		ReadOnlySpan<char> path3,
-		ReadOnlySpan<char> path4)
-		=> System.IO.Path.Join(path1, path2, path3, path4);
+		/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char})" />
+		public string Join(ReadOnlySpan<char> path1,
+			ReadOnlySpan<char> path2,
+			ReadOnlySpan<char> path3,
+			ReadOnlySpan<char> path4)
+			=> System.IO.Path.Join(path1, path2, path3, path4);
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.Join(string, string)" />
-	public string Join(string? path1, string? path2)
-		=> System.IO.Path.Join(path1, path2);
+		/// <inheritdoc cref="Path.Join(string, string)" />
+		public string Join(string? path1, string? path2)
+			=> System.IO.Path.Join(path1, path2);
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.Join(string, string, string)" />
-	public string Join(string? path1, string? path2, string? path3)
-		=> System.IO.Path.Join(path1, path2, path3);
+		/// <inheritdoc cref="Path.Join(string, string, string)" />
+		public string Join(string? path1, string? path2, string? path3)
+			=> System.IO.Path.Join(path1, path2, path3);
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.Join(string, string, string, string)" />
-	public string Join(string? path1, string? path2, string? path3, string? path4)
-		=> System.IO.Path.Join(path1, path2, path3, path4);
+		/// <inheritdoc cref="Path.Join(string, string, string, string)" />
+		public string Join(string? path1, string? path2, string? path3, string? path4)
+			=> System.IO.Path.Join(path1, path2, path3, path4);
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.Join(string[])" />
-	public string Join(params string?[] paths)
-		=> System.IO.Path.Join(paths);
+		/// <inheritdoc cref="Path.Join(string[])" />
+		public string Join(params string?[] paths)
+			=> System.IO.Path.Join(paths);
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.TrimEndingDirectorySeparator(ReadOnlySpan{char})" />
-	public ReadOnlySpan<char> TrimEndingDirectorySeparator(ReadOnlySpan<char> path)
-		=> System.IO.Path.TrimEndingDirectorySeparator(path);
+		/// <inheritdoc cref="Path.TrimEndingDirectorySeparator(ReadOnlySpan{char})" />
+		public ReadOnlySpan<char> TrimEndingDirectorySeparator(ReadOnlySpan<char> path)
+			=> System.IO.Path.TrimEndingDirectorySeparator(path);
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.TrimEndingDirectorySeparator(string)" />
-	public string TrimEndingDirectorySeparator(string path)
-		=> System.IO.Path.TrimEndingDirectorySeparator(path);
+		/// <inheritdoc cref="Path.TrimEndingDirectorySeparator(string)" />
+		public string TrimEndingDirectorySeparator(string path)
+			=> System.IO.Path.TrimEndingDirectorySeparator(path);
 #endif
 
 #if FEATURE_PATH_JOIN
-	/// <inheritdoc cref="Path.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
-	public bool TryJoin(ReadOnlySpan<char> path1,
-		ReadOnlySpan<char> path2,
-		Span<char> destination,
-		out int charsWritten)
-		=> System.IO.Path.TryJoin(path1, path2, destination, out charsWritten);
+		/// <inheritdoc cref="Path.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
+		public bool TryJoin(ReadOnlySpan<char> path1,
+			ReadOnlySpan<char> path2,
+			Span<char> destination,
+			out int charsWritten)
+			=> System.IO.Path.TryJoin(path1, path2, destination, out charsWritten);
 #endif
 
 #if FEATURE_PATH_JOIN
-	/// <inheritdoc cref="Path.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
-	public bool TryJoin(ReadOnlySpan<char> path1,
-		ReadOnlySpan<char> path2,
-		ReadOnlySpan<char> path3,
-		Span<char> destination,
-		out int charsWritten)
-		=> System.IO.Path.TryJoin(path1, path2, path3, destination, out charsWritten);
+		/// <inheritdoc cref="Path.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
+		public bool TryJoin(ReadOnlySpan<char> path1,
+			ReadOnlySpan<char> path2,
+			ReadOnlySpan<char> path3,
+			Span<char> destination,
+			out int charsWritten)
+			=> System.IO.Path.TryJoin(path1, path2, path3, destination, out charsWritten);
 #endif
 
 		#endregion

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.NativePath.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.NativePath.cs
@@ -7,7 +7,7 @@ namespace Testably.Abstractions.Testing.Helpers;
 
 internal partial class Execute
 {
-	private class NativePath : IPath
+	private sealed class NativePath : IPath
 	{
 		private readonly MockFileSystem _fileSystem;
 

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.cs
@@ -3,13 +3,8 @@ using System.Runtime.InteropServices;
 
 namespace Testably.Abstractions.Testing.Helpers;
 
-internal class Execute
+internal partial class Execute
 {
-	/// <summary>
-	///     The default execution engine, which uses the current operating system.
-	/// </summary>
-	public static Execute Default { get; } = new();
-
 	/// <summary>
 	///     Flag indicating if the code runs on <see cref="OSPlatform.Linux" />.
 	/// </summary>
@@ -34,11 +29,16 @@ internal class Execute
 	public bool IsWindows { get; }
 
 	/// <summary>
+	///     The internal implementation of the <see cref="IPath" /> functionality.
+	/// </summary>
+	public IPath Path { get; }
+
+	/// <summary>
 	///     The default <see cref="StringComparison" /> used for comparing paths.
 	/// </summary>
 	public StringComparison StringComparisonMode { get; }
 
-	internal Execute(OSPlatform osPlatform, bool isNetFramework = false)
+	internal Execute(MockFileSystem fileSystem, OSPlatform osPlatform, bool isNetFramework = false)
 	{
 		IsLinux = osPlatform == OSPlatform.Linux;
 		IsMac = osPlatform == OSPlatform.OSX;
@@ -47,9 +47,10 @@ internal class Execute
 		StringComparisonMode = IsLinux
 			? StringComparison.Ordinal
 			: StringComparison.OrdinalIgnoreCase;
+		Path = new NativePath(fileSystem);
 	}
 
-	private Execute()
+	internal Execute(MockFileSystem fileSystem)
 	{
 		IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 		IsMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
@@ -58,5 +59,6 @@ internal class Execute
 		StringComparisonMode = IsLinux
 			? StringComparison.Ordinal
 			: StringComparison.OrdinalIgnoreCase;
+		Path = new NativePath(fileSystem);
 	}
 }

--- a/Source/Testably.Abstractions.Testing/Helpers/FilePlatformIndependenceExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FilePlatformIndependenceExtensions.cs
@@ -28,12 +28,12 @@ internal static class FilePlatformIndependenceExtensions
 
 		return fileSystem.Execute.OnWindows(
 			() => path
-				.Replace(fileSystem.Path.AltDirectorySeparatorChar,
-					fileSystem.Path.DirectorySeparatorChar),
+				.Replace(fileSystem.Execute.Path.AltDirectorySeparatorChar,
+					fileSystem.Execute.Path.DirectorySeparatorChar),
 			() => PathTransformRegex
 				.Replace(path, "${path}")
-				.Replace(fileSystem.Path.AltDirectorySeparatorChar,
-					fileSystem.Path.DirectorySeparatorChar));
+				.Replace(fileSystem.Execute.Path.AltDirectorySeparatorChar,
+					fileSystem.Execute.Path.DirectorySeparatorChar));
 	}
 
 	/// <summary>
@@ -48,7 +48,7 @@ internal static class FilePlatformIndependenceExtensions
 			return path;
 		}
 
-		if (fileSystem.Path.IsPathRooted(path))
+		if (fileSystem.Execute.Path.IsPathRooted(path))
 		{
 			return path;
 		}

--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
@@ -104,4 +104,17 @@ internal static class FileSystemExtensions
 
 		return new NoOpDisposable();
 	}
+
+	/// <summary>
+	///     Ignores all registrations on the <see cref="MockFileSystem.Statistics" /> until the return value is disposed.
+	/// </summary>
+	internal static Execute ExecuteOrDefault(this IFileSystem fileSystem)
+	{
+		if (fileSystem is MockFileSystem mockFileSystem)
+		{
+			return mockFileSystem.Execute;
+		}
+
+		return new Execute(new MockFileSystem());
+	}
 }

--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
@@ -8,6 +8,19 @@ namespace Testably.Abstractions.Testing.Helpers;
 internal static class FileSystemExtensions
 {
 	/// <summary>
+	///     Ignores all registrations on the <see cref="MockFileSystem.Statistics" /> until the return value is disposed.
+	/// </summary>
+	internal static Execute ExecuteOrDefault(this IFileSystem fileSystem)
+	{
+		if (fileSystem is MockFileSystem mockFileSystem)
+		{
+			return mockFileSystem.Execute;
+		}
+
+		return new Execute(new MockFileSystem());
+	}
+
+	/// <summary>
 	///     Determines the new <see cref="IStorageLocation" /> when the <paramref name="location" /> is moved
 	///     from <paramref name="source" /> to <paramref name="destination" />.
 	/// </summary>
@@ -103,18 +116,5 @@ internal static class FileSystemExtensions
 		}
 
 		return new NoOpDisposable();
-	}
-
-	/// <summary>
-	///     Ignores all registrations on the <see cref="MockFileSystem.Statistics" /> until the return value is disposed.
-	/// </summary>
-	internal static Execute ExecuteOrDefault(this IFileSystem fileSystem)
-	{
-		if (fileSystem is MockFileSystem mockFileSystem)
-		{
-			return mockFileSystem.Execute;
-		}
-
-		return new Execute(new MockFileSystem());
 	}
 }

--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
@@ -41,12 +41,12 @@ internal static class FileSystemExtensions
 		string fullFilePath,
 		string givenPath)
 	{
-		if (fileSystem.Path.IsPathRooted(givenPath))
+		if (fileSystem.Execute.Path.IsPathRooted(givenPath))
 		{
 			return fullFilePath;
 		}
 
-		string currentDirectory = fileSystem.Path.GetFullPath(givenPath);
+		string currentDirectory = fileSystem.Execute.Path.GetFullPath(givenPath);
 		if (currentDirectory == string.Empty.PrefixRoot(fileSystem))
 		{
 			fullFilePath = fullFilePath.Substring(currentDirectory.Length);
@@ -75,9 +75,9 @@ internal static class FileSystemExtensions
 			}
 		}
 
-		if (!fullFilePath.StartsWith(givenPath + fileSystem.Path.DirectorySeparatorChar))
+		if (!fullFilePath.StartsWith(givenPath + fileSystem.Execute.Path.DirectorySeparatorChar))
 		{
-			return fileSystem.Path.Combine(givenPath, fullFilePath);
+			return fileSystem.Execute.Path.Combine(givenPath, fullFilePath);
 		}
 
 		return fullFilePath;

--- a/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
@@ -52,7 +52,7 @@ internal static class PathHelper
 	/// </summary>
 	internal static bool HasIllegalCharacters(this string path, MockFileSystem fileSystem)
 	{
-		char[] invalidPathChars = fileSystem.Path.GetInvalidPathChars();
+		char[] invalidPathChars = fileSystem.Execute.Path.GetInvalidPathChars();
 
 		if (path.IndexOfAny(invalidPathChars) >= 0)
 		{
@@ -102,9 +102,9 @@ internal static class PathHelper
 		}
 
 		return fileSystem.Execute.OnWindows(
-			() => path.StartsWith(new string(fileSystem.Path.DirectorySeparatorChar, 2)) ||
-			      path.StartsWith(new string(fileSystem.Path.AltDirectorySeparatorChar, 2)),
-			() => path.StartsWith(new string(fileSystem.Path.DirectorySeparatorChar, 2)));
+			() => path.StartsWith(new string(fileSystem.Execute.Path.DirectorySeparatorChar, 2)) ||
+			      path.StartsWith(new string(fileSystem.Execute.Path.AltDirectorySeparatorChar, 2)),
+			() => path.StartsWith(new string(fileSystem.Execute.Path.DirectorySeparatorChar, 2)));
 	}
 
 	internal static void ThrowCommonExceptionsIfPathToTargetIsInvalid(
@@ -155,13 +155,13 @@ internal static class PathHelper
 					hResult));
 
 			throw ExceptionFactory.PathHasIncorrectSyntax(
-				fileSystem.Path.GetFullPath(path), hResult);
+				fileSystem.Execute.Path.GetFullPath(path), hResult);
 		}
 
 		fileSystem.Execute.OnWindowsIf(path.LastIndexOf(':') > 1 &&
 		                               path.LastIndexOf(':') <
 		                               path.IndexOf(Path.DirectorySeparatorChar),
 			() => throw ExceptionFactory.PathHasIncorrectSyntax(
-				fileSystem.Path.GetFullPath(path), hResult));
+				fileSystem.Execute.Path.GetFullPath(path), hResult));
 	}
 }

--- a/Source/Testably.Abstractions.Testing/InterceptionHandlerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/InterceptionHandlerExtensions.cs
@@ -40,7 +40,7 @@ public static class InterceptionHandlerExtensions
 		Func<ChangeDescription, bool>? predicate = null)
 		=> handler.Event(interceptionCallback,
 			changeDescription => changeDescription.Matches(
-				(handler.FileSystem as MockFileSystem)?.Execute ?? Execute.Default,
+				handler.FileSystem.ExecuteOrDefault(),
 				fileSystemType,
 				WatcherChangeTypes.Changed,
 				path.GetFullPathOrWhiteSpace(handler.FileSystem),
@@ -77,7 +77,7 @@ public static class InterceptionHandlerExtensions
 		Func<ChangeDescription, bool>? predicate = null)
 		=> handler.Event(interceptionCallback,
 			changeDescription => changeDescription.Matches(
-				(handler.FileSystem as MockFileSystem)?.Execute ?? Execute.Default,
+				handler.FileSystem.ExecuteOrDefault(),
 				fileSystemType,
 				WatcherChangeTypes.Created,
 				path.GetFullPathOrWhiteSpace(handler.FileSystem),
@@ -114,7 +114,7 @@ public static class InterceptionHandlerExtensions
 		Func<ChangeDescription, bool>? predicate = null)
 		=> handler.Event(interceptionCallback,
 			changeDescription => changeDescription.Matches(
-				(handler.FileSystem as MockFileSystem)?.Execute ?? Execute.Default,
+				handler.FileSystem.ExecuteOrDefault(),
 				fileSystemType,
 				WatcherChangeTypes.Deleted,
 				path.GetFullPathOrWhiteSpace(handler.FileSystem),

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -86,7 +86,7 @@ public sealed class MockFileSystem : IFileSystem
 	{
 		StatisticsRegistration = new FileSystemStatistics(this);
 		using IDisposable release = StatisticsRegistration.Ignore();
-		Execute = Execute.Default;
+		Execute = new Execute(this);
 		RandomSystem = new MockRandomSystem();
 		TimeSystem = new MockTimeSystem(TimeProvider.Now());
 		_pathMock = new PathMock(this);

--- a/Source/Testably.Abstractions.Testing/MockFileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystemExtensions.cs
@@ -36,10 +36,10 @@ public static class MockFileSystemExtensions
 		string server,
 		Action<IStorageDrive>? driveCallback = null)
 	{
-		string uncPrefix = new(mockFileSystem.Path.DirectorySeparatorChar, 2);
+		string uncPrefix = new(mockFileSystem.Execute.Path.DirectorySeparatorChar, 2);
 		server = server.TrimStart(
-			mockFileSystem.Path.DirectorySeparatorChar,
-			mockFileSystem.Path.AltDirectorySeparatorChar);
+			mockFileSystem.Execute.Path.DirectorySeparatorChar,
+			mockFileSystem.Execute.Path.AltDirectorySeparatorChar);
 		string drive = $"{uncPrefix}{server}";
 		return mockFileSystem.WithDrive(drive, driveCallback);
 	}

--- a/Source/Testably.Abstractions.Testing/NotificationHandlerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/NotificationHandlerExtensions.cs
@@ -41,7 +41,7 @@ public static class NotificationHandlerExtensions
 			Func<ChangeDescription, bool>? predicate = null)
 		=> handler.OnEvent(notificationCallback,
 			changeDescription => changeDescription.Matches(
-				(handler.FileSystem as MockFileSystem)?.Execute ?? Execute.Default,
+				handler.FileSystem.ExecuteOrDefault(),
 				fileSystemType,
 				WatcherChangeTypes.Changed,
 				path.GetFullPathOrWhiteSpace(handler.FileSystem),
@@ -79,7 +79,7 @@ public static class NotificationHandlerExtensions
 			Func<ChangeDescription, bool>? predicate = null)
 		=> handler.OnEvent(notificationCallback,
 			changeDescription => changeDescription.Matches(
-				(handler.FileSystem as MockFileSystem)?.Execute ?? Execute.Default,
+				handler.FileSystem.ExecuteOrDefault(),
 				fileSystemType,
 				WatcherChangeTypes.Created,
 				path.GetFullPathOrWhiteSpace(handler.FileSystem),
@@ -117,7 +117,7 @@ public static class NotificationHandlerExtensions
 			Func<ChangeDescription, bool>? predicate = null)
 		=> handler.OnEvent(notificationCallback,
 			changeDescription => changeDescription.Matches(
-				(handler.FileSystem as MockFileSystem)?.Execute ?? Execute.Default,
+				handler.FileSystem.ExecuteOrDefault(),
 				fileSystemType,
 				WatcherChangeTypes.Deleted,
 				path.GetFullPathOrWhiteSpace(handler.FileSystem),

--- a/Source/Testably.Abstractions.Testing/Statistics/FileSystemStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/FileSystemStatistics.cs
@@ -7,6 +7,12 @@ namespace Testably.Abstractions.Testing.Statistics;
 internal sealed class FileSystemStatistics : IFileSystemStatistics, IStatisticsGate
 {
 	private static readonly AsyncLocal<bool> IsDisabled = new();
+
+	/// <summary>
+	///     The total count of registered statistic calls.
+	/// </summary>
+	public int TotalCount => _counter;
+
 	internal readonly CallStatistics Directory;
 	internal readonly PathStatistics DirectoryInfo;
 	internal readonly PathStatistics DriveInfo;
@@ -23,7 +29,8 @@ internal sealed class FileSystemStatistics : IFileSystemStatistics, IStatisticsG
 		DriveInfo = new PathStatistics(this, fileSystem, nameof(IFileSystem.DriveInfo));
 		FileInfo = new PathStatistics(this, fileSystem, nameof(IFileSystem.FileInfo));
 		FileStream = new PathStatistics(this, fileSystem, nameof(IFileSystem.FileStream));
-		FileSystemWatcher = new PathStatistics(this, fileSystem, nameof(IFileSystem.FileSystemWatcher));
+		FileSystemWatcher =
+			new PathStatistics(this, fileSystem, nameof(IFileSystem.FileSystemWatcher));
 		File = new CallStatistics(this, nameof(IFileSystem.File));
 		Directory = new CallStatistics(this, nameof(IFileSystem.Directory));
 		Path = new CallStatistics(this, nameof(IFileSystem.Path));

--- a/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
@@ -30,7 +30,7 @@ internal class PathStatistics : CallStatistics, IPathStatistics
 		get
 		{
 			string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
-			return _statistics.GetOrAdd(key, 
+			return _statistics.GetOrAdd(key,
 				k => new CallStatistics(_statisticsGate, $"{ToString()}[{k}]"));
 		}
 	}

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
@@ -83,8 +83,8 @@ internal sealed class InMemoryLocation : IStorageLocation
 	/// <inheritdoc cref="IStorageLocation.GetParent()" />
 	public IStorageLocation? GetParent()
 	{
-		string? parentPath = _fileSystem.Path.GetDirectoryName(FullPath);
-		if (_fileSystem.Path.GetPathRoot(FullPath) == FullPath || parentPath == null)
+		string? parentPath = _fileSystem.Execute.Path.GetDirectoryName(FullPath);
+		if (_fileSystem.Execute.Path.GetPathRoot(FullPath) == FullPath || parentPath == null)
 		{
 			return null;
 		}
@@ -98,7 +98,7 @@ internal sealed class InMemoryLocation : IStorageLocation
 
 	private string GetFriendlyNameParent(string parentPath)
 		=> _fileSystem.Execute.OnNetFramework(
-			() => _fileSystem.Path.GetFileName(parentPath),
+			() => _fileSystem.Execute.Path.GetFileName(parentPath),
 			() => parentPath);
 
 	#endregion
@@ -133,13 +133,13 @@ internal sealed class InMemoryLocation : IStorageLocation
 	private static string NormalizeKey(MockFileSystem fileSystem, string fullPath)
 	{
 #if FEATURE_PATH_ADVANCED
-		return fileSystem.Path.TrimEndingDirectorySeparator(fullPath);
+		return fileSystem.Execute.Path.TrimEndingDirectorySeparator(fullPath);
 #else
 		return FileFeatureExtensionMethods.TrimEndingDirectorySeparator(
 			fileSystem,
 			fullPath,
-			fileSystem.Path.DirectorySeparatorChar,
-			fileSystem.Path.AltDirectorySeparatorChar);
+			fileSystem.Execute.Path.DirectorySeparatorChar,
+			fileSystem.Execute.Path.AltDirectorySeparatorChar);
 #endif
 	}
 }

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -177,17 +177,17 @@ internal sealed class InMemoryStorage : IStorage
 		string fullPath = location.FullPath;
 		string fullPathWithoutTrailingSlash = fullPath;
 #if NETSTANDARD2_0
-		if (!fullPath.EndsWith($"{_fileSystem.Path.DirectorySeparatorChar}"))
+		if (!fullPath.EndsWith($"{_fileSystem.Execute.Path.DirectorySeparatorChar}"))
 #else
-		if (!fullPath.EndsWith(_fileSystem.Path.DirectorySeparatorChar))
+		if (!fullPath.EndsWith(_fileSystem.Execute.Path.DirectorySeparatorChar))
 #endif
 		{
-			fullPath += _fileSystem.Path.DirectorySeparatorChar;
+			fullPath += _fileSystem.Execute.Path.DirectorySeparatorChar;
 		}
-		else if (_fileSystem.Path.GetPathRoot(fullPath) != fullPath)
+		else if (_fileSystem.Execute.Path.GetPathRoot(fullPath) != fullPath)
 		{
 			fullPathWithoutTrailingSlash =
-				fullPathWithoutTrailingSlash.TrimEnd(_fileSystem.Path.DirectorySeparatorChar);
+				fullPathWithoutTrailingSlash.TrimEnd(_fileSystem.Execute.Path.DirectorySeparatorChar);
 		}
 
 		foreach (KeyValuePair<IStorageLocation, IStorageContainer> item in _containers
@@ -196,8 +196,8 @@ internal sealed class InMemoryStorage : IStorage
 			            !x.Key.Equals(location)))
 		{
 			string? parentPath =
-				_fileSystem.Path.GetDirectoryName(
-					item.Key.FullPath.TrimEnd(_fileSystem.Path
+				_fileSystem.Execute.Path.GetDirectoryName(
+					item.Key.FullPath.TrimEnd(_fileSystem.Execute.Path
 						.DirectorySeparatorChar));
 			if (!enumerationOptions.RecurseSubdirectories &&
 			    parentPath?.Equals(fullPathWithoutTrailingSlash,
@@ -209,7 +209,7 @@ internal sealed class InMemoryStorage : IStorage
 			if (!EnumerationOptionsHelper.MatchesPattern(
 				_fileSystem.Execute,
 				enumerationOptions,
-				_fileSystem.Path.GetFileName(item.Key.FullPath),
+				_fileSystem.Execute.Path.GetFileName(item.Key.FullPath),
 				searchPattern))
 			{
 				continue;
@@ -249,7 +249,7 @@ internal sealed class InMemoryStorage : IStorage
 
 		if (!driveName.IsUncPath(_fileSystem))
 		{
-			driveName = _fileSystem.Path.GetPathRoot(driveName);
+			driveName = _fileSystem.Execute.Path.GetPathRoot(driveName);
 
 			if (string.IsNullOrEmpty(driveName))
 			{
@@ -572,13 +572,13 @@ internal sealed class InMemoryStorage : IStorage
 	private void CreateParents(MockFileSystem fileSystem, IStorageLocation location)
 	{
 		List<string> parents = new();
-		string? parent = fileSystem.Path.GetDirectoryName(
-			location.FullPath.TrimEnd(fileSystem.Path.DirectorySeparatorChar,
-				fileSystem.Path.AltDirectorySeparatorChar));
+		string? parent = fileSystem.Execute.Path.GetDirectoryName(
+			location.FullPath.TrimEnd(fileSystem.Execute.Path.DirectorySeparatorChar,
+				fileSystem.Execute.Path.AltDirectorySeparatorChar));
 		while (!string.IsNullOrEmpty(parent))
 		{
 			parents.Add(parent);
-			parent = fileSystem.Path.GetDirectoryName(parent);
+			parent = fileSystem.Execute.Path.GetDirectoryName(parent);
 		}
 
 		parents.Reverse();
@@ -747,7 +747,7 @@ internal sealed class InMemoryStorage : IStorage
 	{
 		IStorageLocation? parentLocation = location.GetParent();
 		if (parentLocation != null &&
-		    _fileSystem.Path.GetPathRoot(parentLocation.FullPath) !=
+		    _fileSystem.Execute.Path.GetPathRoot(parentLocation.FullPath) !=
 		    parentLocation.FullPath &&
 		    !_containers.TryGetValue(parentLocation, out _))
 		{

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -187,7 +187,8 @@ internal sealed class InMemoryStorage : IStorage
 		else if (_fileSystem.Execute.Path.GetPathRoot(fullPath) != fullPath)
 		{
 			fullPathWithoutTrailingSlash =
-				fullPathWithoutTrailingSlash.TrimEnd(_fileSystem.Execute.Path.DirectorySeparatorChar);
+				fullPathWithoutTrailingSlash.TrimEnd(
+					_fileSystem.Execute.Path.DirectorySeparatorChar);
 		}
 
 		foreach (KeyValuePair<IStorageLocation, IStorageContainer> item in _containers

--- a/Source/Testably.Abstractions.Testing/Storage/LocationExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/LocationExtensions.cs
@@ -17,7 +17,7 @@ internal static class LocationExtensions
 		{
 			IStorageLocation? parentLocation = location.GetParent();
 			if (parentLocation != null &&
-			    fileSystem.Path.GetPathRoot(parentLocation.FullPath) !=
+			    fileSystem.Execute.Path.GetPathRoot(parentLocation.FullPath) !=
 			    parentLocation.FullPath &&
 			    fileSystem.Storage.GetContainer(parentLocation) is NullContainer)
 			{
@@ -52,7 +52,7 @@ internal static class LocationExtensions
 			IStorageLocation? parentLocation = location?.GetParent();
 			if (directoryNotFoundException != null &&
 			    parentLocation != null &&
-			    fileSystem.Path.GetPathRoot(parentLocation.FullPath) !=
+			    fileSystem.Execute.Path.GetPathRoot(parentLocation.FullPath) !=
 			    parentLocation.FullPath &&
 			    fileSystem.Storage.GetContainer(parentLocation) is NullContainer)
 			{

--- a/Source/Testably.Abstractions/FileSystem/PathWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/PathWrapper.cs
@@ -17,54 +17,54 @@ internal sealed class PathWrapper : IPath
 
 	#region IPath Members
 
-	/// <inheritdoc cref="Path.AltDirectorySeparatorChar" />
+	/// <inheritdoc cref="IPath.AltDirectorySeparatorChar" />
 	public char AltDirectorySeparatorChar
 		=> Path.AltDirectorySeparatorChar;
 
-	/// <inheritdoc cref="Path.DirectorySeparatorChar" />
+	/// <inheritdoc cref="IPath.DirectorySeparatorChar" />
 	public char DirectorySeparatorChar
 		=> Path.DirectorySeparatorChar;
 
 	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
 	public IFileSystem FileSystem => _fileSystem;
 
-	/// <inheritdoc cref="Path.PathSeparator" />
+	/// <inheritdoc cref="IPath.PathSeparator" />
 	public char PathSeparator
 		=> Path.PathSeparator;
 
-	/// <inheritdoc cref="Path.VolumeSeparatorChar" />
+	/// <inheritdoc cref="IPath.VolumeSeparatorChar" />
 	public char VolumeSeparatorChar
 		=> Path.VolumeSeparatorChar;
 
-	/// <inheritdoc cref="Path.ChangeExtension(string, string)" />
+	/// <inheritdoc cref="IPath.ChangeExtension(string, string)" />
 	[return: NotNullIfNotNull("path")]
 	public string? ChangeExtension(string? path, string? extension)
 		=> Path.ChangeExtension(path, extension);
 
-	/// <inheritdoc cref="Path.Combine(string, string)" />
+	/// <inheritdoc cref="IPath.Combine(string, string)" />
 	public string Combine(string path1, string path2)
 		=> Path.Combine(path1, path2);
 
-	/// <inheritdoc cref="Path.Combine(string, string, string)" />
+	/// <inheritdoc cref="IPath.Combine(string, string, string)" />
 	public string Combine(string path1, string path2, string path3)
 		=> Path.Combine(path1, path2, path3);
 
-	/// <inheritdoc cref="Path.Combine(string, string, string, string)" />
+	/// <inheritdoc cref="IPath.Combine(string, string, string, string)" />
 	public string Combine(string path1, string path2, string path3, string path4)
 		=> Path.Combine(path1, path2, path3, path4);
 
-	/// <inheritdoc cref="Path.Combine(string[])" />
+	/// <inheritdoc cref="IPath.Combine(string[])" />
 	public string Combine(params string[] paths)
 		=> Path.Combine(paths);
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.EndsInDirectorySeparator(ReadOnlySpan{T})" />
+	/// <inheritdoc cref="IPath.EndsInDirectorySeparator(ReadOnlySpan{char})" />
 	public bool EndsInDirectorySeparator(ReadOnlySpan<char> path)
 		=> Path.EndsInDirectorySeparator(path);
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.EndsInDirectorySeparator(string)" />
+	/// <inheritdoc cref="IPath.EndsInDirectorySeparator(string)" />
 	public bool EndsInDirectorySeparator(string path)
 		=> Path.EndsInDirectorySeparator(path);
 #endif
@@ -76,87 +76,87 @@ internal sealed class PathWrapper : IPath
 #endif
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.GetDirectoryName(ReadOnlySpan{char})" />
+	/// <inheritdoc cref="IPath.GetDirectoryName(ReadOnlySpan{char})" />
 	public ReadOnlySpan<char> GetDirectoryName(ReadOnlySpan<char> path)
 		=> Path.GetDirectoryName(path);
 #endif
 
-	/// <inheritdoc cref="Path.GetDirectoryName(string)" />
+	/// <inheritdoc cref="IPath.GetDirectoryName(string)" />
 	public string? GetDirectoryName(string? path)
 		=> Path.GetDirectoryName(path);
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.GetExtension(ReadOnlySpan{char})" />
+	/// <inheritdoc cref="IPath.GetExtension(ReadOnlySpan{char})" />
 	public ReadOnlySpan<char> GetExtension(ReadOnlySpan<char> path)
 		=> Path.GetExtension(path);
 #endif
 
-	/// <inheritdoc cref="Path.GetExtension(string)" />
+	/// <inheritdoc cref="IPath.GetExtension(string)" />
 	[return: NotNullIfNotNull("path")]
 	public string? GetExtension(string? path)
 		=> Path.GetExtension(path);
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.GetFileName(ReadOnlySpan{char})" />
+	/// <inheritdoc cref="IPath.GetFileName(ReadOnlySpan{char})" />
 	public ReadOnlySpan<char> GetFileName(ReadOnlySpan<char> path)
 		=> Path.GetFileName(path);
 #endif
 
-	/// <inheritdoc cref="Path.GetFileName(string)" />
+	/// <inheritdoc cref="IPath.GetFileName(string)" />
 	[return: NotNullIfNotNull("path")]
 	public string? GetFileName(string? path)
 		=> Path.GetFileName(path);
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.GetFileNameWithoutExtension(ReadOnlySpan{char})" />
+	/// <inheritdoc cref="IPath.GetFileNameWithoutExtension(ReadOnlySpan{char})" />
 	public ReadOnlySpan<char> GetFileNameWithoutExtension(ReadOnlySpan<char> path)
 		=> Path.GetFileNameWithoutExtension(path);
 #endif
 
-	/// <inheritdoc cref="Path.GetFileNameWithoutExtension(string)" />
+	/// <inheritdoc cref="IPath.GetFileNameWithoutExtension(string)" />
 	[return: NotNullIfNotNull("path")]
 	public string? GetFileNameWithoutExtension(string? path)
 		=> Path.GetFileNameWithoutExtension(path);
 
-	/// <inheritdoc cref="Path.GetFullPath(string)" />
+	/// <inheritdoc cref="IPath.GetFullPath(string)" />
 	public string GetFullPath(string path)
 		=> Path.GetFullPath(path);
 
 #if FEATURE_PATH_RELATIVE
-	/// <inheritdoc cref="Path.GetFullPath(string, string)" />
+	/// <inheritdoc cref="IPath.GetFullPath(string, string)" />
 	public string GetFullPath(string path, string basePath)
 		=> Path.GetFullPath(path, basePath);
 #endif
 
-	/// <inheritdoc cref="Path.GetInvalidFileNameChars()" />
+	/// <inheritdoc cref="IPath.GetInvalidFileNameChars()" />
 	public char[] GetInvalidFileNameChars()
 		=> Path.GetInvalidFileNameChars();
 
-	/// <inheritdoc cref="Path.GetInvalidPathChars()" />
+	/// <inheritdoc cref="IPath.GetInvalidPathChars()" />
 	public char[] GetInvalidPathChars()
 		=> Path.GetInvalidPathChars();
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.GetPathRoot(ReadOnlySpan{char})" />
+	/// <inheritdoc cref="IPath.GetPathRoot(ReadOnlySpan{char})" />
 	public ReadOnlySpan<char> GetPathRoot(ReadOnlySpan<char> path)
 		=> Path.GetPathRoot(path);
 #endif
 
-	/// <inheritdoc cref="Path.GetPathRoot(string?)" />
+	/// <inheritdoc cref="IPath.GetPathRoot(string?)" />
 	public string? GetPathRoot(string? path)
 		=> Path.GetPathRoot(path);
 
-	/// <inheritdoc cref="Path.GetRandomFileName()" />
+	/// <inheritdoc cref="IPath.GetRandomFileName()" />
 	public string GetRandomFileName()
 		=> Path.GetRandomFileName();
 
 #if FEATURE_PATH_RELATIVE
-	/// <inheritdoc cref="Path.GetRelativePath(string, string)" />
+	/// <inheritdoc cref="IPath.GetRelativePath(string, string)" />
 	public string GetRelativePath(string relativeTo, string path)
 		=> Path.GetRelativePath(relativeTo, path);
 #endif
 
-	/// <inheritdoc cref="Path.GetTempFileName()" />
+	/// <inheritdoc cref="IPath.GetTempFileName()" />
 #if !NETSTANDARD2_0
 	[Obsolete(
 		"Insecure temporary file creation methods should not be used. Use `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())` instead.")]
@@ -164,50 +164,50 @@ internal sealed class PathWrapper : IPath
 	public string GetTempFileName()
 		=> Path.GetTempFileName();
 
-	/// <inheritdoc cref="Path.GetTempPath()" />
+	/// <inheritdoc cref="IPath.GetTempPath()" />
 	public string GetTempPath()
 		=> Path.GetTempPath();
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.HasExtension(ReadOnlySpan{char})" />
+	/// <inheritdoc cref="IPath.HasExtension(ReadOnlySpan{char})" />
 	public bool HasExtension(ReadOnlySpan<char> path)
 		=> Path.HasExtension(path);
 #endif
 
-	/// <inheritdoc cref="Path.HasExtension(string)" />
+	/// <inheritdoc cref="IPath.HasExtension(string)" />
 	public bool HasExtension([NotNullWhen(true)] string? path)
 		=> Path.HasExtension(path);
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.IsPathFullyQualified(ReadOnlySpan{char})" />
+	/// <inheritdoc cref="IPath.IsPathFullyQualified(ReadOnlySpan{char})" />
 	public bool IsPathFullyQualified(ReadOnlySpan<char> path)
 		=> Path.IsPathFullyQualified(path);
 #endif
 
 #if FEATURE_PATH_RELATIVE
-	/// <inheritdoc cref="Path.IsPathFullyQualified(string)" />
+	/// <inheritdoc cref="IPath.IsPathFullyQualified(string)" />
 	public bool IsPathFullyQualified(string path)
 		=> Path.IsPathFullyQualified(path);
 #endif
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Path.IsPathRooted(ReadOnlySpan{char})" />
+	/// <inheritdoc cref="IPath.IsPathRooted(ReadOnlySpan{char})" />
 	public bool IsPathRooted(ReadOnlySpan<char> path)
 		=> Path.IsPathRooted(path);
 #endif
 
-	/// <inheritdoc cref="Path.IsPathRooted(string)" />
+	/// <inheritdoc cref="IPath.IsPathRooted(string)" />
 	public bool IsPathRooted(string? path)
 		=> Path.IsPathRooted(path);
 
 #if FEATURE_PATH_JOIN
-	/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char})" />
+	/// <inheritdoc cref="IPath.Join(ReadOnlySpan{char}, ReadOnlySpan{char})" />
 	public string Join(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2)
 		=> Path.Join(path1, path2);
 #endif
 
 #if FEATURE_PATH_JOIN
-	/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char})" />
+	/// <inheritdoc cref="IPath.Join(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char})" />
 	public string Join(ReadOnlySpan<char> path1,
 		ReadOnlySpan<char> path2,
 		ReadOnlySpan<char> path3)
@@ -215,7 +215,7 @@ internal sealed class PathWrapper : IPath
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char})" />
+	/// <inheritdoc cref="IPath.Join(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char})" />
 	public string Join(ReadOnlySpan<char> path1,
 		ReadOnlySpan<char> path2,
 		ReadOnlySpan<char> path3,
@@ -224,43 +224,43 @@ internal sealed class PathWrapper : IPath
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.Join(string, string)" />
+	/// <inheritdoc cref="IPath.Join(string, string)" />
 	public string Join(string? path1, string? path2)
 		=> Path.Join(path1, path2);
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.Join(string, string, string)" />
+	/// <inheritdoc cref="IPath.Join(string, string, string)" />
 	public string Join(string? path1, string? path2, string? path3)
 		=> Path.Join(path1, path2, path3);
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.Join(string, string, string, string)" />
+	/// <inheritdoc cref="IPath.Join(string, string, string, string)" />
 	public string Join(string? path1, string? path2, string? path3, string? path4)
 		=> Path.Join(path1, path2, path3, path4);
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.Join(string[])" />
+	/// <inheritdoc cref="IPath.Join(string[])" />
 	public string Join(params string?[] paths)
 		=> Path.Join(paths);
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.TrimEndingDirectorySeparator(ReadOnlySpan{char})" />
+	/// <inheritdoc cref="IPath.TrimEndingDirectorySeparator(ReadOnlySpan{char})" />
 	public ReadOnlySpan<char> TrimEndingDirectorySeparator(ReadOnlySpan<char> path)
 		=> Path.TrimEndingDirectorySeparator(path);
 #endif
 
 #if FEATURE_PATH_ADVANCED
-	/// <inheritdoc cref="Path.TrimEndingDirectorySeparator(string)" />
+	/// <inheritdoc cref="IPath.TrimEndingDirectorySeparator(string)" />
 	public string TrimEndingDirectorySeparator(string path)
 		=> Path.TrimEndingDirectorySeparator(path);
 #endif
 
 #if FEATURE_PATH_JOIN
-	/// <inheritdoc cref="Path.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
+	/// <inheritdoc cref="IPath.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
 	public bool TryJoin(ReadOnlySpan<char> path1,
 		ReadOnlySpan<char> path2,
 		Span<char> destination,
@@ -269,7 +269,7 @@ internal sealed class PathWrapper : IPath
 #endif
 
 #if FEATURE_PATH_JOIN
-	/// <inheritdoc cref="Path.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
+	/// <inheritdoc cref="IPath.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
 	public bool TryJoin(ReadOnlySpan<char> path1,
 		ReadOnlySpan<char> path2,
 		ReadOnlySpan<char> path3,

--- a/Source/Testably.Abstractions/FileSystem/PathWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/PathWrapper.cs
@@ -1,21 +1,282 @@
-﻿using Testably.Abstractions.Helpers;
-#if FEATURE_FILESYSTEM_NET7
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
+#if !NETSTANDARD2_0
+using System;
 #endif
 
 namespace Testably.Abstractions.FileSystem;
 
-internal sealed class PathWrapper : PathSystemBase
+internal sealed class PathWrapper : IPath
 {
+	private readonly RealFileSystem _fileSystem;
+
 	public PathWrapper(RealFileSystem fileSystem)
-		: base(fileSystem)
 	{
+		_fileSystem = fileSystem;
 	}
+
+	#region IPath Members
+
+	/// <inheritdoc cref="Path.AltDirectorySeparatorChar" />
+	public char AltDirectorySeparatorChar
+		=> Path.AltDirectorySeparatorChar;
+
+	/// <inheritdoc cref="Path.DirectorySeparatorChar" />
+	public char DirectorySeparatorChar
+		=> Path.DirectorySeparatorChar;
+
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
+	public IFileSystem FileSystem => _fileSystem;
+
+	/// <inheritdoc cref="Path.PathSeparator" />
+	public char PathSeparator
+		=> Path.PathSeparator;
+
+	/// <inheritdoc cref="Path.VolumeSeparatorChar" />
+	public char VolumeSeparatorChar
+		=> Path.VolumeSeparatorChar;
+
+	/// <inheritdoc cref="Path.ChangeExtension(string, string)" />
+	[return: NotNullIfNotNull("path")]
+	public string? ChangeExtension(string? path, string? extension)
+		=> Path.ChangeExtension(path, extension);
+
+	/// <inheritdoc cref="Path.Combine(string, string)" />
+	public string Combine(string path1, string path2)
+		=> Path.Combine(path1, path2);
+
+	/// <inheritdoc cref="Path.Combine(string, string, string)" />
+	public string Combine(string path1, string path2, string path3)
+		=> Path.Combine(path1, path2, path3);
+
+	/// <inheritdoc cref="Path.Combine(string, string, string, string)" />
+	public string Combine(string path1, string path2, string path3, string path4)
+		=> Path.Combine(path1, path2, path3, path4);
+
+	/// <inheritdoc cref="Path.Combine(string[])" />
+	public string Combine(params string[] paths)
+		=> Path.Combine(paths);
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.EndsInDirectorySeparator(ReadOnlySpan{T})" />
+	public bool EndsInDirectorySeparator(ReadOnlySpan<char> path)
+		=> Path.EndsInDirectorySeparator(path);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.EndsInDirectorySeparator(string)" />
+	public bool EndsInDirectorySeparator(string path)
+		=> Path.EndsInDirectorySeparator(path);
+#endif
 
 #if FEATURE_FILESYSTEM_NET7
 	/// <inheritdoc cref="IPath.Exists(string)" />
-	public override bool Exists([NotNullWhen(true)] string? path)
+	public bool Exists([NotNullWhen(true)] string? path)
 		=> Path.Exists(path);
 #endif
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.GetDirectoryName(ReadOnlySpan{char})" />
+	public ReadOnlySpan<char> GetDirectoryName(ReadOnlySpan<char> path)
+		=> Path.GetDirectoryName(path);
+#endif
+
+	/// <inheritdoc cref="Path.GetDirectoryName(string)" />
+	public string? GetDirectoryName(string? path)
+		=> Path.GetDirectoryName(path);
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.GetExtension(ReadOnlySpan{char})" />
+	public ReadOnlySpan<char> GetExtension(ReadOnlySpan<char> path)
+		=> Path.GetExtension(path);
+#endif
+
+	/// <inheritdoc cref="Path.GetExtension(string)" />
+	[return: NotNullIfNotNull("path")]
+	public string? GetExtension(string? path)
+		=> Path.GetExtension(path);
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.GetFileName(ReadOnlySpan{char})" />
+	public ReadOnlySpan<char> GetFileName(ReadOnlySpan<char> path)
+		=> Path.GetFileName(path);
+#endif
+
+	/// <inheritdoc cref="Path.GetFileName(string)" />
+	[return: NotNullIfNotNull("path")]
+	public string? GetFileName(string? path)
+		=> Path.GetFileName(path);
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.GetFileNameWithoutExtension(ReadOnlySpan{char})" />
+	public ReadOnlySpan<char> GetFileNameWithoutExtension(ReadOnlySpan<char> path)
+		=> Path.GetFileNameWithoutExtension(path);
+#endif
+
+	/// <inheritdoc cref="Path.GetFileNameWithoutExtension(string)" />
+	[return: NotNullIfNotNull("path")]
+	public string? GetFileNameWithoutExtension(string? path)
+		=> Path.GetFileNameWithoutExtension(path);
+
+	/// <inheritdoc cref="Path.GetFullPath(string)" />
+	public string GetFullPath(string path)
+		=> Path.GetFullPath(path);
+
+#if FEATURE_PATH_RELATIVE
+	/// <inheritdoc cref="Path.GetFullPath(string, string)" />
+	public string GetFullPath(string path, string basePath)
+		=> Path.GetFullPath(path, basePath);
+#endif
+
+	/// <inheritdoc cref="Path.GetInvalidFileNameChars()" />
+	public char[] GetInvalidFileNameChars()
+		=> Path.GetInvalidFileNameChars();
+
+	/// <inheritdoc cref="Path.GetInvalidPathChars()" />
+	public char[] GetInvalidPathChars()
+		=> Path.GetInvalidPathChars();
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.GetPathRoot(ReadOnlySpan{char})" />
+	public ReadOnlySpan<char> GetPathRoot(ReadOnlySpan<char> path)
+		=> Path.GetPathRoot(path);
+#endif
+
+	/// <inheritdoc cref="Path.GetPathRoot(string?)" />
+	public string? GetPathRoot(string? path)
+		=> Path.GetPathRoot(path);
+
+	/// <inheritdoc cref="Path.GetRandomFileName()" />
+	public string GetRandomFileName()
+		=> Path.GetRandomFileName();
+
+#if FEATURE_PATH_RELATIVE
+	/// <inheritdoc cref="Path.GetRelativePath(string, string)" />
+	public string GetRelativePath(string relativeTo, string path)
+		=> Path.GetRelativePath(relativeTo, path);
+#endif
+
+	/// <inheritdoc cref="Path.GetTempFileName()" />
+#if !NETSTANDARD2_0
+	[Obsolete(
+		"Insecure temporary file creation methods should not be used. Use `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())` instead.")]
+#endif
+	public string GetTempFileName()
+		=> Path.GetTempFileName();
+
+	/// <inheritdoc cref="Path.GetTempPath()" />
+	public string GetTempPath()
+		=> Path.GetTempPath();
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.HasExtension(ReadOnlySpan{char})" />
+	public bool HasExtension(ReadOnlySpan<char> path)
+		=> Path.HasExtension(path);
+#endif
+
+	/// <inheritdoc cref="Path.HasExtension(string)" />
+	public bool HasExtension([NotNullWhen(true)] string? path)
+		=> Path.HasExtension(path);
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.IsPathFullyQualified(ReadOnlySpan{char})" />
+	public bool IsPathFullyQualified(ReadOnlySpan<char> path)
+		=> Path.IsPathFullyQualified(path);
+#endif
+
+#if FEATURE_PATH_RELATIVE
+	/// <inheritdoc cref="Path.IsPathFullyQualified(string)" />
+	public bool IsPathFullyQualified(string path)
+		=> Path.IsPathFullyQualified(path);
+#endif
+
+#if FEATURE_SPAN
+	/// <inheritdoc cref="Path.IsPathRooted(ReadOnlySpan{char})" />
+	public bool IsPathRooted(ReadOnlySpan<char> path)
+		=> Path.IsPathRooted(path);
+#endif
+
+	/// <inheritdoc cref="Path.IsPathRooted(string)" />
+	public bool IsPathRooted(string? path)
+		=> Path.IsPathRooted(path);
+
+#if FEATURE_PATH_JOIN
+	/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char})" />
+	public string Join(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2)
+		=> Path.Join(path1, path2);
+#endif
+
+#if FEATURE_PATH_JOIN
+	/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char})" />
+	public string Join(ReadOnlySpan<char> path1,
+		ReadOnlySpan<char> path2,
+		ReadOnlySpan<char> path3)
+		=> Path.Join(path1, path2, path3);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.Join(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char})" />
+	public string Join(ReadOnlySpan<char> path1,
+		ReadOnlySpan<char> path2,
+		ReadOnlySpan<char> path3,
+		ReadOnlySpan<char> path4)
+		=> Path.Join(path1, path2, path3, path4);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.Join(string, string)" />
+	public string Join(string? path1, string? path2)
+		=> Path.Join(path1, path2);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.Join(string, string, string)" />
+	public string Join(string? path1, string? path2, string? path3)
+		=> Path.Join(path1, path2, path3);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.Join(string, string, string, string)" />
+	public string Join(string? path1, string? path2, string? path3, string? path4)
+		=> Path.Join(path1, path2, path3, path4);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.Join(string[])" />
+	public string Join(params string?[] paths)
+		=> Path.Join(paths);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.TrimEndingDirectorySeparator(ReadOnlySpan{char})" />
+	public ReadOnlySpan<char> TrimEndingDirectorySeparator(ReadOnlySpan<char> path)
+		=> Path.TrimEndingDirectorySeparator(path);
+#endif
+
+#if FEATURE_PATH_ADVANCED
+	/// <inheritdoc cref="Path.TrimEndingDirectorySeparator(string)" />
+	public string TrimEndingDirectorySeparator(string path)
+		=> Path.TrimEndingDirectorySeparator(path);
+#endif
+
+#if FEATURE_PATH_JOIN
+	/// <inheritdoc cref="Path.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
+	public bool TryJoin(ReadOnlySpan<char> path1,
+		ReadOnlySpan<char> path2,
+		Span<char> destination,
+		out int charsWritten)
+		=> Path.TryJoin(path1, path2, destination, out charsWritten);
+#endif
+
+#if FEATURE_PATH_JOIN
+	/// <inheritdoc cref="Path.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
+	public bool TryJoin(ReadOnlySpan<char> path1,
+		ReadOnlySpan<char> path2,
+		ReadOnlySpan<char> path3,
+		Span<char> destination,
+		out int charsWritten)
+		=> Path.TryJoin(path1, path2, path3, destination, out charsWritten);
+#endif
+
+	#endregion
 }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Interface_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Interface_net6.0.txt
@@ -24,6 +24,7 @@ namespace Testably.Abstractions.Helpers
         void StoreMetadata<T>(string key, T? value);
         bool TryGetWrappedInstance<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T? wrappedInstance);
     }
+    [System.Obsolete("Will be removed in a future version!")]
     public abstract class PathSystemBase : System.IO.Abstractions.IFileSystemEntity, System.IO.Abstractions.IPath
     {
         protected PathSystemBase(System.IO.Abstractions.IFileSystem fileSystem) { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Interface_net7.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Interface_net7.0.txt
@@ -28,6 +28,7 @@ namespace Testably.Abstractions.Helpers
         void StoreMetadata<T>(string key, T? value);
         bool TryGetWrappedInstance<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T? wrappedInstance);
     }
+    [System.Obsolete("Will be removed in a future version!")]
     public abstract class PathSystemBase : System.IO.Abstractions.IFileSystemEntity, System.IO.Abstractions.IPath
     {
         protected PathSystemBase(System.IO.Abstractions.IFileSystem fileSystem) { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Interface_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Interface_net8.0.txt
@@ -28,6 +28,7 @@ namespace Testably.Abstractions.Helpers
         void StoreMetadata<T>(string key, T? value);
         bool TryGetWrappedInstance<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T? wrappedInstance);
     }
+    [System.Obsolete("Will be removed in a future version!")]
     public abstract class PathSystemBase : System.IO.Abstractions.IFileSystemEntity, System.IO.Abstractions.IPath
     {
         protected PathSystemBase(System.IO.Abstractions.IFileSystem fileSystem) { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.0.txt
@@ -16,6 +16,7 @@ namespace Testably.Abstractions.Helpers
         void StoreMetadata<T>(string key, T? value);
         bool TryGetWrappedInstance<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T? wrappedInstance);
     }
+    [System.Obsolete]
     public abstract class PathSystemBase : System.IO.Abstractions.IFileSystemEntity, System.IO.Abstractions.IPath
     {
         protected PathSystemBase(System.IO.Abstractions.IFileSystem fileSystem) { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.1.txt
@@ -24,6 +24,7 @@ namespace Testably.Abstractions.Helpers
         void StoreMetadata<T>(string key, T? value);
         bool TryGetWrappedInstance<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T? wrappedInstance);
     }
+    [System.Obsolete("Will be removed in a future version!")]
     public abstract class PathSystemBase : System.IO.Abstractions.IFileSystemEntity, System.IO.Abstractions.IPath
     {
         protected PathSystemBase(System.IO.Abstractions.IFileSystem fileSystem) { }

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/EnumerationOptionsHelperTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/EnumerationOptionsHelperTests.cs
@@ -29,7 +29,7 @@ public class EnumerationOptionsHelperTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			EnumerationOptionsHelper.MatchesPattern(Execute.Default,
+			EnumerationOptionsHelper.MatchesPattern(new Execute(new MockFileSystem()),
 				invalidEnumerationOptions,
 				"foo", "*");
 		});

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteExtensionsTests.cs
@@ -211,10 +211,10 @@ public sealed class ExecuteExtensionsTests
 	private static Execute FromType(ExecuteType type)
 		=> type switch
 		{
-			ExecuteType.Windows => new Execute(OSPlatform.Windows),
-			ExecuteType.Linux => new Execute(OSPlatform.Linux),
-			ExecuteType.Mac => new Execute(OSPlatform.OSX),
-			ExecuteType.NetFramework => new Execute(OSPlatform.Windows, true),
+			ExecuteType.Windows => new Execute(new MockFileSystem(), OSPlatform.Windows),
+			ExecuteType.Linux => new Execute(new MockFileSystem(), OSPlatform.Linux),
+			ExecuteType.Mac => new Execute(new MockFileSystem(), OSPlatform.OSX),
+			ExecuteType.NetFramework => new Execute(new MockFileSystem(), OSPlatform.Windows, true),
 			_ => throw new NotSupportedException()
 		};
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteTests.cs
@@ -8,7 +8,7 @@ public sealed class ExecuteTests
 	[Fact]
 	public void Constructor_ForLinux_ShouldInitializeAccordingly()
 	{
-		Execute sut = new(OSPlatform.Linux);
+		Execute sut = new(new MockFileSystem(), OSPlatform.Linux);
 
 		sut.IsLinux.Should().BeTrue();
 		sut.IsMac.Should().BeFalse();
@@ -20,7 +20,7 @@ public sealed class ExecuteTests
 	[Fact]
 	public void Constructor_ForNetFramework_ShouldInitializeAccordingly()
 	{
-		Execute sut = new(OSPlatform.Windows, true);
+		Execute sut = new(new MockFileSystem(), OSPlatform.Windows, true);
 
 		sut.IsLinux.Should().BeFalse();
 		sut.IsMac.Should().BeFalse();
@@ -32,7 +32,7 @@ public sealed class ExecuteTests
 	[Fact]
 	public void Constructor_ForNetFramework_WithLinux_ShouldInitializeLinux()
 	{
-		Execute sut = new(OSPlatform.Linux, true);
+		Execute sut = new(new MockFileSystem(), OSPlatform.Linux, true);
 
 		sut.IsLinux.Should().BeTrue();
 		sut.IsMac.Should().BeFalse();
@@ -44,7 +44,7 @@ public sealed class ExecuteTests
 	[Fact]
 	public void Constructor_ForNetFramework_WithOSX_ShouldInitializeMac()
 	{
-		Execute sut = new(OSPlatform.OSX, true);
+		Execute sut = new(new MockFileSystem(), OSPlatform.OSX, true);
 
 		sut.IsLinux.Should().BeFalse();
 		sut.IsMac.Should().BeTrue();
@@ -56,7 +56,7 @@ public sealed class ExecuteTests
 	[Fact]
 	public void Constructor_ForOSX_ShouldInitializeAccordingly()
 	{
-		Execute sut = new(OSPlatform.OSX);
+		Execute sut = new(new MockFileSystem(), OSPlatform.OSX);
 
 		sut.IsLinux.Should().BeFalse();
 		sut.IsMac.Should().BeTrue();
@@ -68,7 +68,7 @@ public sealed class ExecuteTests
 	[Fact]
 	public void Constructor_ForWindows_ShouldInitializeAccordingly()
 	{
-		Execute sut = new(OSPlatform.Windows);
+		Execute sut = new(new MockFileSystem(), OSPlatform.Windows);
 
 		sut.IsLinux.Should().BeFalse();
 		sut.IsMac.Should().BeFalse();

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryInfoFactoryStatisticsTests.cs
@@ -14,6 +14,7 @@ public sealed class DirectoryInfoFactoryStatisticsTests
 
 		sut.DirectoryInfo.New(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.DirectoryInfo.ShouldOnlyContainMethodCall(nameof(IDirectoryInfoFactory.New),
 			path);
 	}
@@ -26,6 +27,7 @@ public sealed class DirectoryInfoFactoryStatisticsTests
 
 		sut.DirectoryInfo.Wrap(directoryInfo);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.DirectoryInfo.ShouldOnlyContainMethodCall(nameof(IDirectoryInfoFactory.Wrap),
 			directoryInfo);
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryInfoStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryInfoStatisticsTests.cs
@@ -13,6 +13,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").Create();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.Create));
 	}
@@ -26,6 +27,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").CreateAsSymbolicLink(pathToTarget);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.CreateAsSymbolicLink),
 				pathToTarget);
@@ -40,6 +42,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").CreateSubdirectory(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.CreateSubdirectory),
 				path);
@@ -54,6 +57,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").Delete(recursive);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.Delete),
 				recursive);
@@ -67,6 +71,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").Delete();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.Delete));
 	}
@@ -78,6 +83,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateDirectories();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateDirectories));
 	}
@@ -92,6 +98,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateDirectories(searchPattern, enumerationOptions);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateDirectories),
 				searchPattern, enumerationOptions);
@@ -107,6 +114,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateDirectories(searchPattern, searchOption);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateDirectories),
 				searchPattern, searchOption);
@@ -120,6 +128,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateDirectories(searchPattern);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateDirectories),
 				searchPattern);
@@ -132,6 +141,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFiles();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFiles));
 	}
@@ -146,6 +156,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFiles(searchPattern, enumerationOptions);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFiles),
 				searchPattern, enumerationOptions);
@@ -161,6 +172,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFiles(searchPattern, searchOption);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFiles),
 				searchPattern, searchOption);
@@ -174,6 +186,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFiles(searchPattern);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFiles),
 				searchPattern);
@@ -186,6 +199,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFileSystemInfos();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFileSystemInfos));
 	}
@@ -200,6 +214,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFileSystemInfos(searchPattern, enumerationOptions);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFileSystemInfos),
 				searchPattern, enumerationOptions);
@@ -215,6 +230,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFileSystemInfos(searchPattern, searchOption);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFileSystemInfos),
 				searchPattern, searchOption);
@@ -228,6 +244,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFileSystemInfos(searchPattern);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFileSystemInfos),
 				searchPattern);
@@ -241,6 +258,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetDirectories();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetDirectories));
 	}
@@ -256,6 +274,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetDirectories(searchPattern, enumerationOptions);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetDirectories),
 				searchPattern, enumerationOptions);
@@ -272,6 +291,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetDirectories(searchPattern, searchOption);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetDirectories),
 				searchPattern, searchOption);
@@ -286,6 +306,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetDirectories(searchPattern);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetDirectories),
 				searchPattern);
@@ -299,6 +320,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFiles();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFiles));
 	}
@@ -314,6 +336,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFiles(searchPattern, enumerationOptions);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFiles),
 				searchPattern, enumerationOptions);
@@ -330,6 +353,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFiles(searchPattern, searchOption);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFiles),
 				searchPattern, searchOption);
@@ -344,6 +368,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFiles(searchPattern);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFiles),
 				searchPattern);
@@ -357,6 +382,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFileSystemInfos();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFileSystemInfos));
 	}
@@ -372,6 +398,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFileSystemInfos(searchPattern, enumerationOptions);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFileSystemInfos),
 				searchPattern, enumerationOptions);
@@ -388,6 +415,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFileSystemInfos(searchPattern, searchOption);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFileSystemInfos),
 				searchPattern, searchOption);
@@ -402,6 +430,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFileSystemInfos(searchPattern);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFileSystemInfos),
 				searchPattern);
@@ -416,6 +445,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").MoveTo(destDirName);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.MoveTo),
 				destDirName);
@@ -428,6 +458,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").Refresh();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.Refresh));
 	}
@@ -441,6 +472,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").ResolveLinkTarget(returnFinalTarget);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.ResolveLinkTarget),
 				returnFinalTarget);
@@ -454,6 +486,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").Attributes;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.Attributes));
 	}
@@ -467,6 +500,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").Attributes = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.Attributes));
 	}
@@ -479,6 +513,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").CreationTime;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.CreationTime));
 	}
@@ -492,6 +527,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").CreationTime = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.CreationTime));
 	}
@@ -504,6 +540,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").CreationTimeUtc;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.CreationTimeUtc));
 	}
@@ -517,6 +554,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").CreationTimeUtc = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.CreationTimeUtc));
 	}
@@ -529,6 +567,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").Exists;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.Exists));
 	}
@@ -541,6 +580,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").Extension;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.Extension));
 	}
@@ -553,6 +593,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").FullName;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.FullName));
 	}
@@ -565,6 +606,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").LastAccessTime;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.LastAccessTime));
 	}
@@ -578,6 +620,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").LastAccessTime = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.LastAccessTime));
 	}
@@ -590,6 +633,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").LastAccessTimeUtc;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.LastAccessTimeUtc));
 	}
@@ -603,6 +647,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").LastAccessTimeUtc = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.LastAccessTimeUtc));
 	}
@@ -615,6 +660,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").LastWriteTime;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.LastWriteTime));
 	}
@@ -628,6 +674,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").LastWriteTime = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.LastWriteTime));
 	}
@@ -640,6 +687,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").LastWriteTimeUtc;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.LastWriteTimeUtc));
 	}
@@ -653,6 +701,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").LastWriteTimeUtc = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.LastWriteTimeUtc));
 	}
@@ -666,6 +715,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").LinkTarget;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.LinkTarget));
 	}
@@ -679,6 +729,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").Name;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.Name));
 	}
@@ -691,6 +742,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").Parent;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.Parent));
 	}
@@ -703,6 +755,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").Root;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.Root));
 	}
@@ -716,6 +769,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").UnixFileMode;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.UnixFileMode));
 	}
@@ -735,6 +789,7 @@ public sealed class DirectoryInfoStatisticsTests
 		sut.DirectoryInfo.New("foo").UnixFileMode = value;
 		#pragma warning restore CA1416
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.UnixFileMode));
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryStatisticsTests.cs
@@ -14,6 +14,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.CreateDirectory(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.CreateDirectory),
 			path);
 	}
@@ -30,6 +31,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.CreateDirectory(path, unixCreateMode);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.CreateDirectory),
 			path, unixCreateMode);
 	}
@@ -45,6 +47,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.CreateSymbolicLink(path, pathToTarget);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.CreateSymbolicLink),
 			path, pathToTarget);
 	}
@@ -59,6 +62,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.CreateTempSubdirectory(prefix);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.CreateTempSubdirectory),
 			prefix);
@@ -75,6 +79,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.Delete(path, recursive);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.Delete),
 			path, recursive);
 	}
@@ -88,6 +93,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.Delete(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.Delete),
 			path);
 	}
@@ -100,6 +106,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateDirectories(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateDirectories),
 			path);
@@ -116,6 +123,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateDirectories(path, searchPattern, enumerationOptions);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateDirectories),
 			path, searchPattern, enumerationOptions);
@@ -132,6 +140,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateDirectories(path, searchPattern, searchOption);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateDirectories),
 			path, searchPattern, searchOption);
@@ -146,6 +155,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateDirectories(path, searchPattern);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateDirectories),
 			path, searchPattern);
@@ -159,6 +169,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFiles(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.EnumerateFiles),
 			path);
 	}
@@ -174,6 +185,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFiles(path, searchPattern, enumerationOptions);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.EnumerateFiles),
 			path, searchPattern, enumerationOptions);
 	}
@@ -189,6 +201,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFiles(path, searchPattern, searchOption);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.EnumerateFiles),
 			path, searchPattern, searchOption);
 	}
@@ -202,6 +215,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFiles(path, searchPattern);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.EnumerateFiles),
 			path, searchPattern);
 	}
@@ -214,6 +228,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFileSystemEntries(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateFileSystemEntries),
 			path);
@@ -231,6 +246,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFileSystemEntries(path, searchPattern, enumerationOptions);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateFileSystemEntries),
 			path, searchPattern, enumerationOptions);
@@ -247,6 +263,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFileSystemEntries(path, searchPattern, searchOption);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateFileSystemEntries),
 			path, searchPattern, searchOption);
@@ -261,6 +278,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFileSystemEntries(path, searchPattern);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateFileSystemEntries),
 			path, searchPattern);
@@ -274,6 +292,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.Exists(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.Exists),
 			path);
 	}
@@ -286,6 +305,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetCreationTime(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetCreationTime),
 			path);
 	}
@@ -298,6 +318,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetCreationTimeUtc(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetCreationTimeUtc),
 			path);
 	}
@@ -309,6 +330,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetCurrentDirectory();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.GetCurrentDirectory));
 	}
@@ -322,6 +344,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetDirectories(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetDirectories),
 			path);
 	}
@@ -338,6 +361,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetDirectories(path, searchPattern, enumerationOptions);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetDirectories),
 			path, searchPattern, enumerationOptions);
 	}
@@ -354,6 +378,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetDirectories(path, searchPattern, searchOption);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetDirectories),
 			path, searchPattern, searchOption);
 	}
@@ -368,6 +393,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetDirectories(path, searchPattern);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetDirectories),
 			path, searchPattern);
 	}
@@ -380,6 +406,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetDirectoryRoot(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetDirectoryRoot),
 			path);
 	}
@@ -393,6 +420,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFiles(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetFiles),
 			path);
 	}
@@ -409,6 +437,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFiles(path, searchPattern, enumerationOptions);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetFiles),
 			path, searchPattern, enumerationOptions);
 	}
@@ -425,6 +454,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFiles(path, searchPattern, searchOption);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetFiles),
 			path, searchPattern, searchOption);
 	}
@@ -439,6 +469,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFiles(path, searchPattern);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetFiles),
 			path, searchPattern);
 	}
@@ -452,6 +483,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFileSystemEntries(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.GetFileSystemEntries),
 			path);
@@ -469,6 +501,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFileSystemEntries(path, searchPattern, enumerationOptions);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.GetFileSystemEntries),
 			path, searchPattern, enumerationOptions);
@@ -486,6 +519,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFileSystemEntries(path, searchPattern, searchOption);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.GetFileSystemEntries),
 			path, searchPattern, searchOption);
@@ -501,6 +535,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFileSystemEntries(path, searchPattern);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.GetFileSystemEntries),
 			path, searchPattern);
@@ -514,6 +549,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetLastAccessTime(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetLastAccessTime),
 			path);
 	}
@@ -526,6 +562,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetLastAccessTimeUtc(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.GetLastAccessTimeUtc),
 			path);
@@ -539,6 +576,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetLastWriteTime(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetLastWriteTime),
 			path);
 	}
@@ -551,6 +589,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetLastWriteTimeUtc(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetLastWriteTimeUtc),
 			path);
 	}
@@ -562,6 +601,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetLogicalDrives();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetLogicalDrives));
 	}
 
@@ -573,6 +613,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetParent(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetParent),
 			path);
 	}
@@ -587,6 +628,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.Move(sourceDirName, destDirName);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.Move),
 			sourceDirName, destDirName);
 	}
@@ -601,6 +643,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.ResolveLinkTarget(linkPath, returnFinalTarget);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.ResolveLinkTarget),
 			linkPath, returnFinalTarget);
 	}
@@ -616,6 +659,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.SetCreationTime(path, creationTime);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.SetCreationTime),
 			path, creationTime);
 	}
@@ -630,6 +674,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.SetCreationTimeUtc(path, creationTimeUtc);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.SetCreationTimeUtc),
 			path, creationTimeUtc);
 	}
@@ -643,6 +688,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.SetCurrentDirectory(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.SetCurrentDirectory),
 			path);
 	}
@@ -657,6 +703,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.SetLastAccessTime(path, lastAccessTime);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.SetLastAccessTime),
 			path, lastAccessTime);
 	}
@@ -671,6 +718,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.SetLastAccessTimeUtc(path, lastAccessTimeUtc);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.SetLastAccessTimeUtc),
 			path, lastAccessTimeUtc);
@@ -686,6 +734,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.SetLastWriteTime(path, lastWriteTime);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.SetLastWriteTime),
 			path, lastWriteTime);
 	}
@@ -700,6 +749,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.SetLastWriteTimeUtc(path, lastWriteTimeUtc);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.SetLastWriteTimeUtc),
 			path, lastWriteTimeUtc);
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoFactoryStatisticsTests.cs
@@ -14,6 +14,7 @@ public sealed class DriveInfoFactoryStatisticsTests
 
 		sut.DriveInfo.GetDrives();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.DriveInfo.ShouldOnlyContainMethodCall(nameof(IDriveInfoFactory.GetDrives));
 	}
 
@@ -25,6 +26,7 @@ public sealed class DriveInfoFactoryStatisticsTests
 
 		sut.DriveInfo.New(driveName);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.DriveInfo.ShouldOnlyContainMethodCall(nameof(IDriveInfoFactory.New),
 			driveName);
 	}
@@ -37,6 +39,7 @@ public sealed class DriveInfoFactoryStatisticsTests
 
 		sut.DriveInfo.Wrap(driveInfo);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.DriveInfo.ShouldOnlyContainMethodCall(nameof(IDriveInfoFactory.Wrap),
 			driveInfo);
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoStatisticsTests.cs
@@ -14,6 +14,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").AvailableFreeSpace;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.AvailableFreeSpace));
 	}
@@ -27,6 +28,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").DriveFormat;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.DriveFormat));
 	}
@@ -40,6 +42,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").DriveType;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.DriveType));
 	}
@@ -53,6 +56,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").IsReady;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.IsReady));
 	}
@@ -66,6 +70,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").Name;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"].ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.Name));
 	}
 
@@ -78,6 +83,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").RootDirectory;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.RootDirectory));
 	}
@@ -91,6 +97,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").TotalFreeSpace;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.TotalFreeSpace));
 	}
@@ -104,6 +111,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").TotalSize;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.TotalSize));
 	}
@@ -117,6 +125,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").VolumeLabel;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.VolumeLabel));
 	}
@@ -133,6 +142,7 @@ public sealed class DriveInfoStatisticsTests
 		sut.DriveInfo.New("F:").VolumeLabel = value;
 		#pragma warning restore CA1416
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDriveInfo.VolumeLabel));
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoFactoryStatisticsTests.cs
@@ -14,6 +14,7 @@ public class FileInfoFactoryStatisticsTests
 
 		sut.FileInfo.New(fileName);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileInfo.ShouldOnlyContainMethodCall(nameof(IFileInfoFactory.New),
 			fileName);
 	}
@@ -26,6 +27,7 @@ public class FileInfoFactoryStatisticsTests
 
 		sut.FileInfo.Wrap(fileInfo);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileInfo.ShouldOnlyContainMethodCall(nameof(IFileInfoFactory.Wrap),
 			fileInfo);
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoStatisticsTests.cs
@@ -13,6 +13,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").AppendText();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.AppendText));
 	}
@@ -27,6 +28,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").CopyTo(destFileName, overwrite);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.CopyTo),
 				destFileName, overwrite);
@@ -41,6 +43,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").CopyTo(destFileName);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.CopyTo),
 				destFileName);
@@ -53,6 +56,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Create();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Create));
 	}
@@ -66,6 +70,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").CreateAsSymbolicLink(pathToTarget);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.CreateAsSymbolicLink),
 				pathToTarget);
@@ -79,6 +84,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").CreateText();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.CreateText));
 	}
@@ -94,6 +100,7 @@ public class FileInfoStatisticsTests
 		sut.FileInfo.New("foo").Decrypt();
 		#pragma warning restore CA1416
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Decrypt));
 	}
@@ -106,6 +113,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Delete();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Delete));
 	}
@@ -121,6 +129,7 @@ public class FileInfoStatisticsTests
 		sut.FileInfo.New("foo").Encrypt();
 		#pragma warning restore CA1416
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Encrypt));
 	}
@@ -136,6 +145,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").MoveTo(destFileName, overwrite);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.MoveTo),
 				destFileName, overwrite);
@@ -151,6 +161,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").MoveTo(destFileName);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.MoveTo),
 				destFileName);
@@ -166,6 +177,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Open(mode, access, share);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Open),
 				mode, access, share);
@@ -180,6 +192,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Open(mode, access);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Open),
 				mode, access);
@@ -193,6 +206,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Open(mode);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Open),
 				mode);
@@ -208,6 +222,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Open(options);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Open),
 				options);
@@ -222,6 +237,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").OpenRead();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.OpenRead));
 	}
@@ -234,6 +250,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").OpenText();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.OpenText));
 	}
@@ -245,6 +262,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").OpenWrite();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.OpenWrite));
 	}
@@ -256,6 +274,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Refresh();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Refresh));
 	}
@@ -272,6 +291,7 @@ public class FileInfoStatisticsTests
 		sut.FileInfo.New("foo").Replace(destinationFileName, destinationBackupFileName,
 			ignoreMetadataErrors);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Replace),
 				destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
@@ -287,6 +307,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Replace(destinationFileName, destinationBackupFileName);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Replace),
 				destinationFileName, destinationBackupFileName);
@@ -301,6 +322,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").ResolveLinkTarget(returnFinalTarget);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(
 				nameof(IFileInfo.ResolveLinkTarget),
@@ -316,6 +338,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").Attributes;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.Attributes));
 	}
@@ -329,6 +352,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Attributes = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.Attributes));
 	}
@@ -341,6 +365,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").CreationTime;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.CreationTime));
 	}
@@ -354,6 +379,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").CreationTime = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.CreationTime));
 	}
@@ -366,6 +392,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").CreationTimeUtc;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.CreationTimeUtc));
 	}
@@ -379,6 +406,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").CreationTimeUtc = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.CreationTimeUtc));
 	}
@@ -391,6 +419,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").Directory;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.Directory));
 	}
@@ -403,6 +432,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").DirectoryName;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.DirectoryName));
 	}
@@ -415,6 +445,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").Exists;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"].ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.Exists));
 	}
 
@@ -426,6 +457,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").Extension;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.Extension));
 	}
@@ -438,6 +470,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").FullName;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.FullName));
 	}
@@ -450,6 +483,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").IsReadOnly;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.IsReadOnly));
 	}
@@ -463,6 +497,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").IsReadOnly = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.IsReadOnly));
 	}
@@ -475,6 +510,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").LastAccessTime;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.LastAccessTime));
 	}
@@ -488,6 +524,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").LastAccessTime = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.LastAccessTime));
 	}
@@ -500,6 +537,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").LastAccessTimeUtc;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.LastAccessTimeUtc));
 	}
@@ -513,6 +551,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").LastAccessTimeUtc = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.LastAccessTimeUtc));
 	}
@@ -525,6 +564,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").LastWriteTime;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.LastWriteTime));
 	}
@@ -538,6 +578,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").LastWriteTime = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.LastWriteTime));
 	}
@@ -550,6 +591,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").LastWriteTimeUtc;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.LastWriteTimeUtc));
 	}
@@ -563,6 +605,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").LastWriteTimeUtc = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.LastWriteTimeUtc));
 	}
@@ -575,6 +618,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").Length;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"].ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.Length));
 	}
 
@@ -587,6 +631,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").LinkTarget;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.LinkTarget));
 	}
@@ -600,6 +645,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").Name;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"].ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.Name));
 	}
 
@@ -612,6 +658,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").UnixFileMode;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.UnixFileMode));
 	}
@@ -631,6 +678,7 @@ public class FileInfoStatisticsTests
 		sut.FileInfo.New("foo").UnixFileMode = value;
 		#pragma warning restore CA1416
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.UnixFileMode));
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStatisticsTests.cs
@@ -27,6 +27,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.AppendAllLines(path, contents, encoding);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllLines),
 			path, contents, encoding);
 	}
@@ -40,6 +41,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.AppendAllLines(path, contents);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllLines),
 			path, contents);
 	}
@@ -56,6 +58,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.AppendAllLinesAsync(path, contents, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllLinesAsync),
 			path, contents, cancellationToken);
 	}
@@ -74,6 +77,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.AppendAllLinesAsync(path, contents, encoding, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllLinesAsync),
 			path, contents, encoding, cancellationToken);
 	}
@@ -89,6 +93,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.AppendAllText(path, contents, encoding);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllText),
 			path, contents, encoding);
 	}
@@ -102,6 +107,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.AppendAllText(path, contents);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllText),
 			path, contents);
 	}
@@ -117,6 +123,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.AppendAllTextAsync(path, contents, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllTextAsync),
 			path, contents, cancellationToken);
 	}
@@ -135,6 +142,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.AppendAllTextAsync(path, contents, encoding, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllTextAsync),
 			path, contents, encoding, cancellationToken);
 	}
@@ -148,6 +156,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.AppendText(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendText),
 			path);
 	}
@@ -163,6 +172,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Copy(sourceFileName, destFileName, overwrite);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Copy),
 			sourceFileName, destFileName, overwrite);
 	}
@@ -177,6 +187,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Copy(sourceFileName, destFileName);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Copy),
 			sourceFileName, destFileName);
 	}
@@ -191,6 +202,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Create(path, bufferSize, options);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Create),
 			path, bufferSize, options);
 	}
@@ -204,6 +216,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Create(path, bufferSize);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Create),
 			path, bufferSize);
 	}
@@ -216,6 +229,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Create(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Create),
 			path);
 	}
@@ -230,6 +244,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.CreateSymbolicLink(path, pathToTarget);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.CreateSymbolicLink),
 			path, pathToTarget);
 	}
@@ -243,6 +258,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.CreateText(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.CreateText),
 			path);
 	}
@@ -260,6 +276,7 @@ public sealed class FileStatisticsTests
 		sut.File.Decrypt(path);
 		#pragma warning restore CA1416
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Decrypt),
 			path);
 	}
@@ -273,6 +290,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Delete(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Delete),
 			path);
 	}
@@ -290,6 +308,7 @@ public sealed class FileStatisticsTests
 		sut.File.Encrypt(path);
 		#pragma warning restore CA1416
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Encrypt),
 			path);
 	}
@@ -302,6 +321,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Exists(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Exists),
 			path);
 	}
@@ -318,6 +338,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetAttributes(fileHandle);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetAttributes),
 			fileHandle);
 	}
@@ -332,6 +353,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetAttributes(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetAttributes),
 			path);
 	}
@@ -348,6 +370,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetCreationTime(fileHandle);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetCreationTime),
 			fileHandle);
 	}
@@ -362,6 +385,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetCreationTime(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetCreationTime),
 			path);
 	}
@@ -378,6 +402,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetCreationTimeUtc(fileHandle);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetCreationTimeUtc),
 			fileHandle);
 	}
@@ -392,6 +417,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetCreationTimeUtc(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetCreationTimeUtc),
 			path);
 	}
@@ -408,6 +434,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastAccessTime(fileHandle);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastAccessTime),
 			fileHandle);
 	}
@@ -422,6 +449,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastAccessTime(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastAccessTime),
 			path);
 	}
@@ -438,6 +466,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastAccessTimeUtc(fileHandle);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastAccessTimeUtc),
 			fileHandle);
 	}
@@ -452,6 +481,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastAccessTimeUtc(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastAccessTimeUtc),
 			path);
 	}
@@ -468,6 +498,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastWriteTime(fileHandle);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastWriteTime),
 			fileHandle);
 	}
@@ -482,6 +513,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastWriteTime(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastWriteTime),
 			path);
 	}
@@ -498,6 +530,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastWriteTimeUtc(fileHandle);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastWriteTimeUtc),
 			fileHandle);
 	}
@@ -512,6 +545,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastWriteTimeUtc(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastWriteTimeUtc),
 			path);
 	}
@@ -532,6 +566,7 @@ public sealed class FileStatisticsTests
 		sut.File.GetUnixFileMode(fileHandle);
 		#pragma warning restore CA1416
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetUnixFileMode),
 			fileHandle);
 	}
@@ -551,6 +586,7 @@ public sealed class FileStatisticsTests
 		sut.File.GetUnixFileMode(path);
 		#pragma warning restore CA1416
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetUnixFileMode),
 			path);
 	}
@@ -568,6 +604,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Move(sourceFileName, destFileName, overwrite);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Move),
 			sourceFileName, destFileName, overwrite);
 	}
@@ -583,6 +620,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Move(sourceFileName, destFileName);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Move),
 			sourceFileName, destFileName);
 	}
@@ -598,6 +636,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Open(path, mode, access, share);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Open),
 			path, mode, access, share);
 	}
@@ -612,6 +651,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Open(path, mode, access);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Open),
 			path, mode, access);
 	}
@@ -625,6 +665,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Open(path, mode);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Open),
 			path, mode);
 	}
@@ -640,6 +681,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Open(path, options);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Open),
 			path, options);
 	}
@@ -654,6 +696,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.OpenRead(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.OpenRead),
 			path);
 	}
@@ -667,6 +710,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.OpenText(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.OpenText),
 			path);
 	}
@@ -679,6 +723,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.OpenWrite(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.OpenWrite),
 			path);
 	}
@@ -692,6 +737,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadAllBytes(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllBytes),
 			path);
 	}
@@ -707,6 +753,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.ReadAllBytesAsync(path, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllBytesAsync),
 			path, cancellationToken);
 	}
@@ -722,6 +769,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadAllLines(path, encoding);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllLines),
 			path, encoding);
 	}
@@ -735,6 +783,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadAllLines(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllLines),
 			path);
 	}
@@ -750,6 +799,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.ReadAllLinesAsync(path, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllLinesAsync),
 			path, cancellationToken);
 	}
@@ -768,6 +818,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.ReadAllLinesAsync(path, encoding, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllLinesAsync),
 			path, encoding, cancellationToken);
 	}
@@ -783,6 +834,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadAllText(path, encoding);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllText),
 			path, encoding);
 	}
@@ -796,6 +848,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadAllText(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllText),
 			path);
 	}
@@ -811,6 +864,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.ReadAllTextAsync(path, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllTextAsync),
 			path, cancellationToken);
 	}
@@ -828,6 +882,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.ReadAllTextAsync(path, encoding, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllTextAsync),
 			path, encoding, cancellationToken);
 	}
@@ -843,6 +898,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadLines(path, encoding);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadLines),
 			path, encoding);
 	}
@@ -856,6 +912,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadLines(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadLines),
 			path);
 	}
@@ -871,6 +928,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadLinesAsync(path, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadLinesAsync),
 			path, cancellationToken);
 	}
@@ -888,6 +946,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadLinesAsync(path, encoding, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadLinesAsync),
 			path, encoding, cancellationToken);
 	}
@@ -906,6 +965,7 @@ public sealed class FileStatisticsTests
 		sut.File.Replace(sourceFileName, destinationFileName, destinationBackupFileName,
 			ignoreMetadataErrors);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Replace),
 			sourceFileName, destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
 	}
@@ -921,6 +981,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Replace(sourceFileName, destinationFileName, destinationBackupFileName);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Replace),
 			sourceFileName, destinationFileName, destinationBackupFileName);
 	}
@@ -936,6 +997,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ResolveLinkTarget(linkPath, returnFinalTarget);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ResolveLinkTarget),
 			linkPath, returnFinalTarget);
 	}
@@ -954,6 +1016,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetAttributes(fileHandle, fileAttributes);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetAttributes),
 			fileHandle, fileAttributes);
 	}
@@ -969,6 +1032,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetAttributes(path, fileAttributes);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetAttributes),
 			path, fileAttributes);
 	}
@@ -986,6 +1050,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetCreationTime(fileHandle, creationTime);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetCreationTime),
 			fileHandle, creationTime);
 	}
@@ -1001,6 +1066,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetCreationTime(path, creationTime);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetCreationTime),
 			path, creationTime);
 	}
@@ -1018,6 +1084,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetCreationTimeUtc(fileHandle, creationTimeUtc);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetCreationTimeUtc),
 			fileHandle, creationTimeUtc);
 	}
@@ -1033,6 +1100,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetCreationTimeUtc(path, creationTimeUtc);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetCreationTimeUtc),
 			path, creationTimeUtc);
 	}
@@ -1050,6 +1118,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastAccessTime(fileHandle, lastAccessTime);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastAccessTime),
 			fileHandle, lastAccessTime);
 	}
@@ -1065,6 +1134,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastAccessTime(path, lastAccessTime);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastAccessTime),
 			path, lastAccessTime);
 	}
@@ -1082,6 +1152,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastAccessTimeUtc(fileHandle, lastAccessTimeUtc);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastAccessTimeUtc),
 			fileHandle, lastAccessTimeUtc);
 	}
@@ -1097,6 +1168,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastAccessTimeUtc(path, lastAccessTimeUtc);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastAccessTimeUtc),
 			path, lastAccessTimeUtc);
 	}
@@ -1114,6 +1186,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastWriteTime(fileHandle, lastWriteTime);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastWriteTime),
 			fileHandle, lastWriteTime);
 	}
@@ -1129,6 +1202,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastWriteTime(path, lastWriteTime);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastWriteTime),
 			path, lastWriteTime);
 	}
@@ -1146,6 +1220,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastWriteTimeUtc(fileHandle, lastWriteTimeUtc);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastWriteTimeUtc),
 			fileHandle, lastWriteTimeUtc);
 	}
@@ -1161,6 +1236,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastWriteTimeUtc(path, lastWriteTimeUtc);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastWriteTimeUtc),
 			path, lastWriteTimeUtc);
 	}
@@ -1182,6 +1258,7 @@ public sealed class FileStatisticsTests
 		sut.File.SetUnixFileMode(fileHandle, mode);
 		#pragma warning restore CA1416
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetUnixFileMode),
 			fileHandle, mode);
 	}
@@ -1202,6 +1279,7 @@ public sealed class FileStatisticsTests
 		sut.File.SetUnixFileMode(path, mode);
 		#pragma warning restore CA1416
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetUnixFileMode),
 			path, mode);
 	}
@@ -1216,6 +1294,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.WriteAllBytes(path, bytes);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllBytes),
 			path, bytes);
 	}
@@ -1232,6 +1311,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.WriteAllBytesAsync(path, bytes, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllBytesAsync),
 			path, bytes, cancellationToken);
 	}
@@ -1247,6 +1327,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.WriteAllLines(path, contents, encoding);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllLines),
 			path, contents, encoding);
 	}
@@ -1260,6 +1341,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.WriteAllLines(path, contents);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllLines),
 			path, contents);
 	}
@@ -1274,6 +1356,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.WriteAllLines(path, contents, encoding);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllLines),
 			path, contents, encoding);
 	}
@@ -1287,6 +1370,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.WriteAllLines(path, contents);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllLines),
 			path, contents);
 	}
@@ -1303,6 +1387,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.WriteAllLinesAsync(path, contents, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllLinesAsync),
 			path, contents, cancellationToken);
 	}
@@ -1321,6 +1406,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.WriteAllLinesAsync(path, contents, encoding, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllLinesAsync),
 			path, contents, encoding, cancellationToken);
 	}
@@ -1336,6 +1422,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.WriteAllText(path, contents, encoding);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllText),
 			path, contents, encoding);
 	}
@@ -1349,6 +1436,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.WriteAllText(path, contents);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllText),
 			path, contents);
 	}
@@ -1364,6 +1452,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.WriteAllTextAsync(path, contents, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllTextAsync),
 			path, contents, cancellationToken);
 	}
@@ -1382,6 +1471,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.WriteAllTextAsync(path, contents, encoding, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllTextAsync),
 			path, contents, encoding, cancellationToken);
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamFactoryStatisticsTests.cs
@@ -25,6 +25,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(handle, access, bufferSize, isAsync);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			handle, access, bufferSize, isAsync);
 	}
@@ -44,6 +45,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(handle, access, bufferSize);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			handle, access, bufferSize);
 	}
@@ -61,6 +63,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(handle, access);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			handle, access);
 	}
@@ -80,6 +83,7 @@ public class FileStreamFactoryStatisticsTests
 		using FileSystemStream result =
 			sut.FileStream.New(path, mode, access, share, bufferSize, useAsync);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			path, mode, access, share, bufferSize, useAsync);
 	}
@@ -98,6 +102,7 @@ public class FileStreamFactoryStatisticsTests
 		using FileSystemStream result =
 			sut.FileStream.New(path, mode, access, share, bufferSize, options);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			path, mode, access, share, bufferSize, options);
 	}
@@ -114,6 +119,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(path, mode, access, share, bufferSize);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			path, mode, access, share, bufferSize);
 	}
@@ -129,6 +135,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(path, mode, access, share);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			path, mode, access, share);
 	}
@@ -143,6 +150,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(path, mode, access);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			path, mode, access);
 	}
@@ -156,6 +164,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(path, mode);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			path, mode);
 	}
@@ -171,6 +180,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(path, options);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			path, options);
 	}
@@ -191,6 +201,7 @@ public class FileStreamFactoryStatisticsTests
 			// Wrap is not possible on the MockFileSystem, but should still be registered!
 		}
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.Wrap),
 			fileStream);
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamStatisticsTests.cs
@@ -22,6 +22,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.BeginRead(buffer, offset, count, callback, state);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.BeginRead),
 				buffer, offset, count, callback, state);
@@ -40,6 +41,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.BeginWrite(buffer, offset, count, callback, state);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.BeginWrite),
 				buffer, offset, count, callback, state);
@@ -55,6 +57,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.CopyTo(destination, bufferSize);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.CopyTo),
 				destination, bufferSize);
@@ -71,6 +74,7 @@ public class FileStreamStatisticsTests
 
 		await fileStream.CopyToAsync(destination, bufferSize, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.CopyToAsync),
 				destination, bufferSize, cancellationToken);
@@ -86,6 +90,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.EndRead(asyncResult);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(3);
 		sut.Statistics.FileStream["foo"].Methods.Length.Should().Be(2);
 		sut.Statistics.FileStream["foo"].Methods.Should()
 			.ContainSingle(c => c.Name == nameof(FileSystemStream.EndRead) &&
@@ -103,6 +108,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.EndWrite(asyncResult);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(3);
 		sut.Statistics.FileStream["foo"].Methods.Length.Should().Be(2);
 		sut.Statistics.FileStream["foo"].Methods.Should()
 			.ContainSingle(c => c.Name == nameof(FileSystemStream.EndWrite) &&
@@ -119,6 +125,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.Flush(flushToDisk);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.Flush),
 				flushToDisk);
@@ -132,6 +139,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.Flush();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.Flush));
 	}
@@ -145,6 +153,7 @@ public class FileStreamStatisticsTests
 
 		await fileStream.FlushAsync(cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.FlushAsync),
 				cancellationToken);
@@ -161,6 +170,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.Read(buffer, offset, count);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.Read),
 				buffer, offset, count);
@@ -176,6 +186,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.Read(buffer);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.Read),
 				buffer);
@@ -194,6 +205,7 @@ public class FileStreamStatisticsTests
 
 		_ = await fileStream.ReadAsync(buffer, offset, count, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.ReadAsync),
 				buffer, offset, count, cancellationToken);
@@ -210,6 +222,7 @@ public class FileStreamStatisticsTests
 
 		_ = await fileStream.ReadAsync(buffer, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.ReadAsync),
 				buffer, cancellationToken);
@@ -224,6 +237,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.ReadByte();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.ReadByte));
 	}
@@ -238,6 +252,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.Seek(offset, origin);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.Seek),
 				offset, origin);
@@ -252,6 +267,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.SetLength(value);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.SetLength),
 				value);
@@ -265,6 +281,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.ToString();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.ToString));
 	}
@@ -280,6 +297,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.Write(buffer, offset, count);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.Write),
 				buffer, offset, count);
@@ -295,6 +313,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.Write(buffer);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.Write),
 				buffer);
@@ -313,6 +332,7 @@ public class FileStreamStatisticsTests
 
 		await fileStream.WriteAsync(buffer, offset, count, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.WriteAsync),
 				buffer, offset, count, cancellationToken);
@@ -329,6 +349,7 @@ public class FileStreamStatisticsTests
 
 		await fileStream.WriteAsync(buffer, cancellationToken);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.WriteAsync),
 				buffer, cancellationToken);
@@ -344,6 +365,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.WriteByte(value);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.WriteByte),
 				value);
@@ -357,6 +379,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.CanRead;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.CanRead));
 	}
@@ -369,6 +392,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.CanSeek;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.CanSeek));
 	}
@@ -381,6 +405,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.CanTimeout;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.CanTimeout));
 	}
@@ -393,6 +418,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.CanWrite;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.CanWrite));
 	}
@@ -405,6 +431,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.IsAsync;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.IsAsync));
 	}
@@ -417,6 +444,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.Length;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.Length));
 	}
@@ -429,6 +457,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.Name;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.Name));
 	}
@@ -441,6 +470,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.Position;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.Position));
 	}
@@ -454,6 +484,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.Position = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(FileSystemStream.Position));
 	}
@@ -473,6 +504,7 @@ public class FileStreamStatisticsTests
 			// Timeouts are not supported on this stream.
 		}
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.ReadTimeout));
 	}
@@ -493,6 +525,7 @@ public class FileStreamStatisticsTests
 			// Timeouts are not supported on this stream.
 		}
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(FileSystemStream.ReadTimeout));
 	}
@@ -512,6 +545,7 @@ public class FileStreamStatisticsTests
 			// Timeouts are not supported on this stream.
 		}
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.WriteTimeout));
 	}
@@ -532,6 +566,7 @@ public class FileStreamStatisticsTests
 			// Timeouts are not supported on this stream.
 		}
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(FileSystemStream.WriteTimeout));
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherFactoryStatisticsTests.cs
@@ -13,6 +13,7 @@ public class FileSystemWatcherFactoryStatisticsTests
 
 		using IFileSystemWatcher result = sut.FileSystemWatcher.New();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileSystemWatcher.ShouldOnlyContainMethodCall(
 			nameof(IFileSystemWatcherFactory.New));
 	}
@@ -26,6 +27,7 @@ public class FileSystemWatcherFactoryStatisticsTests
 
 		using IFileSystemWatcher result = sut.FileSystemWatcher.New(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileSystemWatcher.ShouldOnlyContainMethodCall(
 			nameof(IFileSystemWatcherFactory.New),
 			path);
@@ -41,6 +43,7 @@ public class FileSystemWatcherFactoryStatisticsTests
 
 		using IFileSystemWatcher result = sut.FileSystemWatcher.New(path, filter);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileSystemWatcher.ShouldOnlyContainMethodCall(
 			nameof(IFileSystemWatcherFactory.New),
 			path, filter);
@@ -55,6 +58,7 @@ public class FileSystemWatcherFactoryStatisticsTests
 
 		using IFileSystemWatcher result = sut.FileSystemWatcher.Wrap(fileSystemWatcher);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.FileSystemWatcher.ShouldOnlyContainMethodCall(
 			nameof(IFileSystemWatcherFactory.Wrap),
 			fileSystemWatcher);

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
@@ -18,6 +18,7 @@ public class FileSystemWatcherStatisticsTests
 
 		fileSystemWatcher.BeginInit();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileSystemWatcher.BeginInit));
 	}
@@ -31,6 +32,7 @@ public class FileSystemWatcherStatisticsTests
 
 		fileSystemWatcher.EndInit();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileSystemWatcher.EndInit));
 	}
@@ -130,6 +132,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").EnableRaisingEvents;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.EnableRaisingEvents));
 	}
@@ -143,6 +146,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").EnableRaisingEvents = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.EnableRaisingEvents));
 	}
@@ -155,6 +159,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").Filter;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.Filter));
 	}
@@ -168,6 +173,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").Filter = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.Filter));
 	}
@@ -181,6 +187,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").Filters;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.Filters));
 	}
@@ -194,6 +201,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").IncludeSubdirectories;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.IncludeSubdirectories));
 	}
@@ -207,6 +215,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").IncludeSubdirectories = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.IncludeSubdirectories));
 	}
@@ -219,6 +228,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").InternalBufferSize;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.InternalBufferSize));
 	}
@@ -232,6 +242,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").InternalBufferSize = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.InternalBufferSize));
 	}
@@ -244,6 +255,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").NotifyFilter;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.NotifyFilter));
 	}
@@ -257,6 +269,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").NotifyFilter = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.NotifyFilter));
 	}
@@ -269,6 +282,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").Path;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.Path));
 	}
@@ -282,6 +296,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").Path = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.Path));
 	}
@@ -294,6 +309,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").Site;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.Site));
 	}
@@ -307,6 +323,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").Site = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.Site));
 	}
@@ -319,6 +336,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").SynchronizingObject;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.SynchronizingObject));
 	}
@@ -332,6 +350,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").SynchronizingObject = value;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.SynchronizingObject));
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/PathStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/PathStatisticsTests.cs
@@ -17,6 +17,7 @@ public class PathStatisticsTests
 
 		sut.Path.ChangeExtension(path, extension);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.ChangeExtension),
 			path, extension);
 	}
@@ -30,6 +31,7 @@ public class PathStatisticsTests
 
 		sut.Path.Combine(path1, path2);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Combine),
 			path1, path2);
 	}
@@ -44,6 +46,7 @@ public class PathStatisticsTests
 
 		sut.Path.Combine(path1, path2, path3);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Combine),
 			path1, path2, path3);
 	}
@@ -59,6 +62,7 @@ public class PathStatisticsTests
 
 		sut.Path.Combine(path1, path2, path3, path4);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Combine),
 			path1, path2, path3, path4);
 	}
@@ -71,6 +75,7 @@ public class PathStatisticsTests
 
 		sut.Path.Combine(paths);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Combine),
 			paths);
 	}
@@ -84,6 +89,7 @@ public class PathStatisticsTests
 
 		sut.Path.EndsInDirectorySeparator(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.EndsInDirectorySeparator),
 			path);
 	}
@@ -98,6 +104,7 @@ public class PathStatisticsTests
 
 		sut.Path.EndsInDirectorySeparator(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.EndsInDirectorySeparator),
 			path);
 	}
@@ -112,6 +119,7 @@ public class PathStatisticsTests
 
 		sut.Path.Exists(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Exists),
 			path);
 	}
@@ -126,6 +134,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetDirectoryName(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetDirectoryName),
 			path);
 	}
@@ -139,6 +148,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetDirectoryName(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetDirectoryName),
 			path);
 	}
@@ -152,6 +162,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetExtension(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetExtension),
 			path);
 	}
@@ -165,6 +176,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetExtension(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetExtension),
 			path);
 	}
@@ -178,6 +190,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetFileName(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetFileName),
 			path);
 	}
@@ -191,6 +204,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetFileName(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetFileName),
 			path);
 	}
@@ -204,6 +218,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetFileNameWithoutExtension(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetFileNameWithoutExtension),
 			path);
 	}
@@ -217,6 +232,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetFileNameWithoutExtension(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetFileNameWithoutExtension),
 			path);
 	}
@@ -229,6 +245,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetFullPath(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetFullPath),
 			path);
 	}
@@ -243,6 +260,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetFullPath(path, basePath);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetFullPath),
 			path, basePath);
 	}
@@ -255,6 +273,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetInvalidFileNameChars();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetInvalidFileNameChars));
 	}
 
@@ -265,6 +284,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetInvalidPathChars();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetInvalidPathChars));
 	}
 
@@ -277,6 +297,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetPathRoot(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetPathRoot),
 			path);
 	}
@@ -290,6 +311,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetPathRoot(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetPathRoot),
 			path);
 	}
@@ -301,6 +323,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetRandomFileName();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetRandomFileName));
 	}
 
@@ -314,6 +337,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetRelativePath(relativeTo, path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetRelativePath),
 			relativeTo, path);
 	}
@@ -326,6 +350,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetTempFileName();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetTempFileName));
 	}
 
@@ -336,6 +361,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetTempPath();
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetTempPath));
 	}
 
@@ -348,6 +374,7 @@ public class PathStatisticsTests
 
 		sut.Path.HasExtension(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.HasExtension),
 			path);
 	}
@@ -361,6 +388,7 @@ public class PathStatisticsTests
 
 		sut.Path.HasExtension(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.HasExtension),
 			path);
 	}
@@ -374,6 +402,7 @@ public class PathStatisticsTests
 
 		sut.Path.IsPathFullyQualified(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.IsPathFullyQualified),
 			path);
 	}
@@ -388,6 +417,7 @@ public class PathStatisticsTests
 
 		sut.Path.IsPathFullyQualified(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.IsPathFullyQualified),
 			path);
 	}
@@ -402,6 +432,7 @@ public class PathStatisticsTests
 
 		sut.Path.IsPathRooted(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.IsPathRooted),
 			path);
 	}
@@ -415,6 +446,7 @@ public class PathStatisticsTests
 
 		sut.Path.IsPathRooted(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.IsPathRooted),
 			path);
 	}
@@ -432,6 +464,7 @@ public class PathStatisticsTests
 
 		sut.Path.Join(path1, path2, path3, path4);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Join),
 			path1, path2, path3, path4);
 	}
@@ -448,6 +481,7 @@ public class PathStatisticsTests
 
 		sut.Path.Join(path1, path2, path3);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Join),
 			path1, path2, path3);
 	}
@@ -463,6 +497,7 @@ public class PathStatisticsTests
 
 		sut.Path.Join(path1, path2);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Join),
 			path1, path2);
 	}
@@ -478,6 +513,7 @@ public class PathStatisticsTests
 
 		sut.Path.Join(path1, path2);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Join),
 			path1, path2);
 	}
@@ -494,6 +530,7 @@ public class PathStatisticsTests
 
 		sut.Path.Join(path1, path2, path3);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Join),
 			path1, path2, path3);
 	}
@@ -511,6 +548,7 @@ public class PathStatisticsTests
 
 		sut.Path.Join(path1, path2, path3, path4);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Join),
 			path1, path2, path3, path4);
 	}
@@ -525,6 +563,7 @@ public class PathStatisticsTests
 
 		sut.Path.Join(paths);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Join),
 			paths);
 	}
@@ -539,6 +578,7 @@ public class PathStatisticsTests
 
 		sut.Path.TrimEndingDirectorySeparator(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.TrimEndingDirectorySeparator),
 			path);
 	}
@@ -553,6 +593,7 @@ public class PathStatisticsTests
 
 		sut.Path.TrimEndingDirectorySeparator(path);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.TrimEndingDirectorySeparator),
 			path);
 	}
@@ -571,6 +612,7 @@ public class PathStatisticsTests
 
 		sut.Path.TryJoin(path1, path2, path3, destination, out int charsWritten);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.TryJoin),
 			path1, path2, path3, destination, charsWritten);
 	}
@@ -588,6 +630,7 @@ public class PathStatisticsTests
 
 		sut.Path.TryJoin(path1, path2, destination, out int charsWritten);
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.TryJoin),
 			path1, path2, destination, charsWritten);
 	}
@@ -600,6 +643,7 @@ public class PathStatisticsTests
 
 		_ = sut.Path.AltDirectorySeparatorChar;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainPropertyGetAccess(
 			nameof(IPath.AltDirectorySeparatorChar));
 	}
@@ -611,6 +655,7 @@ public class PathStatisticsTests
 
 		_ = sut.Path.DirectorySeparatorChar;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainPropertyGetAccess(
 			nameof(IPath.DirectorySeparatorChar));
 	}
@@ -622,6 +667,7 @@ public class PathStatisticsTests
 
 		_ = sut.Path.PathSeparator;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainPropertyGetAccess(nameof(IPath.PathSeparator));
 	}
 
@@ -632,6 +678,7 @@ public class PathStatisticsTests
 
 		_ = sut.Path.VolumeSeparatorChar;
 
+		sut.StatisticsRegistration.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainPropertyGetAccess(nameof(IPath.VolumeSeparatorChar));
 	}
 


### PR DESCRIPTION
Add an internal `NativePath` implementation to avoid unnecessary statistic registrations.
As this effectively implements `PathSystemBase`, this shared base-class should become obsolete.