### PR TITLE
fix: avoid using methods from System.IO in Testing

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
@@ -131,7 +131,7 @@ public static class FileSystemInitializerExtensions
 		options?.Invoke(optionsValue);
 		if (optionsValue.InitializeTempDirectory)
 		{
-			fileSystem.Directory.CreateDirectory(Path.GetTempPath());
+			fileSystem.Directory.CreateDirectory(fileSystem.ExecuteOrDefault().Path.GetTempPath());
 		}
 
 		return new FileSystemInitializer<TFileSystem>(fileSystem, ".");

--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using Testably.Abstractions.RandomSystem;
 using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Storage;
@@ -67,7 +66,7 @@ internal static class FileSystemExtensions
 		{
 			fullFilePath = fullFilePath.Substring(currentDirectory.Length);
 		}
-		else if (fullFilePath.StartsWith(currentDirectory + Path.DirectorySeparatorChar,
+		else if (fullFilePath.StartsWith(currentDirectory + fileSystem.Execute.Path.DirectorySeparatorChar,
 			fileSystem.Execute.StringComparisonMode))
 		{
 			fullFilePath = fullFilePath.Substring(currentDirectory.Length + 1);
@@ -76,11 +75,11 @@ internal static class FileSystemExtensions
 		{
 			string? parentName = currentDirectory;
 			while (parentName != null &&
-			       !fullFilePath.StartsWith(parentName + Path.DirectorySeparatorChar,
+			       !fullFilePath.StartsWith(parentName + fileSystem.Execute.Path.DirectorySeparatorChar,
 				       fileSystem.Execute.StringComparisonMode))
 			{
-				parentName = Path.GetDirectoryName(parentName);
-				int lastIndex = givenPath.LastIndexOf(Path.DirectorySeparatorChar);
+				parentName = fileSystem.Execute.Path.GetDirectoryName(parentName);
+				int lastIndex = givenPath.LastIndexOf(fileSystem.Execute.Path.DirectorySeparatorChar);
 				if (lastIndex >= 0)
 				{
 					givenPath = givenPath.Substring(0, lastIndex);

--- a/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
@@ -41,7 +41,7 @@ internal static class PathHelper
 			return path ?? string.Empty;
 		}
 
-		return fileSystem.Path.GetFullPath(path);
+		return fileSystem.ExecuteOrDefault().Path.GetFullPath(path);
 	}
 
 	/// <summary>

--- a/Source/Testably.Abstractions.Testing/Storage/StorageExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/StorageExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
 using Testably.Abstractions.Testing.Helpers;
@@ -28,13 +27,13 @@ internal static class StorageExtensions
 			StringBuilder givenPathPrefix = new();
 
 			while (searchPattern.StartsWith(
-				       ".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
+				       ".." + fileSystem.Execute.Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
 			       searchPattern.StartsWith(
-				       ".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal))
+				       ".." + fileSystem.Execute.Path.AltDirectorySeparatorChar, StringComparison.Ordinal))
 			{
 				fileSystem.Execute.OnNetFramework(
 					() => throw ExceptionFactory.SearchPatternCannotContainTwoDots());
-				parentDirectories.Push(Path.GetFileName(location.FullPath));
+				parentDirectories.Push(fileSystem.Execute.Path.GetFileName(location.FullPath));
 				location = location.GetParent() ??
 				           throw new UnauthorizedAccessException(
 					           $"The searchPattern '{searchPattern}' has too many '../' for path '{path}'");
@@ -47,10 +46,10 @@ internal static class StorageExtensions
 			if (parentDirectories.Any())
 			{
 				givenPathPrefix.Length--;
-				givenPath = Path.Combine(
+				givenPath = fileSystem.Execute.Path.Combine(
 					givenPath,
 					givenPathPrefix.ToString(),
-					Path.Combine(parentDirectories.ToArray()));
+					fileSystem.Execute.Path.Combine(parentDirectories.ToArray()));
 			}
 		}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/DeleteTests.cs
@@ -15,7 +15,7 @@ public abstract partial class DeleteTests<TFileSystem>
 	{
 		directoryName = directoryName.ToLowerInvariant();
 		FileSystem.Directory.CreateDirectory(directoryName.ToUpperInvariant());
-		string expectedPath = System.IO.Path.Combine(BasePath, directoryName);
+		string expectedPath = FileSystem.Path.Combine(BasePath, directoryName);
 		Exception? exception = Record.Exception(() =>
 		{
 			FileSystem.Directory.Delete(directoryName);
@@ -51,7 +51,7 @@ public abstract partial class DeleteTests<TFileSystem>
 	public void Delete_MissingDirectory_ShouldThrowDirectoryNotFoundException(
 		string directoryName)
 	{
-		string expectedPath = System.IO.Path.Combine(BasePath, directoryName);
+		string expectedPath = FileSystem.Path.Combine(BasePath, directoryName);
 		Exception? exception = Record.Exception(() =>
 		{
 			FileSystem.Directory.Delete(directoryName);
@@ -66,7 +66,7 @@ public abstract partial class DeleteTests<TFileSystem>
 	public void Delete_Recursive_MissingDirectory_ShouldThrowDirectoryNotFoundException(
 		string directoryName)
 	{
-		string expectedPath = System.IO.Path.Combine(BasePath, directoryName);
+		string expectedPath = FileSystem.Path.Combine(BasePath, directoryName);
 		Exception? exception = Record.Exception(() =>
 		{
 			FileSystem.Directory.Delete(directoryName, true);
@@ -248,7 +248,7 @@ public abstract partial class DeleteTests<TFileSystem>
 			// Path information only included in exception message on Windows and not in .NET Framework
 			messageContains: !Test.RunsOnWindows || Test.IsNetFramework
 				? null
-				: $"'{System.IO.Path.Combine(BasePath, path)}'");
+				: $"'{FileSystem.Path.Combine(BasePath, path)}'");
 		FileSystem.Should().HaveDirectory(path);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
@@ -29,7 +29,7 @@ public abstract partial class EnumerateDirectoriesTests<TFileSystem>
 		EnumerateDirectories_MissingDirectory_ShouldThrowDirectoryNotFoundException(
 			string path)
 	{
-		string expectedPath = System.IO.Path.Combine(BasePath, path);
+		string expectedPath = FileSystem.Path.Combine(BasePath, path);
 		Exception? exception =
 			Record.Exception(()
 				=> FileSystem.Directory.EnumerateDirectories(path).ToList());

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateFileSystemInfosTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateFileSystemInfosTests.cs
@@ -19,7 +19,7 @@ public abstract partial class EnumerateFileSystemInfosTests<TFileSystem>
 		EnumerateFileSystemEntries_MissingDirectory_ShouldThrowDirectoryNotFoundException(
 			string path)
 	{
-		string expectedPath = System.IO.Path.Combine(BasePath, path);
+		string expectedPath = FileSystem.Path.Combine(BasePath, path);
 		Exception? exception =
 			Record.Exception(()
 				=> FileSystem.Directory.EnumerateFileSystemEntries(path).ToList());

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateFilesTests.cs
@@ -19,7 +19,7 @@ public abstract partial class EnumerateFilesTests<TFileSystem>
 		EnumerateFiles_MissingDirectory_ShouldThrowDirectoryNotFoundException(
 			string path)
 	{
-		string expectedPath = System.IO.Path.Combine(BasePath, path);
+		string expectedPath = FileSystem.Path.Combine(BasePath, path);
 		Exception? exception =
 			Record.Exception(()
 				=> FileSystem.Directory.EnumerateFiles(path).ToList());

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetDirectoriesTests.cs
@@ -15,7 +15,7 @@ public abstract partial class GetDirectoriesTests<TFileSystem>
 		GetDirectories_MissingDirectory_ShouldThrowDirectoryNotFoundException(
 			string path)
 	{
-		string expectedPath = System.IO.Path.Combine(BasePath, path);
+		string expectedPath = FileSystem.Path.Combine(BasePath, path);
 		Exception? exception =
 			Record.Exception(()
 				=> FileSystem.Directory.GetDirectories(path).ToList());

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFileSystemInfosTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFileSystemInfosTests.cs
@@ -19,7 +19,7 @@ public abstract partial class GetFileSystemInfosTests<TFileSystem>
 		GetFileSystemEntries_MissingDirectory_ShouldThrowDirectoryNotFoundException(
 			string path)
 	{
-		string expectedPath = System.IO.Path.Combine(BasePath, path);
+		string expectedPath = FileSystem.Path.Combine(BasePath, path);
 		Exception? exception =
 			Record.Exception(()
 				=> FileSystem.Directory.GetFileSystemEntries(path).ToList());

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetFilesTests.cs
@@ -19,7 +19,7 @@ public abstract partial class GetFilesTests<TFileSystem>
 		GetFiles_MissingDirectory_ShouldThrowDirectoryNotFoundException(
 			string path)
 	{
-		string expectedPath = System.IO.Path.Combine(BasePath, path);
+		string expectedPath = FileSystem.Path.Combine(BasePath, path);
 		Exception? exception =
 			Record.Exception(()
 				=> FileSystem.Directory.GetFiles(path).ToList());
@@ -266,17 +266,17 @@ public abstract partial class GetFilesTests<TFileSystem>
 	public void GetFiles_WithRelativePathAndSubfolders_ShouldReturnRelativeFilePath(
 		string subfolder1, string subfolder2, string[] files)
 	{
-		string workingDirectory = System.IO.Path.Combine(BasePath, subfolder1, subfolder2);
+		string workingDirectory = FileSystem.Path.Combine(BasePath, subfolder1, subfolder2);
 		FileSystem.Directory.CreateDirectory(workingDirectory);
 		foreach (string file in files)
 		{
-			FileSystem.File.Create(System.IO.Path.Combine(workingDirectory, file));
+			FileSystem.File.Create(FileSystem.Path.Combine(workingDirectory, file));
 		}
 
 		FileSystem.Directory.SetCurrentDirectory(subfolder1);
 		IEnumerable<string> expectation =
-			files.Select(f => System.IO.Path.Combine("..", subfolder1, subfolder2, f));
-		string path = System.IO.Path.Combine("..", subfolder1, subfolder2);
+			files.Select(f => FileSystem.Path.Combine("..", subfolder1, subfolder2, f));
+		string path = FileSystem.Path.Combine("..", subfolder1, subfolder2);
 
 		List<string> result = FileSystem.Directory.GetFiles(path).ToList();
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ResolveLinkTargetTests.cs
@@ -78,7 +78,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 		{
 			string newPath = $"{path}-{i}";
 			FileSystem.Directory.CreateSymbolicLink(newPath,
-				System.IO.Path.Combine(BasePath, previousPath));
+				FileSystem.Path.Combine(BasePath, previousPath));
 			previousPath = newPath;
 		}
 
@@ -102,7 +102,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 		{
 			string newPath = $"{path}-{i}";
 			FileSystem.Directory.CreateSymbolicLink(newPath,
-				System.IO.Path.Combine(BasePath, previousPath));
+				FileSystem.Path.Combine(BasePath, previousPath));
 			previousPath = newPath;
 		}
 
@@ -125,9 +125,9 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 
 		FileSystem.Directory.CreateDirectory(pathToFinalTarget);
 		FileSystem.Directory.CreateSymbolicLink(pathToMissingDirectory,
-			System.IO.Path.Combine(BasePath, pathToFinalTarget));
+			FileSystem.Path.Combine(BasePath, pathToFinalTarget));
 		FileSystem.Directory.CreateSymbolicLink(path,
-			System.IO.Path.Combine(BasePath, pathToMissingDirectory));
+			FileSystem.Path.Combine(BasePath, pathToMissingDirectory));
 		FileSystem.Directory.Delete(pathToMissingDirectory);
 
 		IFileSystemInfo? target =

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/SearchFilterTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/SearchFilterTests.cs
@@ -29,7 +29,7 @@ public abstract partial class SearchFilterTests<TFileSystem>
 			.GetFileSystemEntries(".", searchPattern, SearchOption.AllDirectories);
 
 		result.Length.Should().Be(expectedMatchingFiles);
-		result.Should().Contain(System.IO.Path.Combine(".", "..", "xyz", "a.test"));
+		result.Should().Contain(FileSystem.Path.Combine(".", "..", "xyz", "a.test"));
 	}
 
 	[SkippableTheory]
@@ -54,12 +54,12 @@ public abstract partial class SearchFilterTests<TFileSystem>
 		result.Length.Should().Be(expectedMatchingFiles);
 		if (!searchPattern.EndsWith("a*", StringComparison.Ordinal))
 		{
-			result.Should().Contain(System.IO.Path.Combine(".", "../..", "bar"));
-			result.Should().Contain(System.IO.Path.Combine(".", "../..", "bar", "xyz"));
+			result.Should().Contain(FileSystem.Path.Combine(".", "../..", "bar"));
+			result.Should().Contain(FileSystem.Path.Combine(".", "../..", "bar", "xyz"));
 		}
 
 		result.Should()
-			.Contain(System.IO.Path.Combine(".", "../..", "bar", "xyz", "a.test"));
+			.Contain(FileSystem.Path.Combine(".", "../..", "bar", "xyz", "a.test"));
 	}
 
 	[SkippableTheory]
@@ -84,16 +84,16 @@ public abstract partial class SearchFilterTests<TFileSystem>
 		result.Length.Should().Be(expectedMatchingFiles);
 		if (!searchPattern.EndsWith("a*", StringComparison.Ordinal))
 		{
-			result.Should().Contain(System.IO.Path.Combine(".", "../../..", "foo"));
+			result.Should().Contain(FileSystem.Path.Combine(".", "../../..", "foo"));
 			result.Should()
-				.Contain(System.IO.Path.Combine(".", "../../..", "foo", "bar"));
+				.Contain(FileSystem.Path.Combine(".", "../../..", "foo", "bar"));
 			result.Should()
-				.Contain(System.IO.Path.Combine(".", "../../..", "foo", "bar", "xyz"));
+				.Contain(FileSystem.Path.Combine(".", "../../..", "foo", "bar", "xyz"));
 		}
 
 		result.Should()
 			.Contain(
-				System.IO.Path.Combine(".", "../../..", "foo", "bar", "xyz", "a.test"));
+				FileSystem.Path.Combine(".", "../../..", "foo", "bar", "xyz", "a.test"));
 	}
 
 	[SkippableFact]
@@ -109,8 +109,8 @@ public abstract partial class SearchFilterTests<TFileSystem>
 			.GetFileSystemEntries(".", "a*.t*.", SearchOption.AllDirectories);
 
 		result.Length.Should().Be(2);
-		result.Should().Contain(System.IO.Path.Combine(".", "a.test"));
-		result.Should().Contain(System.IO.Path.Combine(".", "another.test"));
+		result.Should().Contain(FileSystem.Path.Combine(".", "a.test"));
+		result.Should().Contain(FileSystem.Path.Combine(".", "another.test"));
 	}
 
 	[SkippableFact]
@@ -126,7 +126,7 @@ public abstract partial class SearchFilterTests<TFileSystem>
 			.GetFileSystemEntries(".", "a-??s*", SearchOption.AllDirectories);
 
 		result.Length.Should().Be(1);
-		result[0].Should().Be(System.IO.Path.Combine(".", "a-test"));
+		result[0].Should().Be(FileSystem.Path.Combine(".", "a-test"));
 	}
 
 	[SkippableFact]
@@ -182,7 +182,7 @@ public abstract partial class SearchFilterTests<TFileSystem>
 			.GetFileSystemEntries(".", searchPattern, SearchOption.AllDirectories);
 
 		result.Length.Should().Be(expectedMatchingFiles);
-		result.Should().Contain(System.IO.Path.Combine(".", "..", path, "a.test"));
+		result.Should().Contain(FileSystem.Path.Combine(".", "..", path, "a.test"));
 	}
 
 	[SkippableTheory]
@@ -241,7 +241,7 @@ public abstract partial class SearchFilterTests<TFileSystem>
 		else
 		{
 			result.Length.Should().Be(1);
-			result.Should().Contain(System.IO.Path.Combine(".", "test.."));
+			result.Should().Contain(FileSystem.Path.Combine(".", "test.."));
 		}
 	}
 
@@ -291,12 +291,12 @@ public abstract partial class SearchFilterTests<TFileSystem>
 		if (Test.RunsOnWindows)
 		{
 			result.Length.Should().Be(1);
-			result.Should().Contain(System.IO.Path.Combine(".", "test"));
+			result.Should().Contain(FileSystem.Path.Combine(".", "test"));
 		}
 		else
 		{
 			result.Length.Should().Be(3);
-			result.Should().Contain(System.IO.Path.Combine(".", "test."));
+			result.Should().Contain(FileSystem.Path.Combine(".", "test."));
 		}
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
@@ -131,7 +131,7 @@ public abstract partial class CreateTests<TFileSystem>
 		result.Name.Should().Be(expectedName.TrimEnd(
 			FileSystem.Path.DirectorySeparatorChar,
 			FileSystem.Path.AltDirectorySeparatorChar));
-		result.FullName.Should().Be(System.IO.Path.Combine(BasePath, expectedName
+		result.FullName.Should().Be(FileSystem.Path.Combine(BasePath, expectedName
 			.Replace(FileSystem.Path.AltDirectorySeparatorChar,
 				FileSystem.Path.DirectorySeparatorChar)));
 		FileSystem.Should().HaveDirectory(nameWithSuffix);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfoFactory/Tests.cs
@@ -15,10 +15,15 @@ public abstract partial class Tests<TFileSystem>
 #else
 		string expectedMessage = "Illegal characters in path.";
 #endif
-		Exception? exception =
-			Record.Exception(() => FileSystem.DirectoryInfo.New(path));
+		Exception? exception = Record.Exception(() =>
+		{
+			_ = FileSystem.DirectoryInfo.New(path);
+		});
 
 		exception.Should().BeException<ArgumentException>(expectedMessage,
+#if !NETFRAMEWORK
+			paramName: "path",
+#endif
 			hResult: -2147024809);
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ResolveLinkTargetTests.cs
@@ -100,7 +100,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 		{
 			string newPath = $"{path}-{i}";
 			FileSystem.File.CreateSymbolicLink(newPath,
-				System.IO.Path.Combine(BasePath, previousPath));
+				FileSystem.Path.Combine(BasePath, previousPath));
 			previousPath = newPath;
 		}
 
@@ -122,7 +122,7 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 		{
 			string newPath = $"{path}-{i}";
 			FileSystem.File.CreateSymbolicLink(newPath,
-				System.IO.Path.Combine(BasePath, previousPath));
+				FileSystem.Path.Combine(BasePath, previousPath));
 			previousPath = newPath;
 		}
 
@@ -142,9 +142,9 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 	{
 		FileSystem.File.WriteAllText(pathToFinalTarget, null);
 		FileSystem.File.CreateSymbolicLink(pathToMissingFile,
-			System.IO.Path.Combine(BasePath, pathToFinalTarget));
+			FileSystem.Path.Combine(BasePath, pathToFinalTarget));
 		FileSystem.File.CreateSymbolicLink(path,
-			System.IO.Path.Combine(BasePath, pathToMissingFile));
+			FileSystem.Path.Combine(BasePath, pathToMissingFile));
 		FileSystem.File.Delete(pathToMissingFile);
 
 		IFileSystemInfo? target =
@@ -163,11 +163,11 @@ public abstract partial class ResolveLinkTargetTests<TFileSystem>
 	{
 		FileSystem.File.WriteAllText(pathToFinalTarget, null);
 		FileSystem.File.CreateSymbolicLink(pathToMissingFile,
-			System.IO.Path.Combine(BasePath, pathToFinalTarget));
+			FileSystem.Path.Combine(BasePath, pathToFinalTarget));
 		FileSystem.File.CreateSymbolicLink(pathToIntermediateTarget,
-			System.IO.Path.Combine(BasePath, pathToMissingFile));
+			FileSystem.Path.Combine(BasePath, pathToMissingFile));
 		FileSystem.File.CreateSymbolicLink(path,
-			System.IO.Path.Combine(BasePath, pathToIntermediateTarget));
+			FileSystem.Path.Combine(BasePath, pathToIntermediateTarget));
 		FileSystem.File.Delete(pathToMissingFile);
 
 		IFileSystemInfo? target =

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExistsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ExistsTests.cs
@@ -18,6 +18,8 @@ public abstract partial class ExistsTests<TFileSystem>
 	[SkippableTheory]
 	[InlineData("foo", "foo.")]
 	[InlineData("foo.", "foo")]
+	[InlineData("foo", "foo..")]
+	[InlineData("foo..", "foo")]
 	public void Exists_ShouldIgnoreTrailingDot_OnWindows(string path1, string path2)
 	{
 		FileSystem.File.WriteAllText(path1, "some text");

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/ChangeExtensionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/ChangeExtensionTests.cs
@@ -25,12 +25,39 @@ public abstract partial class ChangeExtensionTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
+	public void ChangeExtension_WhenExtensionIsNull_ShouldRemovePreviousExtension(
+		string fileName)
+	{
+		string path = fileName + "..foo";
+		string expectedResult = fileName + ".";
+
+		string result = FileSystem.Path.ChangeExtension(path, null);
+
+		result.Should().Be(expectedResult);
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void ChangeExtension_WithDirectory_ShouldIncludeDirectory(
 		string directory, string fileName, string extension)
 	{
 		string path = FileSystem.Path.Combine(directory, fileName + ".foo");
 		string expectedResult =
 			FileSystem.Path.Combine(directory, fileName + "." + extension);
+
+		string result = FileSystem.Path.ChangeExtension(path, extension);
+
+		result.Should().Be(expectedResult);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void ChangeExtension_WithDotOnlyInDirectory_ShouldAppendExtensionToPath(
+		string directory, string fileName, string extension)
+	{
+		directory = directory + "." + "with-dot";
+		string path = FileSystem.Path.Combine(directory, fileName);
+		string expectedResult = path + "." + extension;
 
 		string result = FileSystem.Path.ChangeExtension(path, extension);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/CombineTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/CombineTests.cs
@@ -26,8 +26,10 @@ public abstract partial class CombineTests<TFileSystem>
 		Exception? exception2 = Record.Exception(() =>
 			FileSystem.Path.Combine(null!, path));
 
-		exception1.Should().BeException<ArgumentNullException>(hResult: -2147467261);
-		exception2.Should().BeException<ArgumentNullException>(hResult: -2147467261);
+		exception1.Should()
+			.BeException<ArgumentNullException>(paramName: "path2", hResult: -2147467261);
+		exception2.Should()
+			.BeException<ArgumentNullException>(paramName: "path1", hResult: -2147467261);
 	}
 
 	[SkippableTheory]
@@ -35,8 +37,8 @@ public abstract partial class CombineTests<TFileSystem>
 	public void Combine_2Paths_Rooted_ShouldReturnLastRootedPath(
 		string path1, string path2)
 	{
-		path1 = System.IO.Path.DirectorySeparatorChar + path1;
-		path2 = System.IO.Path.DirectorySeparatorChar + path2;
+		path1 = FileSystem.Path.DirectorySeparatorChar + path1;
+		path2 = FileSystem.Path.DirectorySeparatorChar + path2;
 
 		string result = FileSystem.Path.Combine(path1, path2);
 
@@ -44,7 +46,9 @@ public abstract partial class CombineTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[AutoData]
+	[InlineAutoData]
+	[InlineAutoData(" ")]
+	[InlineAutoData("foo", " ")]
 	public void Combine_2Paths_ShouldReturnPathsCombinedByDirectorySeparatorChar(
 		string path1, string path2)
 	{
@@ -61,7 +65,7 @@ public abstract partial class CombineTests<TFileSystem>
 	public void Combine_3Paths_OneEmpty_ShouldReturnCombinationOfOtherParts(
 		string pathA, string pathB)
 	{
-		string expectedPath = System.IO.Path.Combine(pathA, pathB);
+		string expectedPath = FileSystem.Path.Combine(pathA, pathB);
 
 		string result1 = FileSystem.Path.Combine(string.Empty, pathA, pathB);
 		string result2 = FileSystem.Path.Combine(pathA, string.Empty, pathB);
@@ -74,18 +78,21 @@ public abstract partial class CombineTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void Combine_3Paths_OneNull_ShouldThrowArgumentNullException(string path)
+	public void Combine_3Paths_OneNull_ShouldThrowArgumentNullException(string pathA, string pathB)
 	{
 		Exception? exception1 = Record.Exception(() =>
-			FileSystem.Path.Combine(path, null!, null!));
+			FileSystem.Path.Combine(pathA, pathB, null!));
 		Exception? exception2 = Record.Exception(() =>
-			FileSystem.Path.Combine(null!, path, null!));
+			FileSystem.Path.Combine(null!, pathA, pathB));
 		Exception? exception3 = Record.Exception(() =>
-			FileSystem.Path.Combine(null!, null!, path));
+			FileSystem.Path.Combine(pathA, null!, pathB));
 
-		exception1.Should().BeException<ArgumentNullException>(hResult: -2147467261);
-		exception2.Should().BeException<ArgumentNullException>(hResult: -2147467261);
-		exception3.Should().BeException<ArgumentNullException>(hResult: -2147467261);
+		exception1.Should()
+			.BeException<ArgumentNullException>(paramName: "path3", hResult: -2147467261);
+		exception2.Should()
+			.BeException<ArgumentNullException>(paramName: "path1", hResult: -2147467261);
+		exception3.Should()
+			.BeException<ArgumentNullException>(paramName: "path2", hResult: -2147467261);
 	}
 
 	[SkippableTheory]
@@ -93,9 +100,9 @@ public abstract partial class CombineTests<TFileSystem>
 	public void Combine_3Paths_Rooted_ShouldReturnLastRootedPath(
 		string path1, string path2, string path3)
 	{
-		path1 = System.IO.Path.AltDirectorySeparatorChar + path1;
-		path2 = System.IO.Path.AltDirectorySeparatorChar + path2;
-		path3 = System.IO.Path.AltDirectorySeparatorChar + path3;
+		path1 = FileSystem.Path.DirectorySeparatorChar + path1;
+		path2 = FileSystem.Path.DirectorySeparatorChar + path2;
+		path3 = FileSystem.Path.DirectorySeparatorChar + path3;
 
 		string result = FileSystem.Path.Combine(path1, path2, path3);
 
@@ -103,7 +110,10 @@ public abstract partial class CombineTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[AutoData]
+	[InlineAutoData]
+	[InlineAutoData(" ")]
+	[InlineAutoData("foo", " ")]
+	[InlineAutoData("foo", "bar", " ")]
 	public void Combine_3Paths_ShouldReturnPathsCombinedByDirectorySeparatorChar(
 		string path1, string path2, string path3)
 	{
@@ -121,7 +131,7 @@ public abstract partial class CombineTests<TFileSystem>
 	public void Combine_4Paths_OneEmpty_ShouldReturnCombinationOfOtherParts(
 		string pathA, string pathB, string pathC)
 	{
-		string expectedPath = System.IO.Path.Combine(pathA, pathB, pathC);
+		string expectedPath = FileSystem.Path.Combine(pathA, pathB, pathC);
 
 		string result1 = FileSystem.Path.Combine(string.Empty, pathA, pathB, pathC);
 		string result2 = FileSystem.Path.Combine(pathA, string.Empty, pathB, pathC);
@@ -136,21 +146,26 @@ public abstract partial class CombineTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void Combine_4Paths_OneNull_ShouldThrowArgumentNullException(string path)
+	public void Combine_4Paths_OneNull_ShouldThrowArgumentNullException(string pathA, string pathB,
+		string pathC)
 	{
 		Exception? exception1 = Record.Exception(() =>
-			FileSystem.Path.Combine(path, null!, null!, null!));
+			FileSystem.Path.Combine(pathA, pathB, pathC, null!));
 		Exception? exception2 = Record.Exception(() =>
-			FileSystem.Path.Combine(null!, path, null!, null!));
+			FileSystem.Path.Combine(null!, pathA, pathB, pathC));
 		Exception? exception3 = Record.Exception(() =>
-			FileSystem.Path.Combine(null!, null!, path, null!));
+			FileSystem.Path.Combine(pathA, null!, pathB, pathC));
 		Exception? exception4 = Record.Exception(() =>
-			FileSystem.Path.Combine(null!, null!, null!, path));
+			FileSystem.Path.Combine(pathA, pathB, null!, pathC));
 
-		exception1.Should().BeException<ArgumentNullException>(hResult: -2147467261);
-		exception2.Should().BeException<ArgumentNullException>(hResult: -2147467261);
-		exception3.Should().BeException<ArgumentNullException>(hResult: -2147467261);
-		exception4.Should().BeException<ArgumentNullException>(hResult: -2147467261);
+		exception1.Should()
+			.BeException<ArgumentNullException>(paramName: "path4", hResult: -2147467261);
+		exception2.Should()
+			.BeException<ArgumentNullException>(paramName: "path1", hResult: -2147467261);
+		exception3.Should()
+			.BeException<ArgumentNullException>(paramName: "path2", hResult: -2147467261);
+		exception4.Should()
+			.BeException<ArgumentNullException>(paramName: "path3", hResult: -2147467261);
 	}
 
 	[SkippableTheory]
@@ -158,10 +173,10 @@ public abstract partial class CombineTests<TFileSystem>
 	public void Combine_4Paths_Rooted_ShouldReturnLastRootedPath(
 		string path1, string path2, string path3, string path4)
 	{
-		path1 = System.IO.Path.DirectorySeparatorChar + path1;
-		path2 = System.IO.Path.DirectorySeparatorChar + path2;
-		path3 = System.IO.Path.DirectorySeparatorChar + path3;
-		path4 = System.IO.Path.DirectorySeparatorChar + path4;
+		path1 = FileSystem.Path.DirectorySeparatorChar + path1;
+		path2 = FileSystem.Path.DirectorySeparatorChar + path2;
+		path3 = FileSystem.Path.DirectorySeparatorChar + path3;
+		path4 = FileSystem.Path.DirectorySeparatorChar + path4;
 
 		string result = FileSystem.Path.Combine(path1, path2, path3, path4);
 
@@ -169,7 +184,11 @@ public abstract partial class CombineTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[AutoData]
+	[InlineAutoData]
+	[InlineAutoData(" ")]
+	[InlineAutoData("foo", " ")]
+	[InlineAutoData("foo", "bar", " ")]
+	[InlineAutoData("foo", "bar", "baz", " ")]
 	public void Combine_4Paths_ShouldReturnPathsCombinedByDirectorySeparatorChar(
 		string path1, string path2, string path3, string path4)
 	{
@@ -189,7 +208,8 @@ public abstract partial class CombineTests<TFileSystem>
 		Exception? exception = Record.Exception(() =>
 			FileSystem.Path.Combine(null!));
 
-		exception.Should().BeException<ArgumentNullException>(hResult: -2147467261);
+		exception.Should()
+			.BeException<ArgumentNullException>(paramName: "paths", hResult: -2147467261);
 	}
 
 	[SkippableTheory]
@@ -197,7 +217,7 @@ public abstract partial class CombineTests<TFileSystem>
 	public void Combine_ParamPaths_OneEmpty_ShouldReturnCombinationOfOtherParts(
 		string path1, string path2, string path3, string path4)
 	{
-		string expectedPath = System.IO.Path.Combine(path1, path2, path3, path4);
+		string expectedPath = FileSystem.Path.Combine(path1, path2, path3, path4);
 
 		string result1 =
 			FileSystem.Path.Combine(string.Empty, path1, path2, path3, path4);
@@ -220,24 +240,29 @@ public abstract partial class CombineTests<TFileSystem>
 	[SkippableTheory]
 	[AutoData]
 	public void Combine_ParamPaths_OneNull_ShouldThrowArgumentNullException(
-		string path)
+		string pathA, string pathB, string pathC, string pathD)
 	{
 		Exception? exception1 = Record.Exception(() =>
-			FileSystem.Path.Combine(path, null!, null!, null!, null!));
+			FileSystem.Path.Combine(pathA, pathB, pathC, pathD, null!));
 		Exception? exception2 = Record.Exception(() =>
-			FileSystem.Path.Combine(null!, path, null!, null!, null!));
+			FileSystem.Path.Combine(null!, pathA, pathB, pathC, pathD));
 		Exception? exception3 = Record.Exception(() =>
-			FileSystem.Path.Combine(null!, null!, path, null!, null!));
+			FileSystem.Path.Combine(pathA, null!, pathB, pathC, pathD));
 		Exception? exception4 = Record.Exception(() =>
-			FileSystem.Path.Combine(null!, null!, null!, path, null!));
+			FileSystem.Path.Combine(pathA, pathB, null!, pathC, pathD));
 		Exception? exception5 = Record.Exception(() =>
-			FileSystem.Path.Combine(null!, null!, null!, null!, path));
+			FileSystem.Path.Combine(pathA, pathB, pathC, null!, pathD));
 
-		exception1.Should().BeException<ArgumentNullException>(hResult: -2147467261);
-		exception2.Should().BeException<ArgumentNullException>(hResult: -2147467261);
-		exception3.Should().BeException<ArgumentNullException>(hResult: -2147467261);
-		exception4.Should().BeException<ArgumentNullException>(hResult: -2147467261);
-		exception5.Should().BeException<ArgumentNullException>(hResult: -2147467261);
+		exception1.Should()
+			.BeException<ArgumentNullException>(paramName: "paths", hResult: -2147467261);
+		exception2.Should()
+			.BeException<ArgumentNullException>(paramName: "paths", hResult: -2147467261);
+		exception3.Should()
+			.BeException<ArgumentNullException>(paramName: "paths", hResult: -2147467261);
+		exception4.Should()
+			.BeException<ArgumentNullException>(paramName: "paths", hResult: -2147467261);
+		exception5.Should()
+			.BeException<ArgumentNullException>(paramName: "paths", hResult: -2147467261);
 	}
 
 	[SkippableTheory]
@@ -245,11 +270,11 @@ public abstract partial class CombineTests<TFileSystem>
 	public void Combine_ParamPaths_Rooted_ShouldReturnLastRootedPath(
 		string path1, string path2, string path3, string path4, string path5)
 	{
-		path1 = System.IO.Path.DirectorySeparatorChar + path1;
-		path2 = System.IO.Path.DirectorySeparatorChar + path2;
-		path3 = System.IO.Path.DirectorySeparatorChar + path3;
-		path4 = System.IO.Path.DirectorySeparatorChar + path4;
-		path5 = System.IO.Path.DirectorySeparatorChar + path5;
+		path1 = FileSystem.Path.DirectorySeparatorChar + path1;
+		path2 = FileSystem.Path.DirectorySeparatorChar + path2;
+		path3 = FileSystem.Path.DirectorySeparatorChar + path3;
+		path4 = FileSystem.Path.DirectorySeparatorChar + path4;
+		path5 = FileSystem.Path.DirectorySeparatorChar + path5;
 
 		string result = FileSystem.Path.Combine(path1, path2, path3, path4, path5);
 
@@ -257,7 +282,12 @@ public abstract partial class CombineTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[AutoData]
+	[InlineAutoData]
+	[InlineAutoData(" ")]
+	[InlineAutoData("foo", " ")]
+	[InlineAutoData("foo", "bar", " ")]
+	[InlineAutoData("foo", "bar", "baz", " ")]
+	[InlineAutoData("foo", "bar", "baz", "muh", " ")]
 	public void Combine_ParamPaths_ShouldReturnPathsCombinedByDirectorySeparatorChar(
 		string path1, string path2, string path3, string path4, string path5)
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetDirectoryNameTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetDirectoryNameTests.cs
@@ -5,13 +5,66 @@ public abstract partial class GetDirectoryNameTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
-	[SkippableFact]
-	public void GetDirectoryName_Null_ShouldReturnNull()
+	[SkippableTheory]
+	[InlineData((string?)null)]
+#if !NETFRAMEWORK
+	[InlineData("")]
+#endif
+	public void GetDirectoryName_NullOrEmpty_ShouldReturnNull(string? path)
 	{
-		string? result = FileSystem.Path.GetDirectoryName(null);
+		string? result = FileSystem.Path.GetDirectoryName(path);
 
 		result.Should().BeNull();
 	}
+
+#if NETFRAMEWORK
+	[SkippableTheory]
+	[InlineData("")]
+	[InlineData(" ")]
+	[InlineData("    ")]
+	[InlineData("\t")]
+	[InlineData("\n")]
+	public void GetDirectoryName_EmptyOrWhiteSpace_ShouldThrowArgumentException(string path)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			_ = FileSystem.Path.GetDirectoryName(path);
+		});
+
+		exception.Should().BeOfType<ArgumentException>();
+	}
+#endif
+
+#if !NETFRAMEWORK
+	[SkippableTheory]
+	[InlineData(" ")]
+	[InlineData("    ")]
+	public void GetDirectoryName_Spaces_ShouldReturnNullOnWindowsOtherwiseEmpty(string? path)
+	{
+		string? result = FileSystem.Path.GetDirectoryName(path);
+
+		if (Test.RunsOnWindows)
+		{
+			result.Should().BeNull();
+		}
+		else
+		{
+			result.Should().Be("");
+		}
+	}
+#endif
+
+#if !NETFRAMEWORK
+	[SkippableTheory]
+	[InlineData("\t")]
+	[InlineData("\n")]
+	public void GetDirectoryName_TabOrNewline_ShouldReturnEmptyString(string? path)
+	{
+		string? result = FileSystem.Path.GetDirectoryName(path);
+
+		result.Should().Be("");
+	}
+#endif
 
 	[SkippableTheory]
 	[AutoData]
@@ -25,6 +78,7 @@ public abstract partial class GetDirectoryNameTests<TFileSystem>
 
 		result.Should().Be(directory);
 	}
