### PR TITLE
feat: enable/disable brittle tests via test settings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,6 +36,6 @@
   <ItemGroup>
     <PackageVersion Include="Testably.Abstractions" Version="2.6.1" />
     <PackageVersion Include="Testably.Abstractions.Testing" Version="2.6.1" />
-    <PackageVersion Include="Testably.Abstractions.FluentAssertions" Version="1.0.0" />
+    <PackageVersion Include="Testably.Abstractions.FluentAssertions" Version="1.0.1" />
   </ItemGroup>
 </Project>

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryCleaner.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryCleaner.cs
@@ -44,7 +44,7 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 			{
 				try
 				{
-					ForceDeleteDirectory(BasePath);
+					ForceDeleteDirectory(BasePath, true);
 					break;
 				}
 				catch (Exception)
@@ -81,10 +81,10 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 	///     Force deletes the directory at the given <paramref name="path" />.<br />
 	///     Removes the <see cref="FileAttributes.ReadOnly" /> flag, if necessary.
 	///     <para />
-	///     If <paramref name="recursive" /> is set (default <see langword="true" />), the sub directories are force deleted as
+	///     If <paramref name="recursive" /> is set, the subdirectories are force deleted as
 	///     well.
 	/// </summary>
-	private void ForceDeleteDirectory(string path, bool recursive = true)
+	private void ForceDeleteDirectory(string path, bool recursive)
 	{
 		if (!_fileSystem.Directory.Exists(path))
 		{
@@ -109,7 +109,7 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 					EnumerationOptionsHelper.DefaultSearchPattern,
 					SearchOption.TopDirectoryOnly))
 			{
-				ForceDeleteDirectory(info.FullName, recursive);
+				ForceDeleteDirectory(info.FullName, true);
 			}
 		}
 
@@ -118,27 +118,29 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 
 	private string InitializeBasePath(Execute execute, string prefix)
 	{
-		string basePath;
+		string basePath = "";
 
-		do
+		for (int j = 0; j <= 5; j++)
 		{
-			string localBasePath = _fileSystem.Path.Combine(
-				_fileSystem.Path.GetTempPath(),
-				prefix + _fileSystem.Path.GetFileNameWithoutExtension(
-					_fileSystem.Path.GetRandomFileName()));
-			execute.OnMac(() => localBasePath = "/private" + localBasePath);
-			basePath = localBasePath;
-		} while (_fileSystem.Directory.Exists(basePath));
+			basePath = CreatePossiblePath(execute, prefix);
 
-		for (int i = 0; i <= 2; i++)
-		{
 			try
 			{
 				_fileSystem.Directory.CreateDirectory(basePath);
+				try
+				{
+					_fileSystem.File.WriteAllText(_fileSystem.Path.Combine(basePath, ".lock"), "");
+				}
+				catch (Exception)
+				{
+					// Give a transient condition like antivirus/indexing a chance to go away
+					Thread.Sleep(10);
+				}
 				break;
 			}
 			catch (Exception)
 			{
+				_fileSystem.Directory.Delete(basePath);
 				// Give a transient condition like antivirus/indexing a chance to go away
 				Thread.Sleep(10);
 			}
@@ -162,6 +164,22 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 			throw new TestingException(
 				$"Could not set current directory to '{basePath}' for tests");
 		}
+
+		return basePath;
+	}
+
+	private string CreatePossiblePath(Execute execute, string prefix)
+	{
+		string basePath;
+		do
+		{
+			string localBasePath = _fileSystem.Path.Combine(
+				_fileSystem.Path.GetTempPath(),
+				prefix.Replace("/","_").Replace("\\","_") + _fileSystem.Path.GetFileNameWithoutExtension(
+					_fileSystem.Path.GetRandomFileName()));
+			execute.OnMac(() => localBasePath = "/private" + localBasePath);
+			basePath = localBasePath;
+		} while (_fileSystem.Directory.Exists(basePath));
 
 		return basePath;
 	}

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryCleaner.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializer/DirectoryCleaner.cs
@@ -44,7 +44,7 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 			{
 				try
 				{
-					ForceDeleteDirectory(BasePath, true);
+					ForceDeleteDirectory(BasePath);
 					break;
 				}
 				catch (Exception)
@@ -81,10 +81,10 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 	///     Force deletes the directory at the given <paramref name="path" />.<br />
 	///     Removes the <see cref="FileAttributes.ReadOnly" /> flag, if necessary.
 	///     <para />
-	///     If <paramref name="recursive" /> is set, the subdirectories are force deleted as
+	///     If <paramref name="recursive" /> is set (default <see langword="true" />), the sub directories are force deleted as
 	///     well.
 	/// </summary>
-	private void ForceDeleteDirectory(string path, bool recursive)
+	private void ForceDeleteDirectory(string path, bool recursive = true)
 	{
 		if (!_fileSystem.Directory.Exists(path))
 		{
@@ -109,59 +109,36 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 					EnumerationOptionsHelper.DefaultSearchPattern,
 					SearchOption.TopDirectoryOnly))
 			{
-				ForceDeleteDirectory(info.FullName, true);
+				ForceDeleteDirectory(info.FullName, recursive);
 			}
 		}
 
 		_fileSystem.Directory.Delete(path);
 	}
 
