### PR TITLE
fix: do not adjust LastAccessTime in `FileStream.EndRead`

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -329,10 +329,6 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 		using IDisposable registration = RegisterMethod(nameof(EndRead),
 			asyncResult);
 
-		_fileSystem.Execute.NotOnWindows(() =>
-		{
-			_container.AdjustTimes(TimeAdjustments.LastAccessTime);
-		});
 		return base.EndRead(asyncResult);
 	}
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -329,7 +329,6 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 		using IDisposable registration = RegisterMethod(nameof(EndRead),
 			asyncResult);
 
-		_container.AdjustTimes(TimeAdjustments.LastAccessTime);
 		return base.EndRead(asyncResult);
 	}
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -329,6 +329,10 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 		using IDisposable registration = RegisterMethod(nameof(EndRead),
 			asyncResult);
 
+		_fileSystem.Execute.NotOnWindows(() =>
+		{
+			_container.AdjustTimes(TimeAdjustments.LastAccessTime);
+		});
 		return base.EndRead(asyncResult);
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -121,16 +121,14 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
 				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		lastWriteTime.Should()
@@ -168,11 +166,9 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 				FileSystem.Directory.GetLastWriteTimeUtc(path);
 
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastWriteTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 	}
 
@@ -184,9 +180,9 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 
 		FileSystem.Directory.CreateDirectory(path);
 
+		DateTime end = TimeSystem.DateTime.Now;
 		DateTime result = FileSystem.Directory.GetCreationTime(path);
-		result.Should().BeOnOrAfter(start.ApplySystemClockTolerance());
-		result.Should().BeOnOrBefore(TimeSystem.DateTime.Now);
+		result.Should().BeBetween(start, end);
 		result.Kind.Should().Be(DateTimeKind.Local);
 	}
 
@@ -198,9 +194,9 @@ public abstract partial class CreateDirectoryTests<TFileSystem>
 
 		FileSystem.Directory.CreateDirectory(path);
 
+		DateTime end = TimeSystem.DateTime.UtcNow;
 		DateTime result = FileSystem.Directory.GetCreationTimeUtc(path);
-		result.Should().BeOnOrAfter(start.ApplySystemClockTolerance());
-		result.Should().BeOnOrBefore(TimeSystem.DateTime.UtcNow);
+		result.Should().BeBetween(start, end);
 		result.Kind.Should().Be(DateTimeKind.Utc);
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
@@ -193,16 +193,14 @@ public abstract partial class DeleteTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
 				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		lastWriteTime.Should()

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/MoveTests.cs
@@ -147,16 +147,13 @@ public abstract partial class MoveTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		lastAccessTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		lastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.AdjustTimes.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.AdjustTimes.cs
@@ -30,16 +30,14 @@ public abstract partial class Tests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			parentCreationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			parentLastAccessTime.Should()
 				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
 			parentLastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		parentLastWriteTime.Should()
@@ -50,14 +48,11 @@ public abstract partial class Tests<TFileSystem>
 		DateTime rootLastWriteTime = FileSystem.Directory.GetLastWriteTimeUtc(path1);
 
 		rootCreationTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		rootLastAccessTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		rootLastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 
 #if FEATURE_FILESYSTEM_LINK
@@ -90,16 +85,14 @@ public abstract partial class Tests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			parentCreationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			parentLastAccessTime.Should()
 				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
 			parentLastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		parentLastWriteTime.Should()
@@ -110,14 +103,11 @@ public abstract partial class Tests<TFileSystem>
 		DateTime rootLastWriteTime = FileSystem.Directory.GetLastWriteTimeUtc(path1);
 
 		rootCreationTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		rootLastAccessTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		rootLastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 #endif
 
@@ -149,16 +139,14 @@ public abstract partial class Tests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			parentCreationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			parentLastAccessTime.Should()
 				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
 			parentLastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		parentLastWriteTime.Should()
@@ -169,14 +157,11 @@ public abstract partial class Tests<TFileSystem>
 		DateTime rootLastWriteTime = FileSystem.Directory.GetLastWriteTimeUtc(path1);
 
 		rootCreationTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		rootLastAccessTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		rootLastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 
 	[SkippableTheory]
