### PR TITLE
feat: allow simulating other operating systems

### DIFF
--- a/Feature.Flags.props
+++ b/Feature.Flags.props
@@ -7,6 +7,7 @@
 		<IS_NET8_OR_HIGHER Condition="'$(TargetFramework)' == 'net8.0'">1</IS_NET8_OR_HIGHER>
 
 		<DefineConstants Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NETFRAMEWORK</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET21_OR_HIGHER)' == '1'">$(DefineConstants);CAN_SIMULATE_OTHER_OS</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET21_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_ASYNC</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET21_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_ENUMERATION_OPTIONS</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET21_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_PATH_JOIN</DefineConstants>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The testing helper also supports advanced scenarios like
 
 The companion projects [Testably.Abstractions.Compression](https://www.nuget.org/packages/Testably.Abstractions.Compression) and [Testably.Abstractions.AccessControl](https://www.nuget.org/packages/Testably.Abstractions.AccessControl) allow working with [Zip-Files](Examples/ZipFile/README.md) and [Access Control Lists](Examples/AccessControlLists/README.md) respectively.
 
-As the test suite runs both against the mocked and the real file system, the behaviour between the two is identical.
+As the test suite runs both against the mocked and the real file system, the behaviour between the two is identical and it also allows [simulating the file system on other operating systems](#simulating-other-operating-systems) (Linux, MacOS and Windows).
 
 In addition, the following interfaces are defined:
 - The `ITimeSystem` interface abstracts away time-related functionality:  
@@ -110,6 +110,25 @@ fileSystem.Initialize()
 		.WithFile("bar.txt"))
 	.WithFile("foo.txt").Which(f => f.HasStringContent("some file content"));
 ```
+
+### Simulating other operating systems
+
+The `MockFileSystem` can also simulate other operating systems than the one it is currently running on. This can be achieved, by providing the corresponding `SimulationMode` in the constructor:
+
+```csharp
+var linuxFileSystem = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Linux));
+// The `linuxFileSystem` now behaves like a Linux file system even under Windows:
+// - case-sensitive
+// - slash as directory separator
+
+var windowsFileSystem = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+// The `windowsFileSystem` now behaves like a Windows file system even under Linux or MacOS:
+// - multiple drives
+// - case-insensitive
+// - backslash as directory separator
+```
+
+By running all tests against the real file system and the simulated under Linux, MacOS and Windows, the behaviour is consistent between the native and simulated mock file systems.
 
 ### Drive management
 ```csharp

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.cs
@@ -40,6 +40,9 @@ internal partial class Execute
 	/// </summary>
 	public StringComparison StringComparisonMode { get; }
 
