### PR TITLE
feat: use SimulationMode instead of OSPlatform

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoFactoryMock.cs
@@ -40,6 +40,12 @@ internal sealed class DirectoryInfoFactoryMock : IDirectoryInfoFactory
 		using IDisposable registration = RegisterMethod(nameof(Wrap),
 			directoryInfo);
 
+		if (_fileSystem.SimulationMode != SimulationMode.Native)
+		{
+			throw new NotSupportedException(
+				"Wrapping a DirectoryInfo in a simulated file system is not supported!");
+		}
+
 		return DirectoryInfoMock.New(
 			_fileSystem.Storage.GetLocation(
 				directoryInfo?.FullName,

--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoFactoryMock.cs
@@ -57,6 +57,12 @@ internal sealed class DriveInfoFactoryMock : IDriveInfoFactory
 		using IDisposable registration = RegisterMethod(nameof(Wrap),
 			driveInfo);
 
+		if (_fileSystem.SimulationMode != SimulationMode.Native)
+		{
+			throw new NotSupportedException(
+				"Wrapping a DriveInfo in a simulated file system is not supported!");
+		}
+
 		if (driveInfo?.Name == null)
 		{
 			return null;

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoFactoryMock.cs
@@ -49,6 +49,12 @@ internal sealed class FileInfoFactoryMock : IFileInfoFactory
 		using IDisposable registration = RegisterMethod(nameof(Wrap),
 			fileInfo);
 
+		if (_fileSystem.SimulationMode != SimulationMode.Native)
+		{
+			throw new NotSupportedException(
+				"Wrapping a FileInfo in a simulated file system is not supported!");
+		}
+
 		return FileInfoMock.New(
 			_fileSystem.Storage.GetLocation(
 				fileInfo?.FullName,

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.cs
@@ -38,12 +38,12 @@ internal partial class Execute
 	/// </summary>
 	public StringComparison StringComparisonMode { get; }
 
-	internal Execute(MockFileSystem fileSystem, OSPlatform osPlatform, bool isNetFramework = false)
+	internal Execute(MockFileSystem fileSystem, SimulationMode simulationMode)
 	{
-		IsLinux = osPlatform == OSPlatform.Linux;
-		IsMac = osPlatform == OSPlatform.OSX;
-		IsWindows = osPlatform == OSPlatform.Windows;
-		IsNetFramework = isNetFramework && IsWindows;
+		IsLinux = simulationMode == SimulationMode.Linux;
+		IsMac = simulationMode == SimulationMode.MacOS;
+		IsWindows = simulationMode == SimulationMode.Windows;
+		IsNetFramework = false;
 		StringComparisonMode = IsLinux
 			? StringComparison.Ordinal
 			: StringComparison.OrdinalIgnoreCase;

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 using Testably.Abstractions.Testing.FileSystem;
 using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.Statistics;
@@ -29,6 +28,15 @@ public sealed class MockFileSystem : IFileSystem
 	///     The used random system.
 	/// </summary>
 	public IRandomSystem RandomSystem { get; }
+
+	/// <summary>
+	///     The simulation mode for the underlying operating system.
+	/// </summary>
+	/// <remarks>
+	///     Can be changed by setting <see cref="Initialization.SimulatingOperatingSystem(Testing.SimulationMode)" /> in
+	///     the constructor.
+	/// </remarks>
+	public SimulationMode SimulationMode { get; }
 
 	/// <summary>
 	///     Contains statistical information about the file system usage.
@@ -93,9 +101,10 @@ public sealed class MockFileSystem : IFileSystem
 		Initialization initialization = new();
 		initializationCallback(initialization);
 
-		Execute = initialization.OperatingSystem == null
+		SimulationMode = initialization.SimulationMode;
+		Execute = SimulationMode == SimulationMode.Native
 			? new Execute(this)
-			: new Execute(this, initialization.OperatingSystem.Value);
+			: new Execute(this, SimulationMode);
 		StatisticsRegistration = new FileSystemStatistics(this);
 		using IDisposable release = StatisticsRegistration.Ignore();
 		RandomSystem = new MockRandomSystem();
@@ -225,28 +234,14 @@ public sealed class MockFileSystem : IFileSystem
 		/// <summary>
 		///     The simulated operating system.
 		/// </summary>
-		internal OSPlatform? OperatingSystem { get; private set; }
+		internal SimulationMode SimulationMode { get; private set; } = SimulationMode.Native;
 
 		/// <summary>
 		///     Specify the operating system that should be simulated.
 		/// </summary>
-		/// <remarks>
-		///     Supported values are<br />
-		///     - <see cref="OSPlatform.Linux" /><br />
-		///     - <see cref="OSPlatform.OSX" /><br />
-		///     - <see cref="OSPlatform.Windows" />
-		/// </remarks>
-		internal Initialization SimulatingOperatingSystem(OSPlatform operatingSystem)
+		internal Initialization SimulatingOperatingSystem(SimulationMode simulationMode)
 		{
-			if (operatingSystem != OSPlatform.Linux &&
-			    operatingSystem != OSPlatform.OSX &&
-			    operatingSystem != OSPlatform.Windows)
-			{
-				throw new NotSupportedException(
-					"Only Linux, OSX and Windows are supported operating systems.");
-			}
-
-			OperatingSystem = operatingSystem;
+			SimulationMode = simulationMode;
 			return this;
 		}
 

--- a/Source/Testably.Abstractions.Testing/SimulationMode.cs
+++ b/Source/Testably.Abstractions.Testing/SimulationMode.cs
@@ -1,0 +1,29 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Testably.Abstractions.Testing;
+
+/// <summary>
+///     The simulation mode for the <see cref="MockFileSystem" />.
+/// </summary>
+public enum SimulationMode
+{
+	/// <summary>
+	///     Use the underlying operating system (default mode).
+	/// </summary>
+	Native = 0,
+
+	/// <summary>
+	///     Simulates <see cref="OSPlatform.Linux" />.
+	/// </summary>
+	Linux = 1,
+
+	/// <summary>
+	///     Simulates <see cref="OSPlatform.OSX" />.
+	/// </summary>
+	MacOS = 2,
+
+	/// <summary>
+	///     Simulates <see cref="OSPlatform.Windows" />.
+	/// </summary>
+	Windows = 3
+}

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -104,6 +104,7 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.FileSystem.INotificationHandler Notify { get; }
         public System.IO.Abstractions.IPath Path { get; }
         public Testably.Abstractions.IRandomSystem RandomSystem { get; }
+        public Testably.Abstractions.Testing.SimulationMode SimulationMode { get; }
         public Testably.Abstractions.Testing.Statistics.IFileSystemStatistics Statistics { get; }
         public Testably.Abstractions.ITimeSystem TimeSystem { get; }
         public override string ToString() { }
@@ -180,6 +181,13 @@ namespace Testably.Abstractions.Testing
             public static Testably.Abstractions.Testing.RandomProvider.Generator<T> op_Implicit(T value) { }
             public static Testably.Abstractions.Testing.RandomProvider.Generator<T> op_Implicit(T[] values) { }
         }
+    }
+    public enum SimulationMode
+    {
+        Native = 0,
+        Linux = 1,
+        MacOS = 2,
+        Windows = 3,
     }
     public static class TimeProvider
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
@@ -104,6 +104,7 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.FileSystem.INotificationHandler Notify { get; }
         public System.IO.Abstractions.IPath Path { get; }
         public Testably.Abstractions.IRandomSystem RandomSystem { get; }
+        public Testably.Abstractions.Testing.SimulationMode SimulationMode { get; }
         public Testably.Abstractions.Testing.Statistics.IFileSystemStatistics Statistics { get; }
         public Testably.Abstractions.ITimeSystem TimeSystem { get; }
         public override string ToString() { }
@@ -180,6 +181,13 @@ namespace Testably.Abstractions.Testing
             public static Testably.Abstractions.Testing.RandomProvider.Generator<T> op_Implicit(T value) { }
             public static Testably.Abstractions.Testing.RandomProvider.Generator<T> op_Implicit(T[] values) { }
         }
+    }
+    public enum SimulationMode
+    {
+        Native = 0,
+        Linux = 1,
+        MacOS = 2,
+        Windows = 3,
     }
     public static class TimeProvider
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -104,6 +104,7 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.FileSystem.INotificationHandler Notify { get; }
         public System.IO.Abstractions.IPath Path { get; }
         public Testably.Abstractions.IRandomSystem RandomSystem { get; }
+        public Testably.Abstractions.Testing.SimulationMode SimulationMode { get; }
         public Testably.Abstractions.Testing.Statistics.IFileSystemStatistics Statistics { get; }
         public Testably.Abstractions.ITimeSystem TimeSystem { get; }
         public override string ToString() { }
@@ -180,6 +181,13 @@ namespace Testably.Abstractions.Testing
             public static Testably.Abstractions.Testing.RandomProvider.Generator<T> op_Implicit(T value) { }
             public static Testably.Abstractions.Testing.RandomProvider.Generator<T> op_Implicit(T[] values) { }
         }
+    }
+    public enum SimulationMode
+    {
+        Native = 0,
+        Linux = 1,
+        MacOS = 2,
+        Windows = 3,
     }
     public static class TimeProvider
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -102,6 +102,7 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.FileSystem.INotificationHandler Notify { get; }
         public System.IO.Abstractions.IPath Path { get; }
         public Testably.Abstractions.IRandomSystem RandomSystem { get; }
