### PR TITLE
refactor: reduce parallel Tasks in Test Suite

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
@@ -471,7 +471,7 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 						cancellationTokenSource.Dispose();
 					}, CancellationToken.None);
 				}
-			}, TaskScheduler.Default);
+			}, TaskScheduler.Current);
 	}
 
 	private void Stop()

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimerMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimerMock.cs
@@ -303,7 +303,7 @@ internal sealed class TimerMock : ITimerMock
 						_cancellationTokenSource = null;
 					}
 				}
-			}, TaskScheduler.Default);
+			}, TaskScheduler.Current);
 		startCreateTimerThreads.Wait(token);
 	}
 

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/FileSystemTestBase.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/FileSystemTestBase.cs
@@ -13,7 +13,7 @@ namespace Testably.Abstractions.TestHelpers;
 /// <remarks>
 ///     Important: You have to mark your class as ´partial`!
 /// </remarks>
-public abstract class FileSystemTestBase<TFileSystem>
+public abstract class FileSystemTestBase<TFileSystem> : TestBase
 	where TFileSystem : IFileSystem
 {
 	public abstract string BasePath { get; }

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/RandomSystemTestBase.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/RandomSystemTestBase.cs
@@ -12,7 +12,7 @@ namespace Testably.Abstractions.TestHelpers;
 /// <remarks>
 ///     Important: You have to mark your class as ´partial`!
 /// </remarks>
-public abstract class RandomSystemTestBase<TRandomSystem>
+public abstract class RandomSystemTestBase<TRandomSystem> : TestBase
 	where TRandomSystem : IRandomSystem
 {
 	public TRandomSystem RandomSystem { get; }

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/TestBase.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/TestBase.cs
@@ -1,0 +1,22 @@
+﻿namespace Testably.Abstractions.TestHelpers;
+
+/// <summary>
+///     Base class for generated tests.
+/// </summary>
+public abstract class TestBase
+{
+	/// <summary>
+	///     The delay in milliseconds when wanting to ensure a timeout in the test.
+	/// </summary>
+	public const int EnsureTimeout = 500;
+
+	/// <summary>
+	///     The delay in milliseconds when expecting a success in the test.
+	/// </summary>
+	public const int ExpectSuccess = 30000;
+
+	/// <summary>
+	///     The delay in milliseconds when expecting a timeout in the test.
+	/// </summary>
+	public const int ExpectTimeout = 30;
+}

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/TimeSystemTestBase.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/TimeSystemTestBase.cs
@@ -12,7 +12,7 @@ namespace Testably.Abstractions.TestHelpers;
 /// <remarks>
 ///     Important: You have to mark your class as ´partial`!
 /// </remarks>
-public abstract class TimeSystemTestBase<TTimeSystem>
+public abstract class TimeSystemTestBase<TTimeSystem> : TestBase
 	where TTimeSystem : ITimeSystem
 {
 	public TTimeSystem TimeSystem { get; }

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/RandomSystemExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/RandomSystemExtensionsTests.cs
@@ -15,7 +15,7 @@ public class RandomSystemExtensionsTests
 					Enumerable.Range(0, 1000))));
 
 		List<string> fileExtensions = [];
-		while (true)
+		for (int i = 0; i < 1000; i++)
 		{
 			string fileExtension = randomSystem.Random.Shared.GenerateFileExtension();
 			if (fileExtensions.Contains(fileExtension, StringComparer.Ordinal))
@@ -43,7 +43,7 @@ public class RandomSystemExtensionsTests
 					Enumerable.Range(0, 1000))));
 
 		List<string> fileNames = [];
