### PR TITLE
fix: support three-character file extension as search pattern in .NET Framework

### DIFF
--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -175,6 +175,12 @@ internal sealed class InMemoryStorage : IStorage
 		enumerationOptions ??= EnumerationOptionsHelper.Compatible;
 
 		string fullPath = location.FullPath;
+
+		if (_fileSystem.Execute.IsNetFramework)
+		{
+			searchPattern = AdjustSearchPatternOnNetFramework(searchPattern);
+		}
+
 		if (enumerationOptions.MatchType == MatchType.Win32)
 		{
 			EnumerationOptionsHelper.NormalizeInputs(_fileSystem.Execute,
@@ -225,6 +231,30 @@ internal sealed class InMemoryStorage : IStorage
 				yield return item.Key;
 			}
 		}
+	}
+
+	/// <summary>
+	///     When you use the asterisk wildcard character in <paramref name="searchPattern" /> and you specify a three-character
+	///     file extension, for example, "*.txt", this method also returns files with extensions that begin with the specified
+	///     extension.
+	/// </summary>
+	/// <remarks>
+	///     For example, the search pattern "*.xls" returns both "book.xls" and "book.xlsx". This behavior only occurs if an
+	///     asterisk is used in the search pattern and the file extension provided is exactly three characters. If you use the
+	///     question mark wildcard character somewhere in the search pattern, this method returns only files that match the
+	///     specified file extension exactly.
+	///     <para />
+	///     <see href="https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.enumeratefiles?view=netframework-4.8" />
+	/// </remarks>
+	private static string AdjustSearchPatternOnNetFramework(string searchPattern)
+	{
+		if (searchPattern.Length == 5 &&
+		    searchPattern.StartsWith("*.", StringComparison.Ordinal))
+		{
+			searchPattern += "*";
+		}
+
+		return searchPattern;
 	}
 
 	/// <inheritdoc cref="IStorage.GetContainer(IStorageLocation)" />

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
@@ -150,6 +150,39 @@ public abstract partial class EnumerateDirectoriesTests<TFileSystem>
 		}
 	}
 
+	[SkippableTheory]
+	[InlineAutoData(true, "*.xls", ".xls")]
+	[InlineAutoData(false, "*.x", ".xls")]
+#if NETFRAMEWORK
+	[InlineAutoData(true, "*.xls", ".xlsx")]
+#else
+	[InlineAutoData(false, "*.xls", ".xlsx")]
+#endif
+	[InlineAutoData(false, "foo.x", ".xls", "foo")]
+	[InlineAutoData(false, "?.xls", ".xlsx", "a")]
+	public void EnumerateDirectories_SearchPattern_WithFileExtension_ShouldReturnExpectedValue(
+		bool expectToBeFound, string searchPattern, string extension,
+		string fileNameWithoutExtension)
+	{
+		string fileName = $"{fileNameWithoutExtension}{extension}";
+		FileSystem.Initialize().WithSubdirectory(fileName);
+
+		List<string> result = FileSystem.Directory
+			.EnumerateDirectories(".", searchPattern).ToList();
+
+		if (expectToBeFound)
+		{
+			result.Should().ContainSingle(
+				extension,
+				$"it should match {searchPattern}");
+		}
+		else
+		{
+			result.Should()
+				.BeEmpty($"{extension} should not match {searchPattern}");
+		}
+	}
+
 #if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS
 	[SkippableTheory]
 	[AutoData]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateFilesTests.cs
@@ -107,6 +107,39 @@ public abstract partial class EnumerateFilesTests<TFileSystem>
 		}
 	}
 
+	[SkippableTheory]
+	[InlineAutoData(true, "*.xls", ".xls")]
+	[InlineAutoData(false, "*.x", ".xls")]
+#if NETFRAMEWORK
+	[InlineAutoData(true, "*.xls", ".xlsx")]
+#else
+	[InlineAutoData(false, "*.xls", ".xlsx")]
+#endif
+	[InlineAutoData(false, "foo.x", ".xls", "foo")]
+	[InlineAutoData(false, "?.xls", ".xlsx", "a")]
+	public void EnumerateFiles_SearchPattern_WithFileExtension_ShouldReturnExpectedValue(
+		bool expectToBeFound, string searchPattern, string extension,
+		string fileNameWithoutExtension)
+	{
+		string fileName = $"{fileNameWithoutExtension}{extension}";
+		FileSystem.Initialize().WithFile(fileName);
+
+		List<string> result = FileSystem.Directory
+			.EnumerateFiles(".", searchPattern).ToList();
+
+		if (expectToBeFound)
+		{
+			result.Should().ContainSingle(
+				extension,
+				$"it should match {searchPattern}");
+		}
+		else
+		{
+			result.Should()
+				.BeEmpty($"{extension} should not match {searchPattern}");
+		}
+	}
+
 #if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS
 	[SkippableTheory]
 	[AutoData]


### PR DESCRIPTION
This fixes the edge case in .NET Framework described in https://github.com/TestableIO/System.IO.Abstractions/issues/895

See [EnumerateFiles](https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.enumeratefiles?view=netframework-4.8):
> **.NET Framework only**: When you use the asterisk wildcard character in `searchPattern` and you specify a three-character file extension, for example, "\*.txt", this method also returns files with extensions that *begin* with the specified extension. For example, the search pattern "\*.xls" returns both "book.xls" and "book.xlsx". This behavior only occurs if an asterisk is used in the search pattern and the file extension provided is exactly three characters. If you use the question mark wildcard character somewhere in the search pattern, this method returns only files that match the specified file extension exactly