+
 #if FEATURE_SPAN
 	[SkippableTheory]
 	[AutoData]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetFullPathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetFullPathTests.cs
@@ -30,6 +30,24 @@ public abstract partial class GetFullPathTests<TFileSystem>
 #endif
 
 #if FEATURE_PATH_RELATIVE
+	[SkippableFact]
+	public void GetFullPath_Relative_RelativeBasePath_ShouldThrowArgumentException()
+	{
+		string relativeBasePath = "not-fully-qualified-base-path";
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.Path.GetFullPath("foo", relativeBasePath);
+		});
+
+		exception.Should().BeException<ArgumentException>(
+			paramName: "basePath",
+			messageContains: "Basepath argument is not fully qualified",
+			hResult: -2147024809);
+	}
+#endif
+
+#if FEATURE_PATH_RELATIVE
 	[SkippableTheory]
 	[InlineData("top/../most/file", "foo/bar", "foo/bar/most/file")]
 	[InlineData("top/../most/../dir/file", "foo", "foo/dir/file")]
@@ -39,9 +57,10 @@ public abstract partial class GetFullPathTests<TFileSystem>
 	{
 		string expectedRootedPath = FileTestHelper.RootDrive(Test,
 			expected.Replace('/', FileSystem.Path.DirectorySeparatorChar));
+		basePath = FileTestHelper.RootDrive(Test, basePath);
 
 		string result = FileSystem.Path
-			.GetFullPath(input, FileTestHelper.RootDrive(Test, basePath));
+			.GetFullPath(input, basePath);
 
 		result.Should().Be(expectedRootedPath);
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/JoinTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/JoinTests.cs
@@ -53,7 +53,7 @@ public abstract partial class JoinTests<TFileSystem>
 	public void Join_3Paths_OneNullOrEmpty_ShouldReturnCombinationOfOtherParts(
 		string? missingPath, string path1, string path2)
 	{
-		string expectedPath = System.IO.Path.Join(path1, path2);
+		string expectedPath = $"{path1}{FileSystem.Path.DirectorySeparatorChar}{path2}";
 
 		string result1 = FileSystem.Path.Join(missingPath, path1, path2);
 		string result2 = FileSystem.Path.Join(path1, missingPath, path2);
@@ -101,7 +101,8 @@ public abstract partial class JoinTests<TFileSystem>
 	public void Join_4Paths_OneNullOrEmpty_ShouldReturnCombinationOfOtherParts(
 		string? missingPath, string path1, string path2, string path3)
 	{
-		string expectedPath = System.IO.Path.Join(path1, path2, path3);
+		string expectedPath =
+			$"{path1}{FileSystem.Path.DirectorySeparatorChar}{path2}{FileSystem.Path.DirectorySeparatorChar}{path3}";
 
 		string result1 = FileSystem.Path.Join(missingPath, path1, path2, path3);
 		string result2 = FileSystem.Path.Join(path1, missingPath, path2, path3);
@@ -154,7 +155,8 @@ public abstract partial class JoinTests<TFileSystem>
 	public void Join_ParamPaths_OneNullOrEmpty_ShouldReturnCombinationOfOtherParts(
 		string? missingPath, string path1, string path2, string path3, string path4)
 	{
-		string expectedPath = System.IO.Path.Join(path1, path2, path3, path4);
+		string expectedPath =
+			$"{path1}{FileSystem.Path.DirectorySeparatorChar}{path2}{FileSystem.Path.DirectorySeparatorChar}{path3}{FileSystem.Path.DirectorySeparatorChar}{path4}";
 
 		string result1 =
 			FileSystem.Path.Join(missingPath, path1, path2, path3, path4);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/Tests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace Testably.Abstractions.Tests.FileSystem.Path;
 
 // ReSharper disable once PartialTypeWithSinglePart
@@ -6,35 +8,107 @@ public abstract partial class Tests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
 	[SkippableFact]
-	public void AltDirectorySeparatorChar_ShouldReturnDefaultValue()
+	public void AltDirectorySeparatorChar_ShouldReturnSlash()
 	{
 		char result = FileSystem.Path.AltDirectorySeparatorChar;
 
-		result.Should().Be(System.IO.Path.AltDirectorySeparatorChar);
+		result.Should().Be('/');
 	}
 
 	[SkippableFact]
-	public void DirectorySeparatorChar_ShouldReturnDefaultValue()
+	public void DirectorySeparatorChar_WhenNotOnWindows_ShouldReturnSlash()
 	{
+		Skip.If(Test.RunsOnWindows);
+
 		char result = FileSystem.Path.DirectorySeparatorChar;
 
-		result.Should().Be(System.IO.Path.DirectorySeparatorChar);
+		result.Should().Be('/');
 	}
 
 	[SkippableFact]
-	public void GetInvalidFileNameChars_ShouldReturnDefaultValue()
+	public void DirectorySeparatorChar_WhenOnWindows_ShouldReturnBackslash()
 	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		char result = FileSystem.Path.DirectorySeparatorChar;
+
+		result.Should().Be('\\');
+	}
+
+	[SkippableFact]
+	public void GetInvalidFileNameChars_WhenNotOnWindows_ShouldReturnCorrectValues()
+	{
+		Skip.If(Test.RunsOnWindows);
+
+		char[] expected = ['\0', '/'];
+
 		char[] result = FileSystem.Path.GetInvalidFileNameChars();
 
-		result.Should().BeEquivalentTo(System.IO.Path.GetInvalidFileNameChars());
+		result.Should().BeEquivalentTo(expected);
 	}
 
 	[SkippableFact]
-	public void GetInvalidPathChars_ShouldReturnDefaultValue()
+	public void GetInvalidFileNameChars_WhenOnWindows_ShouldReturnCorrectValues()
 	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		char[] expected =
+		[
+			'\"', '<', '>', '|', '\0', (char)1, (char)2, (char)3, (char)4, (char)5, (char)6,
+			(char)7, (char)8, (char)9, (char)10, (char)11, (char)12, (char)13, (char)14, (char)15,
+			(char)16, (char)17, (char)18, (char)19, (char)20, (char)21, (char)22, (char)23,
+			(char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30, (char)31, ':',
+			'*', '?', '\\', '/'
+		];
+
+		char[] result = FileSystem.Path.GetInvalidFileNameChars();
+
+		result.Should().BeEquivalentTo(expected);
+	}
+
+	[SkippableFact]
+	public void GetInvalidPathChars_WhenNotOnWindows_ShouldReturnCorrectValues()
+	{
+		Skip.If(Test.RunsOnWindows);
+
+		char[] expected = ['\0'];
+
 		char[] result = FileSystem.Path.GetInvalidPathChars();
 
-		result.Should().BeEquivalentTo(System.IO.Path.GetInvalidPathChars());
+		result.Should().BeEquivalentTo(expected);
+	}
+
+	[SkippableFact]
+	public void GetInvalidPathChars_WhenOnWindows_ShouldReturnCorrectValues()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		char[] expected =
+		[
+			'|', '\0', (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8,
+			(char)9, (char)10, (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17,
+			(char)18, (char)19, (char)20, (char)21, (char)22, (char)23, (char)24, (char)25,
+			(char)26, (char)27, (char)28, (char)29, (char)30, (char)31
+		];
+		if (Test.IsNetFramework)
+		{
+			expected = expected.Concat(['"', '<', '>']).ToArray();
+		}
+
+		char[] result = FileSystem.Path.GetInvalidPathChars();
+
+		result.Should().BeEquivalentTo(expected);
+	}
+
+	[SkippableTheory]
+	[InlineData("D:")]
+	public void GetPathRoot_RootedDrive_ShouldReturnDriveOnWindows(string path)
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		string? result = FileSystem.Path.GetPathRoot(path);
+
+		result.Should().Be(path);
 	}
 
 	[SkippableTheory]
@@ -59,16 +133,6 @@ public abstract partial class Tests<TFileSystem>
 #endif
 
 	[SkippableTheory]
-	[InlineData("D:")]
-	public void GetPathRoot_WithoutTrailingSeparatorChar_ShouldReturnDefaultValue(string path)
-	{
-		string? expectedResult = System.IO.Path.GetPathRoot(path);
-		string? result = FileSystem.Path.GetPathRoot(path);
-
-		result.Should().Be(expectedResult);
-	}
-
-	[SkippableTheory]
 	[InlineData("/foo")]
 	[InlineData("foo/bar")]
 	public void IsPathRooted_ShouldReturnDefaultValue(string path)
@@ -91,18 +155,42 @@ public abstract partial class Tests<TFileSystem>
 #endif
 
 	[SkippableFact]
-	public void PathSeparator_ShouldReturnDefaultValue()
+	public void PathSeparator_WhenNotOnWindows_ShouldReturnColon()
 	{
+		Skip.If(Test.RunsOnWindows);
+
 		char result = FileSystem.Path.PathSeparator;
 
-		result.Should().Be(System.IO.Path.PathSeparator);
+		result.Should().Be(':');
 	}
 
 	[SkippableFact]
-	public void VolumeSeparatorChar_ShouldReturnDefaultValue()
+	public void PathSeparator_WhenOnWindows_ShouldReturnSemicolon()
 	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		char result = FileSystem.Path.PathSeparator;
+
+		result.Should().Be(';');
+	}
+
+	[SkippableFact]
+	public void VolumeSeparatorChar_WhenNotOnWindows_ShouldReturnSlash()
+	{
+		Skip.If(Test.RunsOnWindows);
+
 		char result = FileSystem.Path.VolumeSeparatorChar;
 
-		result.Should().Be(System.IO.Path.VolumeSeparatorChar);
+		result.Should().Be('/');
+	}
+
+	[SkippableFact]
+	public void VolumeSeparatorChar_WhenOnWindows_ShouldReturnColon()
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		char result = FileSystem.Path.VolumeSeparatorChar;
+
+		result.Should().Be(':');
 	}
 }


### PR DESCRIPTION
In order to simulate a FileSystem on other platforms (see #460) we should avoid using System.IO calls in the MockFileSystem and its tests.