-		while (true)
+		for (int i = 0; i < 1000; i++)
 		{
 			string fileName = randomSystem.Random.Shared.GenerateFileName();
 			if (fileNames.Contains(fileName, StringComparer.Ordinal))

--- a/Tests/Testably.Abstractions.Testing.Tests/NotificationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/NotificationTests.cs
@@ -150,10 +150,10 @@ public class NotificationTests
 				// ReSharper disable once AccessToDisposedClosure
 				try
 				{
-					while (!ms.IsSet)
+					for (int i = 0; i < 1000 && !ms.IsSet; i++)
 					{
 						timeSystem.Thread.Sleep(1);
-						await Task.Delay(1);
+						await Task.Delay(5);
 					}
 				}
 				catch (ObjectDisposedException)

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamFactoryStatisticsTests.cs
@@ -189,21 +189,29 @@ public class FileStreamFactoryStatisticsTests
 	[SkippableFact]
 	public void Method_Wrap_FileStream_ShouldRegisterCall()
 	{
+		string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 		MockFileSystem sut = new();
-		FileStream fileStream = new("foo", FileMode.OpenOrCreate);
-
 		try
 		{
-			using FileSystemStream result = sut.FileStream.Wrap(fileStream);
-		}
-		catch (NotSupportedException)
-		{
-			// Wrap is not possible on the MockFileSystem, but should still be registered!
-		}
+			using FileStream fileStream = new(path, FileMode.OpenOrCreate);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
-		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.Wrap),
-			fileStream);
+			try
+			{
+				using FileSystemStream result = sut.FileStream.Wrap(fileStream);
+			}
+			catch (NotSupportedException)
+			{
+				// Wrap is not possible on the MockFileSystem, but should still be registered!
+			}
+
+			sut.StatisticsRegistration.TotalCount.Should().Be(1);
+			sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.Wrap),
+				fileStream);
+		}
+		finally
+		{
+			File.Delete(path);
+		}
 	}
 
 	[SkippableFact]

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
@@ -48,7 +48,7 @@ public class FileSystemWatcherStatisticsTests
 		CancellationToken token = cts.Token;
 		_ = Task.Run(async () =>
 		{
-			while (!token.IsCancellationRequested)
+			for (int i = 0; i < 100 && !token.IsCancellationRequested; i++)
 			{
 				await Task.Delay(10, token);
 				sut.Directory.CreateDirectory(sut.Path.Combine("foo", "some-directory"));
@@ -77,7 +77,7 @@ public class FileSystemWatcherStatisticsTests
 		CancellationToken token = cts.Token;
 		_ = Task.Run(async () =>
 		{
-			while (!token.IsCancellationRequested)
+			for (int i = 0; i < 100 && !token.IsCancellationRequested; i++)
 			{
 				await Task.Delay(10, token);
 				sut.Directory.CreateDirectory(sut.Path.Combine("foo", "some-directory"));
@@ -86,7 +86,12 @@ public class FileSystemWatcherStatisticsTests
 		}, token);
 		WatcherChangeTypes changeType = WatcherChangeTypes.Created;
 
-		fileSystemWatcher.WaitForChanged(changeType);
+		Task.Run(() =>
+		{
+			// ReSharper disable once AccessToDisposedClosure
+			fileSystemWatcher.WaitForChanged(changeType);
+		}, token)
+			.Wait(token);
 		cts.Cancel();
 
 		sut.Statistics.FileSystemWatcher["foo"]
@@ -105,7 +110,7 @@ public class FileSystemWatcherStatisticsTests
 		CancellationToken token = cts.Token;
 		_ = Task.Run(async () =>
 		{
-			while (!token.IsCancellationRequested)
+			for (int i = 0; i < 100 && !token.IsCancellationRequested; i++)
 			{
 				await Task.Delay(10, token);
 				sut.Directory.CreateDirectory(sut.Path.Combine("foo", "some-directory"));

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
@@ -77,7 +77,7 @@ public class FileSystemWatcherStatisticsTests
 		CancellationToken token = cts.Token;
 		_ = Task.Run(async () =>
 		{
-			for (int i = 0; i < 100 && !token.IsCancellationRequested; i++)
+			while (!token.IsCancellationRequested)
 			{
 				await Task.Delay(10, token);
 				sut.Directory.CreateDirectory(sut.Path.Combine("foo", "some-directory"));
@@ -86,12 +86,7 @@ public class FileSystemWatcherStatisticsTests
 		}, token);
 		WatcherChangeTypes changeType = WatcherChangeTypes.Created;
 
-		Task.Run(() =>
-		{
-			// ReSharper disable once AccessToDisposedClosure
-			fileSystemWatcher.WaitForChanged(changeType);
-		}, token)
-			.Wait(token);
+		fileSystemWatcher.WaitForChanged(changeType);
 		cts.Cancel();
 
 		sut.Statistics.FileSystemWatcher["foo"]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 
 // ReSharper disable once PartialTypeWithSinglePart
+[Collection("RealFileSystemTests")]
 public abstract partial class ReadTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
@@ -55,7 +56,7 @@ public abstract partial class ReadTests<TFileSystem>
 			}
 		}, null);
 
-		ms.Wait(30000);
+		ms.Wait(ExpectSuccess).Should().BeTrue();
 		buffer.Should().BeEquivalentTo(bytes);
 	}
 
@@ -106,7 +107,7 @@ public abstract partial class ReadTests<TFileSystem>
 				}
 			}, null);
 
-			ms.Wait(10000);
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 		}
 
 		DateTime creationTime = FileSystem.File.GetCreationTimeUtc(path);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 
 // ReSharper disable once PartialTypeWithSinglePart