-	/// <summary>
-	///     Returns a candidate for a test-directory within the temporary directory that does not yet exist.
-	/// </summary>
-	private string GetPossiblePath(Execute execute, string prefix)
+	private string InitializeBasePath(Execute execute, string prefix)
 	{
 		string basePath;
+
 		do
 		{
 			string localBasePath = _fileSystem.Path.Combine(
 				_fileSystem.Path.GetTempPath(),
-				prefix.Replace("/", "_").Replace("\\", "_") +
-				_fileSystem.Path.GetFileNameWithoutExtension(
+				prefix + _fileSystem.Path.GetFileNameWithoutExtension(
 					_fileSystem.Path.GetRandomFileName()));
 			execute.OnMac(() => localBasePath = "/private" + localBasePath);
 			basePath = localBasePath;
 		} while (_fileSystem.Directory.Exists(basePath));
 
-		return basePath;
-	}
-
-	private string InitializeBasePath(Execute execute, string prefix)
-	{
-		string basePath = "";
-
-		for (int j = 0; j <= 5; j++)
+		for (int i = 0; i <= 2; i++)
 		{
-			basePath = GetPossiblePath(execute, prefix);
-
 			try
 			{
 				_fileSystem.Directory.CreateDirectory(basePath);
-				try
-				{
-					_fileSystem.File.WriteAllText(_fileSystem.Path.Combine(basePath, ".lock"), "");
-				}
-				catch (Exception)
-				{
-					// Give a transient condition like antivirus/indexing a chance to go away
-					Thread.Sleep(10);
-				}
-
 				break;
 			}
 			catch (Exception)
 			{
-				_fileSystem.Directory.Delete(basePath);
 				// Give a transient condition like antivirus/indexing a chance to go away
 				Thread.Sleep(10);
 			}

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/FileSystemTestBase.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/FileSystemTestBase.cs
@@ -39,6 +39,15 @@ public abstract class FileSystemTestBase<TFileSystem>
 	}
 
 	/// <summary>
+	///     Specifies, if brittle tests should be skipped on the real file system.
+	/// </summary>
+	/// <param name="condition">
+	///     (optional) A condition that must be <see langword="true" /> for the test to be skipped on the
+	///     real file system.
+	/// </param>
+	public abstract void SkipIfBrittleTestsShouldBeSkipped(bool condition = true);
+
+	/// <summary>
 	///     Specifies, if long-running tests should be skipped on the real file system.
 	/// </summary>
 	public abstract void SkipIfLongRunningTestsShouldBeSkipped();

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/Settings/RealFileSystemFixture.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/Settings/RealFileSystemFixture.cs
@@ -7,6 +7,7 @@ namespace Testably.Abstractions.TestHelpers.Settings;
 public class RealFileSystemFixture
 {
 	public TestSettingStatus LongRunningTests { get; }
+	public TestSettingStatus BrittleTests { get; }
 	public TestSettingStatus RealFileSystemTests { get; }
 
 	public RealFileSystemFixture()
@@ -20,11 +21,13 @@ public class RealFileSystemFixture
 
 			RealFileSystemTests = environment.RealFileSystemTests;
 			LongRunningTests = environment.LongRunningTests;
+			BrittleTests = environment.BrittleTests;
 		}
 		catch (Exception)
 		{
 			RealFileSystemTests = TestSettingStatus.DisabledInDebugMode;
 			LongRunningTests = TestSettingStatus.DisabledInDebugMode;
+			BrittleTests = TestSettingStatus.DisabledInDebugMode;
 		}
 	}
 }

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/Settings/TestEnvironment.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/Settings/TestEnvironment.cs
@@ -3,18 +3,18 @@
 public class TestEnvironment
 {
 	/// <summary>
+	///     Affects some tests, that are brittle on the real file system.
+	/// </summary>
+	/// <remarks>Per default, they are <see cref="TestSettingStatus.AlwaysDisabled" />.</remarks>
+	public TestSettingStatus BrittleTests { get; set; }
+		= TestSettingStatus.AlwaysDisabled;
+
+	/// <summary>
 	///     Affects some tests, that take a long time to run against the real file system (e.g. timeout).
 	/// </summary>
 	/// <remarks>Per default, they are <see cref="TestSettingStatus.DisabledInDebugMode" />.</remarks>
 	public TestSettingStatus LongRunningTests { get; set; }
 		= TestSettingStatus.DisabledInDebugMode;
-
-	/// <summary>
-	///     Affects some tests, that are brittle on the real file system.
-	/// </summary>
-	/// <remarks>Per default, they are <see cref="TestSettingStatus.DisabledInDebugMode" />.</remarks>
-	public TestSettingStatus BrittleTests { get; set; }
-		= TestSettingStatus.AlwaysDisabled;
 
 	/// <summary>
 	///     Affects all tests against the real file system.

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/Settings/TestEnvironment.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/Settings/TestEnvironment.cs
@@ -10,6 +10,13 @@ public class TestEnvironment
 		= TestSettingStatus.DisabledInDebugMode;
 
 	/// <summary>
+	///     Affects some tests, that are brittle on the real file system.
+	/// </summary>
+	/// <remarks>Per default, they are <see cref="TestSettingStatus.DisabledInDebugMode" />.</remarks>
+	public TestSettingStatus BrittleTests { get; set; }
+		= TestSettingStatus.DisabledInDebugMode;
+
+	/// <summary>
 	///     Affects all tests against the real file system.
 	/// </summary>
 	/// <remarks>Per default, they are <see cref="TestSettingStatus.DisabledInDebugMode" />.</remarks>

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/Settings/TestEnvironment.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/Settings/TestEnvironment.cs
@@ -14,7 +14,7 @@ public class TestEnvironment
 	/// </summary>
 	/// <remarks>Per default, they are <see cref="TestSettingStatus.DisabledInDebugMode" />.</remarks>
 	public TestSettingStatus BrittleTests { get; set; }
-		= TestSettingStatus.DisabledInDebugMode;
+		= TestSettingStatus.AlwaysDisabled;
 
 	/// <summary>
 	///     Affects all tests against the real file system.

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/Settings/TestSettingsFixture.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/Settings/TestSettingsFixture.cs
@@ -6,28 +6,41 @@ namespace Testably.Abstractions.TestHelpers.Settings;
 
 public class TestSettingsFixture
 {
-	public TestSettingStatus LongRunningTests { get; }
 	public TestSettingStatus BrittleTests { get; }
+	public TestSettingStatus LongRunningTests { get; }
 	public TestSettingStatus RealFileSystemTests { get; }
 
 	public TestSettingsFixture()
+	{
+		TestEnvironment environment = LoadTestEnvironment();
+
+		RealFileSystemTests = environment.RealFileSystemTests;
+		LongRunningTests = environment.LongRunningTests;
+		BrittleTests = environment.BrittleTests;
+	}
+
+	private static TestEnvironment LoadTestEnvironment()
 	{
 		try
 		{
 			string path = Path.GetFullPath(
 				Path.Combine("..", "..", "..", "..", "test.settings.json"));
-			string content = File.ReadAllText(path);
-			TestEnvironment environment = JsonConvert.DeserializeObject<TestEnvironment>(content)!;
-
-			RealFileSystemTests = environment.RealFileSystemTests;
-			LongRunningTests = environment.LongRunningTests;
-			BrittleTests = environment.BrittleTests;
+			if (File.Exists(path))
+			{
+				string content = File.ReadAllText(path);
+				TestEnvironment? testEnvironment =
+					JsonConvert.DeserializeObject<TestEnvironment>(content);
+				if (testEnvironment != null)
+				{
+					return testEnvironment;
+				}
+			}
 		}
 		catch (Exception)
 		{
-			RealFileSystemTests = TestSettingStatus.DisabledInDebugMode;
-			LongRunningTests = TestSettingStatus.DisabledInDebugMode;
-			BrittleTests = TestSettingStatus.DisabledInDebugMode;
+			// Ignore all exceptions while reading the test.settings.json file and use the default settings as fallback.
 		}
+
+		return new TestEnvironment();
 	}
 }

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/Settings/TestSettingsFixture.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/Settings/TestSettingsFixture.cs
@@ -4,13 +4,13 @@ using System.IO;
 
 namespace Testably.Abstractions.TestHelpers.Settings;
 
-public class RealFileSystemFixture
+public class TestSettingsFixture
 {
 	public TestSettingStatus LongRunningTests { get; }
 	public TestSettingStatus BrittleTests { get; }
 	public TestSettingStatus RealFileSystemTests { get; }
 
-	public RealFileSystemFixture()
+	public TestSettingsFixture()
 	{
 		try
 		{

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/Test.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/Test.cs
@@ -1,4 +1,3 @@
-using System.IO.Abstractions;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -26,13 +25,6 @@ public class Test
 		RunsOnMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 		RunsOnWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 		IsNetFramework = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
-	}
-
-	public static void SkipBrittleTestsOnRealFileSystem(
-		IFileSystem fileSystem, bool condition = true)
-	{
-		Skip.If(fileSystem is RealFileSystem && condition,
-			"Brittle tests are skipped on the real file system.");
 	}
 
 	public static void SkipBrittleTestsOnRealTimeSystem(

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/Test.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/Test.cs
@@ -1,5 +1,4 @@
 using System.Runtime.InteropServices;
-using Xunit;
 
 namespace Testably.Abstractions.TestHelpers;
 
@@ -25,12 +24,5 @@ public class Test
 		RunsOnMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 		RunsOnWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 		IsNetFramework = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
-	}
-
-	public static void SkipBrittleTestsOnRealTimeSystem(
-		ITimeSystem timeSystem, bool condition = true)
-	{
-		Skip.If(timeSystem is RealTimeSystem && condition,
-			"Brittle tests are skipped on the real time system.");
 	}
 }

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/TimeSystemTestBase.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/TimeSystemTestBase.cs
@@ -28,4 +28,13 @@ public abstract class TimeSystemTestBase<TTimeSystem>
 		throw new NotSupportedException(
 			"The SourceGenerator didn't create the corresponding files!");
 	}
+
+	/// <summary>
+	///     Specifies, if brittle tests should be skipped on the real time system.
+	/// </summary>
+	/// <param name="condition">
+	///     (optional) A condition that must be <see langword="true" /> for the test to be skipped on the
+	///     real time system.
+	/// </param>
+	public abstract void SkipIfBrittleTestsShouldBeSkipped(bool condition = true);
 }

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
@@ -80,9 +80,9 @@ namespace {@class.Namespace}.{@class.Name}
 		public override string BasePath => _directoryCleaner.BasePath;
 
 		private readonly IDirectoryCleaner _directoryCleaner;