+        public Testably.Abstractions.Testing.SimulationMode SimulationMode { get; }
         public Testably.Abstractions.Testing.Statistics.IFileSystemStatistics Statistics { get; }
         public Testably.Abstractions.ITimeSystem TimeSystem { get; }
         public override string ToString() { }
@@ -178,6 +179,13 @@ namespace Testably.Abstractions.Testing
             public static Testably.Abstractions.Testing.RandomProvider.Generator<T> op_Implicit(T value) { }
             public static Testably.Abstractions.Testing.RandomProvider.Generator<T> op_Implicit(T[] values) { }
         }
+    }
+    public enum SimulationMode
+    {
+        Native = 0,
+        Linux = 1,
+        MacOS = 2,
+        Windows = 3,
     }
     public static class TimeProvider
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -102,6 +102,7 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.FileSystem.INotificationHandler Notify { get; }
         public System.IO.Abstractions.IPath Path { get; }
         public Testably.Abstractions.IRandomSystem RandomSystem { get; }
+        public Testably.Abstractions.Testing.SimulationMode SimulationMode { get; }
         public Testably.Abstractions.Testing.Statistics.IFileSystemStatistics Statistics { get; }
         public Testably.Abstractions.ITimeSystem TimeSystem { get; }
         public override string ToString() { }
