### PR TITLE
feat: make statistic interfaces generic

### DIFF
--- a/Source/Testably.Abstractions.Testing/Statistics/CallStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/CallStatistics.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 
 namespace Testably.Abstractions.Testing.Statistics;
 
-internal class CallStatistics : IStatistics
+internal class CallStatistics<TType> : IStatistics<TType>
 {
 	private readonly ConcurrentQueue<MethodStatistic> _methods = new();
 	private readonly string _name;

--- a/Source/Testably.Abstractions.Testing/Statistics/FileSystemStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/FileSystemStatistics.cs
@@ -13,54 +13,64 @@ internal sealed class FileSystemStatistics : IFileSystemStatistics, IStatisticsG
 	/// </summary>
 	public int TotalCount => _counter;
 
-	internal readonly CallStatistics Directory;
-	internal readonly PathStatistics DirectoryInfo;
-	internal readonly PathStatistics DriveInfo;
-	internal readonly CallStatistics File;
-	internal readonly PathStatistics FileInfo;
-	internal readonly PathStatistics FileStream;
-	internal readonly PathStatistics FileSystemWatcher;
-	internal readonly CallStatistics Path;
+	internal readonly CallStatistics<IDirectory> Directory;
+	internal readonly PathStatistics<IDirectoryInfoFactory, IDirectoryInfo> DirectoryInfo;
+	internal readonly PathStatistics<IDriveInfoFactory, IDriveInfo> DriveInfo;
+	internal readonly CallStatistics<IFile> File;
+	internal readonly PathStatistics<IFileInfoFactory, IFileInfo> FileInfo;
+	internal readonly PathStatistics<IFileStreamFactory, FileSystemStream> FileStream;
+
+	internal readonly PathStatistics<IFileSystemWatcherFactory, IFileSystemWatcher>
+		FileSystemWatcher;
+
+	internal readonly CallStatistics<IPath> Path;
 	private int _counter;
 
 	public FileSystemStatistics(MockFileSystem fileSystem)
 	{
-		DirectoryInfo = new PathStatistics(this, fileSystem, nameof(IFileSystem.DirectoryInfo));
-		DriveInfo = new PathStatistics(this, fileSystem, nameof(IFileSystem.DriveInfo));
-		FileInfo = new PathStatistics(this, fileSystem, nameof(IFileSystem.FileInfo));
-		FileStream = new PathStatistics(this, fileSystem, nameof(IFileSystem.FileStream));
-		FileSystemWatcher =
-			new PathStatistics(this, fileSystem, nameof(IFileSystem.FileSystemWatcher));
-		File = new CallStatistics(this, nameof(IFileSystem.File));
-		Directory = new CallStatistics(this, nameof(IFileSystem.Directory));
-		Path = new CallStatistics(this, nameof(IFileSystem.Path));
+		Directory = new CallStatistics<IDirectory>(this, nameof(IFileSystem.Directory));
+		DirectoryInfo = new PathStatistics<IDirectoryInfoFactory, IDirectoryInfo>(
+			this, fileSystem, nameof(IFileSystem.DirectoryInfo));
+		DriveInfo = new PathStatistics<IDriveInfoFactory, IDriveInfo>(
+			this, fileSystem, nameof(IFileSystem.DriveInfo));
+		File = new CallStatistics<IFile>(this, nameof(IFileSystem.File));
+		FileInfo = new PathStatistics<IFileInfoFactory, IFileInfo>(
+			this, fileSystem, nameof(IFileSystem.FileInfo));
+		FileStream = new PathStatistics<IFileStreamFactory, FileSystemStream>(
+			this, fileSystem, nameof(IFileSystem.FileStream));
+		FileSystemWatcher = new PathStatistics<IFileSystemWatcherFactory, IFileSystemWatcher>(
+			this, fileSystem, nameof(IFileSystem.FileSystemWatcher));
+		Path = new CallStatistics<IPath>(this, nameof(IFileSystem.Path));
 	}
 
 	#region IFileSystemStatistics Members
 
 	/// <inheritdoc cref="IFileSystemStatistics.Directory" />
-	IStatistics IFileSystemStatistics.Directory => Directory;
+	IStatistics<IDirectory> IFileSystemStatistics.Directory => Directory;
 
 	/// <inheritdoc cref="IFileSystemStatistics.DirectoryInfo" />
-	IPathStatistics IFileSystemStatistics.DirectoryInfo => DirectoryInfo;
+	IPathStatistics<IDirectoryInfoFactory, IDirectoryInfo> IFileSystemStatistics.DirectoryInfo
+		=> DirectoryInfo;
 
 	/// <inheritdoc cref="IFileSystemStatistics.DriveInfo" />
-	IPathStatistics IFileSystemStatistics.DriveInfo => DriveInfo;
+	IPathStatistics<IDriveInfoFactory, IDriveInfo> IFileSystemStatistics.DriveInfo => DriveInfo;
 
 	/// <inheritdoc cref="IFileSystemStatistics.File" />
-	IStatistics IFileSystemStatistics.File => File;
+	IStatistics<IFile> IFileSystemStatistics.File => File;
 
 	/// <inheritdoc cref="IFileSystemStatistics.FileInfo" />
-	IPathStatistics IFileSystemStatistics.FileInfo => FileInfo;
+	IPathStatistics<IFileInfoFactory, IFileInfo> IFileSystemStatistics.FileInfo => FileInfo;
 
 	/// <inheritdoc cref="IFileSystemStatistics.FileStream" />
-	IPathStatistics IFileSystemStatistics.FileStream => FileStream;
+	IPathStatistics<IFileStreamFactory, FileSystemStream> IFileSystemStatistics.FileStream
+		=> FileStream;
 
 	/// <inheritdoc cref="IFileSystemStatistics.FileSystemWatcher" />
-	IPathStatistics IFileSystemStatistics.FileSystemWatcher => FileSystemWatcher;
+	IPathStatistics<IFileSystemWatcherFactory, IFileSystemWatcher> IFileSystemStatistics.
+		FileSystemWatcher => FileSystemWatcher;
 
 	/// <inheritdoc cref="IFileSystemStatistics.Path" />
-	IStatistics IFileSystemStatistics.Path => Path;
+	IStatistics<IPath> IFileSystemStatistics.Path => Path;
 
 	#endregion
 

--- a/Source/Testably.Abstractions.Testing/Statistics/IFileSystemStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/IFileSystemStatistics.cs
@@ -8,40 +8,40 @@ public interface IFileSystemStatistics
 	/// <summary>
 	///     Statistical information about calls to <see cref="IFileSystem.Directory" />.
 	/// </summary>
-	IStatistics Directory { get; }
+	IStatistics<IDirectory> Directory { get; }
 
 	/// <summary>
 	///     Statistical information about calls to <see cref="IFileSystem.DirectoryInfo" />.
 	/// </summary>
-	IPathStatistics DirectoryInfo { get; }
+	IPathStatistics<IDirectoryInfoFactory, IDirectoryInfo> DirectoryInfo { get; }
 
 	/// <summary>
 	///     Statistical information about calls to <see cref="IFileSystem.DriveInfo" />.
 	/// </summary>
-	IPathStatistics DriveInfo { get; }
+	IPathStatistics<IDriveInfoFactory, IDriveInfo> DriveInfo { get; }
 
 	/// <summary>
 	///     Statistical information about calls to <see cref="IFileSystem.File" />.
 	/// </summary>
-	IStatistics File { get; }
+	IStatistics<IFile> File { get; }
 
 	/// <summary>
 	///     Statistical information about calls to <see cref="IFileSystem.FileInfo" />.
 	/// </summary>
-	IPathStatistics FileInfo { get; }
+	IPathStatistics<IFileInfoFactory, IFileInfo> FileInfo { get; }
 
 	/// <summary>
 	///     Statistical information about calls to <see cref="IFileSystem.FileStream" />.
 	/// </summary>
-	IPathStatistics FileStream { get; }
+	IPathStatistics<IFileStreamFactory, FileSystemStream> FileStream { get; }
 
 	/// <summary>
 	///     Statistical information about calls to <see cref="IFileSystem.FileSystemWatcher" />.
 	/// </summary>
-	IPathStatistics FileSystemWatcher { get; }
+	IPathStatistics<IFileSystemWatcherFactory, IFileSystemWatcher> FileSystemWatcher { get; }
 
 	/// <summary>
 	///     Statistical information about calls to <see cref="IFileSystem.Path" />.
 	/// </summary>
-	IStatistics Path { get; }
+	IStatistics<IPath> Path { get; }
 }