-		private readonly RealFileSystemFixture _fixture;
+		private readonly TestSettingsFixture _fixture;
 
-		public RealFileSystemTests(ITestOutputHelper testOutputHelper, RealFileSystemFixture fixture)
+		public RealFileSystemTests(ITestOutputHelper testOutputHelper, TestSettingsFixture fixture)
 			: base(new Test(), new RealFileSystem(), new RealTimeSystem())
 		{{
 #if DEBUG

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
@@ -56,6 +56,12 @@ namespace {@class.Namespace}.{@class.Name}
 		public void Dispose()
 			=> _directoryCleaner.Dispose();
 
+		/// <inheritdoc cref=""{@class.Name}{{TFileSystem}}.SkipIfBrittleTestsShouldBeSkipped(bool)"" />
+		public override void SkipIfBrittleTestsShouldBeSkipped(bool condition = true)
+		{{
+			// Brittle tests are never skipped against the mock file system!
+		}}
+
 		/// <inheritdoc cref=""{@class.Name}{{TFileSystem}}.LongRunningTestsShouldBeSkipped()"" />
 		public override void SkipIfLongRunningTestsShouldBeSkipped()
 		{{
@@ -82,12 +88,12 @@ namespace {@class.Namespace}.{@class.Name}
 #if DEBUG
 			if (fixture.RealFileSystemTests != TestSettingStatus.AlwaysEnabled)
 			{{
-				throw new SkipException($""RealFileSystemTests are {{fixture.RealFileSystemTests}}. You can enable them by executing the corresponding tests in Testably.Abstractions.TestSettings.RealFileSystemTests."");
+				throw new SkipException($""Tests against the real file system are {{fixture.RealFileSystemTests}}. You can enable them by executing the corresponding tests in Testably.Abstractions.TestSettings.RealFileSystemTests."");
 			}}
 #else
 			if (fixture.RealFileSystemTests == TestSettingStatus.AlwaysDisabled)
 			{{
-				throw new SkipException($""RealFileSystemTests are {{fixture.RealFileSystemTests}}. You can enable them by executing the corresponding tests in Testably.Abstractions.TestSettings.RealFileSystemTests."");
+				throw new SkipException($""Tests against the real file system are {{fixture.RealFileSystemTests}}. You can enable them by executing the corresponding tests in Testably.Abstractions.TestSettings.RealFileSystemTests."");
 			}}
 #endif
 			_fixture = fixture;
@@ -100,15 +106,27 @@ namespace {@class.Namespace}.{@class.Name}
 			=> _directoryCleaner.Dispose();
 
 #if DEBUG
+		/// <inheritdoc cref=""{@class.Name}{{TFileSystem}}.SkipIfBrittleTestsShouldBeSkipped(bool)"" />
+		public override void SkipIfBrittleTestsShouldBeSkipped(bool condition = true)
+			=> Skip.If(condition && _fixture.BrittleTests != TestSettingStatus.AlwaysEnabled,
+				$""Brittle tests are {{_fixture.BrittleTests}}. You can enable them by executing the corresponding tests in Testably.Abstractions.TestSettings.BrittleTests."");
+#else
+		/// <inheritdoc cref=""{@class.Name}{{TFileSystem}}.SkipIfBrittleTestsShouldBeSkipped(bool)"" />
+		public override void SkipIfBrittleTestsShouldBeSkipped(bool condition = true)
+			=> Skip.If(condition && _fixture.BrittleTests == TestSettingStatus.AlwaysDisabled,
+				$""Brittle tests are {{_fixture.BrittleTests}}. You can enable them by executing the corresponding tests in Testably.Abstractions.TestSettings.BrittleTests."");
+#endif
+
+#if DEBUG
 		/// <inheritdoc cref=""{@class.Name}{{TFileSystem}}.LongRunningTestsShouldBeSkipped()"" />
 		public override void SkipIfLongRunningTestsShouldBeSkipped()
 			=> Skip.If(_fixture.LongRunningTests != TestSettingStatus.AlwaysEnabled,
-				$""LongRunningTests are {{_fixture.LongRunningTests}}. You can enable them by executing the corresponding tests in Testably.Abstractions.TestSettings.LongRunningTests."");
+				$""Long-running tests are {{_fixture.LongRunningTests}}. You can enable them by executing the corresponding tests in Testably.Abstractions.TestSettings.LongRunningTests."");
 #else
 		/// <inheritdoc cref=""{@class.Name}{{TFileSystem}}.LongRunningTestsShouldBeSkipped()"" />
 		public override void SkipIfLongRunningTestsShouldBeSkipped()
 			=> Skip.If(_fixture.LongRunningTests == TestSettingStatus.AlwaysDisabled,
-				$""LongRunningTests are {{_fixture.LongRunningTests}}. You can enable them by executing the corresponding tests in Testably.Abstractions.TestSettings.LongRunningTests."");
+				$""Long-running tests are {{_fixture.LongRunningTests}}. You can enable them by executing the corresponding tests in Testably.Abstractions.TestSettings.LongRunningTests."");
 #endif
 	}}
 }}");

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/GlobalGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/GlobalGenerator.cs
@@ -10,7 +10,7 @@ public class GlobalGenerator
 	{
 		StringBuilder sourceBuilder = GetSourceBuilder();
 		GenerateSource(sourceBuilder);
-		string fileName = "DatabaseCollection.cs";
+		string fileName = "XunitCollectionFixtures.cs";
 		context.AddSource(fileName,
 			SourceText.From(sourceBuilder.ToString(), Encoding.UTF8));
 	}
