### PR TITLE
fix: correctly set simulated EventArgs in `FileSystemWatcherMock`

### DIFF
--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherMockTests.cs
@@ -234,6 +234,7 @@ public sealed class FileSystemWatcherMockTests : IDisposable
 		result.Should().BeNull();
 	}
 
+#if !NETFRAMEWORK
 	public sealed class EventArgsTests
 	{
 		[SkippableTheory]
@@ -326,4 +327,5 @@ public sealed class FileSystemWatcherMockTests : IDisposable
 			result.ChangeType.Should().Be(WatcherChangeTypes.Renamed);
 		}
 	}
+#endif
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherMockTests.cs
@@ -234,7 +234,7 @@ public sealed class FileSystemWatcherMockTests : IDisposable
 		result.Should().BeNull();
 	}
 
-	public class EventArgsTests
+	public sealed class EventArgsTests
 	{
 		[SkippableTheory]
 		[InlineAutoData(SimulationMode.Linux)]

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherMockTests.cs
@@ -38,7 +38,7 @@ public sealed class FileSystemWatcherMockTests : IDisposable
 		string path)
 	{
 		FileSystem.Directory.CreateDirectory(path);
-		IFileSystemWatcher fileSystemWatcher =
+		using IFileSystemWatcher fileSystemWatcher =
 			FileSystem.FileSystemWatcher.New(BasePath);
 		using ManualResetEventSlim block1 = new();
 		using ManualResetEventSlim block2 = new();
@@ -83,7 +83,6 @@ public sealed class FileSystemWatcherMockTests : IDisposable
 		}
 
 		block2.Wait(10000).Should().BeTrue();
-		fileSystemWatcher.Dispose();
 		result.Should().NotBeNull();
 		result!.GetException().Should().BeOfType<InternalBufferOverflowException>();
 	}
@@ -96,7 +95,7 @@ public sealed class FileSystemWatcherMockTests : IDisposable
 	{
 		int maxMessages = internalBufferSize / 128;
 		FileSystem.Directory.CreateDirectory(path);
-		IFileSystemWatcher fileSystemWatcher =
+		using IFileSystemWatcher fileSystemWatcher =
 			FileSystem.FileSystemWatcher.New(BasePath);
 		using ManualResetEventSlim block1 = new();
 		using ManualResetEventSlim block2 = new();
@@ -142,7 +141,6 @@ public sealed class FileSystemWatcherMockTests : IDisposable
 		}
 
 		block2.Wait(5000).Should().BeTrue();
-		fileSystemWatcher.Dispose();
 		result.Should().NotBeNull();
 		result!.GetException().Should().BeOfType<InternalBufferOverflowException>();
 	}
