### PR TITLE
feat: rename "Initialization" to "Options"

### DIFF
--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -35,7 +35,7 @@ public sealed class MockFileSystem : IFileSystem
 	///     The simulation mode for the underlying operating system.
 	/// </summary>
 	/// <remarks>
-	///     Can be changed by setting <see cref="Initialization.SimulatingOperatingSystem(Testing.SimulationMode)" /> in
+	///     Can be changed by setting <see cref="MockFileSystemOptions.SimulatingOperatingSystem(Testing.SimulationMode)" /> in
 	///     the constructor.
 	/// </remarks>
 #else
@@ -101,15 +101,15 @@ public sealed class MockFileSystem : IFileSystem
 	/// <summary>
 	///     Initializes the <see cref="MockFileSystem" />.
 	/// </summary>
-	public MockFileSystem() : this(_ => { }) { }
+	public MockFileSystem() : this(o => o) { }
 
 	/// <summary>
-	///     Initializes the <see cref="MockFileSystem" /> with the <paramref name="initializationCallback" />.
+	///     Initializes the <see cref="MockFileSystem" /> with the <paramref name="options" />.
 	/// </summary>
-	public MockFileSystem(Action<Initialization> initializationCallback)
+	public MockFileSystem(Func<MockFileSystemOptions, MockFileSystemOptions> options)
 	{
-		Initialization initialization = new();
-		initializationCallback(initialization);
+		MockFileSystemOptions initialization = new();
+		initialization = options(initialization);
 
 #if CAN_SIMULATE_OTHER_OS
 		SimulationMode = initialization.SimulationMode;
@@ -217,7 +217,7 @@ public sealed class MockFileSystem : IFileSystem
 		return this;
 	}
 