@@ -178,6 +179,13 @@ namespace Testably.Abstractions.Testing
             public static Testably.Abstractions.Testing.RandomProvider.Generator<T> op_Implicit(T value) { }
             public static Testably.Abstractions.Testing.RandomProvider.Generator<T> op_Implicit(T[] values) { }
         }
+    }
+    public enum SimulationMode
+    {
+        Native = 0,
+        Linux = 1,
+        MacOS = 2,
+        Windows = 3,
     }
     public static class TimeProvider
     {

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteExtensionsTests.cs
@@ -1,17 +1,15 @@
-﻿using System.Runtime.InteropServices;
-using Testably.Abstractions.Testing.Helpers;
+﻿using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.Tests.Helpers;
 
 public sealed class ExecuteExtensionsTests
 {
 	[Theory]
-	[InlineData(ExecuteType.Linux, true)]
-	[InlineData(ExecuteType.Mac, true)]
-	[InlineData(ExecuteType.NetFramework, false)]
-	[InlineData(ExecuteType.Windows, true)]
+	[InlineData(SimulationMode.Linux, true)]
+	[InlineData(SimulationMode.MacOS, true)]
+	[InlineData(SimulationMode.Windows, true)]
 	public void NotOnNetFramework_ShouldExecuteDependingOnOperatingSystem(
-		ExecuteType type, bool shouldExecute)
+		SimulationMode type, bool shouldExecute)
 	{
 		bool isExecuted = false;
 		Execute sut = FromType(type);
@@ -22,12 +20,11 @@ public sealed class ExecuteExtensionsTests
 	}
 
 	[Theory]
-	[InlineData(ExecuteType.Linux, true)]
-	[InlineData(ExecuteType.Mac, true)]
-	[InlineData(ExecuteType.NetFramework, false)]
-	[InlineData(ExecuteType.Windows, false)]
+	[InlineData(SimulationMode.Linux, true)]
+	[InlineData(SimulationMode.MacOS, true)]
+	[InlineData(SimulationMode.Windows, false)]
 	public void NotOnWindows_ShouldExecuteDependingOnOperatingSystem(
-		ExecuteType type, bool shouldExecute)
+		SimulationMode type, bool shouldExecute)
 	{
 		bool isExecuted = false;
 		Execute sut = FromType(type);
@@ -38,16 +35,14 @@ public sealed class ExecuteExtensionsTests
 	}
 
 	[Theory]
