### PR TITLE
fix: catch `ObjectDisposedException` in tests

### DIFF
--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 
-// ReSharper disable AccessToDisposedClosure
 // ReSharper disable once PartialTypeWithSinglePart
 public abstract partial class ReadTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
@@ -44,8 +43,16 @@ public abstract partial class ReadTests<TFileSystem>
 		stream.BeginRead(buffer, 0, buffer.Length, ar =>
 		{
 			// ReSharper disable once AccessToDisposedClosure
-			stream.EndRead(ar);
-			ms.Set();
+			try
+			{
+				stream.EndRead(ar);
+				// ReSharper disable once AccessToDisposedClosure
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		}, null);
 
 		ms.Wait(30000);
@@ -85,10 +92,18 @@ public abstract partial class ReadTests<TFileSystem>
 			byte[] buffer = new byte[bytes.Length];
 			stream.BeginRead(buffer, 0, buffer.Length, ar =>
 			{
-				TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
 				// ReSharper disable once AccessToDisposedClosure
-				stream.EndRead(ar);
-				ms.Set();
+				try
+				{
+					TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
+					stream.EndRead(ar);
+					// ReSharper disable once AccessToDisposedClosure
+					ms.Set();
+				}
+				catch (ObjectDisposedException)
+				{
+					// Ignore any ObjectDisposedException
+				}
 			}, null);
 
 			ms.Wait(10000);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 
-// ReSharper disable AccessToDisposedClosure
 // ReSharper disable once PartialTypeWithSinglePart
 public abstract partial class WriteTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
@@ -45,8 +44,16 @@ public abstract partial class WriteTests<TFileSystem>
 			stream.BeginWrite(bytes, 0, bytes.Length, ar =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
-				stream.EndWrite(ar);
-				ms.Set();
+				try
+				{
+					stream.EndWrite(ar);
+					// ReSharper disable once AccessToDisposedClosure
+					ms.Set();
+				}
+				catch (ObjectDisposedException)
+				{
+					// Ignore any ObjectDisposedException
+				}
 			}, null);
 
 			ms.Wait(30000);