+#if !CAN_SIMULATE_OTHER_OS
+	[Obsolete("Simulating other operating systems is not supported on .NET Framework")]
+#endif
 	internal Execute(MockFileSystem fileSystem, SimulationMode simulationMode)
 	{
 		IsLinux = simulationMode == SimulationMode.Linux;

--- a/Source/Testably.Abstractions.Testing/Testably.Abstractions.Testing.csproj
+++ b/Source/Testably.Abstractions.Testing/Testably.Abstractions.Testing.csproj
@@ -21,9 +21,6 @@
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 			<_Parameter1>Testably.Abstractions.Testing.Tests</_Parameter1>
 		</AssemblyAttribute>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-			<_Parameter1>Testably.Abstractions.Tests</_Parameter1>
-		</AssemblyAttribute>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -1,7 +1,6 @@
 [assembly: System.CLSCompliant(true)]
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/Testably.Abstractions.git")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Testably.Abstractions.Testing.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Testably.Abstractions.Tests")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Testably.Abstractions.Testing.FileSystem
 {
@@ -94,6 +93,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockFileSystem : System.IO.Abstractions.IFileSystem
     {
         public MockFileSystem() { }
+        public MockFileSystem(System.Action<Testably.Abstractions.Testing.MockFileSystem.Initialization> initializationCallback) { }
         public System.IO.Abstractions.IDirectory Directory { get; }
         public System.IO.Abstractions.IDirectoryInfoFactory DirectoryInfo { get; }
         public System.IO.Abstractions.IDriveInfoFactory DriveInfo { get; }
@@ -112,6 +112,13 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
+        public class Initialization
+        {
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization SimulatingOperatingSystem(Testably.Abstractions.Testing.SimulationMode simulationMode) { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory() { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory(string path) { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+        }
     }
     public static class MockFileSystemExtensions
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
@@ -1,7 +1,6 @@
 [assembly: System.CLSCompliant(true)]
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/Testably.Abstractions.git")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Testably.Abstractions.Testing.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Testably.Abstractions.Tests")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName=".NET 7.0")]
 namespace Testably.Abstractions.Testing.FileSystem
 {
@@ -94,6 +93,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockFileSystem : System.IO.Abstractions.IFileSystem
     {
         public MockFileSystem() { }
+        public MockFileSystem(System.Action<Testably.Abstractions.Testing.MockFileSystem.Initialization> initializationCallback) { }
         public System.IO.Abstractions.IDirectory Directory { get; }
         public System.IO.Abstractions.IDirectoryInfoFactory DirectoryInfo { get; }
         public System.IO.Abstractions.IDriveInfoFactory DriveInfo { get; }
@@ -112,6 +112,13 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
+        public class Initialization
+        {
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization SimulatingOperatingSystem(Testably.Abstractions.Testing.SimulationMode simulationMode) { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory() { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory(string path) { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+        }
     }
     public static class MockFileSystemExtensions
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -1,7 +1,6 @@
 [assembly: System.CLSCompliant(true)]
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/Testably.Abstractions.git")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Testably.Abstractions.Testing.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Testably.Abstractions.Tests")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace Testably.Abstractions.Testing.FileSystem
 {
@@ -94,6 +93,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockFileSystem : System.IO.Abstractions.IFileSystem
     {
         public MockFileSystem() { }
+        public MockFileSystem(System.Action<Testably.Abstractions.Testing.MockFileSystem.Initialization> initializationCallback) { }
         public System.IO.Abstractions.IDirectory Directory { get; }
         public System.IO.Abstractions.IDirectoryInfoFactory DirectoryInfo { get; }
         public System.IO.Abstractions.IDriveInfoFactory DriveInfo { get; }
@@ -112,6 +112,13 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
+        public class Initialization
+        {
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization SimulatingOperatingSystem(Testably.Abstractions.Testing.SimulationMode simulationMode) { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory() { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory(string path) { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+        }
     }
     public static class MockFileSystemExtensions
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -1,7 +1,6 @@
 [assembly: System.CLSCompliant(true)]
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/Testably.Abstractions.git")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Testably.Abstractions.Testing.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Testably.Abstractions.Tests")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Testably.Abstractions.Testing.FileSystem
 {
@@ -92,6 +91,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockFileSystem : System.IO.Abstractions.IFileSystem
     {
         public MockFileSystem() { }
+        public MockFileSystem(System.Action<Testably.Abstractions.Testing.MockFileSystem.Initialization> initializationCallback) { }
         public System.IO.Abstractions.IDirectory Directory { get; }
         public System.IO.Abstractions.IDirectoryInfoFactory DirectoryInfo { get; }
         public System.IO.Abstractions.IDriveInfoFactory DriveInfo { get; }
@@ -110,6 +110,14 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
+        public class Initialization
+        {
+            [System.Obsolete("Simulating other operating systems is not supported on .NET Framework")]
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization SimulatingOperatingSystem(Testably.Abstractions.Testing.SimulationMode simulationMode) { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory() { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory(string path) { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+        }
     }
     public static class MockFileSystemExtensions
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -1,7 +1,6 @@
 [assembly: System.CLSCompliant(true)]
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/Testably.Abstractions.git")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Testably.Abstractions.Testing.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Testably.Abstractions.Tests")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName=".NET Standard 2.1")]
 namespace Testably.Abstractions.Testing.FileSystem
 {
@@ -92,6 +91,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockFileSystem : System.IO.Abstractions.IFileSystem
     {
         public MockFileSystem() { }
+        public MockFileSystem(System.Action<Testably.Abstractions.Testing.MockFileSystem.Initialization> initializationCallback) { }
         public System.IO.Abstractions.IDirectory Directory { get; }
         public System.IO.Abstractions.IDirectoryInfoFactory DirectoryInfo { get; }
         public System.IO.Abstractions.IDriveInfoFactory DriveInfo { get; }
@@ -110,6 +110,13 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
+        public class Initialization
+        {
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization SimulatingOperatingSystem(Testably.Abstractions.Testing.SimulationMode simulationMode) { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory() { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory(string path) { }
+            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+        }
     }
     public static class MockFileSystemExtensions
     {

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using Testably.Abstractions.Tests.SourceGenerator.Model;
 
 namespace Testably.Abstractions.Tests.SourceGenerator.ClassGenerators;
@@ -131,8 +132,10 @@ namespace {@class.Namespace}.{@class.Name}
 				$""Long-running tests are {{_fixture.LongRunningTests}}. You can enable them by executing the corresponding tests in Testably.Abstractions.TestSettings.LongRunningTests."");
 #endif
 	}}
-}}
-
+}}");
+		if (!@class.Namespace.Equals("Testably.Abstractions.AccessControl.Tests", StringComparison.Ordinal))
+		{
+			sourceBuilder.Append(@$"
 #if !NETFRAMEWORK
 namespace {@class.Namespace}.{@class.Name}
 {{
@@ -253,5 +256,6 @@ namespace {@class.Namespace}.{@class.Name}
 	}}
 }}
 #endif");
+		}
 	}
 }

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Text;
+﻿using System.Text;
 using Testably.Abstractions.Tests.SourceGenerator.Model;
-// ReSharper disable StringLiteralTypo
 
 namespace Testably.Abstractions.Tests.SourceGenerator.ClassGenerators;
 
+// ReSharper disable StringLiteralTypo
 internal class FileSystemClassGenerator : ClassGeneratorBase
 {
 	/// <inheritdoc cref="ClassGeneratorBase.Marker" />
@@ -132,10 +131,8 @@ namespace {@class.Namespace}.{@class.Name}
 				$""Long-running tests are {{_fixture.LongRunningTests}}. You can enable them by executing the corresponding tests in Testably.Abstractions.TestSettings.LongRunningTests."");
 #endif
 	}}
