### PR TITLE
refactor: fix brittle `EventTests`

### DIFF
--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/FileSystemTestBase.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/FileSystemTestBase.cs
@@ -13,7 +13,7 @@ namespace Testably.Abstractions.TestHelpers;
 /// <remarks>
 ///     Important: You have to mark your class as ´partial`!
 /// </remarks>
-public abstract class FileSystemTestBase<TFileSystem>
+public abstract class FileSystemTestBase<TFileSystem> : TestBase
 	where TFileSystem : IFileSystem
 {
 	public abstract string BasePath { get; }

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/RandomSystemTestBase.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/RandomSystemTestBase.cs
@@ -12,7 +12,7 @@ namespace Testably.Abstractions.TestHelpers;
 /// <remarks>
 ///     Important: You have to mark your class as ´partial`!
 /// </remarks>
-public abstract class RandomSystemTestBase<TRandomSystem>
+public abstract class RandomSystemTestBase<TRandomSystem> : TestBase
 	where TRandomSystem : IRandomSystem
 {
 	public TRandomSystem RandomSystem { get; }

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/TestBase.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/TestBase.cs
@@ -1,0 +1,22 @@
+﻿namespace Testably.Abstractions.TestHelpers;
+
+/// <summary>
+///     Base class for generated tests.
+/// </summary>
+public abstract class TestBase
+{
+	/// <summary>
+	///     The delay in milliseconds when wanting to ensure a timeout in the test.
+	/// </summary>
+	public const int EnsureTimeout = 500;
+
+	/// <summary>
+	///     The delay in milliseconds when expecting a success in the test.
+	/// </summary>
+	public const int ExpectSuccess = 30000;
+
+	/// <summary>
+	///     The delay in milliseconds when expecting a timeout in the test.
+	/// </summary>
+	public const int ExpectTimeout = 30;
+}

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/TimeSystemTestBase.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/TimeSystemTestBase.cs
@@ -12,7 +12,7 @@ namespace Testably.Abstractions.TestHelpers;
 /// <remarks>
 ///     Important: You have to mark your class as ´partial`!
 /// </remarks>
-public abstract class TimeSystemTestBase<TTimeSystem>
+public abstract class TimeSystemTestBase<TTimeSystem> : TestBase
 	where TTimeSystem : ITimeSystem
 {
 	public TTimeSystem TimeSystem { get; }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -257,7 +257,7 @@ public abstract partial class CopyTests<TFileSystem>
 
 		FileSystem.File.WriteAllText(sourceName, contents);
 
-		TimeSystem.Thread.Sleep(1000);
+		TimeSystem.Thread.Sleep(EnsureTimeout);
 
 		FileSystem.File.Copy(sourceName, destinationName);
 		FileSystem.Should().HaveFile(sourceName)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
@@ -112,7 +112,7 @@ public abstract partial class CopyToTests<TFileSystem>
 		FileSystem.File.WriteAllText(sourceName, contents);
 		IFileInfo sut = FileSystem.FileInfo.New(sourceName);
 
-		TimeSystem.Thread.Sleep(1000);
+		TimeSystem.Thread.Sleep(EnsureTimeout);
 
 		IFileInfo result = sut.CopyTo(destinationName);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ReadTests.cs
@@ -56,7 +56,7 @@ public abstract partial class ReadTests<TFileSystem>
 			}
 		}, null);
 
-		ms.Wait(30000);
+		ms.Wait(ExpectSuccess).Should().BeTrue();
 		buffer.Should().BeEquivalentTo(bytes);
 	}
 
@@ -107,7 +107,7 @@ public abstract partial class ReadTests<TFileSystem>
 				}
 			}, null);
 
-			ms.Wait(10000);
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 		}
 
 		DateTime creationTime = FileSystem.File.GetCreationTimeUtc(path);
@@ -202,7 +202,7 @@ public abstract partial class ReadTests<TFileSystem>
 	public async Task ReadAsync_CanReadFalse_ShouldThrowNotSupportedException(
 		string path, byte[] bytes)
 	{
-		using CancellationTokenSource cts = new(30000);
+		using CancellationTokenSource cts = new(ExpectSuccess);
 		byte[] buffer = new byte[bytes.Length];
 		await FileSystem.File.WriteAllBytesAsync(path, bytes, cts.Token);
 		Exception? exception;
@@ -228,7 +228,7 @@ public abstract partial class ReadTests<TFileSystem>
 	public async Task ReadAsync_Memory_CanReadFalse_ShouldThrowNotSupportedException(
 		string path, byte[] bytes)
 	{
-		using CancellationTokenSource cts = new(30000);
+		using CancellationTokenSource cts = new(ExpectSuccess);
 		byte[] buffer = new byte[bytes.Length];
 		await FileSystem.File.WriteAllBytesAsync(path, bytes, cts.Token);
 		Exception? exception;
@@ -253,7 +253,7 @@ public abstract partial class ReadTests<TFileSystem>
 	[AutoData]
 	public async Task ReadAsync_ShouldFillBuffer(string path, byte[] bytes)
 	{
-		using CancellationTokenSource cts = new(30000);
+		using CancellationTokenSource cts = new(ExpectSuccess);
 		byte[] buffer = new byte[bytes.Length];
 		await FileSystem.File.WriteAllBytesAsync(path, bytes, cts.Token);
 		await using FileSystemStream stream = FileSystem.File.OpenRead(path);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/WriteTests.cs
@@ -57,7 +57,7 @@ public abstract partial class WriteTests<TFileSystem>
 				}
 			}, null);
 
