### PR TITLE
fix: skip `state: released` flagged issues and PRs during release commenting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,6 +293,8 @@ jobs:
             This is addressed in release {release_link}.
           label-template: |
             state: released
+          skip-label: |
+            state: released
       - name: Checkout sources
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:


### PR DESCRIPTION
Skip `state: released` flagged issues and prs in the [apexskier/github-release-commenter](https://github.com/apexskier/github-release-commenter) action in the release build pipeline.

This is a workaround for a [known limitation](https://github.com/apexskier/github-release-commenter?tab=readme-ov-file#known-limitations) to allow re-triggering the build.
