### PR TITLE
feat: implement `GetTempFileName` for simulated `Path`

### DIFF
--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.MacPath.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.MacPath.cs
@@ -4,12 +4,14 @@ internal partial class Execute
 {
 	private sealed class MacPath(MockFileSystem fileSystem) : LinuxPath(fileSystem)
 	{
+		private readonly MockFileSystem _fileSystem = fileSystem;
 		private string? _tempPath;
 
 		/// <inheritdoc cref="IPath.GetTempPath()" />
 		public override string GetTempPath()
 		{
-			_tempPath ??= $"/var/folders/{RandomString(2)}/{RandomString(2)}_{RandomString(27)}/T/";
+			_tempPath ??=
+				$"/var/folders/{RandomString(_fileSystem, 2)}/{RandomString(_fileSystem, 2)}_{RandomString(_fileSystem, 27)}/T/";
 			return _tempPath;
 		}
 	}

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.NativePath.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.NativePath.cs
@@ -198,7 +198,7 @@ internal partial class Execute
 			"Insecure temporary file creation methods should not be used. Use `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())` instead.")]
 #endif
 		public string GetTempFileName()
-			=> System.IO.Path.GetTempFileName();
+			=> CreateTempFileName(fileSystem);
 
 		/// <inheritdoc cref="Path.GetTempPath()" />
 		public string GetTempPath()

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.SimulatedPath.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.SimulatedPath.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Text;
 #if FEATURE_FILESYSTEM_NET7
 using Testably.Abstractions.Testing.Storage;
@@ -283,7 +282,7 @@ internal partial class Execute
 
 		/// <inheritdoc cref="IPath.GetRandomFileName()" />
 		public string GetRandomFileName()
-			=> $"{RandomString(8)}.{RandomString(3)}";
+			=> $"{RandomString(fileSystem, 8)}.{RandomString(fileSystem, 3)}";
 
 #if FEATURE_PATH_RELATIVE
 		/// <inheritdoc cref="IPath.GetRelativePath(string, string)" />
@@ -305,7 +304,7 @@ internal partial class Execute
 			"Insecure temporary file creation methods should not be used. Use `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())` instead.")]
 #endif
 		public string GetTempFileName()
-			=> System.IO.Path.GetTempFileName();
+			=> CreateTempFileName(fileSystem);
 
 		/// <inheritdoc cref="IPath.GetTempPath()" />
 		public abstract string GetTempPath();
@@ -488,13 +487,6 @@ internal partial class Execute
 			return sb.ToString();
 		}
 #endif
-
-		protected string RandomString(int length)
-		{
-			const string chars = "abcdefghijklmnopqrstuvwxyz0123456789";
-			return new string(Enumerable.Repeat(chars, length)
-				.Select(s => s[fileSystem.RandomSystem.Random.Shared.Next(s.Length)]).ToArray());
-		}
 
 		private bool TryGetExtensionIndex(string path, [NotNullWhen(true)] out int? dotIndex)
 		{

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using Testably.Abstractions.Testing.FileSystem;
 using Testably.Abstractions.Testing.Helpers;
+using Testably.Abstractions.Testing.RandomSystem;
 using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Storage;
 
@@ -107,7 +108,7 @@ public sealed class MockFileSystem : IFileSystem
 			: new Execute(this, SimulationMode);
 		StatisticsRegistration = new FileSystemStatistics(this);
 		using IDisposable release = StatisticsRegistration.Ignore();
-		RandomSystem = new MockRandomSystem();
+		RandomSystem = new MockRandomSystem(initialization.RandomProvider ?? RandomProvider.Default());
 		TimeSystem = new MockTimeSystem(TimeProvider.Now());
 		_pathMock = new PathMock(this);
 		_storage = new InMemoryStorage(this);
@@ -232,6 +233,11 @@ public sealed class MockFileSystem : IFileSystem
 		internal string? CurrentDirectory { get; private set; }
 
 		/// <summary>
+		///     The <see cref="IRandomProvider" /> for the <see cref="RandomSystem" />.
+		/// </summary>
+		internal IRandomProvider? RandomProvider { get; private set; }
+
+		/// <summary>
 		///     The simulated operating system.
 		/// </summary>
 		internal SimulationMode SimulationMode { get; private set; } = SimulationMode.Native;
@@ -260,6 +266,15 @@ public sealed class MockFileSystem : IFileSystem
 		internal Initialization UseCurrentDirectory()
 		{
 			CurrentDirectory = System.IO.Directory.GetCurrentDirectory();
+			return this;
+		}
+
+		/// <summary>
+		///     Use the given <paramref name="randomProvider" /> for the <see cref="RandomSystem" />.
+		/// </summary>
+		internal Initialization UseRandomProvider(IRandomProvider randomProvider)
+		{
+			RandomProvider = randomProvider;
 			return this;
 		}
 	}

