### PR TITLE
refactor: disable simulation mode on .NET Standard

### DIFF
--- a/Feature.Flags.props
+++ b/Feature.Flags.props
@@ -7,7 +7,7 @@
 		<IS_NET8_OR_HIGHER Condition="'$(TargetFramework)' == 'net8.0'">1</IS_NET8_OR_HIGHER>
 
 		<DefineConstants Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NETFRAMEWORK</DefineConstants>
-		<DefineConstants Condition="'$(IS_NET21_OR_HIGHER)' == '1'">$(DefineConstants);CAN_SIMULATE_OTHER_OS</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET6_OR_HIGHER)' == '1'">$(DefineConstants);CAN_SIMULATE_OTHER_OS</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET21_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_ASYNC</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET21_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILESYSTEM_ENUMERATION_OPTIONS</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET21_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_PATH_JOIN</DefineConstants>

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -30,6 +30,7 @@ public sealed class MockFileSystem : IFileSystem
 	/// </summary>
 	public IRandomSystem RandomSystem { get; }
 
+#if CAN_SIMULATE_OTHER_OS
 	/// <summary>
 	///     The simulation mode for the underlying operating system.
 	/// </summary>
@@ -37,6 +38,14 @@ public sealed class MockFileSystem : IFileSystem
 	///     Can be changed by setting <see cref="Initialization.SimulatingOperatingSystem(Testing.SimulationMode)" /> in
 	///     the constructor.
 	/// </remarks>
+#else
+	/// <summary>
+	///     The simulation mode for the underlying operating system.
+	/// </summary>
+	/// <remarks>
+	///     This functionality is only supported on .NET 6 or newer.
+	/// </remarks>
+#endif
 	public SimulationMode SimulationMode { get; }
 
 	/// <summary>
@@ -102,18 +111,13 @@ public sealed class MockFileSystem : IFileSystem
 		Initialization initialization = new();
 		initializationCallback(initialization);
 
-		SimulationMode = initialization.SimulationMode;
 #if CAN_SIMULATE_OTHER_OS
+		SimulationMode = initialization.SimulationMode;
 		Execute = SimulationMode == SimulationMode.Native
 			? new Execute(this)
 			: new Execute(this, SimulationMode);
 #else
-		if (SimulationMode != SimulationMode.Native)
-		{
-			throw new NotSupportedException(
-				"Simulating other operating systems is not supported on .NET Framework");
-		}
-
+		SimulationMode = SimulationMode.Native;
 		Execute = new Execute(this);
 #endif
 		StatisticsRegistration = new FileSystemStatistics(this);

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -258,17 +258,16 @@ public sealed class MockFileSystem : IFileSystem
 			// Avoid public constructor
 		}
 
+#if CAN_SIMULATE_OTHER_OS
 		/// <summary>
 		///     Specify the operating system that should be simulated.
 		/// </summary>
-#if !CAN_SIMULATE_OTHER_OS
-		[Obsolete("Simulating other operating systems is not supported on .NET Framework")]
-#endif
 		public Initialization SimulatingOperatingSystem(SimulationMode simulationMode)
 		{
 			SimulationMode = simulationMode;
 			return this;
 		}