-	[InlineData(ExecuteType.Linux, false, false)]
-	[InlineData(ExecuteType.Linux, true, true)]
-	[InlineData(ExecuteType.Mac, false, false)]
-	[InlineData(ExecuteType.Mac, true, true)]
-	[InlineData(ExecuteType.NetFramework, false, false)]
-	[InlineData(ExecuteType.NetFramework, true, false)]
-	[InlineData(ExecuteType.Windows, false, false)]
-	[InlineData(ExecuteType.Windows, true, false)]
+	[InlineData(SimulationMode.Linux, false, false)]
+	[InlineData(SimulationMode.Linux, true, true)]
+	[InlineData(SimulationMode.MacOS, false, false)]
+	[InlineData(SimulationMode.MacOS, true, true)]
+	[InlineData(SimulationMode.Windows, false, false)]
+	[InlineData(SimulationMode.Windows, true, false)]
 	public void NotOnWindowsIf_ShouldExecuteDependingOnOperatingSystem(
-		ExecuteType type, bool predicate, bool shouldExecute)
+		SimulationMode type, bool predicate, bool shouldExecute)
 	{
 		bool isExecuted = false;
 		Execute sut = FromType(type);
@@ -58,12 +53,11 @@ public sealed class ExecuteExtensionsTests
 	}
 
 	[Theory]
-	[InlineData(ExecuteType.Linux, true)]
-	[InlineData(ExecuteType.Mac, false)]
-	[InlineData(ExecuteType.NetFramework, false)]
-	[InlineData(ExecuteType.Windows, false)]
+	[InlineData(SimulationMode.Linux, true)]
+	[InlineData(SimulationMode.MacOS, false)]
+	[InlineData(SimulationMode.Windows, false)]
 	public void OnLinux_ShouldExecuteDependingOnOperatingSystem(
-		ExecuteType type, bool shouldExecute)
+		SimulationMode type, bool shouldExecute)
 	{
 		bool isExecuted = false;
 		Execute sut = FromType(type);
@@ -74,12 +68,11 @@ public sealed class ExecuteExtensionsTests
 	}
 
 	[Theory]
-	[InlineData(ExecuteType.Linux, 3, 4, 3)]
-	[InlineData(ExecuteType.Mac, 5, 6, 6)]
-	[InlineData(ExecuteType.NetFramework, 7, 8, 8)]
-	[InlineData(ExecuteType.Windows, 1, 2, 2)]
+	[InlineData(SimulationMode.Linux, 3, 4, 3)]
+	[InlineData(SimulationMode.MacOS, 5, 6, 6)]
+	[InlineData(SimulationMode.Windows, 1, 2, 2)]
 	public void OnLinux_WithValue_ShouldExecuteDependingOnOperatingSystem(
-		ExecuteType type, int value, int alternativeValue, int expectedValue)
+		SimulationMode type, int value, int alternativeValue, int expectedValue)
 	{
 		Execute sut = FromType(type);
 
@@ -89,12 +82,11 @@ public sealed class ExecuteExtensionsTests
 	}
 
 	[Theory]
-	[InlineData(ExecuteType.Linux, false)]
-	[InlineData(ExecuteType.Mac, true)]
-	[InlineData(ExecuteType.NetFramework, false)]
-	[InlineData(ExecuteType.Windows, false)]
+	[InlineData(SimulationMode.Linux, false)]
+	[InlineData(SimulationMode.MacOS, true)]
+	[InlineData(SimulationMode.Windows, false)]
 	public void OnMac_ShouldExecuteDependingOnOperatingSystem(
-		ExecuteType type, bool shouldExecute)
+		SimulationMode type, bool shouldExecute)
 	{
 		bool isExecuted = false;
 		Execute sut = FromType(type);
@@ -105,12 +97,11 @@ public sealed class ExecuteExtensionsTests
 	}
 
 	[Theory]
