### PR TITLE
refactor: reduce method complexity in `InMemoryStorage`

### DIFF
--- a/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
+++ b/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
@@ -124,7 +124,6 @@ internal static class ZipUtilities
 	///     <see
 	///         href="https://github.com/dotnet/runtime/blob/v6.0.10/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs#L354" />
 	/// </remarks>
-	#pragma warning disable MA0051 // Method is too long
 	internal static void CreateFromDirectory(
 		IFileSystem fileSystem,
 		string sourceDirectoryName,
@@ -192,7 +191,6 @@ internal static class ZipUtilities
 			}
 		}
 	}
-	#pragma warning restore MA0051 // Method is too long
 #endif
 
 	internal static void ExtractRelativeToDirectory(this IZipArchiveEntry source,

--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
@@ -58,7 +58,8 @@ internal static class FileSystemExtensions
 	{
 		if (fileSystem.Execute.Path.IsPathRooted(givenPath))
 		{
-			if (friendlyName is "/." or "/..")
+			if (friendlyName.Equals("/.", StringComparison.Ordinal) ||
+			    friendlyName.Equals("/..", StringComparison.Ordinal))
 			{
 				return friendlyName;
 			}

--- a/Source/Testably.Abstractions.Testing/Polyfills/FileSystemName.cs
+++ b/Source/Testably.Abstractions.Testing/Polyfills/FileSystemName.cs
@@ -172,7 +172,6 @@ public static class FileSystemName
 	//		   set of contiguous DOS_QMs.
 	//	   DOS_DOT matches either a . or zero characters beyond name string.
 
-#pragma warning disable MA0051 // Method is too long
 	private static bool MatchPattern(string expression, string name, bool ignoreCase,
 		bool useExtendedWildcards)
 	{
@@ -462,6 +461,5 @@ public static class FileSystemName
 
 		return currentState == maxState;
 	}
-#pragma warning restore MA0051 // Method is too long
 }
 #endif

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -226,58 +226,8 @@ internal sealed class InMemoryStorage : IStorage
 				            _fileSystem.Execute.StringComparisonMode) &&
 			            !x.Key.Equals(location)))
 		{
-			string? parentPath =
-				_fileSystem.Execute.Path.GetDirectoryName(
-					item.Key.FullPath.TrimEnd(_fileSystem.Execute.Path
-						.DirectorySeparatorChar));
-			if (parentPath == null)
-			{
-				continue;
-			}
-
-			if (!parentPath.Equals(fullPathWithoutTrailingSlash,
-				_fileSystem.Execute.StringComparisonMode))
-			{
-#if NETSTANDARD2_1
-				if (!enumerationOptions.RecurseSubdirectories)
-				{
-					continue;
-				}
-#else
-				int recursionDepth = parentPath
-					.Substring(fullPathWithoutTrailingSlash.Length)
-					.Count(x => x == _fileSystem.Execute.Path.DirectorySeparatorChar);
-				if (!enumerationOptions.RecurseSubdirectories ||
-				    recursionDepth > enumerationOptions.MaxRecursionDepth)
-				{
-					continue;
-				}
-#endif
-			}
-
-#if NET8_0_OR_GREATER
-			FileAttributes defaultAttributeToSkip = FileAttributes.None;
-#else
-			FileAttributes defaultAttributeToSkip = 0;
-#endif
-			if (enumerationOptions.AttributesToSkip != defaultAttributeToSkip &&
-			    item.Value.Attributes.HasFlag(enumerationOptions.AttributesToSkip))
-			{
-				continue;
-			}
-
-			if (!_fileSystem.AccessControlStrategy
-				.IsAccessGranted(item.Key.FullPath, item.Value.Extensibility))
-			{
-				if (!enumerationOptions.IgnoreInaccessible)
-				{
-					throw ExceptionFactory.AccessToPathDenied(item.Key.FullPath);
-				}
-
-				continue;
-			}
-
-			if (type.HasFlag(item.Value.Type))
+			if (type.HasFlag(item.Value.Type) &&
+			    IncludeItemInEnumeration(item, fullPathWithoutTrailingSlash, enumerationOptions))
 			{
 				string name = _fileSystem.Execute.Path.GetFileName(item.Key.FullPath);
 				if (EnumerationOptionsHelper.MatchesPattern(
@@ -702,7 +652,112 @@ internal sealed class InMemoryStorage : IStorage
 		}
 	}
 
-	#pragma warning disable MA0051 // Method is too long
+#if NETSTANDARD2_1
+	/// <summary>
+	///     Checks, if the <paramref name="item" /> should be included during enumeration, depending on the
+	///     <paramref name="directoryPath" /> to enumerate and the <paramref name="enumerationOptions" />.
+	/// </summary>
+	/// <remarks>
+	///     <see cref="EnumerationOptions.RecurseSubdirectories" />:<br />
+	///     If not set, only items directly in <paramref name="directoryPath" /> are included
+	///     <para />
+	///     <see cref="EnumerationOptions.AttributesToSkip" />:<br />
+	///     If set, only items with the given attributes are included
+	///     <para />
+	///     If the item is not granted access by the <see cref="IAccessControlStrategy" />:<br />
+	///     When <see cref="EnumerationOptions.IgnoreInaccessible" /> is set, the item is ignored, otherwise this method throws
+	///     an <see cref="UnauthorizedAccessException" />.
+	/// </remarks>
+	/// <exception cref="UnauthorizedAccessException">
+	///     When an item is not granted access by the
+	///     <see cref="IAccessControlStrategy" /> and <see cref="EnumerationOptions.IgnoreInaccessible" /> is not set to
+	///     <see langword="true" />.
+	/// </exception>
+#else
+	/// <summary>
+	///     Checks, if the <paramref name="item" /> should be included during enumeration, depending on the
+	///     <paramref name="directoryPath" /> to enumerate and the <paramref name="enumerationOptions" />.
+	/// </summary>
+	/// <remarks>
+	///     <see cref="EnumerationOptions.RecurseSubdirectories" />:<br />
+	///     If not set, only items directly in <paramref name="directoryPath" /> are included
+	///     <para />
+	///     <see cref="EnumerationOptions.MaxRecursionDepth" />:<br />
+	///     If set, only items within the given value of recursion are included
+	///     <para />
+	///     <see cref="EnumerationOptions.AttributesToSkip" />:<br />
+	///     If set, only items with the given attributes are included
+	///     <para />
+	///     If the item is not granted access by the <see cref="IAccessControlStrategy" />:<br />
+	///     When <see cref="EnumerationOptions.IgnoreInaccessible" /> is set, the item is ignored, otherwise this method throws
+	///     an <see cref="UnauthorizedAccessException" />.
+	/// </remarks>
+	/// <exception cref="UnauthorizedAccessException">
+	///     When an item is not granted access by the
+	///     <see cref="IAccessControlStrategy" /> and <see cref="EnumerationOptions.IgnoreInaccessible" /> is not set to
+	///     <see langword="true" />.
+	/// </exception>
+#endif
+	private bool IncludeItemInEnumeration(
+		KeyValuePair<IStorageLocation, IStorageContainer> item,
+		string directoryPath,
+		EnumerationOptions enumerationOptions)
+	{
+		string? parentPath =
+			_fileSystem.Execute.Path.GetDirectoryName(
+				item.Key.FullPath.TrimEnd(_fileSystem.Execute.Path
+					.DirectorySeparatorChar));
+		if (parentPath == null)
+		{
+			return false;
+		}
+
+		if (!parentPath.Equals(directoryPath,
+			_fileSystem.Execute.StringComparisonMode))
+		{
+#if NETSTANDARD2_1
+			if (!enumerationOptions.RecurseSubdirectories)
+			{
+				return false;
+			}
+#else
+			int recursionDepth = parentPath
+				.Substring(directoryPath.Length)
+				.Count(x => x == _fileSystem.Execute.Path.DirectorySeparatorChar);
+			if (!enumerationOptions.RecurseSubdirectories ||
+			    recursionDepth > enumerationOptions.MaxRecursionDepth)
+			{
+				return false;
+			}
+#endif
+		}
+
+#if NET8_0_OR_GREATER
+			FileAttributes defaultAttributeToSkip = FileAttributes.None;
+#else
+		FileAttributes defaultAttributeToSkip = 0;
+#endif
+		if (enumerationOptions.AttributesToSkip != defaultAttributeToSkip &&
+		    item.Value.Attributes.HasFlag(enumerationOptions.AttributesToSkip))
+		{
+			return false;
+		}
+
+		if (!_fileSystem.AccessControlStrategy
+			.IsAccessGranted(item.Key.FullPath, item.Value.Extensibility))
+		{
+			if (!enumerationOptions.IgnoreInaccessible)
+			{
+				throw ExceptionFactory.AccessToPathDenied(item.Key.FullPath);
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
+#pragma warning disable MA0051 // Method is too long
 	private IStorageLocation? MoveInternal(IStorageLocation source,
 		IStorageLocation destination,
 		bool overwrite,
@@ -791,7 +846,7 @@ internal sealed class InMemoryStorage : IStorage
 
 		return source;
 	}
-	#pragma warning restore MA0051 // Method is too long
+#pragma warning restore MA0051 // Method is too long
 
 #if FEATURE_FILESYSTEM_LINK
 	private IStorageLocation? ResolveFinalLinkTarget(IStorageContainer container,

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -393,7 +393,6 @@ internal sealed class InMemoryStorage : IStorage
 	}
 
 	/// <inheritdoc cref="IStorage.Replace(IStorageLocation, IStorageLocation, IStorageLocation?, bool)" />
-	#pragma warning disable MA0051 // Method is too long
 	public IStorageLocation? Replace(IStorageLocation source,
 		IStorageLocation destination,
 		IStorageLocation? backup,
@@ -485,7 +484,6 @@ internal sealed class InMemoryStorage : IStorage
 			}
 		}
 	}
-	#pragma warning restore MA0051 // Method is too long
 
 #if FEATURE_FILESYSTEM_LINK
 	/// <inheritdoc cref="IStorage.ResolveLinkTarget(IStorageLocation, bool)" />
@@ -757,7 +755,6 @@ internal sealed class InMemoryStorage : IStorage
 		return true;
 	}
 
-#pragma warning disable MA0051 // Method is too long
 	private IStorageLocation? MoveInternal(IStorageLocation source,
 		IStorageLocation destination,
 		bool overwrite,
@@ -846,7 +843,6 @@ internal sealed class InMemoryStorage : IStorage
 
 		return source;
 	}
-#pragma warning restore MA0051 // Method is too long
 
 #if FEATURE_FILESYSTEM_LINK
 	private IStorageLocation? ResolveFinalLinkTarget(IStorageContainer container,

--- a/Tests/Testably.Abstractions.Parity.Tests/Net48ParityTests.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/Net48ParityTests.cs
@@ -13,7 +13,6 @@ public class Net48ParityTests : ParityTests
 	///     <para />
 	///     As we only support .NET Standard 2.0 these are blacklisted.
 	/// </summary>
-	#pragma warning disable MA0051 // Method is too long
 	public Net48ParityTests(ITestOutputHelper testOutputHelper)
 		: base(new TestHelpers.Parity(), testOutputHelper)
 	{
@@ -178,6 +177,5 @@ public class Net48ParityTests : ParityTests
 
 		#endregion
 	}
-	#pragma warning restore MA0051 // Method is too long
 }
 #endif


### PR DESCRIPTION
Refactor the check, if items should be included in the enumeration depending on the `EnumerationOptions` into a separate method to reduce the overall complexity.