### PR TITLE
refactor: improve mutation score for Compression extensions

### DIFF
--- a/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
+++ b/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
@@ -204,13 +204,6 @@ internal static class ZipUtilities
 				source.FullName.TrimStart(
 					source.FileSystem.Path.DirectorySeparatorChar,
 					source.FileSystem.Path.AltDirectorySeparatorChar));
-		string? directoryPath =
-			source.FileSystem.Path.GetDirectoryName(fileDestinationPath);
-		if (directoryPath != null &&
-		    !source.FileSystem.Directory.Exists(directoryPath))
-		{
-			source.FileSystem.Directory.CreateDirectory(directoryPath);
-		}
 
 		if (source.FullName.EndsWith('/'))
 		{
@@ -224,6 +217,8 @@ internal static class ZipUtilities
 		}
 		else
 		{
+			source.FileSystem.Directory.CreateDirectory(
+				source.FileSystem.Path.GetDirectoryName(fileDestinationPath) ?? ".");
 			ExtractToFile(source, fileDestinationPath, overwrite);
 		}
 	}

--- a/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
+++ b/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
@@ -136,10 +136,7 @@ internal static class ZipUtilities
 		ArgumentNullException.ThrowIfNull(destination);
 		if (!destination.CanWrite)
 		{
-			throw new ArgumentException("The stream is unwritable.", nameof(destination))
-			{
-				HResult = -2147024809
-			};
+			throw new ArgumentException("The stream is unwritable.", nameof(destination));
 		}
 
 		sourceDirectoryName = fileSystem.Path.GetFullPath(sourceDirectoryName);
@@ -275,10 +272,7 @@ internal static class ZipUtilities
 		ArgumentNullException.ThrowIfNull(source);
 		if (!source.CanRead)
 		{
-			throw new ArgumentException("The stream is unreadable.", nameof(source))
-			{
-				HResult = -2147024809
-			};
+			throw new ArgumentException("The stream is unreadable.", nameof(source));
 		}
 
 		using (ZipArchive archive = new(source, ZipArchiveMode.Read, true, entryNameEncoding))