-	private void InitializeFileSystem(Initialization initialization)
+	private void InitializeFileSystem(MockFileSystemOptions initialization)
 	{
 		try
 		{
@@ -240,7 +240,7 @@ public sealed class MockFileSystem : IFileSystem
 	/// <summary>
 	///     The initialization options for the <see cref="MockFileSystem" />.
 	/// </summary>
-	public class Initialization
+	public class MockFileSystemOptions
 	{
 		/// <summary>
 		///     The current directory.
@@ -257,16 +257,11 @@ public sealed class MockFileSystem : IFileSystem
 		/// </summary>
 		internal SimulationMode SimulationMode { get; private set; } = SimulationMode.Native;
 
-		internal Initialization()
-		{
-			// Avoid public constructor
-		}
-
 #if CAN_SIMULATE_OTHER_OS
 		/// <summary>
 		///     Specify the operating system that should be simulated.
 		/// </summary>
-		public Initialization SimulatingOperatingSystem(SimulationMode simulationMode)
+		public MockFileSystemOptions SimulatingOperatingSystem(SimulationMode simulationMode)
 		{
 			SimulationMode = simulationMode;
 			return this;
@@ -276,7 +271,7 @@ public sealed class MockFileSystem : IFileSystem
 		/// <summary>
 		///     Use the provided <paramref name="path" /> as current directory.
 		/// </summary>
-		public Initialization UseCurrentDirectory(string path)
+		public MockFileSystemOptions UseCurrentDirectory(string path)
 		{
 			CurrentDirectory = path;
 			return this;
@@ -285,7 +280,7 @@ public sealed class MockFileSystem : IFileSystem
 		/// <summary>
 		///     Use <see cref="Directory.GetCurrentDirectory()" /> as current directory.
 		/// </summary>
-		public Initialization UseCurrentDirectory()
+		public MockFileSystemOptions UseCurrentDirectory()
 		{
 			CurrentDirectory = System.IO.Directory.GetCurrentDirectory();
 			return this;
@@ -294,7 +289,7 @@ public sealed class MockFileSystem : IFileSystem
 		/// <summary>
 		///     Use the given <paramref name="randomProvider" /> for the <see cref="RandomSystem" />.
 		/// </summary>
-		public Initialization UseRandomProvider(IRandomProvider randomProvider)
+		public MockFileSystemOptions UseRandomProvider(IRandomProvider randomProvider)
 		{
 			RandomProvider = randomProvider;
 			return this;

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -93,7 +93,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockFileSystem : System.IO.Abstractions.IFileSystem
     {
         public MockFileSystem() { }
-        public MockFileSystem(System.Action<Testably.Abstractions.Testing.MockFileSystem.Initialization> initializationCallback) { }
+        public MockFileSystem(System.Func<Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions, Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions> options) { }
         public System.IO.Abstractions.IDirectory Directory { get; }
         public System.IO.Abstractions.IDirectoryInfoFactory DirectoryInfo { get; }
         public System.IO.Abstractions.IDriveInfoFactory DriveInfo { get; }
@@ -112,12 +112,13 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
-        public class Initialization
+        public class MockFileSystemOptions
         {
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization SimulatingOperatingSystem(Testably.Abstractions.Testing.SimulationMode simulationMode) { }
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory() { }
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory(string path) { }
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+            public MockFileSystemOptions() { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions SimulatingOperatingSystem(Testably.Abstractions.Testing.SimulationMode simulationMode) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory() { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
         }
     }
     public static class MockFileSystemExtensions

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
@@ -93,7 +93,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockFileSystem : System.IO.Abstractions.IFileSystem
     {
         public MockFileSystem() { }
-        public MockFileSystem(System.Action<Testably.Abstractions.Testing.MockFileSystem.Initialization> initializationCallback) { }
+        public MockFileSystem(System.Func<Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions, Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions> options) { }
         public System.IO.Abstractions.IDirectory Directory { get; }
         public System.IO.Abstractions.IDirectoryInfoFactory DirectoryInfo { get; }
         public System.IO.Abstractions.IDriveInfoFactory DriveInfo { get; }
@@ -112,12 +112,13 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
-        public class Initialization
+        public class MockFileSystemOptions
         {
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization SimulatingOperatingSystem(Testably.Abstractions.Testing.SimulationMode simulationMode) { }
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory() { }
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory(string path) { }
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+            public MockFileSystemOptions() { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions SimulatingOperatingSystem(Testably.Abstractions.Testing.SimulationMode simulationMode) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory() { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
         }
     }
     public static class MockFileSystemExtensions

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -93,7 +93,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockFileSystem : System.IO.Abstractions.IFileSystem
     {
         public MockFileSystem() { }
-        public MockFileSystem(System.Action<Testably.Abstractions.Testing.MockFileSystem.Initialization> initializationCallback) { }
+        public MockFileSystem(System.Func<Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions, Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions> options) { }
         public System.IO.Abstractions.IDirectory Directory { get; }
         public System.IO.Abstractions.IDirectoryInfoFactory DirectoryInfo { get; }
         public System.IO.Abstractions.IDriveInfoFactory DriveInfo { get; }
@@ -112,12 +112,13 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
-        public class Initialization
+        public class MockFileSystemOptions
         {
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization SimulatingOperatingSystem(Testably.Abstractions.Testing.SimulationMode simulationMode) { }
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory() { }
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory(string path) { }
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+            public MockFileSystemOptions() { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions SimulatingOperatingSystem(Testably.Abstractions.Testing.SimulationMode simulationMode) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory() { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
         }
     }
     public static class MockFileSystemExtensions

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -91,7 +91,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockFileSystem : System.IO.Abstractions.IFileSystem
     {
         public MockFileSystem() { }
-        public MockFileSystem(System.Action<Testably.Abstractions.Testing.MockFileSystem.Initialization> initializationCallback) { }
+        public MockFileSystem(System.Func<Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions, Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions> options) { }
         public System.IO.Abstractions.IDirectory Directory { get; }
         public System.IO.Abstractions.IDirectoryInfoFactory DirectoryInfo { get; }
         public System.IO.Abstractions.IDriveInfoFactory DriveInfo { get; }
@@ -110,11 +110,12 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
-        public class Initialization
+        public class MockFileSystemOptions
         {
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory() { }
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory(string path) { }
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+            public MockFileSystemOptions() { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory() { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
         }
     }
     public static class MockFileSystemExtensions

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -91,7 +91,7 @@ namespace Testably.Abstractions.Testing
     public sealed class MockFileSystem : System.IO.Abstractions.IFileSystem
     {
         public MockFileSystem() { }
-        public MockFileSystem(System.Action<Testably.Abstractions.Testing.MockFileSystem.Initialization> initializationCallback) { }
+        public MockFileSystem(System.Func<Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions, Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions> options) { }
         public System.IO.Abstractions.IDirectory Directory { get; }
         public System.IO.Abstractions.IDirectoryInfoFactory DirectoryInfo { get; }
         public System.IO.Abstractions.IDriveInfoFactory DriveInfo { get; }
@@ -110,11 +110,12 @@ namespace Testably.Abstractions.Testing
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
-        public class Initialization
+        public class MockFileSystemOptions
         {
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory() { }
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseCurrentDirectory(string path) { }
-            public Testably.Abstractions.Testing.MockFileSystem.Initialization UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+            public MockFileSystemOptions() { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory() { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
         }
     }
     public static class MockFileSystemExtensions

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
@@ -90,9 +90,9 @@ public class MockFileSystemInitializationTests
 	public void SimulatingOperatingSystem_ValidOSPlatform_ShouldSetOperatingSystem(
 		SimulationMode simulationMode)
 	{
-		MockFileSystem.Initialization sut = new();
+		MockFileSystem.MockFileSystemOptions sut = new();
 
-		MockFileSystem.Initialization result = sut.SimulatingOperatingSystem(simulationMode);
+		MockFileSystem.MockFileSystemOptions result = sut.SimulatingOperatingSystem(simulationMode);
 
 		result.SimulationMode.Should().Be(simulationMode);
 		sut.SimulationMode.Should().Be(simulationMode);
@@ -103,9 +103,9 @@ public class MockFileSystemInitializationTests
 	public void UseCurrentDirectory_Empty_ShouldUseCurrentDirectory()
 	{
 		string expected = Directory.GetCurrentDirectory();
-		MockFileSystem.Initialization sut = new();
+		MockFileSystem.MockFileSystemOptions sut = new();
 
-		MockFileSystem.Initialization result = sut.UseCurrentDirectory();
+		MockFileSystem.MockFileSystemOptions result = sut.UseCurrentDirectory();
 
 		result.CurrentDirectory.Should().Be(expected);
 		sut.CurrentDirectory.Should().Be(expected);
@@ -115,9 +115,9 @@ public class MockFileSystemInitializationTests
 	[AutoData]
 	public void UseCurrentDirectory_WithPath_ShouldUsePathCurrentDirectory(string path)
 	{
-		MockFileSystem.Initialization sut = new();
+		MockFileSystem.MockFileSystemOptions sut = new();
 
-		MockFileSystem.Initialization result = sut.UseCurrentDirectory(path);
+		MockFileSystem.MockFileSystemOptions result = sut.UseCurrentDirectory(path);
 
 		result.CurrentDirectory.Should().Be(path);
 		sut.CurrentDirectory.Should().Be(path);


### PR DESCRIPTION
Rename "Initialization" to "Options" in the constructor of `MockFileSystem` and replace `Action<MockFileSystemOptions>` with `Func<MockFileSystemOptions,MockFileSystemOptions>` to allow re-using a stored options class.