### PR TITLE
refactor: improve mutation score for AccessControl extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,9 +177,47 @@ jobs:
           command: dotnet test Examples --no-build
           attempt_limit: 2
         
-  stryker:
-    name: Mutation testing
+  stryker-ubuntu:
+    name: Stryker mutation testing (Ubuntu)
     runs-on: ubuntu-latest
+    timeout-minutes: 300
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
+      - name: Install .NET Stryker
+        shell: bash
+        run: |
+          dotnet tool install dotnet-stryker --tool-path ../tools
+      - name: Prepare Reports directory
+        shell: bash
+        run: |
+          mkdir Tests/StrykerOutput/Reports -p
+      - name: Analyze Testably.Abstractions.Testing
+        env:
+          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+        shell: bash
+        run: |
+          cd Tests
+          ../../tools/dotnet-stryker -f ../.github/stryker/Stryker.Config.Testing.json -v "${GITHUB_HEAD_REF}" -r "Dashboard" -r "html" -r "cleartext" --since:main
+          mv ./StrykerOutput/**/reports/*.html ./StrykerOutput/Reports/Testably.Abstractions.Testing-report.html
+      - name: Upload Stryker reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: Stryker
+          path: Tests/StrykerOutput/Reports/*
+        
+  stryker-windows:
+    name: Stryker mutation testing (Windows)
+    runs-on: windows-latest
     timeout-minutes: 300
     steps:
       - name: Checkout sources
@@ -225,19 +263,18 @@ jobs:
           cd Tests
           ../../tools/dotnet-stryker -f ../.github/stryker/Stryker.Config.Compression.json -v "${GITHUB_HEAD_REF}" -r "Dashboard" -r "html" -r "cleartext" --since:main
           mv ./StrykerOutput/**/reports/*.html ./StrykerOutput/Reports/Testably.Abstractions.Compression-report.html
-      - name: Analyze Testably.Abstractions.Testing
-        env:
-          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
-        shell: bash
-        run: |
-          cd Tests
-          ../../tools/dotnet-stryker -f ../.github/stryker/Stryker.Config.Testing.json -v "${GITHUB_HEAD_REF}" -r "Dashboard" -r "html" -r "cleartext" --since:main
-          mv ./StrykerOutput/**/reports/*.html ./StrykerOutput/Reports/Testably.Abstractions.Testing-report.html
       - name: Upload Stryker reports
         uses: actions/upload-artifact@v3
         with:
           name: Stryker
           path: Tests/StrykerOutput/Reports/*
+
+  stryker:
+    name: Stryker mutation testing result
+    runs-on: ubuntu-latest
+    environment: production
+    needs: [stryker-windows, stryker-ubuntu]
+    steps:
       - name: Add comment to pull request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,6 @@ jobs:
   stryker:
     name: Stryker mutation testing result
     runs-on: ubuntu-latest
-    environment: production
     needs: [stryker-windows, stryker-ubuntu]
     steps:
       - name: Add comment to pull request

--- a/Source/Testably.Abstractions.AccessControl/AccessControlHelpers.cs
+++ b/Source/Testably.Abstractions.AccessControl/AccessControlHelpers.cs
@@ -44,15 +44,4 @@ internal static class AccessControlHelpers
 
 		return fileSystemInfo;
 	}
-
-	public static IDirectoryInfo ThrowIfParentMissing(
-		this IDirectoryInfo fileSystemInfo)
-	{
-		if (fileSystemInfo.Parent?.Exists != true)
-		{
-			throw new UnauthorizedAccessException();
-		}
-
-		return fileSystemInfo;
-	}
 }

--- a/Source/Testably.Abstractions.AccessControl/AccessControlHelpers.cs
+++ b/Source/Testably.Abstractions.AccessControl/AccessControlHelpers.cs
@@ -33,22 +33,12 @@ internal static class AccessControlHelpers
 			if (fileSystemInfo is IDirectoryInfo directoryInfo)
 			{
 				throw new DirectoryNotFoundException(
-					$"Could not find a part of the path '{directoryInfo.FullName}'.")
-				{
-#if FEATURE_EXCEPTION_HRESULT
-					HResult = -2147024893
-#endif
-				};
+					$"Could not find a part of the path '{directoryInfo.FullName}'.");
 			}
 
 			if (fileSystemInfo is IFileInfo fileInfo)
 			{
-				throw new FileNotFoundException($"Could not find file '{fileInfo.FullName}'.")
-				{
-#if FEATURE_EXCEPTION_HRESULT
-					HResult = -2147024894
-#endif
-				};
+				throw new FileNotFoundException($"Could not find file '{fileInfo.FullName}'.");
 			}
 		}
 

--- a/Source/Testably.Abstractions.AccessControl/DirectoryAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/DirectoryAclExtensions.cs
@@ -26,7 +26,6 @@ public static class DirectoryAclExtensions
 		else
 		{
 			_ = directorySecurity ?? throw new ArgumentNullException(nameof(directorySecurity));
-			directoryInfo.ThrowIfParentMissing();
 			directoryInfo.Create();
 			extensibility.StoreMetadata(AccessControlHelpers.AccessControl,
 				directorySecurity);

--- a/Source/Testably.Abstractions.AccessControl/DirectoryInfoAclExtensions.cs
+++ b/Source/Testably.Abstractions.AccessControl/DirectoryInfoAclExtensions.cs
@@ -23,7 +23,6 @@ public static class DirectoryInfoAclExtensions
 		else
 		{
 			_ = directorySecurity ?? throw new ArgumentNullException(nameof(directorySecurity));
-			directoryInfo.ThrowIfParentMissing();
 			directoryInfo.Create();
 			extensibility.StoreMetadata(AccessControlHelpers.AccessControl,
 				directorySecurity);

--- a/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryAclExtensionsTests.cs
@@ -25,20 +25,22 @@ public abstract partial class DirectoryAclExtensionsTests<TFileSystem>
 			.Which.ParamName.Should().Be("directorySecurity");
 	}
 
-	[SkippableFact]
-	public void CreateDirectory_ShouldChangeAccessControl()
+	[SkippableTheory]
+	[InlineData("bar")]
+	[InlineData("bar\\foo")]
+	public void CreateDirectory_ShouldChangeAccessControl(string path)
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
 		#pragma warning disable CA1416
 		DirectorySecurity directorySecurity = FileSystem.CreateDirectorySecurity();
 
-		FileSystem.Directory.CreateDirectory("bar", directorySecurity);
-		DirectorySecurity result = FileSystem.Directory.GetAccessControl("bar");
+		FileSystem.Directory.CreateDirectory(path, directorySecurity);
+		DirectorySecurity result = FileSystem.Directory.GetAccessControl(path);
 		#pragma warning restore CA1416
 
 		result.HasSameAccessRightsAs(directorySecurity).Should().BeTrue();
-		FileSystem.Directory.Exists("bar").Should().BeTrue();
+		FileSystem.Directory.Exists(path).Should().BeTrue();
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryAclExtensionsTests.cs
@@ -14,7 +14,6 @@ public abstract partial class DirectoryAclExtensionsTests<TFileSystem>
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		FileSystem.Directory.CreateDirectory("foo");
 		#pragma warning disable CA1416
 		Exception? exception = Record.Exception(() =>
 		{
@@ -58,6 +57,27 @@ public abstract partial class DirectoryAclExtensionsTests<TFileSystem>
 	}
 
 	[SkippableFact]
+	public void GetAccessControl_ShouldReturnSetResult()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+		Skip.If(FileSystem is RealFileSystem);
+
+		FileSystem.Directory.CreateDirectory("foo");
+
+		#pragma warning disable CA1416
+		DirectorySecurity originalResult =
+			FileSystem.Directory.GetAccessControl("foo");
+
+		FileSystem.Directory.SetAccessControl("foo", originalResult);
+
+		DirectorySecurity result =
+			FileSystem.Directory.GetAccessControl("foo");
+		#pragma warning restore CA1416
+
+		result.Should().Be(originalResult);
+	}
+
+	[SkippableFact]
 	public void GetAccessControl_WithAccessControlSections_ShouldBeInitializedWithNotNullValue()
 	{
 		Skip.IfNot(Test.RunsOnWindows);
@@ -71,6 +91,27 @@ public abstract partial class DirectoryAclExtensionsTests<TFileSystem>
 		#pragma warning restore CA1416
 
 		result.Should().NotBeNull();
+	}
+
+	[SkippableFact]
+	public void GetAccessControl_WithAccessControlSections_ShouldReturnSetResult()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+		Skip.If(FileSystem is RealFileSystem);
+
+		FileSystem.Directory.CreateDirectory("foo");
+
+		#pragma warning disable CA1416
+		DirectorySecurity originalResult =
+			FileSystem.Directory.GetAccessControl("foo", AccessControlSections.None);
+
+		FileSystem.Directory.SetAccessControl("foo", originalResult);
+
+		DirectorySecurity result =
+			FileSystem.Directory.GetAccessControl("foo", AccessControlSections.None);
+		#pragma warning restore CA1416
+
+		result.Should().Be(originalResult);
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryInfoAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryInfoAclExtensionsTests.cs
@@ -28,20 +28,22 @@ public abstract partial class DirectoryInfoAclExtensionsTests<TFileSystem>
 			.Which.ParamName.Should().Be("directorySecurity");
 	}
 
-	[SkippableFact]
-	public void Create_ShouldChangeAccessControl()
+	[SkippableTheory]
+	[InlineData("foo")]
+	[InlineData("foo\\bar")]
+	public void Create_ShouldChangeAccessControl(string path)
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		#pragma warning disable CA1416
+#pragma warning disable CA1416
 		DirectorySecurity directorySecurity = FileSystem.CreateDirectorySecurity();
 
-		FileSystem.DirectoryInfo.New("foo").Create(directorySecurity);
-		DirectorySecurity result = FileSystem.Directory.GetAccessControl("foo");
+		FileSystem.DirectoryInfo.New(path).Create(directorySecurity);
+		DirectorySecurity result = FileSystem.Directory.GetAccessControl(path);
 		#pragma warning restore CA1416
 
 		result.HasSameAccessRightsAs(directorySecurity).Should().BeTrue();
-		FileSystem.Directory.Exists("foo").Should().BeTrue();
+		FileSystem.Directory.Exists(path).Should().BeTrue();
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryInfoAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryInfoAclExtensionsTests.cs
@@ -35,7 +35,7 @@ public abstract partial class DirectoryInfoAclExtensionsTests<TFileSystem>
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-#pragma warning disable CA1416
+		#pragma warning disable CA1416
 		DirectorySecurity directorySecurity = FileSystem.CreateDirectorySecurity();
 
 		FileSystem.DirectoryInfo.New(path).Create(directorySecurity);

--- a/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryInfoAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/DirectoryInfoAclExtensionsTests.cs
@@ -33,7 +33,6 @@ public abstract partial class DirectoryInfoAclExtensionsTests<TFileSystem>
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		FileSystem.Directory.CreateDirectory("foo");
 		#pragma warning disable CA1416
 		DirectorySecurity directorySecurity = FileSystem.CreateDirectorySecurity();
 
@@ -54,7 +53,7 @@ public abstract partial class DirectoryInfoAclExtensionsTests<TFileSystem>
 		Exception? exception = Record.Exception(() =>
 		{
 			#pragma warning disable CA1416
-			sut.GetAccessControl();
+			_ = sut.GetAccessControl();
 			#pragma warning restore CA1416
 		});
 
@@ -78,6 +77,45 @@ public abstract partial class DirectoryInfoAclExtensionsTests<TFileSystem>
 	}
 
 	[SkippableFact]
+	public void GetAccessControl_ShouldReturnSetResult()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+		Skip.If(FileSystem is RealFileSystem);
+
+		FileSystem.Directory.CreateDirectory("foo");
+
+		#pragma warning disable CA1416
+		DirectorySecurity originalResult =
+			FileSystem.DirectoryInfo.New("foo").GetAccessControl();
+
+		FileSystem.DirectoryInfo.New("foo").SetAccessControl(originalResult);
+
+		DirectorySecurity result =
+			FileSystem.DirectoryInfo.New("foo").GetAccessControl();
+		#pragma warning restore CA1416
+
+		result.Should().Be(originalResult);
+	}
+
+	[SkippableFact]
+	public void
+		GetAccessControl_WithAccessControlSections_MissingDirectory_ShouldThrowDirectoryNotFoundException()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+		IDirectoryInfo sut = FileSystem.DirectoryInfo.New("foo");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			#pragma warning disable CA1416
+			_ = sut.GetAccessControl(AccessControlSections.None);
+			#pragma warning restore CA1416
+		});
+
+		exception.Should().BeOfType<DirectoryNotFoundException>()
+			.Which.HResult.Should().Be(-2147024893);
+	}
+
+	[SkippableFact]
 	public void GetAccessControl_WithAccessControlSections_ShouldBeInitializedWithNotNullValue()
 	{
 		Skip.IfNot(Test.RunsOnWindows);
@@ -91,6 +129,27 @@ public abstract partial class DirectoryInfoAclExtensionsTests<TFileSystem>
 		#pragma warning restore CA1416
 
 		result.Should().NotBeNull();
+	}
+
+	[SkippableFact]
+	public void GetAccessControl_WithAccessControlSections_ShouldReturnSetResult()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+		Skip.If(FileSystem is RealFileSystem);
+
+		FileSystem.Directory.CreateDirectory("foo");
+
+		#pragma warning disable CA1416
+		DirectorySecurity originalResult =
+			FileSystem.DirectoryInfo.New("foo").GetAccessControl(AccessControlSections.None);
+
+		FileSystem.DirectoryInfo.New("foo").SetAccessControl(originalResult);
+
+		DirectorySecurity result =
+			FileSystem.DirectoryInfo.New("foo").GetAccessControl(AccessControlSections.None);
+		#pragma warning restore CA1416
+
+		result.Should().Be(originalResult);
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.AccessControl.Tests/ExceptionMissingFileTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/ExceptionMissingFileTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.AccessControl;
+using Testably.Abstractions.AccessControl.Tests.TestHelpers;
 
 namespace Testably.Abstractions.AccessControl.Tests;
 
@@ -29,9 +29,8 @@ public abstract partial class ExceptionMissingFileTests<TFileSystem>
 		{
 			case MethodType.Create:
 				exception.Should()
-					.BeOfType<UnauthorizedAccessException>(
-						$"\n{exceptionType} on {baseType}\n was called with a missing directory")
-					.Which.HResult.Should().Be(-2147024891);
+					.BeNull(
+						$"\n{exceptionType} on {baseType}\n was called with a missing directory");
 				break;
 			case MethodType.GetAccessControl:
 				exception.Should()
@@ -188,25 +187,28 @@ public abstract partial class ExceptionMissingFileTests<TFileSystem>
 		#pragma warning disable CA1416
 		yield return (BaseTypes.Directory, MethodType.Create,
 			(fileSystem, path)
-				=> fileSystem.Directory.CreateDirectory(path, new DirectorySecurity()));
+				=> fileSystem.Directory.CreateDirectory(path,
+					fileSystem.CreateDirectorySecurity()));
 		yield return (BaseTypes.Directory, MethodType.GetAccessControl,
 			(fileSystem, path)
 				=> fileSystem.Directory.GetAccessControl(path));
 
 		yield return (BaseTypes.Directory, MethodType.SetAccessControl,
 			(fileSystem, path)
-				=> fileSystem.Directory.SetAccessControl(path, new DirectorySecurity()));
+				=> fileSystem.Directory.SetAccessControl(path,
+					fileSystem.CreateDirectorySecurity()));
 
 		yield return (BaseTypes.DirectoryInfo, MethodType.Create,
 			(fileSystem, path)
-				=> fileSystem.DirectoryInfo.New(path).Create(new DirectorySecurity()));
+				=> fileSystem.DirectoryInfo.New(path).Create(fileSystem.CreateDirectorySecurity()));
 		yield return (BaseTypes.DirectoryInfo, MethodType.GetAccessControl,
 			(fileSystem, path)
 				=> fileSystem.DirectoryInfo.New(path).GetAccessControl());
 
 		yield return (BaseTypes.DirectoryInfo, MethodType.SetAccessControl,
 			(fileSystem, path)
-				=> fileSystem.DirectoryInfo.New(path).SetAccessControl(new DirectorySecurity()));
+				=> fileSystem.DirectoryInfo.New(path)
+					.SetAccessControl(fileSystem.CreateDirectorySecurity()));
 
 		yield return (BaseTypes.File, MethodType.GetAccessControl,
 			(fileSystem, path)
@@ -214,7 +216,7 @@ public abstract partial class ExceptionMissingFileTests<TFileSystem>
 
 		yield return (BaseTypes.File, MethodType.SetAccessControl,
 			(fileSystem, path)
-				=> fileSystem.File.SetAccessControl(path, new FileSecurity()));
+				=> fileSystem.File.SetAccessControl(path, fileSystem.CreateFileSecurity()));
 
 		yield return (BaseTypes.FileInfo, MethodType.GetAccessControl,
 			(fileSystem, path)
@@ -222,7 +224,7 @@ public abstract partial class ExceptionMissingFileTests<TFileSystem>
 
 		yield return (BaseTypes.FileInfo, MethodType.SetAccessControl,
 			(fileSystem, path)
-				=> fileSystem.FileInfo.New(path).SetAccessControl(new FileSecurity()));
+				=> fileSystem.FileInfo.New(path).SetAccessControl(fileSystem.CreateFileSecurity()));
 		#pragma warning restore CA1416
 	}
 

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileAclExtensionsTests.cs
@@ -23,6 +23,26 @@ public abstract partial class FileAclExtensionsTests<TFileSystem>
 	}
 
 	[SkippableFact]
+	public void GetAccessControl_ShouldReturnSetResult()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+		Skip.If(FileSystem is RealFileSystem);
+
+		FileSystem.File.WriteAllText("foo", null);
+
+		#pragma warning disable CA1416
+		FileSecurity originalResult = FileSystem.File.GetAccessControl("foo");
+
+		FileSystem.File.SetAccessControl("foo", originalResult);
+
+		FileSecurity result =
+			FileSystem.File.GetAccessControl("foo");
+		#pragma warning restore CA1416
+
+		result.Should().Be(originalResult);
+	}
+
+	[SkippableFact]
 	public void GetAccessControl_WithAccessControlSections_ShouldBeInitializedWithNotNullValue()
 	{
 		Skip.IfNot(Test.RunsOnWindows);
@@ -35,6 +55,27 @@ public abstract partial class FileAclExtensionsTests<TFileSystem>
 		#pragma warning restore CA1416
 
 		result.Should().NotBeNull();
+	}
+
+	[SkippableFact]
+	public void GetAccessControl_WithAccessControlSections_ShouldReturnSetResult()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+		Skip.If(FileSystem is RealFileSystem);
+
+		FileSystem.File.WriteAllText("foo", null);
+
+		#pragma warning disable CA1416
+		FileSecurity originalResult =
+			FileSystem.File.GetAccessControl("foo", AccessControlSections.None);
+
+		FileSystem.File.SetAccessControl("foo", originalResult);
+
+		FileSecurity result =
+			FileSystem.File.GetAccessControl("foo", AccessControlSections.None);
+		#pragma warning restore CA1416
+
+		result.Should().Be(originalResult);
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileAclExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.AccessControl;
+﻿using System.IO;
+using System.Security.AccessControl;
 using Testably.Abstractions.AccessControl.Tests.TestHelpers;
 
 namespace Testably.Abstractions.AccessControl.Tests;
@@ -8,6 +9,22 @@ public abstract partial class FileAclExtensionsTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
+	[SkippableFact]
+	public void GetAccessControl_MissingFile_ShouldThrowFileNotFoundException()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			#pragma warning disable CA1416
+			_ = FileSystem.File.GetAccessControl("foo");
+			#pragma warning restore CA1416
+		});
+
+		exception.Should().BeOfType<FileNotFoundException>()
+			.Which.HResult.Should().Be(-2147024894);
+	}
+
 	[SkippableFact]
 	public void GetAccessControl_ShouldBeInitializedWithNotNullValue()
 	{
@@ -40,6 +57,23 @@ public abstract partial class FileAclExtensionsTests<TFileSystem>
 		#pragma warning restore CA1416
 
 		result.Should().Be(originalResult);
+	}
+
+	[SkippableFact]
+	public void
+		GetAccessControl_WithAccessControlSections_MissingFile_ShouldThrowFileNotFoundException()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			#pragma warning disable CA1416
+			_ = FileSystem.File.GetAccessControl("foo", AccessControlSections.None);
+			#pragma warning restore CA1416
+		});
+
+		exception.Should().BeOfType<FileNotFoundException>()
+			.Which.HResult.Should().Be(-2147024894);
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileInfoAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileInfoAclExtensionsTests.cs
@@ -10,7 +10,7 @@ public abstract partial class FileInfoAclExtensionsTests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
 	[SkippableFact]
-	public void GetAccessControl_MissingFile_ShouldThrowDirectoryNotFoundException()
+	public void GetAccessControl_MissingFile_ShouldThrowFileNotFoundException()
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 		IFileInfo sut = FileSystem.FileInfo.New("foo");
@@ -42,6 +42,45 @@ public abstract partial class FileInfoAclExtensionsTests<TFileSystem>
 	}
 
 	[SkippableFact]
+	public void GetAccessControl_ShouldReturnSetResult()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+		Skip.If(FileSystem is RealFileSystem);
+
+		FileSystem.File.WriteAllText("foo", null);
+
+		#pragma warning disable CA1416
+		FileSecurity originalResult =
+			FileSystem.FileInfo.New("foo").GetAccessControl();
+
+		FileSystem.FileInfo.New("foo").SetAccessControl(originalResult);
+
+		FileSecurity result =
+			FileSystem.FileInfo.New("foo").GetAccessControl();
+		#pragma warning restore CA1416
+
+		result.Should().Be(originalResult);
+	}
+
+	[SkippableFact]
+	public void
+		GetAccessControl_WithAccessControlSections_MissingFile_ShouldThrowFileNotFoundException()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+		IFileInfo sut = FileSystem.FileInfo.New("foo");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			#pragma warning disable CA1416
+			sut.GetAccessControl(AccessControlSections.None);
+			#pragma warning restore CA1416
+		});
+
+		exception.Should().BeOfType<FileNotFoundException>()
+			.Which.HResult.Should().Be(-2147024894);
+	}
+
+	[SkippableFact]
 	public void GetAccessControl_WithAccessControlSections_ShouldBeInitializedWithNotNullValue()
 	{
 		Skip.IfNot(Test.RunsOnWindows);
@@ -55,6 +94,27 @@ public abstract partial class FileInfoAclExtensionsTests<TFileSystem>
 		#pragma warning restore CA1416
 
 		result.Should().NotBeNull();
+	}
+
+	[SkippableFact]
+	public void GetAccessControl_WithAccessControlSections_ShouldReturnSetResult()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+		Skip.If(FileSystem is RealFileSystem);
+
+		FileSystem.File.WriteAllText("foo", null);
+
+		#pragma warning disable CA1416
+		FileSecurity originalResult =
+			FileSystem.FileInfo.New("foo").GetAccessControl(AccessControlSections.None);
+
+		FileSystem.FileInfo.New("foo").SetAccessControl(originalResult);
+
+		FileSecurity result =
+			FileSystem.FileInfo.New("foo").GetAccessControl(AccessControlSections.None);
+		#pragma warning restore CA1416
+
+		result.Should().Be(originalResult);
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.AccessControl.Tests/FileInfoAclExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/FileInfoAclExtensionsTests.cs
@@ -18,7 +18,7 @@ public abstract partial class FileInfoAclExtensionsTests<TFileSystem>
 		Exception? exception = Record.Exception(() =>
 		{
 			#pragma warning disable CA1416
-			sut.GetAccessControl();
+			_ = sut.GetAccessControl();
 			#pragma warning restore CA1416
 		});
 
@@ -72,7 +72,7 @@ public abstract partial class FileInfoAclExtensionsTests<TFileSystem>
 		Exception? exception = Record.Exception(() =>
 		{
 			#pragma warning disable CA1416
-			sut.GetAccessControl(AccessControlSections.None);
+			_ = sut.GetAccessControl(AccessControlSections.None);
 			#pragma warning restore CA1416
 		});
 


### PR DESCRIPTION
Add tests for missing cases in AccessControl extensions, detected by Stryker.NET.