@@ -207,8 +192,7 @@ public abstract partial class Tests<TFileSystem>
 			FileSystem.Directory.GetLastWriteTimeUtc(subdirectoryPath);
 
 		parentCreationTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		if (Test.RunsOnWindows)
 		{
 			parentLastAccessTime.Should()
@@ -217,12 +201,10 @@ public abstract partial class Tests<TFileSystem>
 		else
 		{
 			parentLastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		parentLastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.Times.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/Tests.Times.cs
@@ -88,17 +88,16 @@ public abstract partial class Tests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			result.LastAccessTime.Should()
-				.BeOnOrAfter(sleepTime.ApplySystemClockTolerance());
-			result.LastAccessTime.Should().BeOnOrBefore(TimeSystem.DateTime.Now);
+				.BeBetween(sleepTime, TimeSystem.DateTime.Now);
 		}
 		else
 		{
-			result.LastAccessTime.Should().BeOnOrAfter(start.ApplySystemClockTolerance());
-			result.LastAccessTime.Should().BeBefore(sleepTime);
+			result.LastAccessTime.Should()
+				.BeBetween(start, sleepTime);
 		}
 
-		result.LastWriteTime.Should().BeOnOrAfter(sleepTime.ApplySystemClockTolerance());
-		result.LastWriteTime.Should().BeOnOrBefore(TimeSystem.DateTime.Now);
+		result.LastWriteTime.Should()
+			.BeBetween(sleepTime, TimeSystem.DateTime.Now);
 	}
 
 	[SkippableTheory]
@@ -110,8 +109,7 @@ public abstract partial class Tests<TFileSystem>
 		FileSystem.Directory.CreateDirectory(path);
 
 		DateTime result = FileSystem.Directory.GetLastAccessTime(path);
-		result.Should().BeOnOrAfter(start.ApplySystemClockTolerance());
-		result.Should().BeOnOrBefore(TimeSystem.DateTime.Now);
+		result.Should().BeBetween(start, TimeSystem.DateTime.Now);
 		result.Kind.Should().Be(DateTimeKind.Local);
 	}
 
@@ -124,8 +122,7 @@ public abstract partial class Tests<TFileSystem>
 		FileSystem.Directory.CreateDirectory(path);
 
 		DateTime result = FileSystem.Directory.GetLastAccessTimeUtc(path);
-		result.Should().BeOnOrAfter(start.ApplySystemClockTolerance());
-		result.Should().BeOnOrBefore(TimeSystem.DateTime.UtcNow);
+		result.Should().BeBetween(start, TimeSystem.DateTime.UtcNow);
 		result.Kind.Should().Be(DateTimeKind.Utc);
 	}
 
@@ -138,8 +135,7 @@ public abstract partial class Tests<TFileSystem>
 		FileSystem.Directory.CreateDirectory(path);
 
 		DateTime result = FileSystem.Directory.GetLastWriteTime(path);
-		result.Should().BeOnOrAfter(start.ApplySystemClockTolerance());
-		result.Should().BeOnOrBefore(TimeSystem.DateTime.Now);
+		result.Should().BeBetween(start, TimeSystem.DateTime.Now);
 		result.Kind.Should().Be(DateTimeKind.Local);
 	}
 
@@ -152,8 +148,7 @@ public abstract partial class Tests<TFileSystem>
 		FileSystem.Directory.CreateDirectory(path);
 
 		DateTime result = FileSystem.Directory.GetLastWriteTimeUtc(path);