-}}");
-		if (IncludeSimulatedTests(@class))
-		{
-			sourceBuilder.Append(@$"
+}}
+
 #if !NETFRAMEWORK
 namespace {@class.Namespace}.{@class.Name}
 {{
@@ -177,6 +174,7 @@ namespace {@class.Namespace}.{@class.Name}
 		}}
 	}}
 #endif
+
 #if !NETFRAMEWORK
 	// ReSharper disable once UnusedMember.Global
 	public sealed class MacFileSystemTests : {@class.Name}<MockFileSystem>, IDisposable
@@ -215,6 +213,7 @@ namespace {@class.Namespace}.{@class.Name}
 		}}
 	}}
 #endif
+
 #if !NETFRAMEWORK
 	// ReSharper disable once UnusedMember.Global
 	public sealed class WindowsFileSystemTests : {@class.Name}<MockFileSystem>, IDisposable
@@ -254,12 +253,5 @@ namespace {@class.Namespace}.{@class.Name}
 	}}
 }}
 #endif");
-		}
-	}
-
-	private bool IncludeSimulatedTests(ClassModel @class)
-	{
-		return @class.Namespace
-			.StartsWith("Testably.Abstractions.Tests.FileSystem", StringComparison.Ordinal);
 	}
 }

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Text;
 using Testably.Abstractions.Tests.SourceGenerator.Model;
 // ReSharper disable StringLiteralTypo
@@ -260,30 +259,7 @@ namespace {@class.Namespace}.{@class.Name}
 
 	private bool IncludeSimulatedTests(ClassModel @class)
 	{
-		string[] supportedPathTests =
-		[
-			"ChangeExtensionTests",
-			"CombineTests",
-			"EndsInDirectorySeparatorTests",
-			"GetDirectoryNameTests",
-			"GetExtensionTests",
-			"GetFileNameTests",
-			"GetFileNameWithoutExtensionTests",
-			"GetFullPathTests",
-			"GetPathRootTests",
-			"GetRandomFileNameTests",
-			"GetRelativePathTests",
-			"GetTempFileNameTests",
-			"GetTempPathTests",
-			"HasExtensionTests",
-			"IsPathRootedTests",
-			"JoinTests",
-			"Tests",
-			"TrimEndingDirectorySeparatorTests",
-			"TryJoinTests"
-		];
 		return @class.Namespace
-			.StartsWith("Testably.Abstractions.Tests.FileSystem.Path", StringComparison.Ordinal)
-		       && supportedPathTests.Contains(@class.Name);
+			.StartsWith("Testably.Abstractions.Tests.FileSystem", StringComparison.Ordinal);
 	}
 }

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
@@ -133,7 +133,7 @@ namespace {@class.Namespace}.{@class.Name}
 #endif
 	}}
 }}");
-		if (!@class.Namespace.Equals("Testably.Abstractions.AccessControl.Tests", StringComparison.Ordinal))
+		if (IncludeSimulatedTests(@class))
 		{
 			sourceBuilder.Append(@$"
 #if !NETFRAMEWORK
@@ -257,5 +257,11 @@ namespace {@class.Namespace}.{@class.Name}
 }}
 #endif");
 		}
