### PR TITLE
coverage: add missing tests

### DIFF
--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
@@ -88,6 +88,32 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 	}
 #endif
 
+#if FEATURE_COMPRESSION_OVERWRITE
+	[SkippableTheory]
+	[AutoData]
+	public void ExtractToDirectory_WithEncoding_Overwrite_ShouldOverwriteFile(
+		string contents,
+		Encoding encoding)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("bar").Initialized(s => s
+				.WithFile("test.txt"))
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		FileSystem.File.WriteAllText(FileSystem.Path.Combine("foo", "test.txt"),
+			contents);
+
+		FileSystem.ZipFile().CreateFromDirectory("foo", "destination.zip");
+
+		FileSystem.ZipFile().ExtractToDirectory("destination.zip", "bar", encoding, true);
+
+		FileSystem.File.Exists(FileSystem.Path.Combine("bar", "test.txt"))
+			.Should().BeTrue();
+		FileSystem.File.ReadAllText(FileSystem.Path.Combine("bar", "test.txt"))
+			.Should().Be(contents);
+	}
+#endif
+
 	[SkippableTheory]
 	[AutoData]
 	public void ExtractToDirectory_WithEncoding_ShouldZipDirectoryContent(
@@ -224,6 +250,33 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableTheory]
 	[AutoData]
+	public void ExtractToDirectory_WithStream_WithEncoding_Overwrite_ShouldOverwriteFile(
+		string contents,
+		Encoding encoding)
+	{
+		FileSystem.Initialize()
+			.WithSubdirectory("bar").Initialized(s => s
+				.WithFile("test.txt"))
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		FileSystem.File.WriteAllText(FileSystem.Path.Combine("foo", "test.txt"),
+			contents);
+		using MemoryStream stream = new();
+
+		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+
+		FileSystem.ZipFile().ExtractToDirectory(stream, "bar", encoding, true);
+
+		FileSystem.File.Exists(FileSystem.Path.Combine("bar", "test.txt"))
+			.Should().BeTrue();
+		FileSystem.File.ReadAllText(FileSystem.Path.Combine("bar", "test.txt"))
+			.Should().Be(contents);
+	}
+#endif
+
+#if FEATURE_COMPRESSION_STREAM
+	[SkippableTheory]
+	[AutoData]
 	public void ExtractToDirectory_WithStream_WithEncoding_ShouldZipDirectoryContent(
 		Encoding encoding)
 	{
@@ -267,6 +320,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 
 		Exception? exception = Record.Exception(() =>
 		{
+			// ReSharper disable once AccessToDisposedClosure
 			FileSystem.ZipFile().ExtractToDirectory(stream, "bar");
 		});
 

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileMockTests.cs
@@ -10,6 +10,25 @@ namespace Testably.Abstractions.Testing.Tests.FileSystem;
 public class FileMockTests
 {
 #if FEATURE_FILESYSTEM_SAFEFILEHANDLE
+	[Theory]
+	[AutoData]
+	public void GetAttributes_SafeFileHandle_WithMissingFile_ShouldThrowFileNotFoundException(
+		string path)
+	{
+		SafeFileHandle fileHandle = new();
+		MockFileSystem fileSystem = new();
+		fileSystem.WithSafeFileHandleStrategy(
+			new DefaultSafeFileHandleStrategy(_ => new SafeFileHandleMock(path)));
+
+		Exception? exception = Record.Exception(() =>
+		{
+			_ = fileSystem.File.GetAttributes(fileHandle);
+		});
+
+		exception.Should().BeOfType<FileNotFoundException>();
+	}
+#endif
+#if FEATURE_FILESYSTEM_SAFEFILEHANDLE
 	[SkippableTheory]
 	[AutoData]
 	public void GetUnixFileMode_SafeFileHandle_ShouldThrowPlatformNotSupportedExceptionOnWindows(

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/MethodStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/MethodStatisticsTests.cs
@@ -6,6 +6,16 @@ namespace Testably.Abstractions.Testing.Tests.Statistics;
 public sealed class MethodStatisticsTests
 {
 	[Fact]
+	public void Counter_ShouldBeInitializedWithOne()
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "bar");
+		MethodStatistic sut = fileSystem.Statistics.File.Methods.First();
+
+		sut.Counter.Should().Be(1);
+	}
+
+	[Fact]
 	public void ToString_ShouldContainName()
 	{
 		MockFileSystem fileSystem = new();

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/ParameterDescriptionTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/ParameterDescriptionTests.cs
@@ -50,6 +50,31 @@ public sealed class ParameterDescriptionTests
 #endif
 
 	[Theory]
+	[InlineAutoData(true)]
+	[InlineAutoData(false)]
+	public void Is_WithComparer_ShouldUseComparerResult(bool comparerResult, string value)
+	{
+		ParameterDescription sut = ParameterDescription.FromParameter(value);
+
+		bool result = sut.Is<string>(_ => comparerResult);
+
+		result.Should().Be(comparerResult);
+	}
+
+	[Theory]
+	[InlineAutoData(true)]
+	[InlineAutoData(false)]
+	public void Is_WithComparer_WithIncompatibleType_ShouldReturnFalse(bool comparerResult,
+		string value)
+	{
+		ParameterDescription sut = ParameterDescription.FromParameter(value);
+
+		bool result = sut.Is<int>(_ => comparerResult);
+
+		result.Should().BeFalse();
+	}
+
+	[Theory]
 	[AutoData]
 	public void Is_WithFromOutParameter_ShouldCheckForMatchingValue(int value)
 	{

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/PropertyStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/PropertyStatisticsTests.cs
@@ -6,6 +6,16 @@ namespace Testably.Abstractions.Testing.Tests.Statistics;
 public sealed class PropertyStatisticsTests
 {
 	[Fact]
+	public void Counter_ShouldBeInitializedWithOne()
+	{
+		MockFileSystem fileSystem = new();
+		_ = fileSystem.Path.DirectorySeparatorChar;
+		PropertyStatistic sut = fileSystem.Statistics.Path.Properties.First();
+
+		sut.Counter.Should().Be(1);
+	}
+
+	[Fact]
 	public void ToString_Get_ShouldContainNameAndGet()
 	{
 		MockFileSystem fileSystem = new();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/Tests.cs
@@ -29,6 +29,14 @@ public abstract partial class Tests<TFileSystem>
 		result.Should().BeEquivalentTo(System.IO.Path.GetInvalidFileNameChars());
 	}
 
+	[SkippableFact]
+	public void GetInvalidPathChars_ShouldReturnDefaultValue()
+	{
+		char[] result = FileSystem.Path.GetInvalidPathChars();
+
+		result.Should().BeEquivalentTo(System.IO.Path.GetInvalidPathChars());
+	}
+
 	[SkippableTheory]
 	[AutoData]
 	public void GetPathRoot_ShouldReturnDefaultValue(string path)


### PR DESCRIPTION
- Add missing tests for `ZipFile.ExtractToDirectory`
- Add test for initializaltion of statistic counter
- Add missing tests for `ParameterDescription`
- Add missing test for `Path.GetInvalidPathChars`
- Add test for correct exception when calling `GetUnixFileMode` on windows
- Add test for correct exception when accessing a missing file via a `SafeFileHandle`