### PR TITLE
fix: copying a file throws if a file handle with `ReadWrite` share is open

### DIFF
--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -58,7 +58,7 @@ internal sealed class InMemoryStorage : IStorage
 			throw ExceptionFactory.AccessToPathDenied(source.FullPath);
 		}
 
-		using (_ = sourceContainer.RequestAccess(FileAccess.ReadWrite, FileShare.None))
+		using (_ = sourceContainer.RequestAccess(FileAccess.Read, FileShare.ReadWrite))
 		{
 			if (overwrite &&
 			    _containers.TryRemove(destination,

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -264,18 +264,28 @@ public abstract partial class CopyTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[InlineAutoData(FileShare.Read)]
-	[InlineAutoData(FileShare.ReadWrite)]
+	[InlineAutoData(FileAccess.Read, FileShare.Read)]
+	[InlineAutoData(FileAccess.Read, FileShare.ReadWrite)]
+	[InlineAutoData(FileAccess.Read, FileShare.Write)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.Read)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.ReadWrite)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.Write)]
+	[InlineAutoData(FileAccess.Write, FileShare.Read)]
+	[InlineAutoData(FileAccess.Write, FileShare.ReadWrite)]
+	[InlineAutoData(FileAccess.Write, FileShare.Write)]
 	public void Copy_SourceAccessedWithReadShare_ShouldNotThrow(
+		FileAccess fileAccess,
 		FileShare fileShare,
 		string sourcePath,
 		string destinationPath,
 		string sourceContents)
 	{
+		Skip.If(Test.RunsOnWindows && fileShare == FileShare.Write);
+
 		FileSystem.Initialize().WithFile(sourcePath)
 			.Which(f => f.HasStringContent(sourceContents));
 		using (FileSystem.FileStream
-			.New(sourcePath, FileMode.Open, FileAccess.Read, fileShare))
+			.New(sourcePath, FileMode.Open, fileAccess, fileShare))
 		{
 			FileSystem.File.Copy(sourcePath, destinationPath);
 		}
@@ -314,6 +324,8 @@ public abstract partial class CopyTests<TFileSystem>
 		string sourceName,
 		string destinationName)
 	{
+		Skip.If(!Test.RunsOnWindows && fileShare == FileShare.Write);
+
 		FileSystem.File.WriteAllText(sourceName, null);
 		using FileSystemStream stream = FileSystem.File.Open(sourceName, FileMode.Open,
 			FileAccess.Read, fileShare);


### PR DESCRIPTION
Fixes #549 