### PR TITLE
refactor: remove `.ConfigureAwait` in tests

### DIFF
--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -15,7 +15,7 @@
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<NoWarn>701;1702;CA1845</NoWarn>
+		<NoWarn>701;1702;CA1845;MA0004</NoWarn>
 		<OutputPath>..\..\Build\Tests\$(MSBuildProjectName)</OutputPath>
 	</PropertyGroup>
 

--- a/Tests/Testably.Abstractions.Testing.Tests/NotificationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/NotificationTests.cs
@@ -21,11 +21,11 @@ public class NotificationTests
 
 		_ = Task.Run(async () =>
 		{
-			await Task.Delay(10).ConfigureAwait(false);
+			await Task.Delay(10);
 			for (int i = 1; i <= 10; i++)
 			{
 				timeSystem.Thread.Sleep(i);
-				await Task.Delay(1).ConfigureAwait(false);
+				await Task.Delay(1);
 			}
 		});
 
@@ -84,11 +84,11 @@ public class NotificationTests
 
 		_ = Task.Run(async () =>
 		{
-			await Task.Delay(10).ConfigureAwait(false);
+			await Task.Delay(10);
 			for (int i = 1; i <= 10; i++)
 			{
 				timeSystem.Thread.Sleep(i);
-				await Task.Delay(1).ConfigureAwait(false);
+				await Task.Delay(1);
 			}
 		});
 
@@ -109,11 +109,11 @@ public class NotificationTests
 
 		_ = Task.Run(async () =>
 		{
-			await Task.Delay(10).ConfigureAwait(false);
+			await Task.Delay(10);
 			for (int i = 1; i <= 10; i++)
 			{
 				timeSystem.Thread.Sleep(i);
-				await Task.Delay(1).ConfigureAwait(false);
+				await Task.Delay(1);
 			}
 
 			ms.Set();
@@ -142,7 +142,7 @@ public class NotificationTests
 				while (!ms.IsSet)
 				{
 					timeSystem.Thread.Sleep(1);
-					await Task.Delay(1).ConfigureAwait(false);
+					await Task.Delay(1);
 				}
 			});
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
@@ -50,7 +50,7 @@ public class FileSystemWatcherStatisticsTests
 		{
 			while (!token.IsCancellationRequested)
 			{
-				await Task.Delay(10, token).ConfigureAwait(false);
+				await Task.Delay(10, token);
 				sut.Directory.CreateDirectory(sut.Path.Combine("foo", "some-directory"));
 				sut.Directory.Delete(sut.Path.Combine("foo", "some-directory"));
 			}
@@ -79,7 +79,7 @@ public class FileSystemWatcherStatisticsTests
 		{
 			while (!token.IsCancellationRequested)
 			{
-				await Task.Delay(10, token).ConfigureAwait(false);
+				await Task.Delay(10, token);
 				sut.Directory.CreateDirectory(sut.Path.Combine("foo", "some-directory"));
 				sut.Directory.Delete(sut.Path.Combine("foo", "some-directory"));
 			}
@@ -107,7 +107,7 @@ public class FileSystemWatcherStatisticsTests
 		{
 			while (!token.IsCancellationRequested)
 			{
-				await Task.Delay(10, token).ConfigureAwait(false);
+				await Task.Delay(10, token);
 				sut.Directory.CreateDirectory(sut.Path.Combine("foo", "some-directory"));
 				sut.Directory.Delete(sut.Path.Combine("foo", "some-directory"));
 			}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
@@ -68,7 +68,7 @@ public abstract partial class AppendAllLinesAsyncTests<TFileSystem>
 		string filePath = FileSystem.Path.Combine(missingPath, fileName);
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await FileSystem.File.AppendAllLinesAsync(filePath, contents).ConfigureAwait(false);
+			await FileSystem.File.AppendAllLinesAsync(filePath, contents);
 		});
 
 		exception.Should().BeException<DirectoryNotFoundException>(hResult: -2147024893);
@@ -95,7 +95,7 @@ public abstract partial class AppendAllLinesAsyncTests<TFileSystem>
 	{
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await FileSystem.File.AppendAllLinesAsync(path, null!).ConfigureAwait(false);
+			await FileSystem.File.AppendAllLinesAsync(path, null!);
 		});
 
 		exception.Should().BeException<ArgumentNullException>(
@@ -110,7 +110,7 @@ public abstract partial class AppendAllLinesAsyncTests<TFileSystem>
 	{
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await FileSystem.File.AppendAllLinesAsync(path, new List<string>(), null!).ConfigureAwait(false);
+			await FileSystem.File.AppendAllLinesAsync(path, new List<string>(), null!);
 		});
 
 		exception.Should().BeException<ArgumentNullException>(
@@ -144,7 +144,7 @@ public abstract partial class AppendAllLinesAsyncTests<TFileSystem>
 
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await FileSystem.File.AppendAllLinesAsync(path, contents).ConfigureAwait(false);
+			await FileSystem.File.AppendAllLinesAsync(path, contents);
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
@@ -63,7 +63,7 @@ public abstract partial class AppendAllTextAsyncTests<TFileSystem>
 		string filePath = FileSystem.Path.Combine(missingPath, fileName);
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await FileSystem.File.AppendAllTextAsync(filePath, contents).ConfigureAwait(false);
+			await FileSystem.File.AppendAllTextAsync(filePath, contents);
 		});
 
 		exception.Should().BeException<DirectoryNotFoundException>(hResult: -2147024893);