-	[InlineData(ExecuteType.Linux, false)]
-	[InlineData(ExecuteType.Mac, false)]
-	[InlineData(ExecuteType.NetFramework, true)]
-	[InlineData(ExecuteType.Windows, false)]
+	[InlineData(SimulationMode.Linux, false)]
+	[InlineData(SimulationMode.MacOS, false)]
+	[InlineData(SimulationMode.Windows, false)]
 	public void OnNetFramework_ShouldExecuteDependingOnOperatingSystem(
-		ExecuteType type, bool shouldExecute)
+		SimulationMode type, bool shouldExecute)
 	{
 		bool isExecuted = false;
 		Execute sut = FromType(type);
@@ -121,12 +112,11 @@ public sealed class ExecuteExtensionsTests
 	}
 
 	[Theory]
-	[InlineData(ExecuteType.Linux, 3, 4, 4)]
-	[InlineData(ExecuteType.Mac, 5, 6, 6)]
-	[InlineData(ExecuteType.NetFramework, 7, 8, 7)]
-	[InlineData(ExecuteType.Windows, 1, 2, 2)]
+	[InlineData(SimulationMode.Linux, 3, 4, 4)]
+	[InlineData(SimulationMode.MacOS, 5, 6, 6)]
+	[InlineData(SimulationMode.Windows, 1, 2, 2)]
 	public void OnNetFramework_WithValue_ShouldExecuteDependingOnOperatingSystem(
-		ExecuteType type, int value, int alternativeValue, int expectedValue)
+		SimulationMode type, int value, int alternativeValue, int expectedValue)
 	{
 		Execute sut = FromType(type);
 
@@ -136,16 +126,14 @@ public sealed class ExecuteExtensionsTests
 	}
 
 	[Theory]
-	[InlineData(ExecuteType.Linux, false, false)]
-	[InlineData(ExecuteType.Linux, true, false)]
-	[InlineData(ExecuteType.Mac, false, false)]
-	[InlineData(ExecuteType.Mac, true, false)]
-	[InlineData(ExecuteType.NetFramework, false, false)]
-	[InlineData(ExecuteType.NetFramework, true, true)]
-	[InlineData(ExecuteType.Windows, false, false)]
-	[InlineData(ExecuteType.Windows, true, false)]
+	[InlineData(SimulationMode.Linux, false, false)]
+	[InlineData(SimulationMode.Linux, true, false)]
+	[InlineData(SimulationMode.MacOS, false, false)]
+	[InlineData(SimulationMode.MacOS, true, false)]
+	[InlineData(SimulationMode.Windows, false, false)]
+	[InlineData(SimulationMode.Windows, true, false)]
 	public void OnNetFrameworkIf_ShouldExecuteDependingOnOperatingSystem(
-		ExecuteType type, bool predicate, bool shouldExecute)
+		SimulationMode type, bool predicate, bool shouldExecute)
 	{
 		bool isExecuted = false;
 		Execute sut = FromType(type);
@@ -156,12 +144,11 @@ public sealed class ExecuteExtensionsTests
 	}
 
 	[Theory]
-	[InlineData(ExecuteType.Linux, false)]
-	[InlineData(ExecuteType.Mac, false)]
-	[InlineData(ExecuteType.NetFramework, true)]
-	[InlineData(ExecuteType.Windows, true)]
+	[InlineData(SimulationMode.Linux, false)]
+	[InlineData(SimulationMode.MacOS, false)]
+	[InlineData(SimulationMode.Windows, true)]
 	public void OnWindows_ShouldExecuteDependingOnOperatingSystem(
-		ExecuteType type, bool shouldExecute)
+		SimulationMode type, bool shouldExecute)
 	{
 		bool isExecuted = false;
 		Execute sut = FromType(type);
@@ -172,12 +159,11 @@ public sealed class ExecuteExtensionsTests
 	}
 
 	[Theory]