--- a/Source/Testably.Abstractions.Testing/MockRandomSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockRandomSystem.cs
@@ -26,11 +26,11 @@ public sealed class MockRandomSystem : IRandomSystem
 	}
 
 	/// <summary>
-	///     Initializes the <see cref="MockRandomSystem" /> with the specified <paramref name="randomProviderProvider" />.
+	///     Initializes the <see cref="MockRandomSystem" /> with the specified <paramref name="randomProvider" />.
 	/// </summary>
-	public MockRandomSystem(IRandomProvider randomProviderProvider)
+	public MockRandomSystem(IRandomProvider randomProvider)
 	{
-		RandomProvider = randomProviderProvider;
+		RandomProvider = randomProvider;
 		_guidMock = new GuidMock(this);
 		_randomFactoryMock = new RandomFactoryMock(this);
 	}

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -122,7 +122,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockRandomSystem : Testably.Abstractions.IRandomSystem
     {
         public MockRandomSystem() { }
-        public MockRandomSystem(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProviderProvider) { }
+        public MockRandomSystem(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
         public Testably.Abstractions.RandomSystem.IGuid Guid { get; }
         public Testably.Abstractions.RandomSystem.IRandomFactory Random { get; }
         public Testably.Abstractions.Testing.RandomSystem.IRandomProvider RandomProvider { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
@@ -122,7 +122,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockRandomSystem : Testably.Abstractions.IRandomSystem
     {
         public MockRandomSystem() { }
-        public MockRandomSystem(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProviderProvider) { }
+        public MockRandomSystem(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
         public Testably.Abstractions.RandomSystem.IGuid Guid { get; }
         public Testably.Abstractions.RandomSystem.IRandomFactory Random { get; }
         public Testably.Abstractions.Testing.RandomSystem.IRandomProvider RandomProvider { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -122,7 +122,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockRandomSystem : Testably.Abstractions.IRandomSystem
     {
         public MockRandomSystem() { }
-        public MockRandomSystem(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProviderProvider) { }
+        public MockRandomSystem(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
         public Testably.Abstractions.RandomSystem.IGuid Guid { get; }
         public Testably.Abstractions.RandomSystem.IRandomFactory Random { get; }
         public Testably.Abstractions.Testing.RandomSystem.IRandomProvider RandomProvider { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -120,7 +120,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockRandomSystem : Testably.Abstractions.IRandomSystem
     {
         public MockRandomSystem() { }
-        public MockRandomSystem(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProviderProvider) { }
+        public MockRandomSystem(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
         public Testably.Abstractions.RandomSystem.IGuid Guid { get; }
         public Testably.Abstractions.RandomSystem.IRandomFactory Random { get; }
         public Testably.Abstractions.Testing.RandomSystem.IRandomProvider RandomProvider { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -120,7 +120,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockRandomSystem : Testably.Abstractions.IRandomSystem
     {
         public MockRandomSystem() { }
-        public MockRandomSystem(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProviderProvider) { }
+        public MockRandomSystem(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
         public Testably.Abstractions.RandomSystem.IGuid Guid { get; }
         public Testably.Abstractions.RandomSystem.IRandomFactory Random { get; }
         public Testably.Abstractions.Testing.RandomSystem.IRandomProvider RandomProvider { get; }

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
@@ -238,6 +238,7 @@ namespace {@class.Namespace}.{@class.Name}
 			"GetFileNameWithoutExtensionTests",
 			"GetPathRootTests",
 			"GetRandomFileNameTests",
+			"GetTempFileNameTests",
 			"GetTempPathTests",
 			"IsPathRootedTests",
 			"JoinTests",

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/PathMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/PathMockTests.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+
+namespace Testably.Abstractions.Testing.Tests.FileSystem;
+
+public sealed class PathMockTests
+{
+	[Theory]
+	[InlineAutoData(SimulationMode.Native)]
+	[InlineAutoData(SimulationMode.Linux)]
+	[InlineAutoData(SimulationMode.MacOS)]
+	[InlineAutoData(SimulationMode.Windows)]
+	public void GetTempFileName_WithCollisions_ShouldThrowIOException(
+		SimulationMode simulationMode, int fixedRandomValue)
+	{
+		MockFileSystem fileSystem = new(i => i
+			.SimulatingOperatingSystem(simulationMode)
+			.UseRandomProvider(RandomProvider.Generate(
+				intGenerator: new RandomProvider.Generator<int>(() => fixedRandomValue))));
+		string result = fileSystem.Path.GetTempFileName();
+
+		Exception? exception = Record.Exception(() =>
+		{
+			_ = fileSystem.Path.GetTempFileName();
+		});
+
+		exception.Should().BeOfType<IOException>();
+		fileSystem.File.Exists(result).Should().BeTrue();
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 #if NET6_0_OR_GREATER
 #endif
@@ -122,6 +124,22 @@ public class MockFileSystemInitializationTests
 
 		result.CurrentDirectory.Should().Be(path);
 		sut.CurrentDirectory.Should().Be(path);
+	}
+
+	[Theory]
+	[AutoData]
+	public void UseRandomProvider_ShouldUseFixedRandomValue(int fixedRandomValue)
+	{
+		MockFileSystem fileSystem = new(i => i
+			.UseRandomProvider(RandomProvider.Generate(
+				intGenerator: new RandomProvider.Generator<int>(() => fixedRandomValue))));
+
+		List<int> results = Enumerable.Range(1, 100)
+			.Select(_ => fileSystem.RandomSystem.Random.New().Next())
+			.ToList();
+		results.Add(fileSystem.RandomSystem.Random.Shared.Next());
+
+		results.Should().AllBeEquivalentTo(fixedRandomValue);
 	}
 
 	#region Helpers

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetTempFileNameTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetTempFileNameTests.cs
@@ -1,0 +1,25 @@
+namespace Testably.Abstractions.Tests.FileSystem.Path;
+
+// ReSharper disable once PartialTypeWithSinglePart
+public abstract partial class GetTempFileNameTests<TFileSystem>
+	: FileSystemTestBase<TFileSystem>
+	where TFileSystem : IFileSystem
+{
+	[SkippableFact]
+	public void GetTempFileName_ShouldBeInTempPath()
+	{
+		string tempPath = FileSystem.Path.GetTempPath();
+
+		string result = FileSystem.Path.GetTempFileName();
+
+		result.Should().StartWith(tempPath);
+	}
+
+	[SkippableFact]
+	public void GetTempFileName_ShouldExist()
+	{
+		string result = FileSystem.Path.GetTempFileName();
+
+		FileSystem.File.Exists(result).Should().BeTrue();
+	}
+}


### PR DESCRIPTION
Implement the `GetTempFileName` methods for `Path` and allow initialization with `IRandomProvider` to test random edge cases.

*See #460*