-		result.Should().BeOnOrAfter(start.ApplySystemClockTolerance());
-		result.Should().BeOnOrBefore(TimeSystem.DateTime.UtcNow);
+		result.Should().BeBetween(start, TimeSystem.DateTime.UtcNow);
 		result.Kind.Should().Be(DateTimeKind.Utc);
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
@@ -95,16 +95,14 @@ public abstract partial class AppendAllTextTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
 				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		lastWriteTime.Should()

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -154,14 +154,12 @@ public abstract partial class CopyTests<TFileSystem>
 			FileSystem.File.GetLastWriteTimeUtc(destination);
 
 		sourceCreationTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		if (Test.RunsOnMac)
 		{
 #if NET8_0_OR_GREATER
 			sourceLastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 #else
 			sourceLastAccessTime.Should()
 				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
@@ -170,8 +168,7 @@ public abstract partial class CopyTests<TFileSystem>
 		else if (Test.RunsOnWindows)
 		{
 			sourceLastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 		else
 		{
@@ -180,8 +177,7 @@ public abstract partial class CopyTests<TFileSystem>
 		}
 
 		sourceLastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		if (Test.RunsOnWindows)
 		{
 			destinationCreationTime.Should()
@@ -190,8 +186,7 @@ public abstract partial class CopyTests<TFileSystem>
 		else
 		{
 			destinationCreationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		if (!Test.RunsOnMac)
@@ -201,8 +196,7 @@ public abstract partial class CopyTests<TFileSystem>
 		}
 
 		destinationLastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
@@ -139,14 +139,11 @@ public abstract partial class MoveTests<TFileSystem>
 		DateTime lastWriteTime = FileSystem.File.GetLastWriteTimeUtc(destination);
 
 		creationTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		lastAccessTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		lastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/OpenTests.cs
@@ -59,14 +59,11 @@ public abstract partial class OpenTests<TFileSystem>
 		DateTime lastWriteTime = FileSystem.File.GetLastWriteTimeUtc(path);
 
 		creationTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		lastAccessTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		lastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadAllBytesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadAllBytesTests.cs
@@ -50,13 +50,9 @@ public abstract partial class ReadAllBytesTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance())
-				.And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance())
-				.And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 		else
 		{
@@ -65,9 +61,7 @@ public abstract partial class ReadAllBytesTests<TFileSystem>
 		}
 
 		lastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance())
-			.And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReadAllTextTests.cs
@@ -82,13 +82,9 @@ public abstract partial class ReadAllTextTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance())
-				.And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance())
-				.And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 		else
 		{
@@ -97,9 +93,7 @@ public abstract partial class ReadAllTextTests<TFileSystem>
 		}
 
 		lastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance())
-			.And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/SetAttributesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/SetAttributesTests.cs
@@ -40,15 +40,12 @@ public abstract partial class SetAttributesTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		lastAccessTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		lastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/Tests.cs
@@ -80,8 +80,7 @@ public abstract partial class Tests<TFileSystem>
 		FileSystem.File.WriteAllText(path, null);
 
 		DateTime result = FileSystem.File.GetLastAccessTime(path);
-		result.Should().BeOnOrAfter(start.ApplySystemClockTolerance());
-		result.Should().BeOnOrBefore(TimeSystem.DateTime.Now);
+		result.Should().BeBetween(start, TimeSystem.DateTime.Now);
 		result.Kind.Should().Be(DateTimeKind.Local);
 	}
 
@@ -94,8 +93,7 @@ public abstract partial class Tests<TFileSystem>
 		FileSystem.File.WriteAllText(path, null);
 
 		DateTime result = FileSystem.File.GetLastAccessTimeUtc(path);
-		result.Should().BeOnOrAfter(start.ApplySystemClockTolerance());
-		result.Should().BeOnOrBefore(TimeSystem.DateTime.UtcNow);
+		result.Should().BeBetween(start, TimeSystem.DateTime.UtcNow);
 		result.Kind.Should().Be(DateTimeKind.Utc);
 	}
 
@@ -108,8 +106,7 @@ public abstract partial class Tests<TFileSystem>
 		FileSystem.File.WriteAllText(path, null);
 
 		DateTime result = FileSystem.File.GetLastWriteTime(path);
-		result.Should().BeOnOrAfter(start.ApplySystemClockTolerance());
-		result.Should().BeOnOrBefore(TimeSystem.DateTime.Now);
+		result.Should().BeBetween(start, TimeSystem.DateTime.Now);
 		result.Kind.Should().Be(DateTimeKind.Local);
 	}
 
@@ -122,8 +119,7 @@ public abstract partial class Tests<TFileSystem>
 		FileSystem.File.WriteAllText(path, null);
 
 		DateTime result = FileSystem.File.GetLastWriteTimeUtc(path);
-		result.Should().BeOnOrAfter(start.ApplySystemClockTolerance());
-		result.Should().BeOnOrBefore(TimeSystem.DateTime.UtcNow);
+		result.Should().BeBetween(start, TimeSystem.DateTime.UtcNow);
 		result.Kind.Should().Be(DateTimeKind.Utc);
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -58,16 +58,14 @@ public abstract partial class WriteAllTextTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
 				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		lastWriteTime.Should()

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/AdjustTimesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/AdjustTimesTests.cs
@@ -38,11 +38,9 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 		else
 		{
@@ -51,8 +49,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		}
 
 		lastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 
 #if FEATURE_SPAN
