### PR TITLE
feat: implement `HasExtension` and `TrimEndingDirectorySeparator` for simulated `Path`

### DIFF
--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.SimulatedPath.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.SimulatedPath.cs
@@ -430,7 +430,11 @@ internal partial class Execute
 #if FEATURE_PATH_ADVANCED
 		/// <inheritdoc cref="IPath.TrimEndingDirectorySeparator(string)" />
 		public string TrimEndingDirectorySeparator(string path)
-			=> System.IO.Path.TrimEndingDirectorySeparator(path);
+		{
+			return EndsInDirectorySeparator(path) && path.Length != GetRootLength(path)
+				? path.Substring(0, path.Length - 1)
+				: path;
+		}
 #endif
 
 #if FEATURE_PATH_JOIN

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.SimulatedPath.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.SimulatedPath.cs
@@ -342,7 +342,15 @@ internal partial class Execute
 
 		/// <inheritdoc cref="IPath.HasExtension(string)" />
 		public bool HasExtension([NotNullWhen(true)] string? path)
-			=> System.IO.Path.HasExtension(path);
+		{
+			if (path == null)
+			{
+				return false;
+			}
+
+			return TryGetExtensionIndex(path, out var dotIndex)
+			       && dotIndex < path.Length - 1;
+		}
 
 #if FEATURE_SPAN
 		/// <inheritdoc cref="IPath.IsPathFullyQualified(ReadOnlySpan{char})" />

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
@@ -245,6 +245,7 @@ namespace {@class.Namespace}.{@class.Name}
 			"IsPathRootedTests",
 			"JoinTests",
 			"Tests",
+			"TrimEndingDirectorySeparatorTests",
 			"TryJoinTests"
 		];
 		return @class.Namespace

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
@@ -241,6 +241,7 @@ namespace {@class.Namespace}.{@class.Name}
 			"GetPathRootTests",
 			"GetRandomFileNameTests",
 			"GetTempPathTests",
+			"HasExtensionTests",
 			"IsPathRootedTests",
 			"JoinTests",
 			"Tests",

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/HasExtensionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/HasExtensionTests.cs
@@ -14,6 +14,7 @@ public abstract partial class HasExtensionTests<TFileSystem>
 	}
 
 	[SkippableTheory]
+	[InlineAutoData("abc.", false)]
 	[InlineAutoData(".foo", true)]
 	[InlineAutoData(".abc.xyz", true)]
 	[InlineAutoData("foo", false)]
@@ -30,6 +31,7 @@ public abstract partial class HasExtensionTests<TFileSystem>
 
 #if FEATURE_SPAN
 	[SkippableTheory]
+	[InlineAutoData("abc.", false)]
 	[InlineAutoData(".foo", true)]
 	[InlineAutoData(".abc.xyz", true)]
 	[InlineAutoData("foo", false)]


### PR DESCRIPTION
Implement the `HasExtension` and `TrimEndingDirectorySeparator` methods for `Path`.

*See #460*