@@ -102,7 +102,7 @@ public abstract partial class AppendAllTextAsyncTests<TFileSystem>
 
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await FileSystem.File.AppendAllTextAsync(path, contents).ConfigureAwait(false);
+			await FileSystem.File.AppendAllTextAsync(path, contents);
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenReadTests.cs
@@ -82,7 +82,7 @@ public abstract partial class OpenReadTests<TFileSystem>
 			// ReSharper disable once UseAwaitUsing
 			using FileSystemStream stream = FileSystem.File.OpenRead(path);
 			#pragma warning disable CA1835
-			await stream.WriteAsync(bytes, 0, bytes.Length).ConfigureAwait(false);
+			await stream.WriteAsync(bytes, 0, bytes.Length);
 			#pragma warning restore CA1835
 		});
 
@@ -100,7 +100,7 @@ public abstract partial class OpenReadTests<TFileSystem>
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
 			using FileSystemStream stream = FileSystem.File.OpenRead(path);
-			await stream.WriteAsync(bytes.AsMemory()).ConfigureAwait(false);
+			await stream.WriteAsync(bytes.AsMemory());
 		});
 
 		exception.Should().BeException<NotSupportedException>(hResult: -2146233067);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadLinesAsyncTests.cs
@@ -24,7 +24,7 @@ public abstract partial class ReadLinesAsyncTests<TFileSystem>
 
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await foreach (string _ in FileSystem.File.ReadLinesAsync(path, cts.Token).ConfigureAwait(false))
+			await foreach (string _ in FileSystem.File.ReadLinesAsync(path, cts.Token))
 			{
 				// do nothing
 			}
@@ -46,7 +46,7 @@ public abstract partial class ReadLinesAsyncTests<TFileSystem>
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
 			await foreach (string _ in FileSystem.File.ReadLinesAsync(path, Encoding.UTF8,
-				cts.Token).ConfigureAwait(false))
+				cts.Token))
 			{
 				// do nothing
 			}
@@ -62,7 +62,7 @@ public abstract partial class ReadLinesAsyncTests<TFileSystem>
 	{
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await foreach (string _ in FileSystem.File.ReadLinesAsync(path).ConfigureAwait(false))
+			await foreach (string _ in FileSystem.File.ReadLinesAsync(path))
 			{
 				// do nothing
 			}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesAsyncTests.cs
@@ -57,7 +57,7 @@ public abstract partial class WriteAllBytesAsyncTests<TFileSystem>
 	{
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await FileSystem.File.WriteAllBytesAsync(path, null!).ConfigureAwait(false);
+			await FileSystem.File.WriteAllBytesAsync(path, null!);
 		});
 
 		exception.Should().BeException<ArgumentNullException>(paramName: "bytes");