@@ -22,7 +22,15 @@ using Xunit;
 namespace Testably.Abstractions.TestHelpers.Settings;
 
 [CollectionDefinition(""RealFileSystemTests"")]
-public class DatabaseCollection : ICollectionFixture<RealFileSystemFixture>
+public class FileSystemTestSettingsFixture : ICollectionFixture<TestSettingsFixture>
+{
+	// This class has no code, and is never created. Its purpose is simply
+	// to be the place to apply [CollectionDefinition] and all the
+	// ICollectionFixture<> interfaces.
+}
+
+[CollectionDefinition(""RealTimeSystemTests"")]
+public class TimeSystemTestSettingsFixture : ICollectionFixture<TestSettingsFixture>
 {
 	// This class has no code, and is never created. Its purpose is simply
 	// to be the place to apply [CollectionDefinition] and all the

--- a/Tests/Settings/Testably.Abstractions.TestSettings/BrittleTests.cs
+++ b/Tests/Settings/Testably.Abstractions.TestSettings/BrittleTests.cs
@@ -3,10 +3,10 @@ using Testably.Abstractions.TestHelpers.Settings;
 
 namespace Testably.Abstractions.TestSettings;
 
-public sealed class LongRunningTests
+public sealed class BrittleTests
 {
 	/// <summary>
-	///     Some tests take a long time to run against the real file system (e.g. timeout).
+	///     Some tests are brittle on the real file system.
 	///     <para />
 	///     Always disable these tests!
 	/// </summary>
@@ -15,13 +15,13 @@ public sealed class LongRunningTests
 	public void DisableAlways()
 	{
 		_ = Helper.ChangeTestSettings(s =>
-			s.LongRunningTests = TestSettingStatus.AlwaysDisabled);
+			s.BrittleTests = TestSettingStatus.AlwaysDisabled);
 
-		Assert.Pass("Long-running tests are always disabled.");
+		Assert.Pass("Brittle tests are always disabled.");
 	}
 
 	/// <summary>
-	///     Some tests take a long time to run against the real file system (e.g. timeout).
+	///     Some tests are brittle on the real file system.
 	///     <para />
 	///     Disable these tests in DEBUG mode!
 	/// </summary>
@@ -30,23 +30,23 @@ public sealed class LongRunningTests
 	public void DisableInDebugMode()
 	{
 		TestEnvironment result = Helper.ChangeTestSettings(s =>
-			s.LongRunningTests = TestSettingStatus.DisabledInDebugMode);
+			s.BrittleTests = TestSettingStatus.DisabledInDebugMode);
 
 		if (result.RealFileSystemTests == TestSettingStatus.AlwaysDisabled)
 		{
 			Assert.Warn("""
-			            Long-running tests are disabled in DEBUG mode.
+			            Brittle tests are disabled in DEBUG mode.
 			            But the tests against the real file system are always disabled.
 			            """);
 		}
 		else
 		{
-			Assert.Pass("Long-running tests are disabled in DEBUG mode.");
+			Assert.Pass("Brittle tests are disabled in DEBUG mode.");
 		}
 	}
 
 	/// <summary>