-			ms.Wait(30000);
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 		}
 
 		FileSystem.Should().HaveFile(path)
@@ -108,7 +108,7 @@ public abstract partial class WriteTests<TFileSystem>
 				}
 			}, null);
 
-			ms.Wait(10000);
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 		}
 
 		DateTime creationTime = FileSystem.File.GetCreationTimeUtc(path);
@@ -210,7 +210,7 @@ public abstract partial class WriteTests<TFileSystem>
 	public async Task WriteAsync_CanWriteFalse_ShouldThrowNotSupportedException(
 		string path, byte[] bytes)
 	{
-		using CancellationTokenSource cts = new(30000);
+		using CancellationTokenSource cts = new(ExpectSuccess);
 		byte[] buffer = new byte[bytes.Length];
 		await FileSystem.File.WriteAllBytesAsync(path, bytes, cts.Token);
 		Exception? exception;
@@ -236,7 +236,7 @@ public abstract partial class WriteTests<TFileSystem>
 	[AutoData]
 	public async Task WriteAsync_ShouldFillBuffer(string path, byte[] bytes)
 	{
-		using CancellationTokenSource cts = new(30000);
+		using CancellationTokenSource cts = new(ExpectSuccess);
 
 		await using (FileSystemStream stream = FileSystem.File.Create(path))
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EnableRaisingEventsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EnableRaisingEventsTests.cs
@@ -30,13 +30,13 @@ public abstract partial class EnableRaisingEventsTests<TFileSystem>
 		};
 		fileSystemWatcher.EnableRaisingEvents = true;
 		FileSystem.Directory.Delete(path1);
-		ms.Wait(10000).Should().BeTrue();
+		ms.Wait(ExpectSuccess).Should().BeTrue();
 		ms.Reset();
 
 		fileSystemWatcher.EnableRaisingEvents = false;
 
 		FileSystem.Directory.Delete(path2);
-		ms.Wait(30).Should().BeFalse();
+		ms.Wait(ExpectTimeout).Should().BeFalse();
 	}
 
 	[SkippableTheory]
@@ -62,6 +62,6 @@ public abstract partial class EnableRaisingEventsTests<TFileSystem>
 
 		FileSystem.Directory.Delete(path);
 
-		ms.Wait(30).Should().BeFalse();
+		ms.Wait(ExpectTimeout).Should().BeFalse();
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
@@ -72,6 +72,8 @@ public abstract partial class EventTests<TFileSystem>
 		{
 			ms2.Wait(ExpectSuccess).Should().BeTrue();
 			fileSystemWatcher.Changed -= FileSystemWatcherOnChanged;
+			ms1.Reset();
+			ms1.Wait(ExpectSuccess).Should().BeTrue();
 		}
 
 		callCount.Should().BeGreaterThanOrEqualTo(1);
@@ -138,6 +140,8 @@ public abstract partial class EventTests<TFileSystem>
 		{
 			ms2.Wait(ExpectSuccess).Should().BeTrue();
 			fileSystemWatcher.Created -= FileSystemWatcherOnCreated;
+			ms1.Reset();
+			ms1.Wait(ExpectSuccess).Should().BeTrue();
 		}
 
 		callCount.Should().BeGreaterThanOrEqualTo(1);
@@ -206,6 +210,8 @@ public abstract partial class EventTests<TFileSystem>
 		{
 			ms2.Wait(ExpectSuccess).Should().BeTrue();
 			fileSystemWatcher.Deleted -= FileSystemWatcherOnDeleted;
+			ms1.Reset();
+			ms1.Wait(ExpectSuccess).Should().BeTrue();
 		}
 
 		callCount.Should().BeGreaterThanOrEqualTo(1);
@@ -276,6 +282,8 @@ public abstract partial class EventTests<TFileSystem>
 		{
 			ms2.Wait(ExpectSuccess).Should().BeTrue();
 			fileSystemWatcher.Renamed -= FileSystemWatcherOnRenamed;
+			ms1.Reset();
+			ms1.Wait(ExpectSuccess).Should().BeTrue();
 		}
 
 		callCount.Should().BeGreaterThanOrEqualTo(1);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