-	[InlineData(ExecuteType.Linux, 3, 4, 4)]
-	[InlineData(ExecuteType.Mac, 5, 6, 6)]
-	[InlineData(ExecuteType.NetFramework, 7, 8, 7)]
-	[InlineData(ExecuteType.Windows, 1, 2, 1)]
+	[InlineData(SimulationMode.Linux, 3, 4, 4)]
+	[InlineData(SimulationMode.MacOS, 5, 6, 6)]
+	[InlineData(SimulationMode.Windows, 1, 2, 1)]
 	public void OnWindows_WithValue_ShouldExecuteDependingOnOperatingSystem(
-		ExecuteType type, int value, int alternativeValue, int expectedValue)
+		SimulationMode type, int value, int alternativeValue, int expectedValue)
 	{
 		Execute sut = FromType(type);
 
@@ -187,16 +173,14 @@ public sealed class ExecuteExtensionsTests
 	}
 
 	[Theory]
-	[InlineData(ExecuteType.Linux, false, false)]
-	[InlineData(ExecuteType.Linux, true, false)]
-	[InlineData(ExecuteType.Mac, false, false)]
-	[InlineData(ExecuteType.Mac, true, false)]
-	[InlineData(ExecuteType.NetFramework, false, false)]
-	[InlineData(ExecuteType.NetFramework, true, true)]
-	[InlineData(ExecuteType.Windows, false, false)]
-	[InlineData(ExecuteType.Windows, true, true)]
+	[InlineData(SimulationMode.Linux, false, false)]
+	[InlineData(SimulationMode.Linux, true, false)]
+	[InlineData(SimulationMode.MacOS, false, false)]
+	[InlineData(SimulationMode.MacOS, true, false)]
+	[InlineData(SimulationMode.Windows, false, false)]
+	[InlineData(SimulationMode.Windows, true, true)]
 	public void OnWindowsIf_ShouldExecuteDependingOnOperatingSystem(
-		ExecuteType type, bool predicate, bool shouldExecute)
+		SimulationMode type, bool predicate, bool shouldExecute)
 	{
 		bool isExecuted = false;
 		Execute sut = FromType(type);
@@ -208,23 +192,8 @@ public sealed class ExecuteExtensionsTests
 
 	#region Helpers
 
-	private static Execute FromType(ExecuteType type)
-		=> type switch
-		{
-			ExecuteType.Windows => new Execute(new MockFileSystem(), OSPlatform.Windows),
-			ExecuteType.Linux => new Execute(new MockFileSystem(), OSPlatform.Linux),
-			ExecuteType.Mac => new Execute(new MockFileSystem(), OSPlatform.OSX),
-			ExecuteType.NetFramework => new Execute(new MockFileSystem(), OSPlatform.Windows, true),
-			_ => throw new NotSupportedException()
-		};
+	private static Execute FromType(SimulationMode type)
+		=> new(new MockFileSystem(), type);
 
 	#endregion
-
-	public enum ExecuteType
-	{
-		Windows,
-		Linux,
-		Mac,
-		NetFramework
-	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteTests.cs
@@ -1,31 +1,13 @@
-﻿using System.Runtime.InteropServices;
-using Testably.Abstractions.Testing.Helpers;
+﻿using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.Tests.Helpers;
 
 public sealed class ExecuteTests
 {
-#if !NET48
-	[Fact]
-	public void Constructor_ForFreeBSD_ShouldThrowNotSupportedException()
-	{
-		Exception? exception = Record.Exception(() =>
-		{
-			_ = new Execute(new MockFileSystem(), OSPlatform.FreeBSD);
-		});
-
-		exception.Should().BeOfType<NotSupportedException>()
-			.Which.Message.Should()
-			.Contain("Linux").And
-			.Contain("Windows").And
-			.Contain("OSX");
-	}
-#endif
-
 	[Fact]
 	public void Constructor_ForLinux_ShouldInitializeAccordingly()
 	{
-		Execute sut = new(new MockFileSystem(), OSPlatform.Linux);
+		Execute sut = new(new MockFileSystem(), SimulationMode.Linux);
 
 		sut.IsLinux.Should().BeTrue();
 		sut.IsMac.Should().BeFalse();
@@ -35,45 +17,9 @@ public sealed class ExecuteTests
 	}
 
 	[Fact]
-	public void Constructor_ForNetFramework_ShouldInitializeAccordingly()
+	public void Constructor_ForMacOS_ShouldInitializeAccordingly()
 	{
-		Execute sut = new(new MockFileSystem(), OSPlatform.Windows, true);
-
-		sut.IsLinux.Should().BeFalse();
-		sut.IsMac.Should().BeFalse();
-		sut.IsNetFramework.Should().BeTrue();
-		sut.IsWindows.Should().BeTrue();
-		sut.StringComparisonMode.Should().Be(StringComparison.OrdinalIgnoreCase);
-	}
-
-	[Fact]
-	public void Constructor_ForNetFramework_WithLinux_ShouldInitializeLinux()
-	{
-		Execute sut = new(new MockFileSystem(), OSPlatform.Linux, true);
-
-		sut.IsLinux.Should().BeTrue();
-		sut.IsMac.Should().BeFalse();
-		sut.IsNetFramework.Should().BeFalse();
-		sut.IsWindows.Should().BeFalse();
-		sut.StringComparisonMode.Should().Be(StringComparison.Ordinal);
-	}
-
-	[Fact]
-	public void Constructor_ForNetFramework_WithOSX_ShouldInitializeMac()
-	{
-		Execute sut = new(new MockFileSystem(), OSPlatform.OSX, true);
-
-		sut.IsLinux.Should().BeFalse();
-		sut.IsMac.Should().BeTrue();
-		sut.IsNetFramework.Should().BeFalse();
-		sut.IsWindows.Should().BeFalse();
-		sut.StringComparisonMode.Should().Be(StringComparison.OrdinalIgnoreCase);
-	}
-
-	[Fact]
-	public void Constructor_ForOSX_ShouldInitializeAccordingly()
-	{
-		Execute sut = new(new MockFileSystem(), OSPlatform.OSX);
+		Execute sut = new(new MockFileSystem(), SimulationMode.MacOS);
 
 		sut.IsLinux.Should().BeFalse();
 		sut.IsMac.Should().BeTrue();
@@ -85,7 +31,7 @@ public sealed class ExecuteTests
 	[Fact]
 	public void Constructor_ForWindows_ShouldInitializeAccordingly()
 	{
-		Execute sut = new(new MockFileSystem(), OSPlatform.Windows);
+		Execute sut = new(new MockFileSystem(), SimulationMode.Windows);
 
 		sut.IsLinux.Should().BeFalse();
 		sut.IsMac.Should().BeFalse();

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Runtime.InteropServices;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 #if NET6_0_OR_GREATER
 #endif
@@ -15,7 +14,7 @@ public class MockFileSystemInitializationTests
 			"TODO: Enable again, once the Path implementation is sufficiently complete!");
 
 		MockFileSystem sut = new(o => o
-			.SimulatingOperatingSystem(OSPlatform.Linux));
+			.SimulatingOperatingSystem(SimulationMode.Linux));
 
 		sut.Execute.IsLinux.Should().BeTrue();
 		sut.Execute.IsMac.Should().BeFalse();
@@ -24,13 +23,13 @@ public class MockFileSystemInitializationTests
 	}
 
 	[SkippableFact]
-	public void MockFileSystem_WhenSimulatingOSX_ShouldBeMac()
+	public void MockFileSystem_WhenSimulatingMacOS_ShouldBeMac()
 	{
 		Skip.IfNot(Test.RunsOnMac,
 			"TODO: Enable again, once the Path implementation is sufficiently complete!");
 
 		MockFileSystem sut = new(o => o
-			.SimulatingOperatingSystem(OSPlatform.OSX));
+			.SimulatingOperatingSystem(SimulationMode.MacOS));
 
 		sut.Execute.IsLinux.Should().BeFalse();
 		sut.Execute.IsMac.Should().BeTrue();
@@ -45,7 +44,7 @@ public class MockFileSystemInitializationTests
 			"TODO: Enable again, once the Path implementation is sufficiently complete!");
 
 		MockFileSystem sut = new(o => o
-			.SimulatingOperatingSystem(OSPlatform.Windows));
+			.SimulatingOperatingSystem(SimulationMode.Windows));
 
 		sut.Execute.IsLinux.Should().BeFalse();
 		sut.Execute.IsMac.Should().BeFalse();
