### PR TITLE
fix: support search pattern with subdirectories when enumerating a directory

### DIFF
--- a/Source/Testably.Abstractions.Testing/Helpers/EnumerationOptionsHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/EnumerationOptionsHelper.cs
@@ -81,7 +81,7 @@ internal static class EnumerationOptionsHelper
 	}
 
 	/// <summary>
-	///     Validates the directory and expression strings.
+	///     Validates the directory and expression strings.<br />
 	///     If the expression string begins with a directory name, the directory name is moved and appended at the end of the
 	///     directory string.
 	///     <para />
@@ -105,9 +105,7 @@ internal static class EnumerationOptionsHelper
 		// split the inputs if the expression contains a directory separator.
 		//
 		// We also allowed for expression to be "foo\" which would translate to "foo\*".
-
 		string? directoryName = execute.Path.GetDirectoryName(expression);
-
 		if (directoryName?.Length > 0)
 		{
 			// Need to fix up the input paths

--- a/Source/Testably.Abstractions.Testing/Helpers/EnumerationOptionsHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/EnumerationOptionsHelper.cs
@@ -81,9 +81,8 @@ internal static class EnumerationOptionsHelper
 	}
 
 	/// <summary>
-	///     Validates the directory and expression strings to check that they have no invalid characters, any special DOS
-	///     wildcard characters in Win32 in the expression get replaced with their proper escaped representation, and if the
-	///     expression string begins with a directory name, the directory name is moved and appended at the end of the
+	///     Validates the directory and expression strings.
+	///     If the expression string begins with a directory name, the directory name is moved and appended at the end of the
 	///     directory string.
 	///     <para />
 	///     <see
@@ -112,7 +111,8 @@ internal static class EnumerationOptionsHelper
 		if (directoryName?.Length > 0)
 		{
 			// Need to fix up the input paths
-			directory = execute.Path.Combine(directory, directoryName);
+			directory = execute.Path.GetFullPath(
+				execute.Path.Combine(directory, directoryName));
 			expression = expression.Substring(directoryName.Length + 1);
 		}
 	}

--- a/Source/Testably.Abstractions.Testing/Helpers/EnumerationOptionsHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/EnumerationOptionsHelper.cs
@@ -106,24 +106,12 @@ internal static class EnumerationOptionsHelper
 	/// <exception cref="ArgumentOutOfRangeException">
 	///     The match type is out of the range of the valid MatchType enum values.
 	/// </exception>