+[Collection("RealFileSystemTests")]
 public abstract partial class WriteTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
@@ -56,7 +57,7 @@ public abstract partial class WriteTests<TFileSystem>
 				}
 			}, null);
 
-			ms.Wait(30000);
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 		}
 
 		FileSystem.Should().HaveFile(path)
@@ -107,7 +108,7 @@ public abstract partial class WriteTests<TFileSystem>
 				}
 			}, null);
 
-			ms.Wait(10000);
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 		}
 
 		DateTime creationTime = FileSystem.File.GetCreationTimeUtc(path);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EnableRaisingEventsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EnableRaisingEventsTests.cs
@@ -30,13 +30,13 @@ public abstract partial class EnableRaisingEventsTests<TFileSystem>
 		};
 		fileSystemWatcher.EnableRaisingEvents = true;
 		FileSystem.Directory.Delete(path1);
-		ms.Wait(10000).Should().BeTrue();
+		ms.Wait(ExpectSuccess).Should().BeTrue();
 		ms.Reset();
 
 		fileSystemWatcher.EnableRaisingEvents = false;
 
 		FileSystem.Directory.Delete(path2);
-		ms.Wait(30).Should().BeFalse();
+		ms.Wait(ExpectTimeout).Should().BeFalse();
 	}
 
 	[SkippableTheory]
@@ -62,6 +62,6 @@ public abstract partial class EnableRaisingEventsTests<TFileSystem>
 
 		FileSystem.Directory.Delete(path);
 
-		ms.Wait(30).Should().BeFalse();
+		ms.Wait(ExpectTimeout).Should().BeFalse();
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
@@ -66,7 +66,7 @@ public abstract partial class EventTests<TFileSystem>
 		}
 		finally
 		{
-			ms.Wait(10000);
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 			fileSystemWatcher.Changed -= FileSystemWatcherOnChanged;
 		}
 
@@ -127,7 +127,7 @@ public abstract partial class EventTests<TFileSystem>
 		}
 		finally
 		{
-			ms.Wait(10000);
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 			fileSystemWatcher.Created -= FileSystemWatcherOnCreated;
 		}
 
@@ -189,7 +189,7 @@ public abstract partial class EventTests<TFileSystem>
 		}
 		finally
 		{
-			ms.Wait(10000);
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 			fileSystemWatcher.Deleted -= FileSystemWatcherOnDeleted;
 		}
 
@@ -253,7 +253,7 @@ public abstract partial class EventTests<TFileSystem>
 		}
 		finally
 		{
-			ms.Wait(10000);
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 			fileSystemWatcher.Renamed -= FileSystemWatcherOnRenamed;
 		}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/FilterTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/FilterTests.cs
