### PR TITLE
docs: add License Scan badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/5b9b2f79950447a69d69037b43acd590)](https://app.codacy.com/gh/Testably/Testably.Abstractions/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_Testably.Abstractions&branch=main&metric=alert_status)](https://sonarcloud.io/summary/overall?id=Testably_Testably.Abstractions)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FTestably.Abstractions%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/Testably.Abstractions/main)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FTestably%2FTestably.Abstractions.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2FTestably%2FTestably.Abstractions?ref=badge_shield&issueType=license)
 
 This library is a feature complete testing helper for the [IFileSystem abstractions for I/O-related functionality](https://github.com/TestableIO/System.IO.Abstractions) from the `System.IO` namespace. It uses an in-memory file system that behaves exactly like the real file system and can be used in unit tests for dependency injection.  
 The testing helper also supports advanced scenarios like


### PR DESCRIPTION
Add License Scan badge from [FOSSA](https://app.fossa.com/projects/git%2Bgithub.com%2FTestably%2FTestably.Abstractions/refs/branch/main) to README.md.