@@ -13,12 +13,15 @@ public abstract partial class EventTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
-	public async Task Changed_ShouldTriggerUntilEventIsRemoved(string path)
+	public void Changed_ShouldTriggerUntilEventIsRemoved(string path)
 	{
 		int callCount = 0;
 		FileSystem.InitializeIn(BasePath);
 		FileSystem.File.WriteAllText(path, "");
-		using ManualResetEventSlim ms = new();
+		using CancellationTokenSource cts = new(30000);
+		CancellationToken token = cts.Token;
+		using ManualResetEventSlim ms1 = new();
+		using ManualResetEventSlim ms2 = new();
 		using IFileSystemWatcher fileSystemWatcher =
 			FileSystem.FileSystemWatcher.New(BasePath);
 
@@ -28,7 +31,7 @@ public abstract partial class EventTests<TFileSystem>
 			try
 			{
 				callCount++;
-				ms.Set();
+				ms2.Set();
 			}
 			catch (ObjectDisposedException)
 			{
@@ -44,11 +47,12 @@ public abstract partial class EventTests<TFileSystem>
 				try
 				{
 					int i = 0;
-					while (!ms.IsSet)
+					while (!token.IsCancellationRequested)
 					{
-						FileSystem.File.WriteAllText(path,
-							i++.ToString(CultureInfo.InvariantCulture));
+						string content = i++.ToString(CultureInfo.InvariantCulture);
+						FileSystem.File.WriteAllText(path, content);
 						Thread.Sleep(10);
+						ms1.Set();
 					}
 				}
 				catch (IOException)
@@ -59,32 +63,36 @@ public abstract partial class EventTests<TFileSystem>
 				{
 					// Ignore any ObjectDisposedException
 				}
-			});
+			}, token);
 
 			fileSystemWatcher.Changed += FileSystemWatcherOnChanged;
 			fileSystemWatcher.EnableRaisingEvents = true;
 		}
 		finally
 		{
-			ms.Wait(10000);
+			ms2.Wait(10000).Should().BeTrue();
 			fileSystemWatcher.Changed -= FileSystemWatcherOnChanged;
 		}
 
 		callCount.Should().BeGreaterThanOrEqualTo(1);
 		int previousCallCount = callCount;
 
-		await Task.Delay(10);
-		FileSystem.File.WriteAllText(path, "foo");
+		ms1.Reset();
+		ms1.Wait(10000).Should().BeTrue();
 		callCount.Should().Be(previousCallCount);
+		cts.Cancel();
 	}
 
 	[SkippableTheory]
 	[AutoData]
-	public async Task Created_ShouldTriggerUntilEventIsRemoved(string path)
+	public void Created_ShouldTriggerUntilEventIsRemoved(string path)
 	{
 		int callCount = 0;
 		FileSystem.Initialize();
-		using ManualResetEventSlim ms = new();
+		using CancellationTokenSource cts = new(30000);
+		CancellationToken token = cts.Token;
+		using ManualResetEventSlim ms1 = new();
+		using ManualResetEventSlim ms2 = new();
 		using IFileSystemWatcher fileSystemWatcher =
 			FileSystem.FileSystemWatcher.New(BasePath);
 
@@ -94,7 +102,7 @@ public abstract partial class EventTests<TFileSystem>
 			try
 			{
 				callCount++;
-				ms.Set();
+				ms2.Set();
 			}
 			catch (ObjectDisposedException)
 			{
@@ -109,44 +117,50 @@ public abstract partial class EventTests<TFileSystem>
 				// ReSharper disable once AccessToDisposedClosure
 				try
 				{
-					while (!ms.IsSet)
+					while (!token.IsCancellationRequested)
 					{
 						FileSystem.Directory.CreateDirectory(path);
 						FileSystem.Directory.Delete(path);
 						Thread.Sleep(10);
+						ms1.Set();
 					}
 				}
 				catch (ObjectDisposedException)
 				{
 					// Ignore any ObjectDisposedException
 				}
-			});
+			}, token);
 
 			fileSystemWatcher.Created += FileSystemWatcherOnCreated;
 			fileSystemWatcher.EnableRaisingEvents = true;
 		}
 		finally
 		{
-			ms.Wait(10000);
+			ms2.Wait(10000).Should().BeTrue();
 			fileSystemWatcher.Created -= FileSystemWatcherOnCreated;
 		}
 
 		callCount.Should().BeGreaterThanOrEqualTo(1);
 		int previousCallCount = callCount;
 
-		await Task.Delay(10);
+		ms1.Reset();
+		ms1.Wait(10000).Should().BeTrue();
 		FileSystem.Directory.CreateDirectory("other" + path);
 		FileSystem.Directory.Delete("other" + path);
 		callCount.Should().Be(previousCallCount);
+		cts.Cancel();
 	}
 
 	[SkippableTheory]
 	[AutoData]