@@ -38,7 +38,7 @@ public abstract partial class FilterTests<TFileSystem>
 		fileSystemWatcher.Filter = path;
 		fileSystemWatcher.EnableRaisingEvents = true;
 		FileSystem.Directory.Delete(path);
-		ms.Wait(10000).Should().BeTrue();
+		ms.Wait(ExpectSuccess).Should().BeTrue();
 
 		result.Should().NotBeNull();
 		result!.FullPath.Should().Be(FileSystem.Path.GetFullPath(path));
@@ -74,7 +74,7 @@ public abstract partial class FilterTests<TFileSystem>
 		fileSystemWatcher.Filter = filter;
 		fileSystemWatcher.EnableRaisingEvents = true;
 		FileSystem.Directory.Delete(path);
-		ms.Wait(30).Should().BeFalse();
+		ms.Wait(ExpectTimeout).Should().BeFalse();
 
 		result.Should().BeNull();
 	}
@@ -110,7 +110,7 @@ public abstract partial class FilterTests<TFileSystem>
 			FileSystem.Directory.Delete(path);
 		}
 
-		ms.Wait(10000).Should().BeTrue();
+		ms.Wait(ExpectSuccess).Should().BeTrue();
 
 		foreach (string path in otherPaths)
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/IncludeSubdirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/IncludeSubdirectoriesTests.cs
@@ -37,7 +37,7 @@ public abstract partial class IncludeSubdirectoriesTests<TFileSystem>
 		fileSystemWatcher.IncludeSubdirectories = false;
 		fileSystemWatcher.EnableRaisingEvents = true;
 		FileSystem.Directory.Delete(FileSystem.Path.Combine(baseDirectory, path));
-		ms.Wait(30).Should().BeFalse();
+		ms.Wait(ExpectTimeout).Should().BeFalse();
 
 		result.Should().BeNull();
 	}
@@ -72,7 +72,7 @@ public abstract partial class IncludeSubdirectoriesTests<TFileSystem>
 		fileSystemWatcher.IncludeSubdirectories = true;
 		fileSystemWatcher.EnableRaisingEvents = true;
 		FileSystem.Directory.Delete(otherDirectory);
-		ms.Wait(30).Should().BeFalse();
+		ms.Wait(ExpectTimeout).Should().BeFalse();
 
 		result.Should().BeNull();
 	}
@@ -107,7 +107,7 @@ public abstract partial class IncludeSubdirectoriesTests<TFileSystem>
 		fileSystemWatcher.IncludeSubdirectories = true;
 		fileSystemWatcher.EnableRaisingEvents = true;
 		FileSystem.Directory.Delete(subdirectoryPath);
-		ms.Wait(10000).Should().BeTrue();
+		ms.Wait(ExpectSuccess).Should().BeTrue();
 
 		result.Should().NotBeNull();
 		result!.FullPath.Should().Be(FileSystem.Path.GetFullPath(subdirectoryPath));

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/NotifyFiltersTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/NotifyFiltersTests.cs
@@ -9,20 +9,6 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
-	#region Test Setup
-
-	/// <summary>
-	///     The delay in milliseconds when expecting a success in the test.
-	/// </summary>
-	private const int ExpectSuccess = 5000;
-
-	/// <summary>
-	///     The delay in milliseconds when expecting a timeout in the test.
-	/// </summary>
-	private const int ExpectTimeout = 500;
-
-	#endregion
-
 	[SkippableTheory]
 	[AutoData]
 	public void NotifyFilter_AppendFile_ShouldNotNotifyOnOtherFilters(string fileName)
