### PR TITLE
fix: remove the sonarcloud badge from the release README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,8 +320,9 @@ jobs:
           do
             echo "Processing $f" # always double quote "$f" filename
             # do something on $f
-            # Remove the codacy badge as it is not aligned to the release
-            grep -v "Codacy Badge" "./$f" > "./$f.backup" && mv "./$f.backup" "./$f"
+            # Remove the codacy and sonarcloud badge as it is not aligned to the release
+            grep -v "app.codacy.com" "./$f" > "./$f.backup" && mv "./$f.backup" "./$f"
+            grep -v "sonarcloud.io" "./$f" > "./$f.backup" && mv "./$f.backup" "./$f"
             # Change status badges to display explicit version
             sed -i -e "s/branch=main/branch=release%2F${version}/g" "./$f"
             sed -i -e "s/Testably.Abstractions%2Fmain/Testably.Abstractions%2Frelease%2F${version}/g" "./$f"


### PR DESCRIPTION
The Sonarcloud badge displays a "Project not found" error in the [release README](https://www.nuget.org/packages/Testably.Abstractions/3.0.0#readme-body-tab), because the release branches are no longer explicitely tracked:
![image](https://github.com/Testably/Testably.Abstractions/assets/3438234/949d699e-0306-41eb-89e9-b319fbc4507c)

Remove both codacy and sonarcloud badges from release README, as they are not aligned to the release version.