-	public async Task Deleted_ShouldTriggerUntilEventIsRemoved(string path)
+	public void Deleted_ShouldTriggerUntilEventIsRemoved(string path)
 	{
 		int callCount = 0;
 		FileSystem.Initialize();
-		using ManualResetEventSlim ms = new();
+		using CancellationTokenSource cts = new(30000);
+		CancellationToken token = cts.Token;
+		using ManualResetEventSlim ms1 = new();
+		using ManualResetEventSlim ms2 = new();
 		using IFileSystemWatcher fileSystemWatcher =
 			FileSystem.FileSystemWatcher.New(BasePath);
 
@@ -156,7 +170,7 @@ public abstract partial class EventTests<TFileSystem>
 			try
 			{
 				callCount++;
-				ms.Set();
+				ms2.Set();
 			}
 			catch (ObjectDisposedException)
 			{
@@ -171,45 +185,51 @@ public abstract partial class EventTests<TFileSystem>
 				// ReSharper disable once AccessToDisposedClosure
 				try
 				{
-					while (!ms.IsSet)
+					while (!token.IsCancellationRequested)
 					{
 						FileSystem.Directory.CreateDirectory(path);
 						FileSystem.Directory.Delete(path);
 						Thread.Sleep(10);
+						ms1.Set();
 					}
 				}
 				catch (ObjectDisposedException)
 				{
 					// Ignore any ObjectDisposedException
 				}
-			});
+			}, token);
 
 			fileSystemWatcher.Deleted += FileSystemWatcherOnDeleted;
 			fileSystemWatcher.EnableRaisingEvents = true;
 		}
 		finally
 		{
-			ms.Wait(10000);
+			ms2.Wait(10000).Should().BeTrue();
 			fileSystemWatcher.Deleted -= FileSystemWatcherOnDeleted;
 		}
 
 		callCount.Should().BeGreaterThanOrEqualTo(1);
 		int previousCallCount = callCount;
 
-		await Task.Delay(10);
+		ms1.Reset();
+		ms1.Wait(10000).Should().BeTrue();
 		FileSystem.Directory.CreateDirectory("other" + path);
 		FileSystem.Directory.Delete("other" + path);
 		callCount.Should().Be(previousCallCount);
+		cts.Cancel();
 	}
 
 	[SkippableTheory]
 	[AutoData]
-	public async Task Renamed_ShouldTriggerUntilEventIsRemoved(string path)
+	public void Renamed_ShouldTriggerUntilEventIsRemoved(string path)
 	{
 		int callCount = 0;
 		FileSystem.InitializeIn(BasePath);
 		FileSystem.File.WriteAllText(path, "");
-		using ManualResetEventSlim ms = new();
+		using CancellationTokenSource cts = new(30000);
+		CancellationToken token = cts.Token;
+		using ManualResetEventSlim ms1 = new();
+		using ManualResetEventSlim ms2 = new();
 		using IFileSystemWatcher fileSystemWatcher =
 			FileSystem.FileSystemWatcher.New(BasePath);
 
@@ -219,7 +239,7 @@ public abstract partial class EventTests<TFileSystem>
 			try
 			{
 				callCount++;
-				ms.Set();
+				ms2.Set();
 			}
 			catch (ObjectDisposedException)
 			{
@@ -236,32 +256,35 @@ public abstract partial class EventTests<TFileSystem>
 				{
 					int i = 0;
 					FileSystem.File.WriteAllText($"path-{i}", "");
-					while (!ms.IsSet)
+					while (!token.IsCancellationRequested)
 					{
 						FileSystem.File.Move($"path-{i}", $"path-{++i}");
 						Thread.Sleep(10);
+						ms1.Set();
 					}
 				}
 				catch (ObjectDisposedException)
 				{
 					// Ignore any ObjectDisposedException
 				}
-			});
+			}, token);
 
 			fileSystemWatcher.Renamed += FileSystemWatcherOnRenamed;
 			fileSystemWatcher.EnableRaisingEvents = true;
 		}
 		finally
 		{
-			ms.Wait(10000);
+			ms2.Wait(10000).Should().BeTrue();
 			fileSystemWatcher.Renamed -= FileSystemWatcherOnRenamed;
 		}
 
 		callCount.Should().BeGreaterThanOrEqualTo(1);
 		int previousCallCount = callCount;
 
-		await Task.Delay(10);
+		ms1.Reset();
+		ms1.Wait(10000).Should().BeTrue();
 		FileSystem.File.Move(path, "other-path");
 		callCount.Should().Be(previousCallCount);
+		cts.Cancel();
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/EventTests.cs
@@ -18,7 +18,7 @@ public abstract partial class EventTests<TFileSystem>
 		int callCount = 0;
 		FileSystem.InitializeIn(BasePath);
 		FileSystem.File.WriteAllText(path, "");
