### PR TITLE
fix: Report Generator does not support mixing .NET Framework and .NET Core

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,11 +169,6 @@ jobs:
         with:
           name: Code coverage (Windows)
           path: Coverage/Windows
-      - name: Download code coverage files (.NET Framework)
-        uses: actions/download-artifact@v3
-        with:
-          name: Code coverage (.NET Framework)
-          path: Coverage/.NET Framework
       - name: Generate coverage report
         uses: danielpalme/ReportGenerator-GitHub-Action@5.2.4
         with:


### PR DESCRIPTION
Exclude .NET Framework coverage report from the generated coverage report sent to Codacy.