@@ -88,36 +87,17 @@ public class MockFileSystemInitializationTests
 		result.Should().Be(expected);
 	}
 
-#if !NET48
-	[Fact]
-	public void SimulatingOperatingSystem_FreeBSD_ShouldThrowNotSupportedException()
-	{
-		MockFileSystem.Initialization sut = new();
-
-		Exception? exception = Record.Exception(() =>
-		{
-			sut.SimulatingOperatingSystem(OSPlatform.FreeBSD);
-		});
-
-		exception.Should().BeOfType<NotSupportedException>()
-			.Which.Message.Should()
-			.Contain("Linux").And
-			.Contain("Windows").And
-			.Contain("OSX");
-	}
-#endif
-
 	[Theory]
 	[MemberData(nameof(ValidOperatingSystems))]
 	public void SimulatingOperatingSystem_ValidOSPlatform_ShouldSetOperatingSystem(
-		OSPlatform osPlatform)
+		SimulationMode simulationMode)
 	{
 		MockFileSystem.Initialization sut = new();
 
-		MockFileSystem.Initialization result = sut.SimulatingOperatingSystem(osPlatform);
+		MockFileSystem.Initialization result = sut.SimulatingOperatingSystem(simulationMode);
 
-		result.OperatingSystem.Should().Be(osPlatform);
-		sut.OperatingSystem.Should().Be(osPlatform);
+		result.SimulationMode.Should().Be(simulationMode);
+		sut.SimulationMode.Should().Be(simulationMode);
 	}
 
 	[Fact]