-		using CancellationTokenSource cts = new(30000);
+		using CancellationTokenSource cts = new(ExpectSuccess);
 		CancellationToken token = cts.Token;
 		using ManualResetEventSlim ms1 = new();
 		using ManualResetEventSlim ms2 = new();
@@ -70,7 +70,7 @@ public abstract partial class EventTests<TFileSystem>
 		}
 		finally
 		{
-			ms2.Wait(10000).Should().BeTrue();
+			ms2.Wait(ExpectSuccess).Should().BeTrue();
 			fileSystemWatcher.Changed -= FileSystemWatcherOnChanged;
 		}
 
@@ -78,7 +78,7 @@ public abstract partial class EventTests<TFileSystem>
 		int previousCallCount = callCount;
 
 		ms1.Reset();
-		ms1.Wait(10000).Should().BeTrue();
+		ms1.Wait(ExpectSuccess).Should().BeTrue();
 		callCount.Should().Be(previousCallCount);
 		cts.Cancel();
 	}
@@ -89,7 +89,7 @@ public abstract partial class EventTests<TFileSystem>
 	{
 		int callCount = 0;
 		FileSystem.Initialize();
-		using CancellationTokenSource cts = new(30000);
+		using CancellationTokenSource cts = new(ExpectSuccess);
 		CancellationToken token = cts.Token;
 		using ManualResetEventSlim ms1 = new();
 		using ManualResetEventSlim ms2 = new();
@@ -136,7 +136,7 @@ public abstract partial class EventTests<TFileSystem>
 		}
 		finally
 		{
-			ms2.Wait(10000).Should().BeTrue();
+			ms2.Wait(ExpectSuccess).Should().BeTrue();
 			fileSystemWatcher.Created -= FileSystemWatcherOnCreated;
 		}
 
@@ -144,7 +144,7 @@ public abstract partial class EventTests<TFileSystem>
 		int previousCallCount = callCount;
 
 		ms1.Reset();
-		ms1.Wait(10000).Should().BeTrue();
+		ms1.Wait(ExpectSuccess).Should().BeTrue();
 		FileSystem.Directory.CreateDirectory("other" + path);
 		FileSystem.Directory.Delete("other" + path);
 		callCount.Should().Be(previousCallCount);
@@ -157,7 +157,7 @@ public abstract partial class EventTests<TFileSystem>
 	{
 		int callCount = 0;
 		FileSystem.Initialize();
-		using CancellationTokenSource cts = new(30000);
+		using CancellationTokenSource cts = new(ExpectSuccess);
 		CancellationToken token = cts.Token;
 		using ManualResetEventSlim ms1 = new();
 		using ManualResetEventSlim ms2 = new();
@@ -204,7 +204,7 @@ public abstract partial class EventTests<TFileSystem>
 		}
 		finally
 		{
-			ms2.Wait(10000).Should().BeTrue();
+			ms2.Wait(ExpectSuccess).Should().BeTrue();
 			fileSystemWatcher.Deleted -= FileSystemWatcherOnDeleted;
 		}
 
@@ -212,7 +212,7 @@ public abstract partial class EventTests<TFileSystem>
 		int previousCallCount = callCount;
 
 		ms1.Reset();
-		ms1.Wait(10000).Should().BeTrue();
+		ms1.Wait(ExpectSuccess).Should().BeTrue();
 		FileSystem.Directory.CreateDirectory("other" + path);
 		FileSystem.Directory.Delete("other" + path);
 		callCount.Should().Be(previousCallCount);
@@ -226,7 +226,7 @@ public abstract partial class EventTests<TFileSystem>
 		int callCount = 0;
 		FileSystem.InitializeIn(BasePath);
 		FileSystem.File.WriteAllText(path, "");
-		using CancellationTokenSource cts = new(30000);
+		using CancellationTokenSource cts = new(ExpectSuccess);
 		CancellationToken token = cts.Token;
 		using ManualResetEventSlim ms1 = new();
 		using ManualResetEventSlim ms2 = new();
@@ -274,7 +274,7 @@ public abstract partial class EventTests<TFileSystem>
 		}
 		finally
 		{
-			ms2.Wait(10000).Should().BeTrue();
+			ms2.Wait(ExpectSuccess).Should().BeTrue();
 			fileSystemWatcher.Renamed -= FileSystemWatcherOnRenamed;
 		}
 
@@ -282,7 +282,7 @@ public abstract partial class EventTests<TFileSystem>
 		int previousCallCount = callCount;
 
 		ms1.Reset();
-		ms1.Wait(10000).Should().BeTrue();
+		ms1.Wait(ExpectSuccess).Should().BeTrue();
 		FileSystem.File.Move(path, "other-path");
 		callCount.Should().Be(previousCallCount);
 		cts.Cancel();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/FilterTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/FilterTests.cs
@@ -38,7 +38,7 @@ public abstract partial class FilterTests<TFileSystem>
 		fileSystemWatcher.Filter = path;
 		fileSystemWatcher.EnableRaisingEvents = true;
 		FileSystem.Directory.Delete(path);
