### PR TITLE
fix: use local time for Today in `DateTimeMock`

### DIFF
--- a/Source/Testably.Abstractions.Testing/TimeSystem/DateTimeMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/DateTimeMock.cs
@@ -45,7 +45,7 @@ internal sealed class DateTimeMock : IDateTime
 	{
 		get
 		{
-			DateTime value = _mockTimeSystem.TimeProvider.Read().Date;
+			DateTime value = _mockTimeSystem.TimeProvider.Read().ToLocalTime().Date;
 			_callbackHandler.InvokeDateTimeReadCallbacks(value);
 			return value;
 		}


### PR DESCRIPTION
Correctly use local time for calculating `DateTime.Today` in `DateTimeMock`