### PR TITLE
fix: throw correct exception in File.Copy when using an invalid path

### DIFF
--- a/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 
 namespace Testably.Abstractions.Testing.Helpers;
 
@@ -161,9 +160,7 @@ internal static class PathHelper
 				fileSystem.Execute.Path.GetFullPath(path), hResult);
 		}
 
-		fileSystem.Execute.OnWindowsIf(path.LastIndexOf(':') > 1 &&
-		                               path.LastIndexOf(':') <
-		                               path.IndexOf(Path.DirectorySeparatorChar),
+		fileSystem.Execute.OnWindowsIf(path.LastIndexOf(':') > 1,
 			() => throw ExceptionFactory.PathHasIncorrectSyntax(
 				fileSystem.Execute.Path.GetFullPath(path), hResult));
 	}


### PR DESCRIPTION
When providing an invalid path (e.g. `C::/foo`) the thrown exception should be an `IOException` with message "The filename, directory name, or volume label syntax is incorrect" and not a `DirectoryNotFoundException`.