### PR TITLE
fix: dependency error in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,7 +225,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     environment: production
-    needs: [analyze, test-macos, test-ubuntu, test-windows, test-net-framework, test-examples]
+    needs: [test-macos, test-ubuntu, test-windows, test-net-framework, test-examples]
     steps:
       - name: Checkout sources
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4


### PR DESCRIPTION
The release build fails with the following error:
> [Invalid workflow file: .github/workflows/release.yml#L228](https://github.com/Testably/Testably.Abstractions/actions/runs/8469291223/workflow)
The workflow is not valid. .github/workflows/release.yml (Line: 228, Col: 13): Job 'deploy' depends on unknown job 'analyze'. .github/workflows/release.yml (Line: 286, Col: 13): Job 'cleanup' depends on job 'deploy' which creates a cycle in the dependency graph.