--- a/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
+++ b/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
@@ -8,6 +8,7 @@ namespace Testably.Abstractions.Internal;
 internal static class ZipUtilities
 {
 	private const string SearchPattern = "*";
+	private static readonly DateTime FallbackTime = new(1980, 1, 1, 0, 0, 0);
 
 	internal static IZipArchiveEntry CreateEntryFromFile(
 		IZipArchive destination,
@@ -32,7 +33,7 @@ internal static class ZipUtilities
 
 			if (lastWrite.Year is < 1980 or > 2107)
 			{
-				lastWrite = new DateTime(1980, 1, 1, 0, 0, 0);
+				lastWrite = FallbackTime;
 			}
 
 			entry.LastWriteTime = new DateTimeOffset(lastWrite);

--- a/Tests/Testably.Abstractions.Compression.Tests/Internal/ExecuteTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/Internal/ExecuteTests.cs
@@ -5,28 +5,80 @@ namespace Testably.Abstractions.Compression.Tests.Internal;
 public sealed class ExecuteTests
 {
 	[Fact]
-	public void WhenRealFileSystem_MockFileSystem_ShouldExecuteOnMockFileSystem()
+	public void WhenRealFileSystem_MockFileSystem_WithActionCallback_ShouldExecuteOnMockFileSystem()
 	{
 		bool onRealFileSystemExecuted = false;
 		bool onMockFileSystemExecuted = false;
 		MockFileSystem fileSystem = new();
 		Execute.WhenRealFileSystem(fileSystem,
-			() => onRealFileSystemExecuted = true,
-			() => onMockFileSystemExecuted = true);
+			() =>
+			{
+				onRealFileSystemExecuted = true;
+			},
+			() =>
+			{
+				onMockFileSystemExecuted = true;
+			});
 
 		onRealFileSystemExecuted.Should().BeFalse();
 		onMockFileSystemExecuted.Should().BeTrue();
 	}
 
 	[Fact]
-	public void WhenRealFileSystem_RealFileSystem_ShouldExecuteOnRealFileSystem()
+	public void WhenRealFileSystem_MockFileSystem_WithFuncCallback_ShouldExecuteOnMockFileSystem()
+	{
+		bool onRealFileSystemExecuted = false;
+		bool onMockFileSystemExecuted = false;
+		MockFileSystem fileSystem = new();
+		Execute.WhenRealFileSystem(fileSystem,
+			() =>
+			{
+				return onRealFileSystemExecuted = true;
+			},
+			() =>
+			{
+				return onMockFileSystemExecuted = true;
+			});
+
+		onRealFileSystemExecuted.Should().BeFalse();
+		onMockFileSystemExecuted.Should().BeTrue();
+	}
+
+	[Fact]
+	public void WhenRealFileSystem_RealFileSystem_WithActionCallback_ShouldExecuteOnRealFileSystem()
 	{
 		bool onRealFileSystemExecuted = false;
 		bool onMockFileSystemExecuted = false;
 		RealFileSystem fileSystem = new();
 		Execute.WhenRealFileSystem(fileSystem,
-			() => onRealFileSystemExecuted = true,
-			() => onMockFileSystemExecuted = true);
+			() =>
+			{
+				onRealFileSystemExecuted = true;
+			},
+			() =>
+			{
+				onMockFileSystemExecuted = true;
+			});
+
+		onRealFileSystemExecuted.Should().BeTrue();
+		onMockFileSystemExecuted.Should().BeFalse();
+	}
+
+	[Fact]
+	public void WhenRealFileSystem_RealFileSystem_WithFuncCallback_ShouldExecuteOnRealFileSystem()
+	{
+		bool onRealFileSystemExecuted = false;
+		bool onMockFileSystemExecuted = false;
+		RealFileSystem fileSystem = new();
+		Execute.WhenRealFileSystem(fileSystem,
+			() =>
+			{
+				return onRealFileSystemExecuted = true;
+			},
+			() =>
+			{
+				return onMockFileSystemExecuted = true;
+			});
 
 		onRealFileSystemExecuted.Should().BeTrue();
 		onMockFileSystemExecuted.Should().BeFalse();

--- a/Tests/Testably.Abstractions.Compression.Tests/Internal/ZipUtilitiesTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/Internal/ZipUtilitiesTests.cs
@@ -1,0 +1,102 @@
+﻿using System.IO;
+using Testably.Abstractions.Internal;
+
+namespace Testably.Abstractions.Compression.Tests.Internal;
+
+public sealed class ZipUtilitiesTests
+{
+	[Theory]
+	[AutoData]
+	public void ExtractRelativeToDirectory_FileWithTrailingSlash_ShouldThrowIOException(
+		byte[] bytes)
+	{
+		MockFileSystem fileSystem = new();
+		using MemoryStream stream = new(bytes);
+		DummyZipArchiveEntry zipArchiveEntry = new(fileSystem, fullName: "foo/", stream: stream);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			zipArchiveEntry.ExtractRelativeToDirectory("foo", false);
+		});
+
+		exception.Should().BeException<IOException>(
+			messageContains:
+			"Zip entry name ends in directory separator character but contains data");
+	}
+
+	[Fact]
+	public void ExtractRelativeToDirectory_WithSubdirectory_ShouldCreateSubdirectory()
+	{
+		MockFileSystem fileSystem = new();
+		DummyZipArchiveEntry zipArchiveEntry = new(fileSystem, fullName: "foo/");
+
+		zipArchiveEntry.ExtractRelativeToDirectory("bar", false);
+
+		fileSystem.Directory.Exists("bar").Should().BeTrue();
+		fileSystem.Directory.Exists("bar/foo").Should().BeTrue();
+	}
+
+	private sealed class DummyZipArchiveEntry(
+		IFileSystem fileSystem,
+		IZipArchive? archive = null,
+		string? fullName = "",
+		string? name = "",
+		string comment = "",
+		bool isEncrypted = false,
+		Stream? stream = null)
+		: IZipArchiveEntry
+	{
+		#region IZipArchiveEntry Members
+
+		/// <inheritdoc cref="IZipArchiveEntry.Archive" />
+		public IZipArchive Archive => archive ?? throw new NotSupportedException();
+
+		/// <inheritdoc cref="IZipArchiveEntry.Comment" />
+		public string Comment { get; set; } = comment;
+
+		/// <inheritdoc cref="IZipArchiveEntry.CompressedLength" />
+		public long CompressedLength => stream?.Length ?? 0L;
+
+		/// <inheritdoc cref="IZipArchiveEntry.Crc32" />
+		public uint Crc32 => 0u;
+
+		/// <inheritdoc cref="IZipArchiveEntry.ExternalAttributes" />
+		public int ExternalAttributes { get; set; }
+
+		/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
+		public IFileSystem FileSystem { get; } = fileSystem;
+
+		/// <inheritdoc cref="IZipArchiveEntry.FullName" />
+		public string FullName { get; } = fullName ?? "";
+
+		/// <inheritdoc cref="IZipArchiveEntry.IsEncrypted" />
+		public bool IsEncrypted { get; } = isEncrypted;
+
+		/// <inheritdoc cref="IZipArchiveEntry.LastWriteTime" />
+		public DateTimeOffset LastWriteTime { get; set; }
+
+		/// <inheritdoc cref="IZipArchiveEntry.Length" />
+		public long Length => stream?.Length ?? 0L;
+
+		/// <inheritdoc cref="IZipArchiveEntry.Name" />
+		public string Name { get; } = name ?? "";
+
+		/// <inheritdoc cref="IZipArchiveEntry.Delete()" />
+		public void Delete()
+			=> throw new NotSupportedException();
+
+		/// <inheritdoc cref="IZipArchiveEntry.ExtractToFile(string)" />
+		public void ExtractToFile(string destinationFileName)
+			=> throw new NotSupportedException();
+
+		/// <inheritdoc cref="IZipArchiveEntry.ExtractToFile(string, bool)" />
+		public void ExtractToFile(string destinationFileName, bool overwrite)
+			=> throw new NotSupportedException();
+
+		/// <inheritdoc cref="IZipArchiveEntry.Open()" />
+		public Stream Open()
+			=> stream ?? throw new NotSupportedException();
+
+		#endregion
+	}
+}

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
@@ -160,6 +160,30 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 	}
 
 #if FEATURE_COMPRESSION_STREAM
+	[SkippableFact]
+	public void CreateFromDirectory_WithReadOnlyStream_ShouldThrowArgumentException()
+	{
+		FileSystem.Initialize()
+			.WithFile("target.zip")
+			.WithSubdirectory("foo").Initialized(s => s
+				.WithFile("test.txt"));
+		using FileSystemStream stream = FileSystem.FileStream.New(
+			"target.zip", FileMode.Open, FileAccess.Read);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			// ReSharper disable once AccessToDisposedClosure
+			FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		});
+
+		exception.Should().BeException<ArgumentException>(
+			paramName: "destination",
+			hResult: -2147024809,
+			messageContains: "stream is unwritable");
+	}
+#endif
+
+#if FEATURE_COMPRESSION_STREAM
 	[SkippableTheory]
 	[AutoData]
 	public void


### PR DESCRIPTION
Add tests for missing cases in Compression extensions, detected by Stryker.NET.