-		ms.Wait(10000).Should().BeTrue();
+		ms.Wait(ExpectSuccess).Should().BeTrue();
 
 		result.Should().NotBeNull();
 		result!.FullPath.Should().Be(FileSystem.Path.GetFullPath(path));
@@ -74,7 +74,7 @@ public abstract partial class FilterTests<TFileSystem>
 		fileSystemWatcher.Filter = filter;
 		fileSystemWatcher.EnableRaisingEvents = true;
 		FileSystem.Directory.Delete(path);
-		ms.Wait(30).Should().BeFalse();
+		ms.Wait(ExpectTimeout).Should().BeFalse();
 
 		result.Should().BeNull();
 	}
@@ -110,7 +110,7 @@ public abstract partial class FilterTests<TFileSystem>
 			FileSystem.Directory.Delete(path);
 		}
 
-		ms.Wait(10000).Should().BeTrue();
+		ms.Wait(ExpectSuccess).Should().BeTrue();
 
 		foreach (string path in otherPaths)
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/IncludeSubdirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/IncludeSubdirectoriesTests.cs
@@ -37,7 +37,7 @@ public abstract partial class IncludeSubdirectoriesTests<TFileSystem>
 		fileSystemWatcher.IncludeSubdirectories = false;
 		fileSystemWatcher.EnableRaisingEvents = true;
 		FileSystem.Directory.Delete(FileSystem.Path.Combine(baseDirectory, path));
-		ms.Wait(30).Should().BeFalse();
+		ms.Wait(ExpectTimeout).Should().BeFalse();
 
 		result.Should().BeNull();
 	}
@@ -72,7 +72,7 @@ public abstract partial class IncludeSubdirectoriesTests<TFileSystem>
 		fileSystemWatcher.IncludeSubdirectories = true;
 		fileSystemWatcher.EnableRaisingEvents = true;
 		FileSystem.Directory.Delete(otherDirectory);
-		ms.Wait(30).Should().BeFalse();
+		ms.Wait(ExpectTimeout).Should().BeFalse();
 
 		result.Should().BeNull();
 	}
@@ -107,7 +107,7 @@ public abstract partial class IncludeSubdirectoriesTests<TFileSystem>
 		fileSystemWatcher.IncludeSubdirectories = true;
 		fileSystemWatcher.EnableRaisingEvents = true;
 		FileSystem.Directory.Delete(subdirectoryPath);
-		ms.Wait(10000).Should().BeTrue();
+		ms.Wait(ExpectSuccess).Should().BeTrue();
 
 		result.Should().NotBeNull();
 		result!.FullPath.Should().Be(FileSystem.Path.GetFullPath(subdirectoryPath));

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/NotifyFiltersTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/NotifyFiltersTests.cs
@@ -9,20 +9,6 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
-	#region Test Setup
-
-	/// <summary>
-	///     The delay in milliseconds when expecting a success in the test.
-	/// </summary>
-	private const int ExpectSuccess = 5000;
-
-	/// <summary>
-	///     The delay in milliseconds when expecting a timeout in the test.
-	/// </summary>
-	private const int ExpectTimeout = 500;
-
-	#endregion
-
 	[SkippableTheory]
 	[AutoData]
 	public void NotifyFilter_AppendFile_ShouldNotNotifyOnOtherFilters(string fileName)
@@ -67,7 +53,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 
 		FileSystem.File.AppendAllText(fileName, "foo");
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 
@@ -165,7 +151,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 
 		FileSystem.Directory.CreateDirectory(path);
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 
@@ -241,7 +227,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 
 		FileSystem.File.WriteAllText(path, "foo");
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 
@@ -317,7 +303,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 
 		FileSystem.Directory.Delete(path);
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 
@@ -393,7 +379,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 
 		FileSystem.File.Delete(path);
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 
@@ -524,7 +510,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 			FileSystem.Path.Combine(sourcePath, sourceName),
 			FileSystem.Path.Combine(destinationPath, destinationName));
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 
@@ -566,7 +552,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 
 		FileSystem.File.Move(sourceName, destinationName);
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 
@@ -657,7 +643,7 @@ public abstract partial class NotifyFiltersTests<TFileSystem>
 
 		FileSystem.File.WriteAllText(fileName, "foo");
 
-		ms.Wait(ExpectTimeout).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 		result.Should().BeNull();
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/Tests.cs
@@ -104,7 +104,7 @@ public abstract partial class Tests<TFileSystem>
 				}
 			});
 			IWaitForChangedResult result =
-				fileSystemWatcher.WaitForChanged(WatcherChangeTypes.Created, 30000);
+				fileSystemWatcher.WaitForChanged(WatcherChangeTypes.Created, ExpectSuccess);
 
 			fileSystemWatcher.EnableRaisingEvents.Should().BeTrue();
 			result.TimedOut.Should().BeFalse();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileSystemWatcher/WaitForChangedTests.cs