@@ -153,7 +151,7 @@ public sealed class FileSystemWatcherMockTests : IDisposable
 	public void Filter_ShouldResetFiltersToOnlyContainASingleValue(
 		string[] filters, string expectedFilter)
 	{
-		IFileSystemWatcher fileSystemWatcher =
+		using IFileSystemWatcher fileSystemWatcher =
 			FileSystem.FileSystemWatcher.New(BasePath);
 		foreach (string filter in filters)
 		{
@@ -234,5 +232,98 @@ public sealed class FileSystemWatcherMockTests : IDisposable
 
 		block2.Wait(100).Should().BeFalse();
 		result.Should().BeNull();
+	}
+
+	public class EventArgsTests
+	{
+		[SkippableTheory]
+		[InlineAutoData(SimulationMode.Linux)]
+		[InlineAutoData(SimulationMode.MacOS)]
+		[InlineAutoData(SimulationMode.Windows)]
+		public void FileSystemEventArgs_ShouldUseDirectorySeparatorFromSimulatedFileSystem(
+			SimulationMode simulationMode, string parentDirectory, string directoryName)
+		{
+			MockFileSystem fileSystem =
+				new MockFileSystem(s => s.SimulatingOperatingSystem(simulationMode));
+			fileSystem.Directory.CreateDirectory(parentDirectory);
+			FileSystemEventArgs? result = null;
+			string expectedFullPath = fileSystem.Path.GetFullPath(
+				fileSystem.Path.Combine(parentDirectory, directoryName));
+			string expectedName = fileSystem.Path.Combine(parentDirectory, directoryName);
+
+			using IFileSystemWatcher fileSystemWatcher =
+				fileSystem.FileSystemWatcher.New(parentDirectory);
+			using ManualResetEventSlim ms = new();
+			fileSystemWatcher.Created += (_, eventArgs) =>
+			{
+				result = eventArgs;
+				// ReSharper disable once AccessToDisposedClosure
+				try
+				{
+					ms.Set();
+				}
+				catch (ObjectDisposedException)
+				{
+					// Ignore any ObjectDisposedException
+				}
+			};
+			fileSystemWatcher.NotifyFilter = NotifyFilters.DirectoryName;
+			fileSystemWatcher.EnableRaisingEvents = true;
+			fileSystem.Directory.CreateDirectory(expectedName);
+			ms.Wait(5000);
+
+			result.Should().NotBeNull();
+			result!.FullPath.Should().Be(expectedFullPath);
+			result.Name.Should().Be(expectedName);
+			result.ChangeType.Should().Be(WatcherChangeTypes.Created);
+		}
+
+		[SkippableTheory]
+		[InlineAutoData(SimulationMode.Linux)]
+		[InlineAutoData(SimulationMode.MacOS)]
+		[InlineAutoData(SimulationMode.Windows)]
+		public void RenamedEventArgs_ShouldUseDirectorySeparatorFromSimulatedFileSystem(
+			SimulationMode simulationMode, string parentDirectory,
+			string sourceName, string destinationName)
+		{
+			MockFileSystem fileSystem =
+				new MockFileSystem(s => s.SimulatingOperatingSystem(simulationMode));
+			fileSystem.Directory.CreateDirectory(parentDirectory);
+			RenamedEventArgs? result = null;
+			string expectedOldFullPath = fileSystem.Path.GetFullPath(
+				fileSystem.Path.Combine(parentDirectory, sourceName));
+			string expectedFullPath = fileSystem.Path.GetFullPath(
+				fileSystem.Path.Combine(parentDirectory, destinationName));
+			fileSystem.Directory.CreateDirectory(parentDirectory);
+			fileSystem.File.WriteAllText(expectedOldFullPath, "foo");
+
+			using IFileSystemWatcher fileSystemWatcher =
+				fileSystem.FileSystemWatcher.New(parentDirectory);
+			using ManualResetEventSlim ms = new();
+			fileSystemWatcher.Renamed += (_, eventArgs) =>
+			{
+				result = eventArgs;
+				// ReSharper disable once AccessToDisposedClosure
+				try
+				{
+					ms.Set();
+				}
+				catch (ObjectDisposedException)
+				{
+					// Ignore any ObjectDisposedException
+				}
+			};
+			fileSystemWatcher.NotifyFilter = NotifyFilters.FileName;
+			fileSystemWatcher.EnableRaisingEvents = true;
+			fileSystem.File.Move(expectedOldFullPath, expectedFullPath);
+			ms.Wait(5000);
+
+			result.Should().NotBeNull();
+			result!.FullPath.Should().Be(expectedFullPath);
+			result.Name.Should().Be(destinationName);
+			result!.OldFullPath.Should().Be(expectedOldFullPath);
+			result.OldName.Should().Be(sourceName);
+			result.ChangeType.Should().Be(WatcherChangeTypes.Renamed);
+		}
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EnableRaisingEventsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EnableRaisingEventsTests.cs
@@ -3,6 +3,7 @@ using System.Threading;
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 
 // ReSharper disable once PartialTypeWithSinglePart
+[Collection("RealFileSystemTests")]
 public abstract partial class EnableRaisingEventsTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 
 // ReSharper disable once PartialTypeWithSinglePart
+[Collection("RealFileSystemTests")]
 public abstract partial class EventTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/FilterTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/FilterTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 
 // ReSharper disable once PartialTypeWithSinglePart
+[Collection("RealFileSystemTests")]
 public abstract partial class FilterTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/IncludeSubdirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/IncludeSubdirectoriesTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 
 // ReSharper disable once PartialTypeWithSinglePart
+[Collection("RealFileSystemTests")]
 public abstract partial class IncludeSubdirectoriesTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/NotifyFiltersTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/NotifyFiltersTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 
 // ReSharper disable once PartialTypeWithSinglePart
+[Collection("RealFileSystemTests")]
 public abstract partial class NotifyFiltersTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 
 // ReSharper disable once PartialTypeWithSinglePart
+[Collection("RealFileSystemTests")]
 public abstract partial class Tests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 namespace Testably.Abstractions.Tests.FileSystem.FileSystemWatcher;
 
 // ReSharper disable once PartialTypeWithSinglePart
+[Collection("RealFileSystemTests")]
 public abstract partial class WaitForChangedTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem


### PR DESCRIPTION
The [FileSystemEventArgs](https://github.com/dotnet/runtime/blob/v8.0.4/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs) implicitly combines the path in `FullPath` from its constructor arguments. When the file system is simulated, the directory separator char is incorrect.
When using the simulation mode, use reflection to correctly set the underlying backing field.