-	///     Some tests take a long time to run against the real file system (e.g. timeout).
+	///     Some tests are brittle on the real file system.
 	///     <para />
 	///     Always enable these tests!
 	/// </summary>
@@ -55,18 +55,18 @@ public sealed class LongRunningTests
 	public void EnableAlways()
 	{
 		TestEnvironment result = Helper.ChangeTestSettings(s =>
-			s.LongRunningTests = TestSettingStatus.AlwaysEnabled);
+			s.BrittleTests = TestSettingStatus.AlwaysEnabled);
 
 		if (result.RealFileSystemTests != TestSettingStatus.AlwaysEnabled)
 		{
 			Assert.Warn("""
-			            Long-running tests are always enabled.
+			            Brittle tests are always enabled.
 			            But the tests against the real file system are not always enabled.
 			            """);
 		}
 		else
 		{
-			Assert.Pass("Long-running tests are always enabled.");
+			Assert.Pass("Brittle tests are always enabled.");
 		}
 	}
 

--- a/Tests/Settings/Testably.Abstractions.TestSettings/Helper.cs
+++ b/Tests/Settings/Testably.Abstractions.TestSettings/Helper.cs
@@ -26,7 +26,9 @@ internal static class Helper
 		{
 			string path = GetTestSettingsPath();
 			string content = File.ReadAllText(path);
-			return JsonSerializer.Deserialize<TestEnvironment>(content)
+			JsonSerializerOptions options = new JsonSerializerOptions();
+			options.Converters.Add(new JsonStringEnumConverter());
+			return JsonSerializer.Deserialize<TestEnvironment>(content, options)
 			       ?? throw new NotSupportedException("The file has an invalid syntax!");
 		}
 		catch (Exception)