--- a/Source/Testably.Abstractions.Testing/Statistics/IPathStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/IPathStatistics.cs
@@ -6,12 +6,12 @@
 /// <remarks>
 ///     See also <seealso cref="IStatistics" /> .
 /// </remarks>
-public interface IPathStatistics : IStatistics
+public interface IPathStatistics<TFactory, TType> : IStatistics<TFactory>
 {
 	/// <summary>
 	///     Returns the underlying <see cref="IStatistics" /> under <paramref name="path" />.
 	/// </summary>
-	IStatistics this[string path]
+	IStatistics<TType> this[string path]
 	{
 		get;
 	}

--- a/Source/Testably.Abstractions.Testing/Statistics/IStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/IStatistics.cs
@@ -15,3 +15,12 @@ public interface IStatistics
 	/// </summary>
 	PropertyStatistic[] Properties { get; }
 }
+
+/// <summary>
+///     Contains statistical information about the mock usage.
+/// </summary>
+// ReSharper disable once UnusedTypeParameter
+public interface IStatistics<TType> : IStatistics
+{
+	// Empty wrapper interface to by type-safe.
+}

--- a/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
@@ -5,11 +5,11 @@ using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.Statistics;
 
-internal class PathStatistics : CallStatistics, IPathStatistics
+internal class PathStatistics<TFactory, TType> : CallStatistics<TFactory>, IPathStatistics<TFactory, TType>
 {
 	private readonly MockFileSystem _fileSystem;
 
-	private readonly ConcurrentDictionary<string, CallStatistics> _statistics;
+	private readonly ConcurrentDictionary<string, CallStatistics<TType>> _statistics;
 	private readonly IStatisticsGate _statisticsGate;
 
 	public PathStatistics(
@@ -18,7 +18,7 @@ internal class PathStatistics : CallStatistics, IPathStatistics
 		string name)
 		: base(statisticsGate, name)
 	{
-		_statistics = new ConcurrentDictionary<string, CallStatistics>(
+		_statistics = new ConcurrentDictionary<string, CallStatistics<TType>>(
 			fileSystem.Execute.StringComparisonMode == StringComparison.Ordinal
 				? StringComparer.Ordinal
 				: StringComparer.OrdinalIgnoreCase);
@@ -28,14 +28,14 @@ internal class PathStatistics : CallStatistics, IPathStatistics
 
 	#region IPathStatistics Members
 
-	/// <inheritdoc cref="IPathStatistics.this[string]" />
-	public IStatistics this[string path]
+	/// <inheritdoc cref="IPathStatistics{TFactory,TType}.this[string]" />
+	public IStatistics<TType> this[string path]
 	{
 		get
 		{
 			string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
 			return _statistics.GetOrAdd(key,
-				k => new CallStatistics(_statisticsGate, $"{ToString()}[{k}]"));
+				k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
 		}
 	}
 
@@ -49,9 +49,9 @@ internal class PathStatistics : CallStatistics, IPathStatistics
 		params ParameterDescription[] parameters)
 	{
 		string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
-		CallStatistics callStatistics =
+		CallStatistics<TType> callStatistics =
 			_statistics.GetOrAdd(key,
-				k => new CallStatistics(_statisticsGate, $"{ToString()}[{k}]"));
+				k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
 		return callStatistics.RegisterMethod(name, parameters);
 	}
 
@@ -63,9 +63,9 @@ internal class PathStatistics : CallStatistics, IPathStatistics
 	internal IDisposable RegisterProperty(string path, string name, PropertyAccess access)
 	{
 		string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
-		CallStatistics callStatistics =
+		CallStatistics<TType> callStatistics =
 			_statistics.GetOrAdd(key,
-				k => new CallStatistics(_statisticsGate, $"{ToString()}[{k}]"));
+				k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
 		return callStatistics.RegisterProperty(name, access);
 	}
 

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -269,24 +269,25 @@ namespace Testably.Abstractions.Testing.Statistics
 {
     public interface IFileSystemStatistics
     {
-        Testably.Abstractions.Testing.Statistics.IStatistics Directory { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics DirectoryInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics DriveInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IStatistics File { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileStream { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileSystemWatcher { get; }
-        Testably.Abstractions.Testing.Statistics.IStatistics Path { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IDirectory> Directory { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IDirectoryInfoFactory, System.IO.Abstractions.IDirectoryInfo> DirectoryInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IDriveInfoFactory, System.IO.Abstractions.IDriveInfo> DriveInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IFile> File { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileInfoFactory, System.IO.Abstractions.IFileInfo> FileInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
     }
-    public interface IPathStatistics : Testably.Abstractions.Testing.Statistics.IStatistics
+    public interface IPathStatistics<TFactory, TType> : Testably.Abstractions.Testing.Statistics.IStatistics, Testably.Abstractions.Testing.Statistics.IStatistics<TFactory>
     {
-        Testably.Abstractions.Testing.Statistics.IStatistics this[string path] { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<TType> this[string path] { get; }
     }
     public interface IStatistics
     {
         Testably.Abstractions.Testing.Statistics.MethodStatistic[] Methods { get; }
         Testably.Abstractions.Testing.Statistics.PropertyStatistic[] Properties { get; }
     }
+    public interface IStatistics<TType> : Testably.Abstractions.Testing.Statistics.IStatistics { }
     public sealed class MethodStatistic
     {
         public int Counter { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
@@ -269,24 +269,25 @@ namespace Testably.Abstractions.Testing.Statistics
 {
     public interface IFileSystemStatistics
     {
-        Testably.Abstractions.Testing.Statistics.IStatistics Directory { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics DirectoryInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics DriveInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IStatistics File { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileStream { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileSystemWatcher { get; }
-        Testably.Abstractions.Testing.Statistics.IStatistics Path { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IDirectory> Directory { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IDirectoryInfoFactory, System.IO.Abstractions.IDirectoryInfo> DirectoryInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IDriveInfoFactory, System.IO.Abstractions.IDriveInfo> DriveInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IFile> File { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileInfoFactory, System.IO.Abstractions.IFileInfo> FileInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
     }
-    public interface IPathStatistics : Testably.Abstractions.Testing.Statistics.IStatistics
+    public interface IPathStatistics<TFactory, TType> : Testably.Abstractions.Testing.Statistics.IStatistics, Testably.Abstractions.Testing.Statistics.IStatistics<TFactory>
     {
-        Testably.Abstractions.Testing.Statistics.IStatistics this[string path] { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<TType> this[string path] { get; }
     }
     public interface IStatistics
     {
         Testably.Abstractions.Testing.Statistics.MethodStatistic[] Methods { get; }
         Testably.Abstractions.Testing.Statistics.PropertyStatistic[] Properties { get; }
     }
+    public interface IStatistics<TType> : Testably.Abstractions.Testing.Statistics.IStatistics { }
     public sealed class MethodStatistic
     {
         public int Counter { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -267,24 +267,25 @@ namespace Testably.Abstractions.Testing.Statistics
 {
     public interface IFileSystemStatistics
     {
-        Testably.Abstractions.Testing.Statistics.IStatistics Directory { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics DirectoryInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics DriveInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IStatistics File { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileStream { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileSystemWatcher { get; }
-        Testably.Abstractions.Testing.Statistics.IStatistics Path { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IDirectory> Directory { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IDirectoryInfoFactory, System.IO.Abstractions.IDirectoryInfo> DirectoryInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IDriveInfoFactory, System.IO.Abstractions.IDriveInfo> DriveInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IFile> File { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileInfoFactory, System.IO.Abstractions.IFileInfo> FileInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
     }
-    public interface IPathStatistics : Testably.Abstractions.Testing.Statistics.IStatistics
+    public interface IPathStatistics<TFactory, TType> : Testably.Abstractions.Testing.Statistics.IStatistics, Testably.Abstractions.Testing.Statistics.IStatistics<TFactory>
     {
-        Testably.Abstractions.Testing.Statistics.IStatistics this[string path] { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<TType> this[string path] { get; }
     }
     public interface IStatistics
     {
         Testably.Abstractions.Testing.Statistics.MethodStatistic[] Methods { get; }
         Testably.Abstractions.Testing.Statistics.PropertyStatistic[] Properties { get; }
     }
+    public interface IStatistics<TType> : Testably.Abstractions.Testing.Statistics.IStatistics { }
     public sealed class MethodStatistic
     {
         public int Counter { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -267,24 +267,25 @@ namespace Testably.Abstractions.Testing.Statistics
 {
     public interface IFileSystemStatistics
     {
-        Testably.Abstractions.Testing.Statistics.IStatistics Directory { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics DirectoryInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics DriveInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IStatistics File { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileStream { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileSystemWatcher { get; }
-        Testably.Abstractions.Testing.Statistics.IStatistics Path { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IDirectory> Directory { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IDirectoryInfoFactory, System.IO.Abstractions.IDirectoryInfo> DirectoryInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IDriveInfoFactory, System.IO.Abstractions.IDriveInfo> DriveInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IFile> File { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileInfoFactory, System.IO.Abstractions.IFileInfo> FileInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
     }
-    public interface IPathStatistics : Testably.Abstractions.Testing.Statistics.IStatistics
+    public interface IPathStatistics<TFactory, TType> : Testably.Abstractions.Testing.Statistics.IStatistics, Testably.Abstractions.Testing.Statistics.IStatistics<TFactory>
     {
-        Testably.Abstractions.Testing.Statistics.IStatistics this[string path] { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<TType> this[string path] { get; }
     }
     public interface IStatistics
     {
         Testably.Abstractions.Testing.Statistics.MethodStatistic[] Methods { get; }
         Testably.Abstractions.Testing.Statistics.PropertyStatistic[] Properties { get; }
     }
+    public interface IStatistics<TType> : Testably.Abstractions.Testing.Statistics.IStatistics { }
     public sealed class MethodStatistic
     {
         public int Counter { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -267,24 +267,25 @@ namespace Testably.Abstractions.Testing.Statistics
 {
     public interface IFileSystemStatistics
     {
-        Testably.Abstractions.Testing.Statistics.IStatistics Directory { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics DirectoryInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics DriveInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IStatistics File { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileInfo { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileStream { get; }
-        Testably.Abstractions.Testing.Statistics.IPathStatistics FileSystemWatcher { get; }
-        Testably.Abstractions.Testing.Statistics.IStatistics Path { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IDirectory> Directory { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IDirectoryInfoFactory, System.IO.Abstractions.IDirectoryInfo> DirectoryInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IDriveInfoFactory, System.IO.Abstractions.IDriveInfo> DriveInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IFile> File { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileInfoFactory, System.IO.Abstractions.IFileInfo> FileInfo { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
     }
-    public interface IPathStatistics : Testably.Abstractions.Testing.Statistics.IStatistics
+    public interface IPathStatistics<TFactory, TType> : Testably.Abstractions.Testing.Statistics.IStatistics, Testably.Abstractions.Testing.Statistics.IStatistics<TFactory>
     {
-        Testably.Abstractions.Testing.Statistics.IStatistics this[string path] { get; }
+        Testably.Abstractions.Testing.Statistics.IStatistics<TType> this[string path] { get; }
     }
     public interface IStatistics
     {
         Testably.Abstractions.Testing.Statistics.MethodStatistic[] Methods { get; }
         Testably.Abstractions.Testing.Statistics.PropertyStatistic[] Properties { get; }
     }
+    public interface IStatistics<TType> : Testably.Abstractions.Testing.Statistics.IStatistics { }
     public sealed class MethodStatistic
     {
         public int Counter { get; }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryInfoFactoryStatisticsTests.cs
@@ -35,7 +35,8 @@ public sealed class DirectoryInfoFactoryStatisticsTests
 	[SkippableFact]
 	public void ToString_ShouldBeDirectoryInfo()
 	{
-		IPathStatistics sut = new MockFileSystem().Statistics.DirectoryInfo;
+		IPathStatistics<IDirectoryInfoFactory, IDirectoryInfo> sut
+			= new MockFileSystem().Statistics.DirectoryInfo;
 
 		string? result = sut.ToString();
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoFactoryStatisticsTests.cs
@@ -47,7 +47,8 @@ public sealed class DriveInfoFactoryStatisticsTests
 	[SkippableFact]
 	public void ToString_ShouldBeDriveInfo()
 	{
-		IPathStatistics sut = new MockFileSystem().Statistics.DriveInfo;
+		IPathStatistics<IDriveInfoFactory, IDriveInfo> sut
+			= new MockFileSystem().Statistics.DriveInfo;
 
 		string? result = sut.ToString();
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoFactoryStatisticsTests.cs
@@ -35,7 +35,8 @@ public class FileInfoFactoryStatisticsTests
 	[SkippableFact]
 	public void ToString_ShouldBeFileInfo()
 	{
-		IPathStatistics sut = new MockFileSystem().Statistics.FileInfo;
+		IPathStatistics<IFileInfoFactory, IFileInfo> sut
+			= new MockFileSystem().Statistics.FileInfo;
 
 		string? result = sut.ToString();
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamFactoryStatisticsTests.cs
@@ -209,7 +209,8 @@ public class FileStreamFactoryStatisticsTests
 	[SkippableFact]
 	public void ToString_ShouldBeFileStream()
 	{
-		IPathStatistics sut = new MockFileSystem().Statistics.FileStream;
+		IPathStatistics<IFileStreamFactory, FileSystemStream> sut
+			= new MockFileSystem().Statistics.FileStream;
 
 		string? result = sut.ToString();
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherFactoryStatisticsTests.cs
@@ -67,7 +67,8 @@ public class FileSystemWatcherFactoryStatisticsTests
 	[SkippableFact]
 	public void ToString_ShouldBeFileSystemWatcher()
 	{
-		IPathStatistics sut = new MockFileSystem().Statistics.FileSystemWatcher;
+		IPathStatistics<IFileSystemWatcherFactory, IFileSystemWatcher> sut
+			= new MockFileSystem().Statistics.FileSystemWatcher;
 
 		string? result = sut.ToString();
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/PathStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/PathStatisticsTests.cs
@@ -9,7 +9,7 @@ public sealed class PathStatisticsTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.InitializeIn("/foo");
-		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+		IPathStatistics<IFileInfoFactory, IFileInfo> sut = fileSystem.Statistics.FileInfo;
 
 		IStatistics absolutPath = sut["/foo"];
 		IStatistics relativePath = sut["."];
@@ -21,7 +21,7 @@ public sealed class PathStatisticsTests
 	public void Key_DifferentDrives_ShouldBeConsideredDifferent()
 	{
 		MockFileSystem fileSystem = new();
-		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+		IPathStatistics<IFileInfoFactory, IFileInfo> sut = fileSystem.Statistics.FileInfo;
 
 		IStatistics result1 = sut[@"C:\"];
 		IStatistics result2 = sut[@"D:\"];
@@ -33,7 +33,7 @@ public sealed class PathStatisticsTests
 	public void Key_DifferentUncRootPaths_ShouldBeConsideredDifferent()
 	{
 		MockFileSystem fileSystem = new();
-		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+		IPathStatistics<IFileInfoFactory, IFileInfo> sut = fileSystem.Statistics.FileInfo;
 
 		IStatistics result1 = sut[@"\\foo1"];
 		IStatistics result2 = sut[@"\\foo2"];
@@ -45,7 +45,7 @@ public sealed class PathStatisticsTests
 	public void Key_NullShouldBeSameAsEmptyKey()
 	{
 		MockFileSystem fileSystem = new();
-		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+		IPathStatistics<IFileInfoFactory, IFileInfo> sut = fileSystem.Statistics.FileInfo;
 
 		IStatistics nullKey = sut[null!];
 		IStatistics emptyKey = sut[""];
@@ -58,7 +58,7 @@ public sealed class PathStatisticsTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.InitializeIn("/foo/bar");
-		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+		IPathStatistics<IFileInfoFactory, IFileInfo> sut = fileSystem.Statistics.FileInfo;
 
 		IStatistics absolutPath = sut["/foo"];
 		IStatistics relativePath = sut[".."];
@@ -73,7 +73,7 @@ public sealed class PathStatisticsTests
 	{
 		const string key = @"C:";
 		MockFileSystem fileSystem = new();
-		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+		IPathStatistics<IFileInfoFactory, IFileInfo> sut = fileSystem.Statistics.FileInfo;
 
 		IStatistics result1 = sut[key];
 		IStatistics result2 = sut[key + separator];
@@ -88,7 +88,7 @@ public sealed class PathStatisticsTests
 	{
 		const string key = @"C:\foo";
 		MockFileSystem fileSystem = new();
-		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+		IPathStatistics<IFileInfoFactory, IFileInfo> sut = fileSystem.Statistics.FileInfo;
 
 		IStatistics result1 = sut[key];
 		IStatistics result2 = sut[key + separator];
@@ -103,7 +103,7 @@ public sealed class PathStatisticsTests
 	{
 		const string key = @"\\server1\foo";
 		MockFileSystem fileSystem = new();
-		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+		IPathStatistics<IFileInfoFactory, IFileInfo> sut = fileSystem.Statistics.FileInfo;
 
 		IStatistics result1 = sut[key];
 		IStatistics result2 = sut[key + separator];
@@ -115,7 +115,7 @@ public sealed class PathStatisticsTests
 	public void Key_WithNull_ShouldNotThrow()
 	{
 		MockFileSystem fileSystem = new();
-		IPathStatistics sut = fileSystem.Statistics.FileInfo;
+		IPathStatistics<IFileInfoFactory, IFileInfo> sut = fileSystem.Statistics.FileInfo;
 
 		Exception? exception = Record.Exception(() => _ = sut[null!]);
 


### PR DESCRIPTION
In order to know the type stored in a statistic, the interfaces should be generic and provide details about the information stored in them.

This is the last step that fixes #476 .