@@ -37,7 +37,7 @@ public abstract partial class WaitForChangedTests<TFileSystem>
 				}
 			});
 
-			using (CancellationTokenSource cts = new(5000))
+			using (CancellationTokenSource cts = new(ExpectSuccess))
 			{
 				cts.Token.Register(() => throw new TimeoutException());
 				IWaitForChangedResult result =

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerFactoryTests.cs
@@ -41,7 +41,7 @@ public abstract partial class TimerFactoryTests<TTimeSystem>
 			{
 				lock (timers)
 				{
-					timers.Add(TimeSystem.Timer.New(TimerCallback, null, 60000, 60000));
+					timers.Add(TimeSystem.Timer.New(TimerCallback, null, ExpectSuccess, ExpectSuccess));
 					Assert.True(TimeSystem.Timer.ActiveCount >= timers.Count);
 				}
 			}
@@ -137,7 +137,7 @@ public abstract partial class TimerFactoryTests<TTimeSystem>
 			}
 		}, null, 0, 50);
 
-		ms.Wait(30000).Should().BeTrue();
+		ms.Wait(ExpectSuccess).Should().BeTrue();
 		count.Should().BeGreaterOrEqualTo(2);
 	}
 
@@ -160,7 +160,7 @@ public abstract partial class TimerFactoryTests<TTimeSystem>
 			}
 		}, null, 5, 0);
 
-		ms.Wait(30000).Should().BeTrue();
+		ms.Wait(ExpectSuccess).Should().BeTrue();
 		await Task.Delay(100);
 		count.Should().Be(1);
 	}
@@ -182,6 +182,6 @@ public abstract partial class TimerFactoryTests<TTimeSystem>
 			}
 		});
 
-		ms.Wait(300).Should().BeFalse();
+		ms.Wait(EnsureTimeout).Should().BeFalse();
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -171,7 +171,7 @@ public abstract partial class TimerTests<TTimeSystem>
 
 		List<int> triggerTimes = [];
 		DateTime previousTime = TimeSystem.DateTime.Now;
-		using ManualResetEventSlim ms = new();
+		using ManualResetEventSlim ms1 = new();
 		using ManualResetEventSlim ms2 = new();
 		using ManualResetEventSlim ms3 = new();
 		#pragma warning disable MA0147 // Avoid async void method for delegate
@@ -184,7 +184,7 @@ public abstract partial class TimerTests<TTimeSystem>
 						DateTime now = TimeSystem.DateTime.Now;
 						double diff = (now - previousTime).TotalMilliseconds;
 						previousTime = now;
-						ms.Set();
+						ms1.Set();
 						triggerTimes.Add((int)diff);
 						// ReSharper disable once AccessToDisposedClosure
 						ms2.Wait(ExpectSuccess).Should().BeTrue();
@@ -204,7 +204,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				null, 0 * TimerMultiplier, 200 * TimerMultiplier))
 			#pragma warning restore MA0147 // Avoid async void method for delegate
 		{
-			ms.Wait(ExpectSuccess).Should().BeTrue();
+			ms1.Wait(ExpectSuccess).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
@@ -246,7 +246,7 @@ public abstract partial class TimerTests<TTimeSystem>
 
 		List<int> triggerTimes = [];
 		DateTime previousTime = TimeSystem.DateTime.Now;
-		using ManualResetEventSlim ms = new();
+		using ManualResetEventSlim ms1 = new();
 		using ManualResetEventSlim ms2 = new();
 		using ManualResetEventSlim ms3 = new();
 		#pragma warning disable MA0147 // Avoid async void method for delegate
@@ -259,7 +259,7 @@ public abstract partial class TimerTests<TTimeSystem>
 						DateTime now = TimeSystem.DateTime.Now;
 						double diff = (now - previousTime).TotalMilliseconds;
 						previousTime = now;
-						ms.Set();
+						ms1.Set();
 						triggerTimes.Add((int)diff);
 						// ReSharper disable once AccessToDisposedClosure
 						ms2.Wait(ExpectSuccess).Should().BeTrue();
@@ -279,7 +279,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				null, 0L * TimerMultiplier, 200L * TimerMultiplier))
 			#pragma warning restore MA0147 // Avoid async void method for delegate
 		{
-			ms.Wait(ExpectSuccess).Should().BeTrue();
+			ms1.Wait(ExpectSuccess).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
@@ -321,7 +321,7 @@ public abstract partial class TimerTests<TTimeSystem>
 
 		List<int> triggerTimes = [];
 		DateTime previousTime = TimeSystem.DateTime.Now;
-		using ManualResetEventSlim ms = new();
+		using ManualResetEventSlim ms1 = new();
 		using ManualResetEventSlim ms2 = new();
 		using ManualResetEventSlim ms3 = new();
 		#pragma warning disable MA0147 // Avoid async void method for delegate
@@ -334,7 +334,7 @@ public abstract partial class TimerTests<TTimeSystem>
 						DateTime now = TimeSystem.DateTime.Now;
 						double diff = (now - previousTime).TotalMilliseconds;
 						previousTime = now;
-						ms.Set();
+						ms1.Set();
 						triggerTimes.Add((int)diff);
 						// ReSharper disable once AccessToDisposedClosure
 						ms2.Wait(ExpectSuccess).Should().BeTrue();
@@ -354,7 +354,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				TimeSpan.FromMilliseconds(200 * TimerMultiplier)))
 			#pragma warning restore MA0147 // Avoid async void method for delegate
 		{
-			ms.Wait(ExpectSuccess).Should().BeTrue();
+			ms1.Wait(ExpectSuccess).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 				{
 					// ReSharper disable once AccessToDisposedClosure

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimerTests.cs
@@ -187,7 +187,7 @@ public abstract partial class TimerTests<TTimeSystem>
 						ms.Set();
 						triggerTimes.Add((int)diff);
 						// ReSharper disable once AccessToDisposedClosure
-						ms2.Wait(30000);
+						ms2.Wait(ExpectSuccess).Should().BeTrue();
 						if (triggerTimes.Count > 3)
 						{
 							// ReSharper disable once AccessToDisposedClosure
@@ -204,7 +204,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				null, 0 * TimerMultiplier, 200 * TimerMultiplier))
 			#pragma warning restore MA0147 // Avoid async void method for delegate
 		{
-			ms.Wait(30000).Should().BeTrue();
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
@@ -220,7 +220,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				}
 			}, null, 100 * TimerMultiplier, 0 * TimerMultiplier);
 
