### PR TITLE
docs: improve links in nuget README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -328,6 +328,8 @@ jobs:
             sed -i -e "s/Testably.Abstractions%2Fmain/Testably.Abstractions%2Frelease%2F${version}/g" "./$f"
             sed -i -e "s/Testably.Abstractions%2Fmain/Testably.Abstractions%2Frelease%2F${version}/g" "./$f"
             sed -i -e "s/Testably.Abstractions\/main)/Testably.Abstractions\/release\/${version})/g" "./$f"
+            sed -i -e "s/Testably.Abstractions\/actions\/workflows\/build.yml\/badge.svg)/Testably.Abstractions\/actions\/workflows\/build.yml\/badge.svg?branch=release\/${version})/g" "./$f"
+            sed -i -e "s/Testably.Abstractions\/actions\/workflows\/build.yml)/Testably.Abstractions\/actions\/workflows\/build.yml?query=branch%3Arelease%2F${version})/g" "./$f"
             # Add absolute path to example section
             sed -i -e 's/\(Examples\/README.md\)/https:\/\/github.com\/Testably\/Testably.Abstractions\/blob\/main\/Examples\/README.md/g' "./$f"
           done

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![Testably.Abstractions](https://raw.githubusercontent.com/Testably/Testably.Abstractions/main/Docs/Images/social-preview.png)  
 [![Nuget](https://img.shields.io/nuget/v/Testably.Abstractions)](https://www.nuget.org/packages/Testably.Abstractions)
 [![Build](https://github.com/Testably/Testably.Abstractions/actions/workflows/build.yml/badge.svg)](https://github.com/Testably/Testably.Abstractions/actions/workflows/build.yml)
-[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/5b9b2f79950447a69d69037b43acd590)](https://app.codacy.com/gh/Testably/Testably.Abstractions/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_Testably.Abstractions&branch=main&metric=alert_status)](https://sonarcloud.io/summary/overall?id=Testably_Testably.Abstractions)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/5b9b2f79950447a69d69037b43acd590)](https://app.codacy.com/gh/Testably/Testably.Abstractions/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FTestably.Abstractions%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/Testably.Abstractions/main)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FTestably%2FTestably.Abstractions.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2FTestably%2FTestably.Abstractions?ref=badge_shield&issueType=license)
 


### PR DESCRIPTION
Update the badge to Github builds on the release readme on nuget.org to include the branch information.