### PR TITLE
feat: add retry also to .NET Framework tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,10 @@ jobs:
       - name: Build solution
         run: msbuild.exe Testably.Abstractions.sln /p:NetFrameworkOnly=True /p:platform="Any CPU" /p:configuration="Release" -t:restore,build -p:RestorePackagesConfig=true
       - name: Run tests
-        run: vstest.console.exe .\Build\Tests\Testably.Abstractions.Tests\net48\Testably.Abstractions.Tests.dll .\Build\Tests\Testably.Abstractions.Parity.Tests\net48\Testably.Abstractions.Parity.Tests.dll .\Build\Tests\Testably.Abstractions.Testing.Tests\net48\Testably.Abstractions.Testing.Tests.dll /Logger:trx /ResultsDirectory:TestResults
+        uses: Wandalen/wretry.action@v1.4.10
+        with:
+          command: vstest.console.exe .\Build\Tests\Testably.Abstractions.Tests\net48\Testably.Abstractions.Tests.dll .\Build\Tests\Testably.Abstractions.Parity.Tests\net48\Testably.Abstractions.Parity.Tests.dll .\Build\Tests\Testably.Abstractions.Testing.Tests\net48\Testably.Abstractions.Testing.Tests.dll /Logger:trx /ResultsDirectory:TestResults
+          attempt_limit: 2
       - name: Upload test results (.NET Framework)
         if: ${{ always() }}
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Currently the .NET Framework tests don't implement the retry-policy which results in sometimes failing tests (e.g. https://github.com/Testably/Testably.Abstractions/actions/runs/8352478169/job/22862628346?pr=516)