-			ms3.Wait(10000 * TimerMultiplier);
+			ms3.Wait(ExpectSuccess * TimerMultiplier).Should().BeTrue();
 		}
 
 		if (triggerTimes[0] < 30 * TimerMultiplier)
@@ -262,7 +262,7 @@ public abstract partial class TimerTests<TTimeSystem>
 						ms.Set();
 						triggerTimes.Add((int)diff);
 						// ReSharper disable once AccessToDisposedClosure
-						ms2.Wait(30000);
+						ms2.Wait(ExpectSuccess).Should().BeTrue();
 						if (triggerTimes.Count > 3)
 						{
 							// ReSharper disable once AccessToDisposedClosure
@@ -279,7 +279,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				null, 0L * TimerMultiplier, 200L * TimerMultiplier))
 			#pragma warning restore MA0147 // Avoid async void method for delegate
 		{
-			ms.Wait(30000).Should().BeTrue();
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
@@ -295,7 +295,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				}
 			}, null, 100L * TimerMultiplier, 0L * TimerMultiplier);
 
-			ms3.Wait(10000);
+			ms3.Wait(ExpectSuccess).Should().BeTrue();
 		}
 
 		if (triggerTimes[0] < 30 * TimerMultiplier)
@@ -337,7 +337,7 @@ public abstract partial class TimerTests<TTimeSystem>
 						ms.Set();
 						triggerTimes.Add((int)diff);
 						// ReSharper disable once AccessToDisposedClosure
-						ms2.Wait(30000);
+						ms2.Wait(ExpectSuccess).Should().BeTrue();
 						if (triggerTimes.Count > 3)
 						{
 							// ReSharper disable once AccessToDisposedClosure
@@ -354,7 +354,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				TimeSpan.FromMilliseconds(200 * TimerMultiplier)))
 			#pragma warning restore MA0147 // Avoid async void method for delegate
 		{
-			ms.Wait(30000).Should().BeTrue();
+			ms.Wait(ExpectSuccess).Should().BeTrue();
 			using ITimer timer2 = TimeSystem.Timer.New(_ =>
 				{
 					// ReSharper disable once AccessToDisposedClosure
@@ -372,7 +372,7 @@ public abstract partial class TimerTests<TTimeSystem>
 				}, null, TimeSpan.FromMilliseconds(100 * TimerMultiplier),
 				TimeSpan.FromMilliseconds(0 * TimerMultiplier));
 
-			ms3.Wait(10000);
+			ms3.Wait(ExpectSuccess).Should().BeTrue();
 		}
 
 		if (triggerTimes[0] < 30 * TimerMultiplier)


### PR DESCRIPTION
The `FileSystemWatcher.EventTests` sometimes fail, due to race-condition. Therefore make the following changes:
- Continually make the triggering changes in a background task, until the `CancellationToken` is cancelled at the end of the test
- Add and listen to separate triggers for when the triggering change was made and when the change was detected in the callback
- Make tests synchronous
- Add class `TestBase` with common timeout settings and use them throughout the Testably.Abstractions.Tests project.