@@ -73,7 +73,7 @@ public abstract partial class WriteAllBytesAsyncTests<TFileSystem>
 
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await FileSystem.File.WriteAllBytesAsync(path, bytes).ConfigureAwait(false);
+			await FileSystem.File.WriteAllBytesAsync(path, bytes);
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(
@@ -95,7 +95,7 @@ public abstract partial class WriteAllBytesAsyncTests<TFileSystem>
 
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await FileSystem.File.WriteAllBytesAsync(path, bytes).ConfigureAwait(false);
+			await FileSystem.File.WriteAllBytesAsync(path, bytes);
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(hResult: -2147024891);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesAsyncTests.cs
@@ -131,7 +131,7 @@ public abstract partial class WriteAllLinesAsyncTests<TFileSystem>
 
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await FileSystem.File.WriteAllLinesAsync(path, contents).ConfigureAwait(false);
+			await FileSystem.File.WriteAllLinesAsync(path, contents);
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(
@@ -153,7 +153,7 @@ public abstract partial class WriteAllLinesAsyncTests<TFileSystem>
 
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await FileSystem.File.WriteAllLinesAsync(path, contents).ConfigureAwait(false);
+			await FileSystem.File.WriteAllLinesAsync(path, contents);
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(hResult: -2147024891);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextAsyncTests.cs
@@ -98,7 +98,7 @@ public abstract partial class WriteAllTextAsyncTests<TFileSystem>
 	{
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await FileSystem.File.WriteAllTextAsync(path, null).ConfigureAwait(false);
+			await FileSystem.File.WriteAllTextAsync(path, null);
 		});
 
 		exception.Should().BeNull();
@@ -114,7 +114,7 @@ public abstract partial class WriteAllTextAsyncTests<TFileSystem>
 
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await FileSystem.File.WriteAllTextAsync(path, contents).ConfigureAwait(false);
+			await FileSystem.File.WriteAllTextAsync(path, contents);
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(
@@ -136,7 +136,7 @@ public abstract partial class WriteAllTextAsyncTests<TFileSystem>
 
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await FileSystem.File.WriteAllTextAsync(path, contents).ConfigureAwait(false);
+			await FileSystem.File.WriteAllTextAsync(path, contents);
 		});
 
 		exception.Should().BeException<UnauthorizedAccessException>(hResult: -2147024891);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -195,7 +195,7 @@ public abstract partial class ReadTests<TFileSystem>
 		{
 			// ReSharper disable once AccessToDisposedClosure
 			#pragma warning disable CA1835
-			_ = await stream.ReadAsync(buffer, 0, bytes.Length, cts.Token).ConfigureAwait(false);
+			_ = await stream.ReadAsync(buffer, 0, bytes.Length, cts.Token);
 			#pragma warning restore CA1835
 		});
 
@@ -220,7 +220,7 @@ public abstract partial class ReadTests<TFileSystem>
 		{
 			// ReSharper disable once AccessToDisposedClosure
 			#pragma warning disable CA1835
-			_ = await stream.ReadAsync(buffer.AsMemory(), cts.Token).ConfigureAwait(false);
+			_ = await stream.ReadAsync(buffer.AsMemory(), cts.Token);
 			#pragma warning restore CA1835
 		});
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/Tests.cs
@@ -100,7 +100,7 @@ public abstract partial class Tests<TFileSystem>
 		{
 			using FileSystemStream stream = FileSystem.File.OpenRead(path);
 			using MemoryStream destination = new(buffer);
-			await stream.CopyToAsync(destination, 0).ConfigureAwait(false);
+			await stream.CopyToAsync(destination, 0);
 		});
 
 		exception.Should().BeException<ArgumentOutOfRangeException>(
@@ -222,7 +222,7 @@ public abstract partial class Tests<TFileSystem>
 		{
 			// ReSharper disable once UseAwaitUsing
 			using FileSystemStream stream = FileSystem.File.Create(path);
-			await stream.FlushAsync(cts.Token).ConfigureAwait(false);
+			await stream.FlushAsync(cts.Token);
 		});
 
 		exception.Should().BeException<TaskCanceledException>(hResult: -2146233029);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