@@ -80,11 +77,9 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 		else
 		{
@@ -93,8 +88,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		}
 
 		lastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 #endif
 
@@ -124,11 +118,9 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 		else
 		{
@@ -137,8 +129,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		}
 
 		lastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 
 #if FEATURE_SPAN
@@ -166,11 +157,9 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 		else
 		{
@@ -179,8 +168,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		}
 
 		lastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 #endif
 
@@ -213,11 +201,9 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 		else
 		{
@@ -226,8 +212,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		}
 
 		lastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 #endif
 
@@ -256,11 +241,9 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 		else
 		{
@@ -269,8 +252,7 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		}
 
 		lastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 
 	[SkippableTheory]
@@ -296,16 +278,13 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		lastAccessTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		lastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 
 #if FEATURE_SPAN
@@ -334,16 +313,14 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
 				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		lastWriteTime.Should()
@@ -378,16 +355,14 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
 				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		lastWriteTime.Should()
@@ -420,16 +395,14 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
 				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		lastWriteTime.Should()
@@ -467,16 +440,14 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
 				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		lastWriteTime.Should()
@@ -511,16 +482,14 @@ public abstract partial class AdjustTimesTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
 				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		lastWriteTime.Should()

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/DisposeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/DisposeTests.cs
@@ -15,8 +15,6 @@ public abstract partial class DisposeTests<TFileSystem>
 	public void Dispose_CalledTwiceShouldDoNothing(
 		string path, byte[] bytes)
 	{
-		SkipIfBrittleTestsShouldBeSkipped();
-
 		FileSystem.File.WriteAllBytes(path, bytes);
 
 		using FileSystemStream stream = FileSystem.FileStream.New(path, FileMode.Open,

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -72,8 +72,6 @@ public abstract partial class ReadTests<TFileSystem>
 	[AutoData]
 	public void EndRead_ShouldNotAdjustTimes(string path, byte[] bytes)
 	{
-		SkipIfBrittleTestsShouldBeSkipped();
-
 		using ManualResetEventSlim ms = new();
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
 		FileSystem.File.WriteAllBytes(path, bytes);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -97,14 +97,11 @@ public abstract partial class ReadTests<TFileSystem>
 		DateTime lastWriteTime = FileSystem.File.GetLastWriteTimeUtc(path);
 
 		creationTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		lastAccessTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		lastWriteTime.Should()
-			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-			.BeOnOrBefore(creationTimeEnd);
+			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 
 #if FEATURE_SPAN

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -73,6 +73,8 @@ public abstract partial class ReadTests<TFileSystem>
 	[AutoData]
 	public void EndRead_ShouldNotAdjustTimes(string path, byte[] bytes)
 	{
+		SkipIfBrittleTestsShouldBeSkipped(Test.RunsOnMac);
+
 		using ManualResetEventSlim ms = new();
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
 		FileSystem.File.WriteAllBytes(path, bytes);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -77,7 +77,6 @@ public abstract partial class ReadTests<TFileSystem>
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
 		FileSystem.File.WriteAllBytes(path, bytes);
 		DateTime creationTimeEnd = TimeSystem.DateTime.UtcNow;
-		DateTime updateTime = DateTime.MinValue;
 
 		using (FileSystemStream stream = FileSystem.File.OpenRead(path))
 		{
@@ -85,7 +84,6 @@ public abstract partial class ReadTests<TFileSystem>
 			stream.BeginRead(buffer, 0, buffer.Length, ar =>
 			{
 				TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
-				updateTime = TimeSystem.DateTime.UtcNow;
 				// ReSharper disable once AccessToDisposedClosure
 				stream.EndRead(ar);
 				ms.Set();
@@ -102,7 +100,8 @@ public abstract partial class ReadTests<TFileSystem>
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);
 		lastAccessTime.Should()
-			.BeOnOrAfter(updateTime);
+			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
+			.BeOnOrBefore(creationTimeEnd);
 		lastWriteTime.Should()
 			.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
 			.BeOnOrBefore(creationTimeEnd);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 
+// ReSharper disable AccessToDisposedClosure
 // ReSharper disable once PartialTypeWithSinglePart
 public abstract partial class ReadTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -77,21 +77,22 @@ public abstract partial class ReadTests<TFileSystem>
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
 		FileSystem.File.WriteAllBytes(path, bytes);
 		DateTime creationTimeEnd = TimeSystem.DateTime.UtcNow;
-		using FileSystemStream stream = FileSystem.File.OpenRead(path);
 		DateTime updateTime = DateTime.MinValue;
 
-		byte[] buffer = new byte[bytes.Length];
-		stream.BeginRead(buffer, 0, buffer.Length, ar =>
+		using (FileSystemStream stream = FileSystem.File.OpenRead(path))
 		{
-			TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
-			updateTime = TimeSystem.DateTime.UtcNow;
-			// ReSharper disable once AccessToDisposedClosure
-			stream.EndRead(ar);
-			ms.Set();
-		}, null);
+			byte[] buffer = new byte[bytes.Length];
+			stream.BeginRead(buffer, 0, buffer.Length, ar =>
+			{
+				TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
+				updateTime = TimeSystem.DateTime.UtcNow;
+				// ReSharper disable once AccessToDisposedClosure
+				stream.EndRead(ar);
+				ms.Set();
+			}, null);
 
-		ms.Wait(10000);
-		stream.Dispose();
+			ms.Wait(10000);
+		}
 
 		DateTime creationTime = FileSystem.File.GetCreationTimeUtc(path);
 		DateTime lastAccessTime = FileSystem.File.GetLastAccessTimeUtc(path);
@@ -115,15 +116,16 @@ public abstract partial class ReadTests<TFileSystem>
 	{
 		byte[] buffer = new byte[bytes.Length];
 		FileSystem.File.WriteAllBytes(path, bytes);
-		using FileSystemStream stream = FileSystem.File.OpenWrite(path);
+		Exception? exception;
 
-		Exception? exception = Record.Exception(() =>
+		using (FileSystemStream stream = FileSystem.File.OpenWrite(path))
 		{
-			// ReSharper disable once AccessToDisposedClosure
-			_ = stream.Read(buffer.AsSpan());
-		});
-
-		stream.Dispose();
+			exception = Record.Exception(() =>
+			{
+				// ReSharper disable once AccessToDisposedClosure
+				_ = stream.Read(buffer.AsSpan());
+			});
+		}
 
 		exception.Should().BeException<NotSupportedException>(hResult: -2146233067);
 	}
@@ -152,15 +154,16 @@ public abstract partial class ReadTests<TFileSystem>
 	{
 		byte[] buffer = new byte[bytes.Length];
 		FileSystem.File.WriteAllBytes(path, bytes);
-		using FileSystemStream stream = FileSystem.File.OpenWrite(path);
+		Exception? exception;
 
-		Exception? exception = Record.Exception(() =>
+		using (FileSystemStream stream = FileSystem.File.OpenWrite(path))
 		{
-			// ReSharper disable once AccessToDisposedClosure
-			_ = stream.Read(buffer, 0, bytes.Length);
-		});
-
-		stream.Dispose();
+			exception = Record.Exception(() =>
+			{
+				// ReSharper disable once AccessToDisposedClosure
+				_ = stream.Read(buffer, 0, bytes.Length);
+			});
+		}
 
 		exception.Should().BeException<NotSupportedException>(hResult: -2146233067);
 	}
@@ -188,17 +191,18 @@ public abstract partial class ReadTests<TFileSystem>
 		using CancellationTokenSource cts = new(30000);
 		byte[] buffer = new byte[bytes.Length];
 		await FileSystem.File.WriteAllBytesAsync(path, bytes, cts.Token);
-		await using FileSystemStream stream = FileSystem.File.OpenWrite(path);
+		Exception? exception;
 
-		Exception? exception = await Record.ExceptionAsync(async () =>
+		await using (FileSystemStream stream = FileSystem.File.OpenWrite(path))
 		{
-			// ReSharper disable once AccessToDisposedClosure
-			#pragma warning disable CA1835
-			_ = await stream.ReadAsync(buffer, 0, bytes.Length, cts.Token);
-			#pragma warning restore CA1835
-		});
-
-		await stream.DisposeAsync();
+			exception = await Record.ExceptionAsync(async () =>
+			{
+				// ReSharper disable once AccessToDisposedClosure
+				#pragma warning disable CA1835
+				_ = await stream.ReadAsync(buffer, 0, bytes.Length, cts.Token);
+				#pragma warning restore CA1835
+			});
+		}
 
 		exception.Should().BeException<NotSupportedException>(hResult: -2146233067);
 	}
@@ -213,17 +217,18 @@ public abstract partial class ReadTests<TFileSystem>
 		using CancellationTokenSource cts = new(30000);
 		byte[] buffer = new byte[bytes.Length];
 		await FileSystem.File.WriteAllBytesAsync(path, bytes, cts.Token);
-		await using FileSystemStream stream = FileSystem.File.OpenWrite(path);
+		Exception? exception;
 
-		Exception? exception = await Record.ExceptionAsync(async () =>
+		await using (FileSystemStream stream = FileSystem.File.OpenWrite(path))
 		{
-			// ReSharper disable once AccessToDisposedClosure
-			#pragma warning disable CA1835
-			_ = await stream.ReadAsync(buffer.AsMemory(), cts.Token);
-			#pragma warning restore CA1835
-		});
-
-		await stream.DisposeAsync();
+			exception = await Record.ExceptionAsync(async () =>
+			{
+				// ReSharper disable once AccessToDisposedClosure
+				#pragma warning disable CA1835
+				_ = await stream.ReadAsync(buffer.AsMemory(), cts.Token);
+				#pragma warning restore CA1835
+			});
+		}
 
 		exception.Should().BeException<NotSupportedException>(hResult: -2146233067);
 	}
