### PR TITLE
fix: disable build warning CS0436 in `Testably.Abstractions.Testing.Tests`

### DIFF
--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/StatisticsTests.Helpers.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/StatisticsTests.Helpers.cs
@@ -324,6 +324,7 @@ public sealed partial class StatisticsTests
 			return type.Name;
 		}
 
+		#pragma warning disable CS0436 // Nullable is also declared in Testable.Abstractions.Testing which internals are visible to this project
 		private static bool HasSpecialNameInLowerCase(Type type,
 			[NotNullWhen(true)] out string? name)
 		{
@@ -385,5 +386,6 @@ public sealed partial class StatisticsTests
 			name = null;
 			return false;
 		}
+		#pragma warning restore CS0436
 	}
 }


### PR DESCRIPTION
`Nullable` is declared both in Testable.Abstractions.Testing and Testable.Abstractions.Testing.Tests. As internals are visible to the test project, this project has conflicting declarations of the `NotNullWhenAttribute` resulting in the following build warning `warning CS0436: The type 'NotNullWhenAttribute' in '...\net40\Nullable\NotNullWhenAttribute.cs' conflicts with the imported type 'NotNullWhenAttribute' in 'Testably.Abstractions.Testing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in '...\net40\Nullable\NotNullWhenAttribute.cs'.`

Disable this build warning, as the Nullable package is identical in both projects.