@@ -67,7 +53,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 
 		FileSystem.File.AppendAllText(fileName, "foo");
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 
@@ -165,7 +151,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 
 		FileSystem.Directory.CreateDirectory(path);
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 
@@ -241,7 +227,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 
 		FileSystem.File.WriteAllText(path, "foo");
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 
@@ -317,7 +303,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 
 		FileSystem.Directory.Delete(path);
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 
@@ -393,7 +379,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 
 		FileSystem.File.Delete(path);
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 
@@ -524,7 +510,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.Path.Combine(sourcePath, sourceName),
 			FileSystem.Path.Combine(destinationPath, destinationName));
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 
@@ -566,7 +552,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 
 		FileSystem.File.Move(sourceName, destinationName);
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 
@@ -657,7 +643,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 
 		FileSystem.File.WriteAllText(fileName, "foo");
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerFactoryTests.cs
@@ -137,7 +137,7 @@ public abstract partial class TimerFactoryTests<TTimeSystem>
 			}
 		}, null, 0, 50);
 
-		ms.Wait(30000).Should().BeTrue();
+		ms.Wait(ExpectSuccess).Should().BeTrue();
 		count.Should().BeGreaterOrEqualTo(2);
 	}
 
@@ -160,7 +160,7 @@ public abstract partial class TimerFactoryTests<TTimeSystem>
 			}
 		}, null, 5, 0);
 
-		ms.Wait(30000).Should().BeTrue();
+		ms.Wait(ExpectSuccess).Should().BeTrue();
 		await Task.Delay(100);
 		count.Should().Be(1);
 	}
@@ -182,6 +182,6 @@ public abstract partial class TimerFactoryTests<TTimeSystem>
 			}
 		});
 
-		ms.Wait(300).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -171,7 +171,7 @@ public abstract partial class TimerTests<TTimeSystem>
 
 		List<int> triggerTimes = [];
 		DateTime previousTime = TimeSystem.DateTime.Now;
-		using ManualResetEventSlim ms = new();
+		using ManualResetEventSlim ms1 = new();
 		using ManualResetEventSlim ms2 = new();
 		using ManualResetEventSlim ms3 = new();
 		#pragma warning disable MA0147 // Avoid async void method for delegate
@@ -184,10 +184,10 @@ public abstract partial class TimerTests<TTimeSystem>
 						DateTime now = TimeSystem.DateTime.Now;
 						double diff = (now - previousTime).TotalMilliseconds;
 						previousTime = now;
-						ms.Set();
+						ms1.Set();
 						triggerTimes.Add((int)diff);
 						// ReSharper disable once AccessToDisposedClosure
-						ms2.Wait(30000);
+						ms2.Wait(ExpectSuccess);
 						if (triggerTimes.Count > 3)
 						{
 							// ReSharper disable once AccessToDisposedClosure
@@ -204,7 +204,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				null, 0 * TimerMultiplier, 200 * TimerMultiplier))
 			#pragma warning restore MA0147 // Avoid async void method for delegate
 		{
-			ms.Wait(ExpectSuccess).Should().BeTrue();
+			ms1.Wait(ExpectSuccess).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
@@ -220,7 +220,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				}
 			}, null, 100 * TimerMultiplier, 0 * TimerMultiplier);
 
-			ms3.Wait(10000 * TimerMultiplier);
+			ms3.Wait(ExpectSuccess * TimerMultiplier);
 		}
 
 		if (triggerTimes[0] < 30 * TimerMultiplier)
@@ -246,7 +246,7 @@ public abstract partial class TimerTests<TTimeSystem>
 
 		List<int> triggerTimes = [];
 		DateTime previousTime = TimeSystem.DateTime.Now;
-		using ManualResetEventSlim ms = new();
+		using ManualResetEventSlim ms1 = new();
 		using ManualResetEventSlim ms2 = new();
 		using ManualResetEventSlim ms3 = new();
 		#pragma warning disable MA0147 // Avoid async void method for delegate
@@ -259,10 +259,10 @@ public abstract partial class TimerTests<TTimeSystem>
 						DateTime now = TimeSystem.DateTime.Now;
 						double diff = (now - previousTime).TotalMilliseconds;
 						previousTime = now;