--- a/Tests/Settings/Testably.Abstractions.TestSettings/RealFileSystemTests.cs
+++ b/Tests/Settings/Testably.Abstractions.TestSettings/RealFileSystemTests.cs
@@ -17,7 +17,7 @@ public sealed class RealFileSystemTests
 		_ = Helper.ChangeTestSettings(s =>
 			s.RealFileSystemTests = TestSettingStatus.AlwaysDisabled);
 
-		Assert.Pass("Tests against the real file system are enabled in DEBUG mode.");
+		Assert.Pass("Tests against the real file system are always disabled.");
 	}
 
 	/// <summary>
@@ -47,7 +47,7 @@ public sealed class RealFileSystemTests
 		_ = Helper.ChangeTestSettings(s =>
 			s.RealFileSystemTests = TestSettingStatus.AlwaysEnabled);
 
-		Assert.Pass("Tests against the real file system are enabled in DEBUG mode.");
+		Assert.Pass("Tests against the real file system are always enabled.");
 	}
 
 	[TestCase]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/DisposeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/DisposeTests.cs
@@ -15,7 +15,7 @@ public abstract partial class DisposeTests<TFileSystem>
 	public void Dispose_CalledTwiceShouldDoNothing(
 		string path, byte[] bytes)
 	{
-		Test.SkipBrittleTestsOnRealFileSystem(FileSystem);
+		SkipIfBrittleTestsShouldBeSkipped();
 
 		FileSystem.File.WriteAllBytes(path, bytes);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -72,7 +72,7 @@ public abstract partial class ReadTests<TFileSystem>
 	[AutoData]
 	public void EndRead_ShouldNotAdjustTimes(string path, byte[] bytes)
 	{
-		Test.SkipBrittleTestsOnRealFileSystem(FileSystem);
+		SkipIfBrittleTestsShouldBeSkipped();
 
 		ManualResetEventSlim ms = new();
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/Tests.cs
@@ -169,7 +169,7 @@ public abstract partial class Tests<TFileSystem>
 	public void Flush_ShouldNotUpdateFileContentWhenAlreadyFlushed(
 		string path, byte[] bytes1, byte[] bytes2)
 	{
-		Test.SkipBrittleTestsOnRealFileSystem(FileSystem);
+		SkipIfBrittleTestsShouldBeSkipped();
 
 		using (FileSystemStream stream1 = FileSystem.File.Open(
 			path,

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
@@ -74,7 +74,7 @@ public abstract partial class WriteTests<TFileSystem>
 	[AutoData]
 	public void EndWrite_ShouldAdjustTimes(string path, byte[] bytes)
 	{
-		Test.SkipBrittleTestsOnRealFileSystem(FileSystem);
+		SkipIfBrittleTestsShouldBeSkipped();
 
 		ManualResetEventSlim ms = new();
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/IncludeSubdirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/IncludeSubdirectoriesTests.cs
@@ -65,7 +65,7 @@ public abstract partial class IncludeSubdirectoriesTests<TFileSystem>
 	public void IncludeSubdirectories_SetToTrue_ShouldTriggerNotificationOnSubdirectories(
 		string baseDirectory, string subdirectoryName)
 	{
-		Test.SkipBrittleTestsOnRealFileSystem(FileSystem, !Test.RunsOnWindows);
+		SkipIfBrittleTestsShouldBeSkipped(!Test.RunsOnWindows);
 
 		FileSystem.Initialize()
 			.WithSubdirectory(baseDirectory).Initialized(s => s

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
@@ -14,7 +14,7 @@ public abstract partial class Tests<TFileSystem>
 	[AutoData]
 	public void BeginInit_ShouldStopListening(string path)
 	{
-		Test.SkipBrittleTestsOnRealFileSystem(FileSystem);
+		SkipIfBrittleTestsShouldBeSkipped();
 
 		FileSystem.Initialize();
 		ManualResetEventSlim ms = new();
@@ -67,7 +67,7 @@ public abstract partial class Tests<TFileSystem>
 	[AutoData]
 	public void EndInit_ShouldRestartListening(string path)
 	{
-		Test.SkipBrittleTestsOnRealFileSystem(FileSystem);
+		SkipIfBrittleTestsShouldBeSkipped();
 
 		FileSystem.Initialize();
 		ManualResetEventSlim ms = new();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
@@ -13,7 +13,7 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 	[AutoData]
 	public void WaitForChanged_ShouldBlockUntilEventHappens(string path)
 	{
-		Test.SkipBrittleTestsOnRealFileSystem(FileSystem);
+		SkipIfBrittleTestsShouldBeSkipped();
 
 		FileSystem.Initialize();
 		ManualResetEventSlim ms = new();
@@ -54,7 +54,7 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 	public void WaitForChanged_Timeout_ShouldReturnTimedOut(string path,
 		Func<IFileSystemWatcher, IWaitForChangedResult> callback)
 	{
-		Test.SkipBrittleTestsOnRealFileSystem(FileSystem);
+		SkipIfBrittleTestsShouldBeSkipped();
 
 		FileSystem.Initialize();
 		ManualResetEventSlim ms = new();

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -147,7 +147,7 @@ public abstract partial class TimerTests<TTimeSystem>
 	[SkippableFact]
 	public void Change_WithInt_ShouldResetTimer()
 	{
-		Test.SkipBrittleTestsOnRealTimeSystem(TimeSystem);
+		SkipIfBrittleTestsShouldBeSkipped();
 
 		List<int> triggerTimes = new();
 		DateTime previousTime = TimeSystem.DateTime.Now;
@@ -202,7 +202,7 @@ public abstract partial class TimerTests<TTimeSystem>
 	[SkippableFact]
 	public void Change_WithLong_ShouldResetTimer()
 	{
-		Test.SkipBrittleTestsOnRealTimeSystem(TimeSystem);
+		SkipIfBrittleTestsShouldBeSkipped();
 
 		List<int> triggerTimes = new();
 		DateTime previousTime = TimeSystem.DateTime.Now;
@@ -257,7 +257,7 @@ public abstract partial class TimerTests<TTimeSystem>
 	[SkippableFact]
 	public void Change_WithTimeSpan_ShouldResetTimer()
 	{
-		Test.SkipBrittleTestsOnRealTimeSystem(TimeSystem);
+		SkipIfBrittleTestsShouldBeSkipped();
 
 		List<int> triggerTimes = new();
 		DateTime previousTime = TimeSystem.DateTime.Now;


### PR DESCRIPTION
Some tests are marked as brittle. These should be skippable via test settings.