@@ -146,8 +126,8 @@ public class MockFileSystemInitializationTests
 
 	#region Helpers
 
-	public static TheoryData<OSPlatform> ValidOperatingSystems()
-		=> new(OSPlatform.Linux, OSPlatform.OSX, OSPlatform.Windows);
+	public static TheoryData<SimulationMode> ValidOperatingSystems()
+		=> new(SimulationMode.Linux, SimulationMode.MacOS, SimulationMode.Windows);
 
 	#endregion
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/Tests.cs
@@ -121,6 +121,9 @@ public abstract partial class Tests<TFileSystem>
 	[SkippableFact]
 	public void Wrap_Null_ShouldReturnNull()
 	{
+		Skip.If(FileSystem is MockFileSystem mockFileSystem &&
+		        mockFileSystem.SimulationMode != SimulationMode.Native);
+
 		IDriveInfo? result = FileSystem.DriveInfo.Wrap(null);
 
 		result.Should().BeNull();
@@ -129,11 +132,32 @@ public abstract partial class Tests<TFileSystem>
 	[SkippableFact]
 	public void Wrap_ShouldReturnDriveInfoWithSameName()
 	{
+		Skip.If(FileSystem is MockFileSystem mockFileSystem &&
+		        mockFileSystem.SimulationMode != SimulationMode.Native);
+
 		System.IO.DriveInfo driveInfo = System.IO.DriveInfo.GetDrives().First();
 
 		IDriveInfo result = FileSystem.DriveInfo.Wrap(driveInfo);
 
 		result.Name.Should().Be(driveInfo.Name);
+	}
+
+	[SkippableFact]
+	public void Wrap_WithSimulatedMockFileSystem_ShouldThrowNotSupportedException()
+	{
+		Skip.IfNot(FileSystem is MockFileSystem mockFileSystem &&
+		           mockFileSystem.SimulationMode != SimulationMode.Native);
+
+		System.IO.DriveInfo driveInfo = System.IO.DriveInfo.GetDrives().First();
+
+		Exception? exception = Record.Exception(() =>
+		{
+			_ = FileSystem.DriveInfo.Wrap(driveInfo);
+		});
+
+		exception.Should().BeOfType<NotSupportedException>().Which
+			.Message.Should()
+			.Contain("Wrapping a DriveInfo in a simulated file system is not supported");
 	}
 
 	#region Helpers


### PR DESCRIPTION
Add a `SimulationMode` enumeration property to the `MockFileSystem`, so that simulated file systems can be detected at runtime.

Also throw `NotSupportedException` when wrapping a `DirectoryInfo`, `DriveInfo` or `FileInfo` on a simulated `MockFileSystem`.