-	internal static bool NormalizeInputs(ref string directory, ref string expression,
+	internal static bool NormalizeInputs(
+		ref string directory,
+		ref string expression,
 		MatchType matchType)
 	{
-		char[] s_unixEscapeChars =
-		{
-			'\\',
-			'"',
-			'<',
-			'>'
-		};
-		//if (Path.IsPathRooted(expression))
-		//	throw new ArgumentException(SR.Arg_Path2IsRooted, nameof(expression));
-
-		//if (expression.Contains('\0'))
-		//	throw new ArgumentException(SR.Argument_NullCharInPath, expression);
-
-		//if (directory.Contains('\0'))
-		//	throw new ArgumentException(SR.Argument_NullCharInPath, directory);
+		char[] unixEscapeChars = ['\\', '"', '<', '>'];
 
 		// We always allowed breaking the passed ref directory and filter to be separated
 		// any way the user wanted. Looking for "C:\foo\*.cs" could be passed as "C:\" and
@@ -168,7 +156,7 @@ internal static class EnumerationOptionsHelper
 					// special case wildcards that we'll convert some * and ? into. They're also valid as filenames on Unix,
 					// which is not true in Windows and as such we'll escape any that occur on the input string.
 					if (Path.DirectorySeparatorChar != '\\' &&
-					    expression.IndexOfAny(s_unixEscapeChars) != -1)
+					    expression.IndexOfAny(unixEscapeChars) != -1)
 					{
 						// Backslash isn't the default separator, need to escape (e.g. Unix)
 						expression = expression.Replace("\\", "\\\\", StringComparison.Ordinal);

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -175,6 +175,15 @@ internal sealed class InMemoryStorage : IStorage
 		enumerationOptions ??= EnumerationOptionsHelper.Compatible;
 
 		string fullPath = location.FullPath;
+		if (searchPattern.Contains(
+			_fileSystem.Execute.Path.DirectorySeparatorChar,
+			StringComparison.Ordinal))
+		{
+			EnumerationOptionsHelper.NormalizeInputs(ref fullPath, ref searchPattern,
+				enumerationOptions.MatchType);
+			fullPath = _fileSystem.Execute.Path.GetFullPath(fullPath);
+		}
+
 		string fullPathWithoutTrailingSlash = fullPath;
 		if (!fullPath.EndsWith(_fileSystem.Execute.Path.DirectorySeparatorChar))
 		{

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -177,8 +177,9 @@ internal sealed class InMemoryStorage : IStorage
 		string fullPath = location.FullPath;
 		if (enumerationOptions.MatchType == MatchType.Win32)
 		{
-			EnumerationOptionsHelper.NormalizeInputs(_fileSystem.Execute, ref fullPath, ref searchPattern);
-			fullPath = _fileSystem.Execute.Path.GetFullPath(fullPath);
+			EnumerationOptionsHelper.NormalizeInputs(_fileSystem.Execute,
+				ref fullPath,
+				ref searchPattern);
 		}
 
 		string fullPathWithoutTrailingSlash = fullPath;

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -175,12 +175,9 @@ internal sealed class InMemoryStorage : IStorage
 		enumerationOptions ??= EnumerationOptionsHelper.Compatible;
 
 		string fullPath = location.FullPath;
-		if (searchPattern.Contains(
-			_fileSystem.Execute.Path.DirectorySeparatorChar,
-			StringComparison.Ordinal))
+		if (enumerationOptions.MatchType == MatchType.Win32)
 		{
-			EnumerationOptionsHelper.NormalizeInputs(ref fullPath, ref searchPattern,
-				enumerationOptions.MatchType);
+			EnumerationOptionsHelper.NormalizeInputs(_fileSystem.Execute, ref fullPath, ref searchPattern);
 			fullPath = _fileSystem.Execute.Path.GetFullPath(fullPath);
 		}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateFilesTests.cs
@@ -32,21 +32,6 @@ public abstract partial class EnumerateFilesTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void EnumerateFiles_Path_ShouldBeCaseInsensitive_OnWindows(string path)
-	{
-		Skip.IfNot(Test.RunsOnWindows);
-
-		FileSystem.Initialize()
-			.WithSubdirectory(path.ToUpperInvariant()).Initialized(s => s
-				.WithAFile());
-
-		string[] result = FileSystem.Directory.GetFiles(path.ToLowerInvariant());
-
-		result.Length.Should().Be(1);
-	}
-
-	[SkippableTheory]
-	[AutoData]
 	public void
 		EnumerateFiles_SearchOptionAllDirectories_FullPath_ShouldReturnAllFilesWithFullPath(
 			string path)
@@ -120,30 +105,6 @@ public abstract partial class EnumerateFilesTests<TFileSystem>
 			result.Should()
 				.BeEmpty($"{fileName} should not match {searchPattern}");
 		}
-	}
-
-	[SkippableFact]
-	public void
-		EnumerateFiles_SearchPatternForFileWithoutExtension_ShouldWorkConsistently()
-	{
-		FileSystem.Initialize()
-			.WithFile("file_without_extension")
-			.WithFile("file.with.an.extension");
-
-		string[] result = FileSystem.Directory.GetFiles(".", "*.");
-
-		result.Length.Should().Be(1);
-	}
-
-	[SkippableFact]
-	public void EnumerateFiles_SearchPatternWithTooManyAsterisk_ShouldWorkConsistently()
-	{
-		FileSystem.Initialize()
-			.WithFile("result.test.001.txt");
-
-		string[] result = FileSystem.Directory.GetFiles(".", "*.test.*.*.*.*");
-
-		result.Length.Should().Be(1);
 	}
 
 #if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
@@ -31,39 +31,9 @@ public abstract partial class GetFilesTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void GetFiles_Path_NotOnWindows_ShouldBeCaseSensitive(string path)
+	public void GetFiles_Path_NotOnLinux_ShouldBeCaseInsensitive(string path)
 	{
-		Skip.If(Test.RunsOnWindows);
-
-		FileSystem.Initialize()
-			.WithSubdirectory(path.ToUpperInvariant()).Initialized(s => s
-				.WithAFile());
-
-		string[] result1 = Array.Empty<string>();
-		Exception? exception = Record.Exception(() =>
-		{
-			result1 = FileSystem.Directory.GetFiles(path.ToLowerInvariant());
-		});
-		string[] result2 = FileSystem.Directory.GetFiles(path.ToUpperInvariant());
-
-		if (Test.RunsOnLinux)
-		{
-			exception.Should().BeOfType<DirectoryNotFoundException>();
-		}
-		else
-		{
-			exception.Should().BeNull();
-			result1.Should().BeEmpty();
-		}
-
-		result2.Length.Should().Be(1);
-	}
-
-	[SkippableTheory]
-	[AutoData]
-	public void GetFiles_Path_OnWindows_ShouldBeCaseInsensitive(string path)
-	{
-		Skip.IfNot(Test.RunsOnWindows);
+		Skip.If(Test.RunsOnLinux);
 
 		FileSystem.Initialize()
 			.WithSubdirectory(path.ToUpperInvariant()).Initialized(s => s
@@ -72,6 +42,26 @@ public abstract partial class GetFilesTests<TFileSystem>
 		string[] result = FileSystem.Directory.GetFiles(path.ToLowerInvariant());
 
 		result.Length.Should().Be(1);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void GetFiles_Path_OnLinux_ShouldBeCaseSensitive(string path)
+	{
+		Skip.IfNot(Test.RunsOnLinux);
+
+		FileSystem.Initialize()
+			.WithSubdirectory(path.ToUpperInvariant()).Initialized(s => s
+				.WithAFile());
+
+		Exception? exception = Record.Exception(() =>
+		{
+			_ = FileSystem.Directory.GetFiles(path.ToLowerInvariant());
+		});
+		string[] result2 = FileSystem.Directory.GetFiles(path.ToUpperInvariant());
+
+		exception.Should().BeOfType<DirectoryNotFoundException>();
+		result2.Length.Should().Be(1);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
@@ -154,7 +154,8 @@ public abstract partial class GetFilesTests<TFileSystem>
 	}
 
 	[SkippableFact]
-	public void GetFiles_SearchPatternWithDirectorySeparator_ShouldReturnFilesInSubdirectoryOnWindows()
+	public void
+		GetFiles_SearchPatternWithDirectorySeparator_ShouldReturnFilesInSubdirectoryOnWindows()
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("foo").Initialized(d => d
@@ -168,14 +169,14 @@ public abstract partial class GetFilesTests<TFileSystem>
 		{
 			result1.Length.Should().Be(1);
 			FileSystem.File.ReadAllText(result1[0]).Should().Be("inner");
+			result2.Length.Should().Be(1);
+			FileSystem.File.ReadAllText(result2[0]).Should().Be("outer");
 		}
 		else
 		{
 			result1.Should().BeEmpty();
+			result2.Should().BeEmpty();
 		}
-
-		result2.Length.Should().Be(1);
-		FileSystem.File.ReadAllText(result2[0]).Should().Be("outer");
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
@@ -39,14 +39,24 @@ public abstract partial class GetFilesTests<TFileSystem>
 			.WithSubdirectory(path.ToUpperInvariant()).Initialized(s => s
 				.WithAFile());
 
+		string[] result1 = Array.Empty<string>();
 		Exception? exception = Record.Exception(() =>
 		{
-			_ = FileSystem.Directory.GetFiles(path.ToLowerInvariant());
+			result1 = FileSystem.Directory.GetFiles(path.ToLowerInvariant());
 		});
-		string[] result = FileSystem.Directory.GetFiles(path.ToUpperInvariant());
+		string[] result2 = FileSystem.Directory.GetFiles(path.ToUpperInvariant());
 
-		exception.Should().BeOfType<DirectoryNotFoundException>();
-		result.Length.Should().Be(1);
+		if (Test.RunsOnLinux)
+		{
+			exception.Should().BeOfType<DirectoryNotFoundException>();
+		}
+		else
+		{
+			exception.Should().BeNull();
+			result1.Should().BeEmpty();
+		}
+
+		result2.Length.Should().Be(1);
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFilesTests.cs
@@ -175,4 +175,25 @@ public abstract partial class EnumerateFilesTests<TFileSystem>
 
 		result.Count().Should().Be(2);
 	}
+
+	[SkippableFact]
+	public void
+		EnumerateFiles_WithSearchPatternWithDirectorySeparator_ShouldReturnFilesInSubdirectory()
+	{
+		IDirectoryInfo baseDirectory =
+			FileSystem.Initialize()
+				.WithSubdirectory("foo").Initialized(d => d
+					.WithFile("bar.txt").Which(f => f.HasStringContent("inner")))
+				.WithFile("bar.txt").Which(f => f.HasStringContent("outer"))
+				.BaseDirectory;
+
+		List<IFileInfo> result1 = baseDirectory.EnumerateFiles("foo\\*.txt").ToList();
+		List<IFileInfo> result2 = baseDirectory.EnumerateFiles(".\\*.txt").ToList();
+
+		result1.Count.Should().Be(1);
+		FileSystem.File.ReadAllText(result1.Single().FullName).Should().Be("inner");
+
+		result2.Count.Should().Be(1);
+		FileSystem.File.ReadAllText(result1.Single().FullName).Should().Be("outer");
+	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFilesTests.cs
@@ -194,6 +194,6 @@ public abstract partial class EnumerateFilesTests<TFileSystem>
 		FileSystem.File.ReadAllText(result1.Single().FullName).Should().Be("inner");
 
 		result2.Count.Should().Be(1);
-		FileSystem.File.ReadAllText(result1.Single().FullName).Should().Be("outer");
+		FileSystem.File.ReadAllText(result2.Single().FullName).Should().Be("outer");
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFilesTests.cs
@@ -194,13 +194,13 @@ public abstract partial class EnumerateFilesTests<TFileSystem>
 		{
 			result1.Count.Should().Be(1);
 			FileSystem.File.ReadAllText(result1.Single().FullName).Should().Be("inner");
+			result2.Count.Should().Be(1);
+			FileSystem.File.ReadAllText(result2.Single().FullName).Should().Be("outer");
 		}
 		else
 		{
 			result1.Should().BeEmpty();
+			result2.Should().BeEmpty();
 		}
-
-		result2.Count.Should().Be(1);
-		FileSystem.File.ReadAllText(result2.Single().FullName).Should().Be("outer");
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/EnumerateFilesTests.cs
@@ -178,7 +178,7 @@ public abstract partial class EnumerateFilesTests<TFileSystem>
 
 	[SkippableFact]
 	public void
-		EnumerateFiles_WithSearchPatternWithDirectorySeparator_ShouldReturnFilesInSubdirectory()
+		EnumerateFiles_WithSearchPatternWithDirectorySeparator_ShouldReturnFilesInSubdirectoryOnWindows()
 	{
 		IDirectoryInfo baseDirectory =
 			FileSystem.Initialize()
@@ -190,8 +190,15 @@ public abstract partial class EnumerateFilesTests<TFileSystem>
 		List<IFileInfo> result1 = baseDirectory.EnumerateFiles("foo\\*.txt").ToList();
 		List<IFileInfo> result2 = baseDirectory.EnumerateFiles(".\\*.txt").ToList();
 
-		result1.Count.Should().Be(1);
-		FileSystem.File.ReadAllText(result1.Single().FullName).Should().Be("inner");
+		if (Test.RunsOnWindows)
+		{
+			result1.Count.Should().Be(1);
+			FileSystem.File.ReadAllText(result1.Single().FullName).Should().Be("inner");
+		}
+		else
+		{
+			result1.Should().BeEmpty();
+		}
 
 		result2.Count.Should().Be(1);
 		FileSystem.File.ReadAllText(result2.Single().FullName).Should().Be("outer");


### PR DESCRIPTION
Support the mentioned formats in https://github.com/TestableIO/System.IO.Abstractions/issues/596, especially the following:
> Another pattern that works in the real filesystem and not on the MockFileSystem is `"someDirectory\\*.txt"`, this includes `".\\*.txt"`