-						ms.Set();
+						ms1.Set();
 						triggerTimes.Add((int)diff);
 						// ReSharper disable once AccessToDisposedClosure
-						ms2.Wait(30000);
+						ms2.Wait(ExpectSuccess);
 						if (triggerTimes.Count > 3)
 						{
 							// ReSharper disable once AccessToDisposedClosure
@@ -279,7 +279,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				null, 0L * TimerMultiplier, 200L * TimerMultiplier))
 			#pragma warning restore MA0147 // Avoid async void method for delegate
 		{
-			ms.Wait(ExpectSuccess).Should().BeTrue();
+			ms1.Wait(ExpectSuccess).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
@@ -295,7 +295,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				}
 			}, null, 100L * TimerMultiplier, 0L * TimerMultiplier);
 
-			ms3.Wait(10000);
+			ms3.Wait(ExpectSuccess);
 		}
 
 		if (triggerTimes[0] < 30 * TimerMultiplier)
@@ -321,7 +321,7 @@ public abstract partial class TimerTests<TTimeSystem>
 
 		List<int> triggerTimes = [];
 		DateTime previousTime = TimeSystem.DateTime.Now;
-		using ManualResetEventSlim ms = new();
+		using ManualResetEventSlim ms1 = new();
 		using ManualResetEventSlim ms2 = new();
 		using ManualResetEventSlim ms3 = new();
 		#pragma warning disable MA0147 // Avoid async void method for delegate
@@ -334,10 +334,10 @@ public abstract partial class TimerTests<TTimeSystem>
 						DateTime now = TimeSystem.DateTime.Now;
 						double diff = (now - previousTime).TotalMilliseconds;
 						previousTime = now;
-						ms.Set();
+						ms1.Set();
 						triggerTimes.Add((int)diff);
 						// ReSharper disable once AccessToDisposedClosure
-						ms2.Wait(30000);
+						ms2.Wait(ExpectSuccess);
 						if (triggerTimes.Count > 3)
 						{
 							// ReSharper disable once AccessToDisposedClosure
@@ -354,7 +354,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				TimeSpan.FromMilliseconds(200 * TimerMultiplier)))
 			#pragma warning restore MA0147 // Avoid async void method for delegate
 		{
-			ms.Wait(ExpectSuccess).Should().BeTrue();
+			ms1.Wait(ExpectSuccess).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 				{
 					// ReSharper disable once AccessToDisposedClosure
@@ -372,7 +372,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				}, null, TimeSpan.FromMilliseconds(100 * TimerMultiplier),
 				TimeSpan.FromMilliseconds(0 * TimerMultiplier));
 
-			ms3.Wait(10000);
+			ms3.Wait(ExpectSuccess);
 		}
 
 		if (triggerTimes[0] < 30 * TimerMultiplier)

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -204,7 +204,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				null, 0 * TimerMultiplier, 200 * TimerMultiplier))
 			#pragma warning restore MA0147 // Avoid async void method for delegate
 		{
-			ms.Wait(30000).Should().BeTrue();
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
@@ -279,7 +279,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				null, 0L * TimerMultiplier, 200L * TimerMultiplier))
 			#pragma warning restore MA0147 // Avoid async void method for delegate
 		{
-			ms.Wait(30000).Should().BeTrue();
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
@@ -354,7 +354,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				TimeSpan.FromMilliseconds(200 * TimerMultiplier)))
 			#pragma warning restore MA0147 // Avoid async void method for delegate
 		{
-			ms.Wait(30000).Should().BeTrue();
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 				{
 					// ReSharper disable once AccessToDisposedClosure


### PR DESCRIPTION
- Use `TaskScheduler.Current` instead of `TaskScheduler.Default`
- Consolidate usage of `ManualResetEventSlim` and the used timeouts
- Make `FileStream.ReadTests` and `FileStream.WriteTests` part of the sequential executed tests
- Avoid while-loops in tests