+#endif
 
 		/// <summary>
 		///     Use the provided <paramref name="path" /> as current directory.

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -112,8 +112,6 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
         public class Initialization
         {
-            [System.Obsolete("Simulating other operating systems is not supported on .NET Framework")]
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization SimulatingOperatingSystem(Testably.Abstractions.Testing.SimulationMode simulationMode) { }
             public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory() { }
             public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory(string path) { }
             public Testably.Abstractions.Testing.MockFileSystem.Initialization UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -112,7 +112,6 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
         public class Initialization
         {
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization SimulatingOperatingSystem(Testably.Abstractions.Testing.SimulationMode simulationMode) { }
             public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory() { }
             public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory(string path) { }
             public Testably.Abstractions.Testing.MockFileSystem.Initialization UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/PathMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/PathMockTests.cs
@@ -4,13 +4,12 @@ namespace Testably.Abstractions.Testing.Tests.FileSystem;
 
 public sealed class PathMockTests
 {
+#if CAN_SIMULATE_OTHER_OS
 	[Theory]
 	[InlineAutoData(SimulationMode.Native)]
-#if CAN_SIMULATE_OTHER_OS
 	[InlineAutoData(SimulationMode.Linux)]
 	[InlineAutoData(SimulationMode.MacOS)]
 	[InlineAutoData(SimulationMode.Windows)]
-#endif
 	public void GetTempFileName_WithCollisions_ShouldThrowIOException(
 		SimulationMode simulationMode, int fixedRandomValue)
 	{
@@ -30,4 +29,24 @@ public sealed class PathMockTests
 		exception.Should().BeOfType<IOException>();
 		fileSystem.File.Exists(result).Should().BeTrue();
 	}
+#else
+	[Theory]
+	[AutoData]
+	public void GetTempFileName_WithCollisions_ShouldThrowIOException(
+		int fixedRandomValue)
+	{
+		MockFileSystem fileSystem = new(o => o
+			.UseRandomProvider(RandomProvider.Generate(
+				intGenerator: new RandomProvider.Generator<int>(() => fixedRandomValue))));
+		string result = fileSystem.Path.GetTempFileName();
+
+		Exception? exception = Record.Exception(() =>
+		{
+			_ = fileSystem.Path.GetTempFileName();
+		});
+
+		exception.Should().BeOfType<IOException>();
+		fileSystem.File.Exists(result).Should().BeTrue();
+	}
+#endif
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
@@ -84,6 +84,7 @@ public class MockFileSystemInitializationTests
 		result.Should().Be(expected);
 	}
 
+#if CAN_SIMULATE_OTHER_OS
 	[Theory]
 	[MemberData(nameof(ValidOperatingSystems))]
 	public void SimulatingOperatingSystem_ValidOSPlatform_ShouldSetOperatingSystem(
@@ -91,13 +92,12 @@ public class MockFileSystemInitializationTests
 	{
 		MockFileSystem.Initialization sut = new();
 
-		#pragma warning disable CS0618
 		MockFileSystem.Initialization result = sut.SimulatingOperatingSystem(simulationMode);
-		#pragma warning restore CS0618
 
 		result.SimulationMode.Should().Be(simulationMode);
 		sut.SimulationMode.Should().Be(simulationMode);
 	}
+#endif
 
 	[Fact]
 	public void UseCurrentDirectory_Empty_ShouldUseCurrentDirectory()
@@ -141,8 +141,10 @@ public class MockFileSystemInitializationTests
 
 	#region Helpers
 
+#if CAN_SIMULATE_OTHER_OS
 	public static TheoryData<SimulationMode> ValidOperatingSystems()
 		=> new(SimulationMode.Linux, SimulationMode.MacOS, SimulationMode.Windows);
+#endif
 
 	#endregion
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -92,27 +92,6 @@ public class MockFileSystemTests
 		drive.VolumeLabel.Should().NotBeNullOrEmpty();
 	}
 
-#if !CAN_SIMULATE_OTHER_OS
-	[SkippableTheory]
-	[InlineData(SimulationMode.Linux)]
-	[InlineData(SimulationMode.MacOS)]
-	[InlineData(SimulationMode.Windows)]
-	public void FileSystemMock_ShouldNotSupportSimulatingOtherOperatingSystemsOnNetFramework(
-		SimulationMode simulationMode)
-	{
-		Exception? exception = Record.Exception(() =>
-		{
-			#pragma warning disable CS0618
-			_ = new MockFileSystem(o => o.SimulatingOperatingSystem(simulationMode));
-			#pragma warning restore CS0618
-		});
-
-		exception.Should().BeOfType<NotSupportedException>()
-			.Which.Message.Should()
-			.Contain("Simulating other operating systems is not supported on .NET Framework");
-	}
-#endif
-
 	[SkippableTheory]
 	[InlineData("A:\\")]
 	[InlineData("G:\\")]


### PR DESCRIPTION
Be more restrictive with the simulation mode and only enable it on .NET (6 or newer).

It is always possible to add it also to e.g. .NET Standard 2.1 without a breaking change, but removing it would be considered one.