@@ -254,16 +259,16 @@ public abstract partial class ReadTests<TFileSystem>
 		string path, byte[] bytes)
 	{
 		FileSystem.File.WriteAllBytes(path, bytes);
+		Exception? exception;
 
-		using FileSystemStream stream = FileSystem.File.OpenWrite(path);
-
-		Exception? exception = Record.Exception(() =>
+		using (FileSystemStream stream = FileSystem.File.OpenWrite(path))
 		{
-			// ReSharper disable once AccessToDisposedClosure
-			_ = stream.ReadByte();
-		});
-
-		stream.Dispose();
+			exception = Record.Exception(() =>
+			{
+				// ReSharper disable once AccessToDisposedClosure
+				_ = stream.ReadByte();
+			});
+		}
 
 		exception.Should().BeException<NotSupportedException>(hResult: -2146233067);
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -79,7 +79,6 @@ public abstract partial class ReadTests<TFileSystem>
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
 		FileSystem.File.WriteAllBytes(path, bytes);
 		DateTime creationTimeEnd = TimeSystem.DateTime.UtcNow;
-		DateTime updateTime = DateTime.MinValue;
 
 		using (FileSystemStream stream = FileSystem.File.OpenRead(path))
 		{
@@ -89,7 +88,6 @@ public abstract partial class ReadTests<TFileSystem>
 				TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
 				// ReSharper disable once AccessToDisposedClosure
 				stream.EndRead(ar);
-				updateTime = TimeSystem.DateTime.UtcNow;
 				ms.Set();
 			}, null);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -100,16 +100,8 @@ public abstract partial class ReadTests<TFileSystem>
 
 		creationTime.Should()
 			.BeBetween(creationTimeStart, creationTimeEnd);
