### PR TITLE
refactor: avoid blocking in tests

### DIFF
--- a/Tests/Testably.Abstractions.Testing.Tests/NotificationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/NotificationTests.cs
@@ -19,13 +19,13 @@ public class NotificationTests
 				}
 			});
 
-		_ = Task.Run(async () =>
+		_ = Task.Run(() =>
 		{
-			await Task.Delay(10);
+			Thread.Sleep(10);
 			for (int i = 1; i <= 10; i++)
 			{
 				timeSystem.Thread.Sleep(i);
-				await Task.Delay(1);
+				Thread.Sleep(1);
 			}
 		});
 
@@ -82,13 +82,13 @@ public class NotificationTests
 				receivedCount++;
 			});
 
-		_ = Task.Run(async () =>
+		_ = Task.Run(() =>
 		{
-			await Task.Delay(10);
+			Thread.Sleep(10);
 			for (int i = 1; i <= 10; i++)
 			{
 				timeSystem.Thread.Sleep(i);
-				await Task.Delay(1);
+				Thread.Sleep(1);
 			}
 		});
 
@@ -107,16 +107,16 @@ public class NotificationTests
 			receivedCount++;
 		}, t => t.TotalMilliseconds > 6);
 
-		_ = Task.Run(async () =>
+		_ = Task.Run(() =>
 		{
 			// ReSharper disable once AccessToDisposedClosure
 			try
 			{
-				await Task.Delay(10);
+				Thread.Sleep(10);
 				for (int i = 1; i <= 10; i++)
 				{
 					timeSystem.Thread.Sleep(i);
-					await Task.Delay(1);
+					Thread.Sleep(1);
 				}
 
 				ms.Set();
@@ -145,7 +145,7 @@ public class NotificationTests
 					isCalled = true;
 				});
 
-			_ = Task.Run(async () =>
+			_ = Task.Run(() =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
 				try
@@ -153,7 +153,7 @@ public class NotificationTests
 					while (!ms.IsSet)
 					{
 						timeSystem.Thread.Sleep(1);
-						await Task.Delay(1);
+						Thread.Sleep(1);
 					}
 				}
 				catch (ObjectDisposedException)

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
@@ -66,33 +66,6 @@ public class FileSystemWatcherStatisticsTests
 				timeout);
 	}
 
-	[SkippableFact(Skip = "Temporarily disable test without timeout")]
-	public void Method_WaitForChanged_WatcherChangeTypes_ShouldRegisterCall()
-	{
-		MockFileSystem sut = new();
-		sut.Initialize().WithSubdirectory("foo");
-		using IFileSystemWatcher fileSystemWatcher = sut.FileSystemWatcher.New("foo");
-		// Changes in the background are necessary, so that FileSystemWatcher.WaitForChanged returns.
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(1));
-		CancellationToken token = cts.Token;
-		_ = Task.Run(() =>
-		{
-			while (!token.IsCancellationRequested)
-			{
-				Thread.Sleep(10);
-				sut.Directory.CreateDirectory(sut.Path.Combine("foo", "some-directory"));
-				sut.Directory.Delete(sut.Path.Combine("foo", "some-directory"));
-			}
-		}, token);
-		WatcherChangeTypes changeType = WatcherChangeTypes.Created;
-
-		fileSystemWatcher.WaitForChanged(changeType);
-		cts.Cancel();
-
-		sut.Statistics.FileSystemWatcher["foo"]
-			.ShouldOnlyContainMethodCall(nameof(IFileSystemWatcher.WaitForChanged), changeType);
-	}
-
 #if FEATURE_FILESYSTEM_NET7
 	[SkippableFact]
 	public void Method_WaitForChanged_WatcherChangeTypes_TimeSpan_ShouldRegisterCall()

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
@@ -44,7 +44,7 @@ public class FileSystemWatcherStatisticsTests
 		sut.Initialize().WithSubdirectory("foo");
 		using IFileSystemWatcher fileSystemWatcher = sut.FileSystemWatcher.New("foo");
 		// Changes in the background are necessary, so that FileSystemWatcher.WaitForChanged returns.
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(1));
+		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
 		CancellationToken token = cts.Token;
 		_ = Task.Run(() =>
 		{
@@ -74,7 +74,7 @@ public class FileSystemWatcherStatisticsTests
 		sut.Initialize().WithSubdirectory("foo");
 		using IFileSystemWatcher fileSystemWatcher = sut.FileSystemWatcher.New("foo");
 		// Changes in the background are necessary, so that FileSystemWatcher.WaitForChanged returns.
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(1));
+		using CancellationTokenSource cts = new();
 		CancellationToken token = cts.Token;
 		_ = Task.Run(() =>
 		{
@@ -103,7 +103,7 @@ public class FileSystemWatcherStatisticsTests
 		sut.Initialize().WithSubdirectory("foo");
 		using IFileSystemWatcher fileSystemWatcher = sut.FileSystemWatcher.New("foo");
 		// Changes in the background are necessary, so that FileSystemWatcher.WaitForChanged returns.
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(1));
+		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
 		CancellationToken token = cts.Token;
 		_ = Task.Run(() =>
 		{

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
@@ -66,7 +66,7 @@ public class FileSystemWatcherStatisticsTests
 				timeout);
 	}
 
-	[SkippableFact]
+	[SkippableFact(Skip = "Temporarily disable test without timeout")]
 	public void Method_WaitForChanged_WatcherChangeTypes_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
@@ -46,11 +46,11 @@ public class FileSystemWatcherStatisticsTests
 		// Changes in the background are necessary, so that FileSystemWatcher.WaitForChanged returns.
 		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(1));
 		CancellationToken token = cts.Token;
-		_ = Task.Run(async () =>
+		_ = Task.Run(() =>
 		{
 			while (!token.IsCancellationRequested)
 			{
-				await Task.Delay(10, token);
+				Thread.Sleep(10);
 				sut.Directory.CreateDirectory(sut.Path.Combine("foo", "some-directory"));
 				sut.Directory.Delete(sut.Path.Combine("foo", "some-directory"));
 			}
@@ -75,11 +75,11 @@ public class FileSystemWatcherStatisticsTests
 		// Changes in the background are necessary, so that FileSystemWatcher.WaitForChanged returns.
 		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(1));
 		CancellationToken token = cts.Token;
-		_ = Task.Run(async () =>
+		_ = Task.Run(() =>
 		{
 			while (!token.IsCancellationRequested)
 			{
-				await Task.Delay(10, token);
+				Thread.Sleep(10);
 				sut.Directory.CreateDirectory(sut.Path.Combine("foo", "some-directory"));
 				sut.Directory.Delete(sut.Path.Combine("foo", "some-directory"));
 			}
@@ -103,11 +103,11 @@ public class FileSystemWatcherStatisticsTests
 		// Changes in the background are necessary, so that FileSystemWatcher.WaitForChanged returns.
 		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(1));
 		CancellationToken token = cts.Token;
-		_ = Task.Run(async () =>
+		_ = Task.Run(() =>
 		{
 			while (!token.IsCancellationRequested)
 			{
-				await Task.Delay(10, token);
+				Thread.Sleep(10);
 				sut.Directory.CreateDirectory(sut.Path.Combine("foo", "some-directory"));
 				sut.Directory.Delete(sut.Path.Combine("foo", "some-directory"));
 			}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 
 // ReSharper disable once PartialTypeWithSinglePart
+[Collection("RealFileSystemTests")]
 public abstract partial class ReadTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 namespace Testably.Abstractions.Tests.FileSystem.FileStream;
 
 // ReSharper disable once PartialTypeWithSinglePart
+[Collection("RealFileSystemTests")]
 public abstract partial class WriteTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
@@ -38,7 +38,7 @@ public abstract partial class EventTests<TFileSystem>
 
 		try
 		{
-			_ = Task.Run(async () =>
+			_ = Task.Run(() =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
 				try
@@ -48,7 +48,7 @@ public abstract partial class EventTests<TFileSystem>
 					{
 						FileSystem.File.WriteAllText(path,
 							i++.ToString(CultureInfo.InvariantCulture));
-						await Task.Delay(10);
+						Thread.Sleep(10);
 					}
 				}
 				catch (IOException)
@@ -104,7 +104,7 @@ public abstract partial class EventTests<TFileSystem>
 
 		try
 		{
-			_ = Task.Run(async () =>
+			_ = Task.Run(() =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
 				try
@@ -113,7 +113,7 @@ public abstract partial class EventTests<TFileSystem>
 					{
 						FileSystem.Directory.CreateDirectory(path);
 						FileSystem.Directory.Delete(path);
-						await Task.Delay(10);
+						Thread.Sleep(10);
 					}
 				}
 				catch (ObjectDisposedException)
@@ -166,7 +166,7 @@ public abstract partial class EventTests<TFileSystem>
 
 		try
 		{
-			_ = Task.Run(async () =>
+			_ = Task.Run(() =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
 				try
@@ -175,7 +175,7 @@ public abstract partial class EventTests<TFileSystem>
 					{
 						FileSystem.Directory.CreateDirectory(path);
 						FileSystem.Directory.Delete(path);
-						await Task.Delay(10);
+						Thread.Sleep(10);
 					}
 				}
 				catch (ObjectDisposedException)
@@ -229,7 +229,7 @@ public abstract partial class EventTests<TFileSystem>
 
 		try
 		{
-			_ = Task.Run(async () =>
+			_ = Task.Run(() =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
 				try
@@ -239,7 +239,7 @@ public abstract partial class EventTests<TFileSystem>
 					while (!ms.IsSet)
 					{
 						FileSystem.File.Move($"path-{i}", $"path-{++i}");
-						await Task.Delay(10);
+						Thread.Sleep(10);
 					}
 				}
 				catch (ObjectDisposedException)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
@@ -28,14 +28,14 @@ public abstract partial class Tests<TFileSystem>
 		fileSystemWatcher.EnableRaisingEvents.Should().BeTrue();
 		try
 		{
-			_ = Task.Run(async () =>
+			_ = Task.Run(() =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
 				try
 				{
 					while (!ms.IsSet)
 					{
-						await Task.Delay(10);
+						Thread.Sleep(10);
 						FileSystem.Directory.CreateDirectory(path);
 						FileSystem.Directory.Delete(path);
 					}
@@ -86,14 +86,14 @@ public abstract partial class Tests<TFileSystem>
 		fileSystemWatcher.EnableRaisingEvents.Should().BeTrue();
 		try
 		{
-			_ = Task.Run(async () =>
+			_ = Task.Run(() =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
 				try
 				{
 					while (!ms.IsSet)
 					{
-						await Task.Delay(10);
+						Thread.Sleep(10);
 						FileSystem.Directory.CreateDirectory(path);
 						FileSystem.Directory.Delete(path);
 					}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
@@ -19,14 +19,14 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 			FileSystem.FileSystemWatcher.New(BasePath);
 		try
 		{
-			_ = Task.Run(async () =>
+			_ = Task.Run(() =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
 				try
 				{
 					while (!ms.IsSet)
 					{
-						await Task.Delay(10);
+						Thread.Sleep(10);
 						FileSystem.Directory.CreateDirectory(path);
 						FileSystem.Directory.Delete(path);
 					}
@@ -68,14 +68,14 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 		try
 		{
 			fileSystemWatcher.EnableRaisingEvents = true;
-			_ = Task.Run(async () =>
+			_ = Task.Run(() =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
 				try
 				{
 					while (!ms.IsSet)
 					{
-						await Task.Delay(10);
+						Thread.Sleep(10);
 						FileSystem.Directory.CreateDirectory(fullPath);
 						FileSystem.Directory.Delete(fullPath);
 					}


### PR DESCRIPTION
- Avoid async methods in `Task.Run` in tests
- Make `FileStream.ReadTests` and `FileStream.WriteTests` part of the sequentially executed tests
- Set `EnableRaisingEvents` in `FileSystemWatcherStatisticsTests`