@@ -85,11 +92,19 @@ public abstract partial class WriteTests<TFileSystem>
 		{
 			stream.BeginWrite(bytes, 0, bytes.Length, ar =>
 			{
-				TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
-				updateTime = TimeSystem.DateTime.UtcNow;
 				// ReSharper disable once AccessToDisposedClosure
-				stream.EndWrite(ar);
-				ms.Set();
+				try
+				{
+					TimeSystem.Thread.Sleep(FileTestHelper.AdjustTimesDelay);
+					updateTime = TimeSystem.DateTime.UtcNow;
+					stream.EndWrite(ar);
+					// ReSharper disable once AccessToDisposedClosure
+					ms.Set();
+				}
+				catch (ObjectDisposedException)
+				{
+					// Ignore any ObjectDisposedException
+				}
 			}, null);
 
 			ms.Wait(10000);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EnableRaisingEventsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EnableRaisingEventsTests.cs
@@ -17,7 +17,15 @@ public abstract partial class EnableRaisingEventsTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Deleted += (_, _) =>
 		{
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.EnableRaisingEvents = true;
 		FileSystem.Directory.Delete(path1);
@@ -40,7 +48,15 @@ public abstract partial class EnableRaisingEventsTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Deleted += (_, _) =>
 		{
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 
 		FileSystem.Directory.Delete(path);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
@@ -23,19 +23,40 @@ public abstract partial class EventTests<TFileSystem>
 
 		void FileSystemWatcherOnChanged(object sender, FileSystemEventArgs e)
 		{
-			callCount++;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				callCount++;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		}
 
 		try
 		{
 			_ = Task.Run(async () =>
 			{
-				int i = 0;
-				while (!ms.IsSet)
+				// ReSharper disable once AccessToDisposedClosure
+				try
 				{
-					await Task.Delay(10);
-					FileSystem.File.WriteAllText(path, i++.ToString(CultureInfo.InvariantCulture));
+					int i = 0;
+					while (!ms.IsSet)
+					{
+						FileSystem.File.WriteAllText(path,
+							i++.ToString(CultureInfo.InvariantCulture));
+						await Task.Delay(10);
+					}
+				}
+				catch (IOException)
+				{
+					// Ignore any IOException
+				}
+				catch (ObjectDisposedException)
+				{
+					// Ignore any ObjectDisposedException
 				}
 			});
 
@@ -68,19 +89,35 @@ public abstract partial class EventTests<TFileSystem>
 
 		void FileSystemWatcherOnCreated(object sender, FileSystemEventArgs e)
 		{
-			callCount++;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				callCount++;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		}
 
 		try
 		{
 			_ = Task.Run(async () =>
 			{
-				while (!ms.IsSet)
+				// ReSharper disable once AccessToDisposedClosure
+				try
 				{
-					await Task.Delay(10);
-					FileSystem.Directory.CreateDirectory(path);
-					FileSystem.Directory.Delete(path);
+					while (!ms.IsSet)
+					{
+						FileSystem.Directory.CreateDirectory(path);
+						FileSystem.Directory.Delete(path);
+						await Task.Delay(10);
+					}
+				}
+				catch (ObjectDisposedException)
+				{
+					// Ignore any ObjectDisposedException
 				}
 			});
 
@@ -114,19 +151,35 @@ public abstract partial class EventTests<TFileSystem>
 
 		void FileSystemWatcherOnDeleted(object sender, FileSystemEventArgs e)
 		{
-			callCount++;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				callCount++;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		}
 
 		try
 		{
 			_ = Task.Run(async () =>
 			{
-				while (!ms.IsSet)
+				// ReSharper disable once AccessToDisposedClosure
+				try
 				{
-					await Task.Delay(10);
-					FileSystem.Directory.CreateDirectory(path);
-					FileSystem.Directory.Delete(path);
+					while (!ms.IsSet)
+					{
+						FileSystem.Directory.CreateDirectory(path);
+						FileSystem.Directory.Delete(path);
+						await Task.Delay(10);
+					}
+				}
+				catch (ObjectDisposedException)
+				{
+					// Ignore any ObjectDisposedException
 				}
 			});
 
@@ -161,20 +214,36 @@ public abstract partial class EventTests<TFileSystem>
 
 		void FileSystemWatcherOnRenamed(object sender, FileSystemEventArgs e)
 		{
-			callCount++;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				callCount++;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		}
 
 		try
 		{
 			_ = Task.Run(async () =>
 			{
-				int i = 0;
-				FileSystem.File.WriteAllText($"path-{i}", "");
-				while (!ms.IsSet)
+				// ReSharper disable once AccessToDisposedClosure
+				try
 				{
-					await Task.Delay(10);
-					FileSystem.File.Move($"path-{i}", $"path-{++i}");
+					int i = 0;
+					FileSystem.File.WriteAllText($"path-{i}", "");
+					while (!ms.IsSet)
+					{
+						FileSystem.File.Move($"path-{i}", $"path-{++i}");
+						await Task.Delay(10);
+					}
+				}
+				catch (ObjectDisposedException)
+				{
+					// Ignore any ObjectDisposedException
 				}
 			});
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/FilterTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/FilterTests.cs
@@ -23,8 +23,16 @@ public abstract partial class FilterTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Deleted += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.Filter = path;
 		fileSystemWatcher.EnableRaisingEvents = true;
@@ -51,8 +59,16 @@ public abstract partial class FilterTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Deleted += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.Filter = filter;
 		fileSystemWatcher.EnableRaisingEvents = true;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/IncludeSubdirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/IncludeSubdirectoriesTests.cs
@@ -3,7 +3,6 @@ using System.Threading;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 
-// ReSharper disable AccessToDisposedClosure
 // ReSharper disable once PartialTypeWithSinglePart
 public abstract partial class IncludeSubdirectoriesTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
@@ -23,8 +22,16 @@ public abstract partial class IncludeSubdirectoriesTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Deleted += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.IncludeSubdirectories = false;
 		fileSystemWatcher.EnableRaisingEvents = true;
@@ -50,8 +57,16 @@ public abstract partial class IncludeSubdirectoriesTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(baseDirectory);
 		fileSystemWatcher.Deleted += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.IncludeSubdirectories = true;
 		fileSystemWatcher.EnableRaisingEvents = true;
@@ -77,8 +92,16 @@ public abstract partial class IncludeSubdirectoriesTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Deleted += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.IncludeSubdirectories = true;
 		fileSystemWatcher.EnableRaisingEvents = true;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/NotifyFiltersTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/NotifyFiltersTests.cs
@@ -3,7 +3,6 @@ using System.Threading;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 
-// ReSharper disable AccessToDisposedClosure
 // ReSharper disable once PartialTypeWithSinglePart
 public abstract partial class NotifyFiltersTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
@@ -36,8 +35,16 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Changed += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.NotifyFilter = NotifyFilters.DirectoryName |
 		                                 NotifyFilters.FileName;
@@ -99,8 +106,16 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Changed += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.NotifyFilter = notifyFilter;
 		fileSystemWatcher.EnableRaisingEvents = true;
@@ -127,8 +142,16 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Created += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.NotifyFilter = NotifyFilters.Attributes |
 		                                 NotifyFilters.CreationTime |
@@ -159,8 +182,16 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Created += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.NotifyFilter = notifyFilter;
 		fileSystemWatcher.EnableRaisingEvents = true;
@@ -187,8 +218,16 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Deleted += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.NotifyFilter = NotifyFilters.Attributes |
 		                                 NotifyFilters.CreationTime |
@@ -219,8 +258,16 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Deleted += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.NotifyFilter = notifyFilter;
 		fileSystemWatcher.EnableRaisingEvents = true;
@@ -247,8 +294,16 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Deleted += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.NotifyFilter = NotifyFilters.Attributes |
 		                                 NotifyFilters.CreationTime |
@@ -279,8 +334,16 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Deleted += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.NotifyFilter = notifyFilter;
 		fileSystemWatcher.EnableRaisingEvents = true;
@@ -314,8 +377,16 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Renamed += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 
 		fileSystemWatcher.IncludeSubdirectories = true;
@@ -357,8 +428,16 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Renamed += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 
 		fileSystemWatcher.IncludeSubdirectories = true;
@@ -387,8 +466,16 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Renamed += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.NotifyFilter = NotifyFilters.Attributes |
 		                                 NotifyFilters.CreationTime |
@@ -421,8 +508,16 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Renamed += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 
 		fileSystemWatcher.NotifyFilter = notifyFilter;
@@ -454,8 +549,16 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Changed += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.NotifyFilter = NotifyFilters.DirectoryName |
 		                                 NotifyFilters.FileName;
@@ -517,8 +620,16 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		fileSystemWatcher.Changed += (_, eventArgs) =>
 		{
-			result = eventArgs;
-			ms.Set();
+			// ReSharper disable once AccessToDisposedClosure
+			try
+			{
+				result = eventArgs;
+				ms.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Ignore any ObjectDisposedException
+			}
 		};
 		fileSystemWatcher.NotifyFilter = notifyFilter;
 		fileSystemWatcher.EnableRaisingEvents = true;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 
-// ReSharper disable AccessToDisposedClosure
 // ReSharper disable once PartialTypeWithSinglePart
 public abstract partial class Tests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
@@ -30,11 +29,19 @@ public abstract partial class Tests<TFileSystem>
 		{
 			_ = Task.Run(async () =>
 			{
-				while (!ms.IsSet)
+				// ReSharper disable once AccessToDisposedClosure
+				try
 				{
-					await Task.Delay(10);
-					FileSystem.Directory.CreateDirectory(path);
-					FileSystem.Directory.Delete(path);
+					while (!ms.IsSet)
+					{
+						await Task.Delay(10);
+						FileSystem.Directory.CreateDirectory(path);
+						FileSystem.Directory.Delete(path);
+					}
+				}
+				catch (ObjectDisposedException)
+				{
+					// Ignore any ObjectDisposedException
 				}
 			});
 			IWaitForChangedResult result =
@@ -80,11 +87,19 @@ public abstract partial class Tests<TFileSystem>
 		{
 			_ = Task.Run(async () =>
 			{
-				while (!ms.IsSet)
+				// ReSharper disable once AccessToDisposedClosure
+				try
 				{
-					await Task.Delay(10);
-					FileSystem.Directory.CreateDirectory(path);
-					FileSystem.Directory.Delete(path);
+					while (!ms.IsSet)
+					{
+						await Task.Delay(10);
+						FileSystem.Directory.CreateDirectory(path);
+						FileSystem.Directory.Delete(path);
+					}
+				}
+				catch (ObjectDisposedException)
+				{
+					// Ignore any ObjectDisposedException
 				}
 			});
 			IWaitForChangedResult result =

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-// ReSharper disable AccessToDisposedClosure
 
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 
@@ -21,11 +20,19 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 		{
 			_ = Task.Run(async () =>
 			{
-				while (!ms.IsSet)
+				// ReSharper disable once AccessToDisposedClosure
+				try
 				{
-					await Task.Delay(10);
-					FileSystem.Directory.CreateDirectory(path);
-					FileSystem.Directory.Delete(path);
+					while (!ms.IsSet)
+					{
+						await Task.Delay(10);
+						FileSystem.Directory.CreateDirectory(path);
+						FileSystem.Directory.Delete(path);
+					}
+				}
+				catch (ObjectDisposedException)
+				{
+					// Ignore any ObjectDisposedException
 				}
 			});
 
@@ -62,11 +69,19 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 			fileSystemWatcher.EnableRaisingEvents = true;
 			_ = Task.Run(async () =>
 			{
-				while (!ms.IsSet)
+				// ReSharper disable once AccessToDisposedClosure
+				try
 				{
-					await Task.Delay(10);
-					FileSystem.Directory.CreateDirectory(fullPath);
-					FileSystem.Directory.Delete(fullPath);
+					while (!ms.IsSet)
+					{
+						await Task.Delay(10);
+						FileSystem.Directory.CreateDirectory(fullPath);
+						FileSystem.Directory.Delete(fullPath);
+					}
+				}
+				catch (ObjectDisposedException)
+				{
+					// Ignore any ObjectDisposedException
 				}
 			});
 			IWaitForChangedResult result = callback(fileSystemWatcher);

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -5,7 +5,6 @@ using ITimer = Testably.Abstractions.TimeSystem.ITimer;
 
 namespace Testably.Abstractions.Tests.TimeSystem;
 
-// ReSharper disable AccessToDisposedClosure
 // ReSharper disable once PartialTypeWithSinglePart
 public abstract partial class TimerTests<TTimeSystem>
 	: TimeSystemTestBase<TTimeSystem>
@@ -27,6 +26,7 @@ public abstract partial class TimerTests<TTimeSystem>
 		timer.Dispose();
 		Exception? exception = Record.Exception(() =>
 		{
+			// ReSharper disable once AccessToDisposedClosure
 			timer.Change(100, 200);
 		});
 
@@ -46,6 +46,7 @@ public abstract partial class TimerTests<TTimeSystem>
 
 		Exception? exception = Record.Exception(() =>
 		{
+			// ReSharper disable once AccessToDisposedClosure
 			timer.Change(Timeout.Infinite, 0);
 		});
 
@@ -61,6 +62,7 @@ public abstract partial class TimerTests<TTimeSystem>
 
 		Exception? exception = Record.Exception(() =>
 		{
+			// ReSharper disable once AccessToDisposedClosure
 			timer.Change(0, Timeout.Infinite);
 		});
 
@@ -78,6 +80,7 @@ public abstract partial class TimerTests<TTimeSystem>
 
 		Exception? exception = Record.Exception(() =>
 		{
+			// ReSharper disable once AccessToDisposedClosure
 			timer.Change(dueTime, 0);
 		});
 
@@ -97,6 +100,7 @@ public abstract partial class TimerTests<TTimeSystem>
 
 		Exception? exception = Record.Exception(() =>
 		{
+			// ReSharper disable once AccessToDisposedClosure
 			timer.Change(0, period);
 		});
 
@@ -154,6 +158,7 @@ public abstract partial class TimerTests<TTimeSystem>
 		// ReSharper disable once AsyncVoidLambda
 		using (ITimer timer1 = TimeSystem.Timer.New(async _ =>
 			{
+				// ReSharper disable once AccessToDisposedClosure
 				try
 				{
 					DateTime now = TimeSystem.DateTime.Now;
@@ -161,9 +166,11 @@ public abstract partial class TimerTests<TTimeSystem>
 					previousTime = now;
 					ms.Set();
 					triggerTimes.Add((int)diff);
+					// ReSharper disable once AccessToDisposedClosure
 					ms2.Wait(30000);
 					if (triggerTimes.Count > 3)
 					{
+						// ReSharper disable once AccessToDisposedClosure
 						ms3.Set();
 					}
 
@@ -179,9 +186,11 @@ public abstract partial class TimerTests<TTimeSystem>
 			ms.Wait(30000).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 			{
+				// ReSharper disable once AccessToDisposedClosure
 				try
 				{
 					timer1.Change(0 * TimerMultiplier, 200 * TimerMultiplier);
+					// ReSharper disable once AccessToDisposedClosure
 					ms2.Set();
 				}
 				catch (ObjectDisposedException)
@@ -222,6 +231,7 @@ public abstract partial class TimerTests<TTimeSystem>
 		// ReSharper disable once AsyncVoidLambda
 		using (ITimer timer1 = TimeSystem.Timer.New(async _ =>
 			{
+				// ReSharper disable once AccessToDisposedClosure
 				try
 				{
 					DateTime now = TimeSystem.DateTime.Now;
@@ -229,9 +239,11 @@ public abstract partial class TimerTests<TTimeSystem>
 					previousTime = now;
 					ms.Set();
 					triggerTimes.Add((int)diff);
+					// ReSharper disable once AccessToDisposedClosure
 					ms2.Wait(30000);
 					if (triggerTimes.Count > 3)
 					{
+						// ReSharper disable once AccessToDisposedClosure
 						ms3.Set();
 					}
 
@@ -247,9 +259,11 @@ public abstract partial class TimerTests<TTimeSystem>
 			ms.Wait(30000).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 			{
+				// ReSharper disable once AccessToDisposedClosure
 				try
 				{
 					timer1.Change(0L * TimerMultiplier, 200L * TimerMultiplier);
+					// ReSharper disable once AccessToDisposedClosure
 					ms2.Set();
 				}
 				catch (ObjectDisposedException)
@@ -290,6 +304,7 @@ public abstract partial class TimerTests<TTimeSystem>
 		// ReSharper disable once AsyncVoidLambda
 		using (ITimer timer1 = TimeSystem.Timer.New(async _ =>
 			{
+				// ReSharper disable once AccessToDisposedClosure
 				try
 				{
 					DateTime now = TimeSystem.DateTime.Now;
@@ -297,9 +312,11 @@ public abstract partial class TimerTests<TTimeSystem>
 					previousTime = now;
 					ms.Set();
 					triggerTimes.Add((int)diff);
+					// ReSharper disable once AccessToDisposedClosure
 					ms2.Wait(30000);
 					if (triggerTimes.Count > 3)
 					{
+						// ReSharper disable once AccessToDisposedClosure
 						ms3.Set();
 					}
 
@@ -315,10 +332,12 @@ public abstract partial class TimerTests<TTimeSystem>
 			ms.Wait(30000).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 				{
+					// ReSharper disable once AccessToDisposedClosure
 					try
 					{
 						timer1.Change(TimeSpan.FromMilliseconds(0 * TimerMultiplier),
 							TimeSpan.FromMilliseconds(200 * TimerMultiplier));
+						// ReSharper disable once AccessToDisposedClosure
 						ms2.Set();
 					}
 					catch (ObjectDisposedException)
@@ -360,6 +379,7 @@ public abstract partial class TimerTests<TTimeSystem>
 		result.Should().BeTrue();
 		Exception? exception = Record.Exception(() =>
 		{
+			// ReSharper disable once AccessToDisposedClosure
 			timer.Change(0, 0);
 		});
 
@@ -383,6 +403,7 @@ public abstract partial class TimerTests<TTimeSystem>
 		result.Should().BeTrue();
 		Exception? exception = Record.Exception(() =>
 		{
+			// ReSharper disable once AccessToDisposedClosure
 			timer.Change(0, 0);
 		});
 
@@ -406,6 +427,7 @@ public abstract partial class TimerTests<TTimeSystem>
 		result.Should().BeTrue();
 		Exception? exception = Record.Exception(() =>
 		{
+			// ReSharper disable once AccessToDisposedClosure
 			timer.Change(0, 0);
 		});
 
@@ -442,6 +464,7 @@ public abstract partial class TimerTests<TTimeSystem>
 
 		Exception? exception = Record.Exception(() =>
 		{
+			// ReSharper disable once AccessToDisposedClosure
 			timer.Change(0, 0);
 		});
 


### PR DESCRIPTION
Test run sporadically fails on Ubuntu without failing test:
> The active test run was aborted. Reason: Test host process crashed : Unhandled exception. System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Threading.ManualResetEventSlim'.
   at System.Threading.ManualResetEventSlim.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.ManualResetEventSlim.Wait(Int32 millisecondsTimeout)
   at Testably.Abstractions.Tests.TimeSystem.TimerTests`1.<>c__DisplayClass10_0.<<Change_WithLong_ShouldResetTimer>b__0>d.MoveNext() in /home/runner/work/Testably.Abstractions/Testably.Abstractions/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs:line 221
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_1(Object state)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()