+	}
+
+	private bool IncludeSimulatedTests(ClassModel @class)
+	{
+		return !@class.Namespace.Equals(
+			"Testably.Abstractions.AccessControl.Tests", StringComparison.Ordinal);
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/PathMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/PathMockTests.cs
@@ -6,9 +6,11 @@ public sealed class PathMockTests
 {
 	[Theory]
 	[InlineAutoData(SimulationMode.Native)]
+#if !NETFRAMEWORK
 	[InlineAutoData(SimulationMode.Linux)]
 	[InlineAutoData(SimulationMode.MacOS)]
 	[InlineAutoData(SimulationMode.Windows)]
+#endif
 	public void GetTempFileName_WithCollisions_ShouldThrowIOException(
 		SimulationMode simulationMode, int fixedRandomValue)
 	{

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/PathMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/PathMockTests.cs
@@ -14,10 +14,12 @@ public sealed class PathMockTests
 	public void GetTempFileName_WithCollisions_ShouldThrowIOException(
 		SimulationMode simulationMode, int fixedRandomValue)
 	{
+		#pragma warning disable CS0618
 		MockFileSystem fileSystem = new(i => i
 			.SimulatingOperatingSystem(simulationMode)
 			.UseRandomProvider(RandomProvider.Generate(
 				intGenerator: new RandomProvider.Generator<int>(() => fixedRandomValue))));
+		#pragma warning restore CS0618
 		string result = fileSystem.Path.GetTempFileName();
 
 		Exception? exception = Record.Exception(() =>

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteExtensionsTests.cs
@@ -192,8 +192,10 @@ public sealed class ExecuteExtensionsTests
 
 	#region Helpers
 
+	#pragma warning disable CS0618
 	private static Execute FromType(SimulationMode type)
 		=> new(new MockFileSystem(), type);
+	#pragma warning restore CS0618
 
 	#endregion
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/ExecuteTests.cs
@@ -7,7 +7,9 @@ public sealed class ExecuteTests
 	[Fact]
 	public void Constructor_ForLinux_ShouldInitializeAccordingly()
 	{
+		#pragma warning disable CS0618
 		Execute sut = new(new MockFileSystem(), SimulationMode.Linux);
+		#pragma warning restore CS0618
 
 		sut.IsLinux.Should().BeTrue();
 		sut.IsMac.Should().BeFalse();
@@ -19,7 +21,9 @@ public sealed class ExecuteTests
 	[Fact]
 	public void Constructor_ForMacOS_ShouldInitializeAccordingly()
 	{
+		#pragma warning disable CS0618
 		Execute sut = new(new MockFileSystem(), SimulationMode.MacOS);
+		#pragma warning restore CS0618
 
 		sut.IsLinux.Should().BeFalse();
 		sut.IsMac.Should().BeTrue();
@@ -31,7 +35,9 @@ public sealed class ExecuteTests
 	[Fact]
 	public void Constructor_ForWindows_ShouldInitializeAccordingly()
 	{
+		#pragma warning disable CS0618
 		Execute sut = new(new MockFileSystem(), SimulationMode.Windows);
+		#pragma warning restore CS0618
 
 		sut.IsLinux.Should().BeFalse();
 		sut.IsMac.Should().BeFalse();

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/PathHelperTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/PathHelperTests.cs
@@ -120,6 +120,7 @@ public class PathHelperTests
 			.Which.Message.Should().Contain($"'{path}'");
 	}
 
+#if !NETFRAMEWORK
 	[SkippableTheory]
 	[InlineData('|')]
 	[InlineData((char)1)]
@@ -127,8 +128,6 @@ public class PathHelperTests
 	public void ThrowCommonExceptionsIfPathIsInvalid_WithInvalidCharacters(
 		char invalidChar)
 	{
-		Skip.If(Test.IsNetFramework);
-
 		MockFileSystem fileSystem = new(i => i
 			.SimulatingOperatingSystem(SimulationMode.Windows));
 		string path = invalidChar + "path";
@@ -137,15 +136,10 @@ public class PathHelperTests
 		{
 			path.EnsureValidFormat(fileSystem);
 		});
-
-#if NETFRAMEWORK
-		exception.Should().BeOfType<ArgumentException>()
-			.Which.Message.Should().Contain("path");
-#else
 		exception.Should().BeOfType<IOException>()
 			.Which.Message.Should().Contain(path);
-#endif
 	}
+#endif
 
 	[Fact]
 	public void

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
@@ -9,12 +9,10 @@ namespace Testably.Abstractions.Testing.Tests;
 
 public class MockFileSystemInitializationTests
 {
+#if !NETFRAMEWORK
 	[SkippableFact]
 	public void MockFileSystem_WhenSimulatingLinux_ShouldBeLinux()
 	{
-		Skip.IfNot(Test.RunsOnLinux,
-			"TODO: Enable again, once the Path implementation is sufficiently complete!");
-
 		MockFileSystem sut = new(o => o
 			.SimulatingOperatingSystem(SimulationMode.Linux));
 
@@ -23,13 +21,12 @@ public class MockFileSystemInitializationTests
 		sut.Execute.IsWindows.Should().BeFalse();
 		sut.Execute.IsNetFramework.Should().BeFalse();
 	}
+#endif
 
+#if !NETFRAMEWORK
 	[SkippableFact]
 	public void MockFileSystem_WhenSimulatingMacOS_ShouldBeMac()
 	{
-		Skip.IfNot(Test.RunsOnMac,
-			"TODO: Enable again, once the Path implementation is sufficiently complete!");
-
 		MockFileSystem sut = new(o => o
 			.SimulatingOperatingSystem(SimulationMode.MacOS));
 
@@ -38,13 +35,12 @@ public class MockFileSystemInitializationTests
 		sut.Execute.IsWindows.Should().BeFalse();
 		sut.Execute.IsNetFramework.Should().BeFalse();
 	}
+#endif
 
+#if !NETFRAMEWORK
 	[SkippableFact]
 	public void MockFileSystem_WhenSimulatingWindows_ShouldBeWindows()
 	{
-		Skip.IfNot(Test.RunsOnWindows,
-			"TODO: Enable again, once the Path implementation is sufficiently complete!");
-
 		MockFileSystem sut = new(o => o
 			.SimulatingOperatingSystem(SimulationMode.Windows));
 
@@ -53,6 +49,7 @@ public class MockFileSystemInitializationTests
 		sut.Execute.IsWindows.Should().BeTrue();
 		sut.Execute.IsNetFramework.Should().BeFalse();
 	}
+#endif
 
 	[Fact]
 	public void MockFileSystem_WithCurrentDirectory_ShouldInitializeCurrentDirectory()

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
@@ -2,8 +2,6 @@
 using System.IO;
 using System.Linq;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
-#if NET6_0_OR_GREATER
-#endif
 
 namespace Testably.Abstractions.Testing.Tests;
 
@@ -93,7 +91,9 @@ public class MockFileSystemInitializationTests
 	{
 		MockFileSystem.Initialization sut = new();
 
+		#pragma warning disable CS0618
 		MockFileSystem.Initialization result = sut.SimulatingOperatingSystem(simulationMode);
+		#pragma warning restore CS0618
 
 		result.SimulationMode.Should().Be(simulationMode);
 		sut.SimulationMode.Should().Be(simulationMode);

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -102,7 +102,9 @@ public class MockFileSystemTests
 	{
 		Exception? exception = Record.Exception(() =>
 		{
+			#pragma warning disable CS0618
 			_ = new MockFileSystem(i => i.SimulatingOperatingSystem(simulationMode));
+			#pragma warning restore CS0618
 		});
 
 		exception.Should().BeOfType<NotSupportedException>()

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -92,6 +92,25 @@ public class MockFileSystemTests
 		drive.VolumeLabel.Should().NotBeNullOrEmpty();
 	}
 
+#if NETFRAMEWORK
+	[SkippableTheory]
+	[InlineData(SimulationMode.Linux)]
+	[InlineData(SimulationMode.MacOS)]
+	[InlineData(SimulationMode.Windows)]
+	public void FileSystemMock_ShouldNotSupportSimulatingOtherOperatingSystemsOnNetFramework(
+		SimulationMode simulationMode)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			_ = new MockFileSystem(i => i.SimulatingOperatingSystem(simulationMode));
+		});
+
+		exception.Should().BeOfType<NotSupportedException>()
+			.Which.Message.Should()
+			.Contain("Simulating other operating systems is not supported on .NET Framework");
+	}
+#endif
+
 	[SkippableTheory]
 	[InlineData("A:\\")]
 	[InlineData("G:\\")]


### PR DESCRIPTION
Enable the simulation tests for all shared tests and make the simulation mode functionality public.
With this mode, it is possible to simulate the file system on another operating system, e.g. you can simulate a Linux file system on a Windows machine or vice versa.

The mode can be enabled in the constructor:
```
  var fileSystem = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Linux));
```

**Limitation:**
The simulation mode currently only works on .NET (Core) and throw a `NotSupportedException` in the constructor, when setting it on .NET Framework.

*This fixes #460.*