### PR TITLE
feat: support remaining properties of `EnumerationOptions`

### DIFF
--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -261,6 +261,17 @@ internal sealed class InMemoryStorage : IStorage
 				continue;
 			}
 
+			if (!_fileSystem.AccessControlStrategy
+				.IsAccessGranted(item.Key.FullPath, item.Value.Extensibility))
+			{
+				if (!enumerationOptions.IgnoreInaccessible)
+				{
+					throw ExceptionFactory.AccessToPathDenied(item.Key.FullPath);
+				}
+
+				continue;
+			}
+
 			if (type.HasFlag(item.Value.Type))
 			{
 				string name = _fileSystem.Execute.Path.GetFileName(item.Key.FullPath);


### PR DESCRIPTION
Add support for the `IgnoreInaccessible` option of `EnumerationOptions`.

In order to simulate access errors in the `MockFileSystem`, specify the `IAccessControlStrategy`, e.g.:
```csharp
string inaccessiblePath = @"C:\Windows\System32\config";
mockFileSystem.WithAccessControlStrategy(
    new DefaultAccessControlStrategy((p, _)
        => !p.Equals(inaccessiblePath)));
```
When trying to enumerate the inaccessible file or directory, the `MockFileSystem` will throw an `UnauthorizedAccessException`. If `EnumerationOptions.IgnoreInaccessible` is set to true, it will instead skip the inaccessible file or directory.

*After #589 this implements the remaining properties of `EnumerationOptions` that are mentioned in https://github.com/TestableIO/System.IO.Abstractions/issues/653*