@@ -208,7 +208,7 @@ public abstract partial class WriteTests<TFileSystem>
 			{
 				// ReSharper disable once AccessToDisposedClosure
 				#pragma warning disable CA1835
-				await stream.WriteAsync(buffer, 0, bytes.Length, cts.Token).ConfigureAwait(false);
+				await stream.WriteAsync(buffer, 0, bytes.Length, cts.Token);
 				#pragma warning restore CA1835
 			});
 		}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
@@ -34,7 +34,7 @@ public abstract partial class EventTests<TFileSystem>
 				int i = 0;
 				while (!ms.IsSet)
 				{
-					await Task.Delay(10).ConfigureAwait(false);
+					await Task.Delay(10);
 					FileSystem.File.WriteAllText(path, i++.ToString(CultureInfo.InvariantCulture));
 				}
 			});
@@ -78,7 +78,7 @@ public abstract partial class EventTests<TFileSystem>
 			{
 				while (!ms.IsSet)
 				{
-					await Task.Delay(10).ConfigureAwait(false);
+					await Task.Delay(10);
 					FileSystem.Directory.CreateDirectory(path);
 					FileSystem.Directory.Delete(path);
 				}
@@ -124,7 +124,7 @@ public abstract partial class EventTests<TFileSystem>
 			{
 				while (!ms.IsSet)
 				{
-					await Task.Delay(10).ConfigureAwait(false);
+					await Task.Delay(10);
 					FileSystem.Directory.CreateDirectory(path);
 					FileSystem.Directory.Delete(path);
 				}
@@ -173,7 +173,7 @@ public abstract partial class EventTests<TFileSystem>
 				FileSystem.File.WriteAllText($"path-{i}", "");
 				while (!ms.IsSet)
 				{
-					await Task.Delay(10).ConfigureAwait(false);
+					await Task.Delay(10);
 					FileSystem.File.Move($"path-{i}", $"path-{++i}");
 				}
 			});

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
@@ -33,7 +33,7 @@ public abstract partial class Tests<TFileSystem>
 			{
 				while (!ms.IsSet)
 				{
-					await Task.Delay(10).ConfigureAwait(false);
+					await Task.Delay(10);
 					FileSystem.Directory.CreateDirectory(path);
 					FileSystem.Directory.Delete(path);
 				}
@@ -85,7 +85,7 @@ public abstract partial class Tests<TFileSystem>
 			{
 				while (!ms.IsSet)
 				{
-					await Task.Delay(10).ConfigureAwait(false);
+					await Task.Delay(10);
 					FileSystem.Directory.CreateDirectory(path);
 					FileSystem.Directory.Delete(path);
 				}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
@@ -25,7 +25,7 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 			{
 				while (!ms.IsSet)
 				{
-					await Task.Delay(10).ConfigureAwait(false);
+					await Task.Delay(10);
 					FileSystem.Directory.CreateDirectory(path);
 					FileSystem.Directory.Delete(path);
 				}
@@ -67,7 +67,7 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 			{
 				while (!ms.IsSet)
 				{
-					await Task.Delay(10).ConfigureAwait(false);
+					await Task.Delay(10);
 					FileSystem.Directory.CreateDirectory(path);
 					FileSystem.Directory.Delete(path);
 				}

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TaskTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TaskTests.cs
@@ -19,8 +19,7 @@ public abstract partial class TaskTests<TTimeSystem>
 
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await TimeSystem.Task.Delay(millisecondsTimeout, cts.Token)
-				;
+			await TimeSystem.Task.Delay(millisecondsTimeout, cts.Token);
 		});
 
 		exception.Should().BeException<TaskCanceledException>(hResult: -2146233029);
@@ -62,8 +61,7 @@ public abstract partial class TaskTests<TTimeSystem>
 
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await TimeSystem.Task.Delay(timeout, cts.Token)
-				;
+			await TimeSystem.Task.Delay(timeout, cts.Token);
 		});
 
 		exception.Should().BeException<TaskCanceledException>(hResult: -2146233029);
@@ -76,8 +74,7 @@ public abstract partial class TaskTests<TTimeSystem>
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
 			await TimeSystem.Task