-		if (Test.RunsOnWindows)
-		{
-			lastAccessTime.Should()
-				.BeBetween(creationTimeStart, creationTimeEnd);
-		}
-		else
-		{
-			lastAccessTime.Should()
-				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
-		}
+		lastAccessTime.Should()
+			.BeBetween(creationTimeStart, creationTimeEnd);
 		lastWriteTime.Should()
 			.BeBetween(creationTimeStart, creationTimeEnd);
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/Tests.cs
@@ -169,8 +169,6 @@ public abstract partial class Tests<TFileSystem>
 	public void Flush_ShouldNotUpdateFileContentWhenAlreadyFlushed(
 		string path, byte[] bytes1, byte[] bytes2)
 	{
-		SkipIfBrittleTestsShouldBeSkipped();
-
 		using (FileSystemStream stream1 = FileSystem.File.Open(
 			path,
 			FileMode.OpenOrCreate,

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
@@ -102,16 +102,14 @@ public abstract partial class WriteTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			creationTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
 				.BeOnOrAfter(updateTime);
 		}
 		else
 		{
 			lastAccessTime.Should()
-				.BeOnOrAfter(creationTimeStart.ApplySystemClockTolerance()).And
-				.BeOnOrBefore(creationTimeEnd);
+				.BeBetween(creationTimeStart, creationTimeEnd);
 		}
 
 		lastWriteTime.Should()

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
@@ -74,8 +74,6 @@ public abstract partial class WriteTests<TFileSystem>
 	[AutoData]
 	public void EndWrite_ShouldAdjustTimes(string path, byte[] bytes)
 	{
-		SkipIfBrittleTestsShouldBeSkipped();
-
 		using ManualResetEventSlim ms = new();
 		DateTime creationTimeStart = TimeSystem.DateTime.UtcNow;
 		FileSystem.File.WriteAllBytes(path, bytes);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 
+// ReSharper disable AccessToDisposedClosure
 // ReSharper disable once PartialTypeWithSinglePart
 public abstract partial class WriteTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
@@ -104,7 +104,7 @@ public abstract partial class WriteTests<TFileSystem>
 			creationTime.Should()
 				.BeBetween(creationTimeStart, creationTimeEnd);
 			lastAccessTime.Should()
-				.BeOnOrAfter(updateTime);
+				.BeOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/TimeTestHelper.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/TimeTestHelper.cs
@@ -12,7 +12,7 @@ public static class TimeTestHelper
 	///     The tolerance in milliseconds to apply on the <paramref name="time" />.<br />
 	///     Defaults to 25ms.
 	/// </param>
-	public static DateTime ApplySystemClockTolerance(this DateTime time, int tolerance = 25)
+	public static DateTime ApplySystemClockTolerance(this DateTime time, int tolerance = 35)
 	{
 		return time.AddMilliseconds(-1 * tolerance);
 	}

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/TimeTestHelper.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/TimeTestHelper.cs
@@ -1,7 +1,24 @@
+using FluentAssertions.Primitives;
+
 namespace Testably.Abstractions.Tests.TestHelpers;
 
 public static class TimeTestHelper
 {
+	/// <summary>
+	///     Asserts that the current <see cref="DateTime" /> is between the <paramref name="startTime" /> and
+	///     <paramref name="endTime" /> while applying the system clock tolerance.
+	/// </summary>
+	public static AndConstraint<DateTimeAssertions> BeBetween(this DateTimeAssertions assertion,
+		DateTime startTime, DateTime endTime,
+		TimeSpan? tolerance = null,
+		string because = "", params object[] becauseArgs)
+	{
+		tolerance ??= TimeSpan.FromMilliseconds(35);
+		return assertion
+			.BeOnOrAfter(startTime - tolerance.Value, because, becauseArgs).And
+			.BeOnOrBefore(endTime + tolerance.Value, because, becauseArgs);
+	}
+
 	/// <summary>
 	///     Applies a tolerance due to imprecise system clock.
 	///     <para />
@@ -10,7 +27,7 @@ public static class TimeTestHelper
 	/// <param name="time">The time on which the tolerance should be applied.</param>
 	/// <param name="tolerance">
 	///     The tolerance in milliseconds to apply on the <paramref name="time" />.<br />
-	///     Defaults to 25ms.
+	///     Defaults to 35ms.
 	/// </param>
 	public static DateTime ApplySystemClockTolerance(this DateTime time, int tolerance = 35)
 	{

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/DateTimeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/DateTimeTests.cs
@@ -1,3 +1,5 @@
+using Testably.Abstractions.Tests.TestHelpers;
+
 namespace Testably.Abstractions.Tests.TimeSystem;
 
 // ReSharper disable once PartialTypeWithSinglePart
@@ -29,15 +31,14 @@ public abstract partial class DateTimeTests<TTimeSystem>
 	public void Now_ShouldBeSetToNow()
 	{
 		// Tests are brittle on the build system
-		const int tolerance = 250;
+		TimeSpan tolerance = TimeSpan.FromMilliseconds(250);
 
 		DateTime before = DateTime.Now;
 		DateTime result = TimeSystem.DateTime.Now;
 		DateTime after = DateTime.Now;
 
 		result.Kind.Should().Be(DateTimeKind.Local);
-		result.Should().BeOnOrAfter(before.ApplySystemClockTolerance(tolerance));
-		result.ApplySystemClockTolerance(tolerance).Should().BeOnOrBefore(after);
+		result.Should().BeBetween(before, after, tolerance);
 	}
 
 	[SkippableFact]
@@ -50,8 +51,7 @@ public abstract partial class DateTimeTests<TTimeSystem>
 		result.Hour.Should().Be(0);
 		result.Minute.Should().Be(0);
 		result.Second.Should().Be(0);
-		result.Should().BeOnOrAfter(before.ApplySystemClockTolerance());
-		result.ApplySystemClockTolerance().Should().BeOnOrBefore(after);
+		result.Should().BeBetween(before, after);
 	}
 
 	[SkippableFact]
@@ -68,14 +68,13 @@ public abstract partial class DateTimeTests<TTimeSystem>
 	public void UtcNow_ShouldBeSetToUtcNow()
 	{
 		// Tests are brittle on the build system
-		const int tolerance = 250;
+		TimeSpan tolerance = TimeSpan.FromMilliseconds(250);
 
 		DateTime before = DateTime.UtcNow;
 		DateTime result = TimeSystem.DateTime.UtcNow;
 		DateTime after = DateTime.UtcNow;
 
 		result.Kind.Should().Be(DateTimeKind.Utc);
-		result.Should().BeOnOrAfter(before.ApplySystemClockTolerance(tolerance));
-		result.ApplySystemClockTolerance(tolerance).Should().BeOnOrBefore(after);
+		result.Should().BeBetween(before, after, tolerance);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TaskTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TaskTests.cs
@@ -47,8 +47,8 @@ public abstract partial class TaskTests<TTimeSystem>
 		await TimeSystem.Task.Delay(millisecondsTimeout);
 		DateTime after = TimeSystem.DateTime.UtcNow;
 
-		after.Should().BeOnOrAfter(before.AddMilliseconds(millisecondsTimeout)
-			.ApplySystemClockTolerance());
+		after.Should().BeOnOrAfter(
+			before.AddMilliseconds(millisecondsTimeout).ApplySystemClockTolerance());
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/ThreadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/ThreadTests.cs
@@ -16,13 +16,14 @@ public abstract partial class ThreadTests<TTimeSystem>
 	[SkippableFact]
 	public void Sleep_Milliseconds_ShouldSleepForSpecifiedMilliseconds()
 	{
-		int millisecondsTimeout = 10;
+		int millisecondsTimeout = 100;
 
 		DateTime before = TimeSystem.DateTime.UtcNow;
 		TimeSystem.Thread.Sleep(millisecondsTimeout);
 		DateTime after = TimeSystem.DateTime.UtcNow;
 
-		after.Should().BeOnOrAfter(before.AddMilliseconds(millisecondsTimeout));
+		after.Should().BeOnOrAfter(
+			before.AddMilliseconds(millisecondsTimeout).ApplySystemClockTolerance());
 	}
 
 	[SkippableFact]
@@ -38,12 +39,13 @@ public abstract partial class ThreadTests<TTimeSystem>
 	[SkippableFact]
 	public void Sleep_Timespan_ShouldSleepForSpecifiedMilliseconds()
 	{
-		TimeSpan timeout = TimeSpan.FromMilliseconds(10);
+		TimeSpan timeout = TimeSpan.FromMilliseconds(100);
 
 		DateTime before = TimeSystem.DateTime.UtcNow;
 		TimeSystem.Thread.Sleep(timeout);
 		DateTime after = TimeSystem.DateTime.UtcNow;
 
-		after.Should().BeOnOrAfter(before.Add(timeout));
+		after.Should().BeOnOrAfter(
+			before.Add(timeout).ApplySystemClockTolerance());
 	}
 }


### PR DESCRIPTION
Fix incorrect adjustment of the LastAccessTime in `FileStream.EndRead` and activate the skipped brittle tests.
Refactor assertions for `DateTime` between two times by adding an extension method `BeBetween` which checks for the time being between start and end and applying the system clock tolerance on both values.

*Note: The test keeps failing arbitrarily on MacOS, as the LastAccessTime is sometimes adjusted, so the test remains skipped on MacOS*