### PR TITLE
fix: ensure correct behavior when moving or replacing a file with an open handle

### DIFF
--- a/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
@@ -83,6 +83,7 @@ internal interface IStorageContainer : IFileSystemEntity, ITimeSystemEntity
 	/// <returns>An <see cref="IStorageAccessHandle" /> that is used to release the access lock on dispose.</returns>
 	IStorageAccessHandle RequestAccess(FileAccess access, FileShare share,
 		bool deleteAccess = false,
+		bool ignoreFileShare = false,
 		bool ignoreMetadataErrors = true,
 		int? hResult = null);
 

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -409,12 +409,14 @@ internal sealed class InMemoryStorage : IStorage
 		using (_ = sourceContainer.RequestAccess(
 			FileAccess.ReadWrite,
 			FileShare.None,
-			ignoreMetadataErrors: ignoreMetadataErrors))
+			ignoreMetadataErrors: ignoreMetadataErrors,
+			ignoreFileShare: true))
 		{
 			using (_ = destinationContainer.RequestAccess(
 				FileAccess.ReadWrite,
 				FileShare.None,
-				ignoreMetadataErrors: ignoreMetadataErrors))
+				ignoreMetadataErrors: ignoreMetadataErrors,
+				ignoreFileShare: true))
 			{
 				if (_containers.TryRemove(destination,
 					out IStorageContainer? existingDestinationContainer))
@@ -664,6 +666,7 @@ internal sealed class InMemoryStorage : IStorage
 		}
 
 		using (container.RequestAccess(FileAccess.Write, FileShare.None,
+			ignoreFileShare: true,
 			hResult: sourceType == FileSystemTypes.Directory ? -2147024891 : -2147024864))
 		{
 			if (children.Any() && recursive)

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -91,9 +91,10 @@ internal sealed class NullContainer : IStorageContainer
 	public byte[] GetBytes()
 		=> Array.Empty<byte>();
 
-	/// <inheritdoc cref="IStorageContainer.RequestAccess(FileAccess, FileShare, bool, bool, int?)" />
+	/// <inheritdoc cref="IStorageContainer.RequestAccess(FileAccess, FileShare, bool, bool, bool, int?)" />
 	public IStorageAccessHandle RequestAccess(FileAccess access, FileShare share,
 		bool deleteAccess = false,
+		bool ignoreFileShare = false,
 		bool ignoreMetadataErrors = true,
 		int? hResult = null)
 		=> new NullStorageAccessHandle(access, share, deleteAccess);

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
@@ -12,7 +12,7 @@ namespace Testably.Abstractions.Testing.Tests.TestHelpers;
 ///     A <see cref="IStorageContainer" /> for testing purposes.
 ///     <para />
 ///     Set <see cref="IsLocked" /> to <see langword="true" /> to simulate a locked file
-///     (<see cref="RequestAccess(FileAccess, FileShare, bool, bool, int?)" /> throws an <see cref="IOException" />).
+///     (<see cref="RequestAccess(FileAccess, FileShare, bool, bool, bool, int?)" /> throws an <see cref="IOException" />).
 /// </summary>
 internal sealed class LockableContainer(
 	MockFileSystem fileSystem,
@@ -24,7 +24,7 @@ internal sealed class LockableContainer(
 
 	/// <summary>
 	///     Simulate a locked file, if set to <see langword="true" />.<br />
-	///     In this case <see cref="RequestAccess(FileAccess, FileShare, bool, bool, int?)" /> throws
+	///     In this case <see cref="RequestAccess(FileAccess, FileShare, bool, bool, bool, int?)" /> throws
 	///     an <see cref="IOException" />, otherwise it will succeed.
 	/// </summary>
 	public bool IsLocked { get; set; }
@@ -89,9 +89,10 @@ internal sealed class LockableContainer(
 	public byte[] GetBytes()
 		=> _bytes;
 
-	/// <inheritdoc cref="IStorageContainer.RequestAccess(FileAccess, FileShare, bool, bool, int?)" />
+	/// <inheritdoc cref="IStorageContainer.RequestAccess(FileAccess, FileShare, bool, bool, bool, int?)" />
 	public IStorageAccessHandle RequestAccess(FileAccess access, FileShare share,
 		bool deleteAccess = false,
+		bool ignoreFileShare = false,
 		bool ignoreMetadataErrors = true,
 		int? hResult = null)
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -289,9 +289,6 @@ public abstract partial class CopyTests<TFileSystem>
 		FileSystem.File.ReadAllText(destinationPath).Should().Be(sourceContents);
 	}
 
-	/// <summary>
-	///     https://github.com/dotnet/runtime/issues/52700
-	/// </summary>
 	[SkippableTheory]
 	[InlineAutoData(FileAccess.Read)]
 	[InlineAutoData(FileAccess.ReadWrite)]
@@ -302,7 +299,7 @@ public abstract partial class CopyTests<TFileSystem>
 		string destinationPath,
 		string sourceContents)
 	{
-		Skip.If(Test.RunsOnWindows);
+		Skip.If(Test.RunsOnWindows, "see https://github.com/dotnet/runtime/issues/52700");
 
 		FileSystem.Initialize().WithFile(sourcePath)
 			.Which(f => f.HasStringContent(sourceContents));
@@ -346,11 +343,12 @@ public abstract partial class CopyTests<TFileSystem>
 		string sourceName,
 		string destinationName)
 	{
-		Skip.If(!Test.RunsOnWindows && fileShare == FileShare.Write, "see https://github.com/dotnet/runtime/issues/52700");
+		Skip.If(!Test.RunsOnWindows && fileShare == FileShare.Write,
+			"see https://github.com/dotnet/runtime/issues/52700");
 
 		FileSystem.File.WriteAllText(sourceName, null);
-		using FileSystemStream stream = FileSystem.File.Open(sourceName, FileMode.Open,
-			FileAccess.Read, fileShare);
+		using FileSystemStream stream = FileSystem.File.Open(
+			sourceName, FileMode.Open, FileAccess.Read, fileShare);
 
 		Exception? exception = Record.Exception(() =>
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
@@ -146,6 +146,33 @@ public abstract partial class MoveTests<TFileSystem>
 			.BeBetween(creationTimeStart, creationTimeEnd);
 	}
 
+	/// <summary>
+	///     https://github.com/dotnet/runtime/issues/52700
+	/// </summary>
+	[SkippableTheory]
+	[InlineAutoData(FileAccess.Read)]
+	[InlineAutoData(FileAccess.ReadWrite)]
+	[InlineAutoData(FileAccess.Write)]
+	public void Move_SourceAccessedWithWriteShare_ShouldNotThrowOnLinuxOrMac(
+		FileAccess fileAccess,
+		string sourcePath,
+		string destinationPath,
+		string sourceContents)
+	{
+		Skip.If(Test.RunsOnWindows);
+
+		FileSystem.Initialize().WithFile(sourcePath)
+			.Which(f => f.HasStringContent(sourceContents));
+		using (FileSystem.FileStream
+			.New(sourcePath, FileMode.Open, fileAccess, FileShare.Write))
+		{
+			FileSystem.File.Move(sourcePath, destinationPath);
+		}
+
+		FileSystem.File.Exists(destinationPath).Should().BeTrue();
+		FileSystem.File.ReadAllText(destinationPath).Should().Be(sourceContents);
+	}
+
 	[SkippableTheory]
 	[AutoData]
 	public void Move_SourceAndDestinationIdentical_ShouldNotThrowException(string path)
@@ -181,14 +208,26 @@ public abstract partial class MoveTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[AutoData]
+	[InlineAutoData(FileAccess.Read, FileShare.None)]
+	[InlineAutoData(FileAccess.Read, FileShare.Read)]
+	[InlineAutoData(FileAccess.Read, FileShare.ReadWrite)]
+	[InlineAutoData(FileAccess.Read, FileShare.Write)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.None)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.Read)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.ReadWrite)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.Write)]
+	[InlineAutoData(FileAccess.Write, FileShare.None)]
+	[InlineAutoData(FileAccess.Write, FileShare.Read)]
+	[InlineAutoData(FileAccess.Write, FileShare.ReadWrite)]
+	[InlineAutoData(FileAccess.Write, FileShare.Write)]
 	public void Move_SourceLocked_ShouldThrowIOException_OnWindows(
+		FileShare fileShare,
 		string sourceName,
 		string destinationName)
 	{
 		FileSystem.File.WriteAllText(sourceName, null);
 		using FileSystemStream stream = FileSystem.File.Open(sourceName, FileMode.Open,
-			FileAccess.Read, FileShare.Read);
+			FileAccess.Read, fileShare);
 
 		Exception? exception = Record.Exception(() =>
 		{
@@ -197,8 +236,7 @@ public abstract partial class MoveTests<TFileSystem>
 
 		if (Test.RunsOnWindows)
 		{
-			exception.Should().BeException<IOException>(
-				hResult: -2147024864);
+			exception.Should().BeException<IOException>(hResult: -2147024864);
 			FileSystem.Should().NotHaveFile(destinationName);
 		}
 		else

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
@@ -174,8 +174,21 @@ public abstract partial class ReplaceTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[AutoData]
+	[InlineAutoData(FileAccess.Read, FileShare.None)]
+	[InlineAutoData(FileAccess.Read, FileShare.Read)]
+	[InlineAutoData(FileAccess.Read, FileShare.ReadWrite)]
+	[InlineAutoData(FileAccess.Read, FileShare.Write)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.None)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.Read)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.ReadWrite)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.Write)]
+	[InlineAutoData(FileAccess.Write, FileShare.None)]
+	[InlineAutoData(FileAccess.Write, FileShare.Read)]
+	[InlineAutoData(FileAccess.Write, FileShare.ReadWrite)]
+	[InlineAutoData(FileAccess.Write, FileShare.Write)]
 	public void Replace_SourceLocked_ShouldThrowIOException_OnWindows(
+		FileAccess fileAccess,
+		FileShare fileShare,
 		string sourceName,
 		string destinationName,
 		string backupName,
@@ -186,8 +199,8 @@ public abstract partial class ReplaceTests<TFileSystem>
 		FileSystem.File.WriteAllText(destinationName, destinationContents);
 
 		Exception? exception;
-		using (FileSystemStream _ = FileSystem.File.Open(sourceName,
-			FileMode.Open, FileAccess.Read, FileShare.Read))
+		using (FileSystemStream _ = FileSystem.File.Open(
+			sourceName, FileMode.Open, fileAccess, fileShare))
 		{
 			exception = Record.Exception(() =>
 			{
@@ -208,6 +221,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 		}
 		else
 		{
+			// https://github.com/dotnet/runtime/issues/52700
 			FileSystem.Should().NotHaveFile(sourceName);
 			FileSystem.Should().HaveFile(destinationName)
 				.Which.HasContent(sourceContents);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
@@ -321,8 +321,21 @@ public abstract partial class ReplaceTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[AutoData]
+	[InlineAutoData(FileAccess.Read, FileShare.None)]
+	[InlineAutoData(FileAccess.Read, FileShare.Read)]
+	[InlineAutoData(FileAccess.Read, FileShare.ReadWrite)]
+	[InlineAutoData(FileAccess.Read, FileShare.Write)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.None)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.Read)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.ReadWrite)]
+	[InlineAutoData(FileAccess.ReadWrite, FileShare.Write)]
+	[InlineAutoData(FileAccess.Write, FileShare.None)]
+	[InlineAutoData(FileAccess.Write, FileShare.Read)]
+	[InlineAutoData(FileAccess.Write, FileShare.ReadWrite)]
+	[InlineAutoData(FileAccess.Write, FileShare.Write)]
 	public void Replace_SourceLocked_ShouldThrowIOException_OnWindows(
+		FileAccess fileAccess,
+		FileShare fileShare,
 		string sourceName,
 		string destinationName,
 		string backupName,
@@ -334,8 +347,8 @@ public abstract partial class ReplaceTests<TFileSystem>
 		IFileInfo sut = FileSystem.FileInfo.New(sourceName);
 
 		Exception? exception;
-		using (FileSystemStream _ = FileSystem.File.Open(sourceName,
-			FileMode.Open, FileAccess.Read, FileShare.Read))
+		using (FileSystemStream _ = FileSystem.File.Open(
+			sourceName, FileMode.Open, fileAccess, fileShare))
 		{
 			exception = Record.Exception(() =>
 			{
@@ -357,6 +370,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 		}
 		else
 		{
+			// https://github.com/dotnet/runtime/issues/52700
 			sut.Should().NotExist();
 			FileSystem.Should().NotHaveFile(sourceName);
 			FileSystem.Should().HaveFile(destinationName)


### PR DESCRIPTION
Ignore FileShare for `Move` and `Replace` methods on Linux or MacOS.
*See https://github.com/dotnet/runtime/issues/52700 for more details.*

Add tests to verify the correct behavior for the following methods while an open file handle exists:
- `File.Copy`
- `File.Move`
- `File.Replace`
- `FileInfo.CopyTo`
- `FileInfo.MoveTo`
- `FileInfo.Replace`