-				.Delay(TimeSpan.FromMilliseconds(-2))
-				;
+					.Delay(TimeSpan.FromMilliseconds(-2));
 		});
 
 		exception.Should().BeException<ArgumentOutOfRangeException>(hResult: -2146233086);

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TaskTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TaskTests.cs
@@ -20,7 +20,7 @@ public abstract partial class TaskTests<TTimeSystem>
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
 			await TimeSystem.Task.Delay(millisecondsTimeout, cts.Token)
-				.ConfigureAwait(false);
+				;
 		});
 
 		exception.Should().BeException<TaskCanceledException>(hResult: -2146233029);
@@ -32,8 +32,8 @@ public abstract partial class TaskTests<TTimeSystem>
 	{
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
-			await TimeSystem.Task.Delay(-2).ConfigureAwait(false);
-		}).ConfigureAwait(false);
+			await TimeSystem.Task.Delay(-2);
+		});
 
 		exception.Should().BeException<ArgumentOutOfRangeException>(hResult: -2146233086);
 	}
@@ -45,7 +45,7 @@ public abstract partial class TaskTests<TTimeSystem>
 		int millisecondsTimeout = 100;
 
 		DateTime before = TimeSystem.DateTime.UtcNow;
-		await TimeSystem.Task.Delay(millisecondsTimeout).ConfigureAwait(false);
+		await TimeSystem.Task.Delay(millisecondsTimeout);
 		DateTime after = TimeSystem.DateTime.UtcNow;
 
 		after.Should().BeOnOrAfter(before.AddMilliseconds(millisecondsTimeout)
@@ -63,7 +63,7 @@ public abstract partial class TaskTests<TTimeSystem>
 		Exception? exception = await Record.ExceptionAsync(async () =>
 		{
 			await TimeSystem.Task.Delay(timeout, cts.Token)
-				.ConfigureAwait(false);
+				;
 		});
 
 		exception.Should().BeException<TaskCanceledException>(hResult: -2146233029);
@@ -77,8 +77,8 @@ public abstract partial class TaskTests<TTimeSystem>
 		{
 			await TimeSystem.Task
 				.Delay(TimeSpan.FromMilliseconds(-2))
-				.ConfigureAwait(false);
-		}).ConfigureAwait(false);
+				;
+		});
 
 		exception.Should().BeException<ArgumentOutOfRangeException>(hResult: -2146233086);
 	}
@@ -90,7 +90,7 @@ public abstract partial class TaskTests<TTimeSystem>
 		TimeSpan timeout = TimeSpan.FromMilliseconds(100);
 
 		DateTime before = TimeSystem.DateTime.UtcNow;
-		await TimeSystem.Task.Delay(timeout).ConfigureAwait(false);
+		await TimeSystem.Task.Delay(timeout);
 		DateTime after = TimeSystem.DateTime.UtcNow;
 
 		after.Should().BeOnOrAfter(before.Add(timeout).ApplySystemClockTolerance());

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -169,7 +169,7 @@ public abstract partial class TimerTests<TTimeSystem>
 					ms3.Set();
 				}
 
-				await Task.Delay(10).ConfigureAwait(false);
+				await Task.Delay(10);
 			},
 			null, 0 * TimerMultiplier, 200 * TimerMultiplier);
 		ms.Wait(30000).Should().BeTrue();
@@ -224,7 +224,7 @@ public abstract partial class TimerTests<TTimeSystem>
 					ms3.Set();
 				}
 
-				await Task.Delay(10).ConfigureAwait(false);
+				await Task.Delay(10);
 			},
 			null, 0L * TimerMultiplier, 200L * TimerMultiplier);
 		ms.Wait(30000).Should().BeTrue();
@@ -279,7 +279,7 @@ public abstract partial class TimerTests<TTimeSystem>
 					ms3.Set();
 				}
 
-				await Task.Delay(10).ConfigureAwait(false);
+				await Task.Delay(10);
 			}, null, TimeSpan.FromMilliseconds(0 * TimerMultiplier),
 			TimeSpan.FromMilliseconds(200 * TimerMultiplier));
 		ms.Wait(30000).Should().BeTrue();


### PR DESCRIPTION
Avoid calls to `.ConfigureAwait(false)` as specified in [xUnit1030](https://xunit.net/xunit.analyzers/rules/xUnit1030)