### PR TITLE
feat: Enable Stryker CI-Build

### DIFF
--- a/.github/workflows/ci-stryker.yml
+++ b/.github/workflows/ci-stryker.yml
@@ -74,14 +74,14 @@ jobs:
         run: |
           prNumber="${{ github.event.number }}"
           commentsUrl="https://api.github.com/repos/Testably/Testably.Abstractions/issues/$prNumber/comments"
-          dashboardLink="[Stryker dashboard](https://dashboard.stryker-mutator.io/reports/github.com/Testably/Testably.Abstractions/${GITHUB_HEAD_REF}) on the build pipeline"
+          dashboardLink="[Stryker.NET](https://stryker-mutator.io/docs/stryker-net/introduction/) was executed on the changes in the pull request:  \n[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FTestably.Abstractions%2F${GITHUB_HEAD_REF})](https://dashboard.stryker-mutator.io/reports/github.com/Testably/Testably.Abstractions/${GITHUB_HEAD_REF})"
           echo "Search for comment in PR#$prNumber containing $dashboardLink..."
           result=$(curl -X GET $commentsUrl \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN")
           if [[ $result != *"$dashboardLink"* ]]
           then
-            body="{\"body\":\"Please check the $dashboardLink.\"}"
+            body="{\"body\":\"$dashboardLink\"}"
             curl -X POST $commentsUrl \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: token $GITHUB_TOKEN" \

--- a/.github/workflows/ci-stryker.yml
+++ b/.github/workflows/ci-stryker.yml
@@ -2,6 +2,8 @@ name: "CI (Stryker)"
 
 on:
   workflow_dispatch: 
+  pull_request:
+    branches: [main]
     
 jobs:
   stryker:

--- a/.github/workflows/ci-stryker.yml
+++ b/.github/workflows/ci-stryker.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash
         run: |
           cd Tests
-          ../../tools/dotnet-stryker -f ../.github/stryker/Stryker.Config.json -v "${GITHUB_HEAD_REF}" -r "html" -r "cleartext" --since:main
+          ../../tools/dotnet-stryker -f ../.github/stryker/Stryker.Config.json -v "${GITHUB_HEAD_REF}" -r "Dashboard" -r "html" -r "cleartext" --since:main
           mv ./StrykerOutput/**/reports/*.html ./StrykerOutput/Reports/Testably.Abstractions-report.html
       - name: Analyze Testably.Abstractions.AccessControl
         env:
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: |
           cd Tests
-          ../../tools/dotnet-stryker -f ../.github/stryker/Stryker.Config.AccessControl.json -v "${GITHUB_HEAD_REF}" -r "html" -r "cleartext" --since:main
+          ../../tools/dotnet-stryker -f ../.github/stryker/Stryker.Config.AccessControl.json -v "${GITHUB_HEAD_REF}" -r "Dashboard" -r "html" -r "cleartext" --since:main
           mv ./StrykerOutput/**/reports/*.html ./StrykerOutput/Reports/Testably.Abstractions.AccessControl-report.html
       - name: Analyze Testably.Abstractions.Compression
         env:
@@ -52,7 +52,7 @@ jobs:
         shell: bash
         run: |
           cd Tests
-          ../../tools/dotnet-stryker -f ../.github/stryker/Stryker.Config.Compression.json -v "${GITHUB_HEAD_REF}" -r "html" -r "cleartext" --since:main
+          ../../tools/dotnet-stryker -f ../.github/stryker/Stryker.Config.Compression.json -v "${GITHUB_HEAD_REF}" -r "Dashboard" -r "html" -r "cleartext" --since:main
           mv ./StrykerOutput/**/reports/*.html ./StrykerOutput/Reports/Testably.Abstractions.Compression-report.html
       - name: Analyze Testably.Abstractions.Testing
         env:
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: |
           cd Tests
-          ../../tools/dotnet-stryker -f ../.github/stryker/Stryker.Config.Testing.json -v "${GITHUB_HEAD_REF}" -r "html" -r "cleartext" --since:main
+          ../../tools/dotnet-stryker -f ../.github/stryker/Stryker.Config.Testing.json -v "${GITHUB_HEAD_REF}" -r "Dashboard" -r "html" -r "cleartext" --since:main
           mv ./StrykerOutput/**/reports/*.html ./StrykerOutput/Reports/Testably.Abstractions.Testing-report.html
       - name: Upload Stryker reports
         uses: actions/upload-artifact@v3
@@ -74,16 +74,17 @@ jobs:
         run: |
           prNumber="${{ github.event.number }}"
           commentsUrl="https://api.github.com/repos/Testably/Testably.Abstractions/issues/$prNumber/comments"
-          dashboardLink="attached Stryker dashboards on the build pipeline"
+          dashboardLink="[Stryker dashboard](https://dashboard.stryker-mutator.io/reports/github.com/Testably/Testably.Abstractions/${GITHUB_HEAD_REF}) on the build pipeline"
           echo "Search for comment in PR#$prNumber containing $dashboardLink..."
           result=$(curl -X GET $commentsUrl \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN")
           if [[ $result != *"$dashboardLink"* ]]
           then
-            body="{\"body\":\"Please check the attached Stryker dashboards on the build pipeline.\"}"
+            body="{\"body\":\"Please check the $dashboardLink.\"}"
             curl -X POST $commentsUrl \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: token $GITHUB_TOKEN" \
           	  -d "$body"
           fi
+


### PR DESCRIPTION
Enable a stryker CI-Build with the [`since`-Flag](https://stryker-mutator.io/docs/stryker-net/configuration/#since-flag-committish) and write a corresponding comment with the Stryker Dashboard Badge to the pull request.