### PR TITLE
refactor: reduce memory footprint of statistics functionality

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoFactoryMock.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Testably.Abstractions.Testing.Helpers;
-using Testably.Abstractions.Testing.Statistics;
 
 namespace Testably.Abstractions.Testing.FileSystem;
 
@@ -57,5 +56,5 @@ internal sealed class DirectoryInfoFactoryMock : IDirectoryInfoFactory
 
 	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
 		=> _fileSystem.StatisticsRegistration.DirectoryInfo.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1));
+			parameter1);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoFactoryMock.cs
@@ -23,8 +23,9 @@ internal sealed class DirectoryInfoFactoryMock : IDirectoryInfoFactory
 	/// <inheritdoc cref="IDirectoryInfoFactory.New(string)" />
 	public IDirectoryInfo New(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterMethod(nameof(New),
+				path);
 
 		return DirectoryInfoMock.New(
 			_fileSystem.Storage.GetLocation(path
@@ -36,8 +37,9 @@ internal sealed class DirectoryInfoFactoryMock : IDirectoryInfoFactory
 	[return: NotNullIfNotNull("directoryInfo")]
 	public IDirectoryInfo? Wrap(DirectoryInfo? directoryInfo)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Wrap),
-			directoryInfo);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterMethod(nameof(Wrap),
+				directoryInfo);
 
 		if (_fileSystem.SimulationMode != SimulationMode.Native)
 		{
@@ -53,8 +55,4 @@ internal sealed class DirectoryInfoFactoryMock : IDirectoryInfoFactory
 	}
 
 	#endregion
-
-	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
-		=> _fileSystem.StatisticsRegistration.DirectoryInfo.RegisterMethod(name,
-			parameter1);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
@@ -443,12 +443,12 @@ internal sealed class DirectoryInfoMock
 
 	protected override IDisposable RegisterMethod<T1>(string name, T1 parameter1)
 		=> _fileSystem.StatisticsRegistration.DirectoryInfo.RegisterMethod(Location.FullPath, name,
-			ParameterDescription.FromParameter(parameter1));
+			parameter1);
 
 	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
 		=> _fileSystem.StatisticsRegistration.DirectoryInfo.RegisterMethod(Location.FullPath, name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2));
+			parameter1,
+			parameter2);
 
 	protected override IDisposable RegisterProperty(string name, PropertyAccess access)
 		=> _fileSystem.StatisticsRegistration.DirectoryInfo.RegisterProperty(Location.FullPath,

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryInfoMock.cs
@@ -31,7 +31,9 @@ internal sealed class DirectoryInfoMock
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Exists), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.DirectoryInfo.RegisterPathProperty(Location.FullPath,
+					nameof(Exists), PropertyAccess.Get);
 
 			return base.Exists && FileSystemType == FileSystemTypes.Directory;
 		}
@@ -42,7 +44,9 @@ internal sealed class DirectoryInfoMock
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Parent), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.DirectoryInfo.RegisterPathProperty(Location.FullPath,
+					nameof(Parent), PropertyAccess.Get);
 
 			return New(Location.GetParent(), _fileSystem);
 		}
@@ -53,7 +57,9 @@ internal sealed class DirectoryInfoMock
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Root), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.DirectoryInfo.RegisterPathProperty(Location.FullPath,
+					nameof(Root), PropertyAccess.Get);
 
 			return New(_fileSystem.Storage.GetLocation(string.Empty.PrefixRoot(_fileSystem)),
 				_fileSystem);
@@ -63,7 +69,8 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.Create()" />
 	public void Create()
 	{
-		using IDisposable registration = RegisterMethod(nameof(Create));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(Create));
 
 		FullName.EnsureValidFormat(_fileSystem);
 
@@ -82,8 +89,9 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.CreateSubdirectory(string)" />
 	public IDirectoryInfo CreateSubdirectory(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(CreateSubdirectory),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(CreateSubdirectory),
+				path);
 
 		DirectoryInfoMock directory = New(
 			_fileSystem.Storage.GetLocation(
@@ -98,8 +106,9 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.Delete(bool)" />
 	public void Delete(bool recursive)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Delete),
-			recursive);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(Delete),
+				recursive);
 
 		if (!_fileSystem.Storage.DeleteContainer(
 			_fileSystem.Storage.GetLocation(FullName), recursive))
@@ -113,7 +122,8 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IFileSystemInfo.Delete()" />
 	public override void Delete()
 	{
-		using IDisposable registration = RegisterMethod(nameof(Delete));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(Delete));
 
 		if (!_fileSystem.Storage.DeleteContainer(Location))
 		{
@@ -126,7 +136,8 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.EnumerateDirectories()" />
 	public IEnumerable<IDirectoryInfo> EnumerateDirectories()
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateDirectories));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(EnumerateDirectories));
 
 		return EnumerateDirectories(
 			EnumerationOptionsHelper.DefaultSearchPattern,
@@ -137,8 +148,9 @@ internal sealed class DirectoryInfoMock
 	public IEnumerable<IDirectoryInfo>
 		EnumerateDirectories(string searchPattern)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateDirectories),
-			searchPattern);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(EnumerateDirectories),
+				searchPattern);
 
 		return EnumerateDirectories(searchPattern, SearchOption.TopDirectoryOnly);
 	}
@@ -147,8 +159,9 @@ internal sealed class DirectoryInfoMock
 	public IEnumerable<IDirectoryInfo> EnumerateDirectories(
 		string searchPattern, SearchOption searchOption)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateDirectories),
-			searchPattern, searchOption);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(EnumerateDirectories),
+				searchPattern, searchOption);
 
 		return EnumerateInternal(FileSystemTypes.Directory,
 				FullName,
@@ -163,8 +176,9 @@ internal sealed class DirectoryInfoMock
 		string searchPattern,
 		EnumerationOptions enumerationOptions)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateDirectories),
-			searchPattern, enumerationOptions);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(EnumerateDirectories),
+				searchPattern, enumerationOptions);
 
 		return EnumerateInternal(FileSystemTypes.Directory,
 				FullName,
@@ -177,7 +191,8 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.EnumerateFiles()" />
 	public IEnumerable<IFileInfo> EnumerateFiles()
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFiles));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(EnumerateFiles));
 
 		return EnumerateFiles(
 			EnumerationOptionsHelper.DefaultSearchPattern,
@@ -187,8 +202,9 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.EnumerateFiles(string)" />
 	public IEnumerable<IFileInfo> EnumerateFiles(string searchPattern)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFiles),
-			searchPattern);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(EnumerateFiles),
+				searchPattern);
 
 		return EnumerateFiles(searchPattern, SearchOption.TopDirectoryOnly);
 	}
@@ -197,8 +213,9 @@ internal sealed class DirectoryInfoMock
 	public IEnumerable<IFileInfo> EnumerateFiles(
 		string searchPattern, SearchOption searchOption)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFiles),
-			searchPattern, searchOption);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(EnumerateFiles),
+				searchPattern, searchOption);
 
 		return EnumerateInternal(FileSystemTypes.File,
 				FullName,
@@ -212,8 +229,9 @@ internal sealed class DirectoryInfoMock
 	public IEnumerable<IFileInfo> EnumerateFiles(
 		string searchPattern, EnumerationOptions enumerationOptions)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFiles),
-			searchPattern, enumerationOptions);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(EnumerateFiles),
+				searchPattern, enumerationOptions);
 
 		return EnumerateInternal(FileSystemTypes.File,
 				FullName,
@@ -226,7 +244,8 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.EnumerateFileSystemInfos()" />
 	public IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos()
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFileSystemInfos));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(EnumerateFileSystemInfos));
 
 		return EnumerateFileSystemInfos(
 			EnumerationOptionsHelper.DefaultSearchPattern,
@@ -237,8 +256,9 @@ internal sealed class DirectoryInfoMock
 	public IEnumerable<IFileSystemInfo>
 		EnumerateFileSystemInfos(string searchPattern)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFileSystemInfos),
-			searchPattern);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(EnumerateFileSystemInfos),
+				searchPattern);
 
 		return EnumerateFileSystemInfos(searchPattern, SearchOption.TopDirectoryOnly);
 	}
@@ -247,8 +267,9 @@ internal sealed class DirectoryInfoMock
 	public IEnumerable<IFileSystemInfo> EnumerateFileSystemInfos(
 		string searchPattern, SearchOption searchOption)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFileSystemInfos),
-			searchPattern, searchOption);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(EnumerateFileSystemInfos),
+				searchPattern, searchOption);
 
 		return EnumerateInternal(FileSystemTypes.DirectoryOrFile,
 				FullName,
@@ -263,8 +284,9 @@ internal sealed class DirectoryInfoMock
 		string searchPattern,
 		EnumerationOptions enumerationOptions)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFileSystemInfos),
-			searchPattern, enumerationOptions);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(EnumerateFileSystemInfos),
+				searchPattern, enumerationOptions);
 
 		return EnumerateInternal(FileSystemTypes.DirectoryOrFile,
 				FullName,
@@ -277,7 +299,8 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.GetDirectories()" />
 	public IDirectoryInfo[] GetDirectories()
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetDirectories));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(GetDirectories));
 
 		return EnumerateDirectories().ToArray();
 	}
@@ -285,8 +308,9 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.GetDirectories(string)" />
 	public IDirectoryInfo[] GetDirectories(string searchPattern)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetDirectories),
-			searchPattern);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(GetDirectories),
+				searchPattern);
 
 		return EnumerateDirectories(searchPattern).ToArray();
 	}
@@ -295,8 +319,9 @@ internal sealed class DirectoryInfoMock
 	public IDirectoryInfo[] GetDirectories(
 		string searchPattern, SearchOption searchOption)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetDirectories),
-			searchPattern, searchOption);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(GetDirectories),
+				searchPattern, searchOption);
 
 		return EnumerateDirectories(searchPattern, searchOption).ToArray();
 	}
@@ -307,8 +332,9 @@ internal sealed class DirectoryInfoMock
 		string searchPattern,
 		EnumerationOptions enumerationOptions)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetDirectories),
-			searchPattern, enumerationOptions);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(GetDirectories),
+				searchPattern, enumerationOptions);
 
 		return EnumerateDirectories(searchPattern, enumerationOptions).ToArray();
 	}
@@ -317,7 +343,8 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.GetFiles()" />
 	public IFileInfo[] GetFiles()
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFiles));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(GetFiles));
 
 		return EnumerateFiles().ToArray();
 	}
@@ -325,8 +352,9 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.GetFiles(string)" />
 	public IFileInfo[] GetFiles(string searchPattern)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFiles),
-			searchPattern);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(GetFiles),
+				searchPattern);
 
 		return EnumerateFiles(searchPattern).ToArray();
 	}
@@ -335,8 +363,9 @@ internal sealed class DirectoryInfoMock
 	public IFileInfo[] GetFiles(string searchPattern,
 		SearchOption searchOption)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFiles),
-			searchPattern, searchOption);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(GetFiles),
+				searchPattern, searchOption);
 
 		return EnumerateFiles(searchPattern, searchOption).ToArray();
 	}
@@ -346,8 +375,9 @@ internal sealed class DirectoryInfoMock
 	public IFileInfo[] GetFiles(string searchPattern,
 		EnumerationOptions enumerationOptions)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFiles),
-			searchPattern, enumerationOptions);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(GetFiles),
+				searchPattern, enumerationOptions);
 
 		return EnumerateFiles(searchPattern, enumerationOptions).ToArray();
 	}
@@ -356,7 +386,8 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.GetFileSystemInfos()" />
 	public IFileSystemInfo[] GetFileSystemInfos()
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFileSystemInfos));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(GetFileSystemInfos));
 
 		return EnumerateFileSystemInfos().ToArray();
 	}
@@ -364,8 +395,9 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.GetFileSystemInfos(string)" />
 	public IFileSystemInfo[] GetFileSystemInfos(string searchPattern)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFileSystemInfos),
-			searchPattern);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(GetFileSystemInfos),
+				searchPattern);
 
 		return EnumerateFileSystemInfos(searchPattern).ToArray();
 	}
@@ -374,8 +406,9 @@ internal sealed class DirectoryInfoMock
 	public IFileSystemInfo[] GetFileSystemInfos(
 		string searchPattern, SearchOption searchOption)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFileSystemInfos),
-			searchPattern, searchOption);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(GetFileSystemInfos),
+				searchPattern, searchOption);
 
 		return EnumerateFileSystemInfos(searchPattern, searchOption).ToArray();
 	}
@@ -386,8 +419,9 @@ internal sealed class DirectoryInfoMock
 		string searchPattern,
 		EnumerationOptions enumerationOptions)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFileSystemInfos),
-			searchPattern, enumerationOptions);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(GetFileSystemInfos),
+				searchPattern, enumerationOptions);
 
 		return EnumerateFileSystemInfos(searchPattern, enumerationOptions).ToArray();
 	}
@@ -396,8 +430,9 @@ internal sealed class DirectoryInfoMock
 	/// <inheritdoc cref="IDirectoryInfo.MoveTo(string)" />
 	public void MoveTo(string destDirName)
 	{
-		using IDisposable registration = RegisterMethod(nameof(MoveTo),
-			destDirName);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DirectoryInfo.RegisterPathMethod(Location.FullPath, nameof(MoveTo),
+				destDirName);
 
 		Location = _fileSystem.Storage.Move(
 			           _fileSystem.Storage.GetLocation(FullName),
@@ -438,19 +473,16 @@ internal sealed class DirectoryInfoMock
 			enumerationOptions);
 	}
 
-	protected override IDisposable RegisterMethod(string name)
-		=> _fileSystem.StatisticsRegistration.DirectoryInfo.RegisterMethod(Location.FullPath, name);
+	protected override IDisposable RegisterPathMethod(string name)
+		=> _fileSystem.StatisticsRegistration.DirectoryInfo.RegisterPathMethod(Location.FullPath,
+			name);
 
-	protected override IDisposable RegisterMethod<T1>(string name, T1 parameter1)
-		=> _fileSystem.StatisticsRegistration.DirectoryInfo.RegisterMethod(Location.FullPath, name,
+	protected override IDisposable RegisterPathMethod<T1>(string name, T1 parameter1)
+		=> _fileSystem.StatisticsRegistration.DirectoryInfo.RegisterPathMethod(Location.FullPath,
+			name,
 			parameter1);
 
-	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
-		=> _fileSystem.StatisticsRegistration.DirectoryInfo.RegisterMethod(Location.FullPath, name,
-			parameter1,
-			parameter2);
-
-	protected override IDisposable RegisterProperty(string name, PropertyAccess access)
-		=> _fileSystem.StatisticsRegistration.DirectoryInfo.RegisterProperty(Location.FullPath,
+	protected override IDisposable RegisterPathProperty(string name, PropertyAccess access)
+		=> _fileSystem.StatisticsRegistration.DirectoryInfo.RegisterPathProperty(Location.FullPath,
 			name, access);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using Testably.Abstractions.Testing.Helpers;
-using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.FileSystem;
@@ -675,19 +674,19 @@ internal sealed class DirectoryMock : IDirectory
 
 	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
 		=> _fileSystem.StatisticsRegistration.Directory.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1));
+			parameter1);
 
 	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
 		=> _fileSystem.StatisticsRegistration.Directory.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2));
+			parameter1,
+			parameter2);
 
 	private IDisposable RegisterMethod<T1, T2, T3>(string name, T1 parameter1, T2 parameter2,
 		T3 parameter3)
 		=> _fileSystem.StatisticsRegistration.Directory.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3));
+			parameter1,
+			parameter2,
+			parameter3);
 
 	private static void ThrowMissingFileCreatedTimeException(MockFileSystem fileSystem, string path)
 	{

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
@@ -26,8 +26,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.CreateDirectory(string)" />
 	public IDirectoryInfo CreateDirectory(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(CreateDirectory),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(CreateDirectory),
+				path);
 
 		path.EnsureValidFormat(_fileSystem);
 
@@ -43,8 +44,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.CreateDirectory(string, UnixFileMode)" />
 	public IDirectoryInfo CreateDirectory(string path, UnixFileMode unixCreateMode)
 	{
-		using IDisposable registration = RegisterMethod(nameof(CreateDirectory),
-			path, unixCreateMode);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(CreateDirectory),
+				path, unixCreateMode);
 
 		IDirectoryInfo directoryInfo = CreateDirectory(path);
 		#pragma warning disable CA1416
@@ -59,8 +61,9 @@ internal sealed class DirectoryMock : IDirectory
 	public IFileSystemInfo CreateSymbolicLink(
 		string path, string pathToTarget)
 	{
-		using IDisposable registration = RegisterMethod(nameof(CreateSymbolicLink),
-			path, pathToTarget);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(CreateSymbolicLink),
+				path, pathToTarget);
 
 		path.EnsureValidFormat(_fileSystem);
 		IDirectoryInfo fileSystemInfo =
@@ -74,8 +77,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.CreateTempSubdirectory(string)" />
 	public IDirectoryInfo CreateTempSubdirectory(string? prefix = null)
 	{
-		using IDisposable registration = RegisterMethod(nameof(CreateTempSubdirectory),
-			prefix);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(CreateTempSubdirectory),
+				prefix);
 
 		string basePath;
 
@@ -89,6 +93,7 @@ internal sealed class DirectoryMock : IDirectory
 			{
 				localBasePath = "/private" + localBasePath;
 			}
+
 			basePath = localBasePath;
 		} while (_fileSystem.Directory.Exists(basePath));
 
@@ -100,8 +105,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.Delete(string)" />
 	public void Delete(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Delete),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(Delete),
+				path);
 
 		_fileSystem.DirectoryInfo
 			.New(path.EnsureValidFormat(_fileSystem))
@@ -111,8 +117,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.Delete(string, bool)" />
 	public void Delete(string path, bool recursive)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Delete),
-			path, recursive);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(Delete),
+				path, recursive);
 
 		_fileSystem.DirectoryInfo
 			.New(path.EnsureValidFormat(_fileSystem))
@@ -122,8 +129,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.EnumerateDirectories(string)" />
 	public IEnumerable<string> EnumerateDirectories(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateDirectories),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(EnumerateDirectories),
+				path);
 
 		return EnumerateDirectories(path,
 			EnumerationOptionsHelper.DefaultSearchPattern,
@@ -133,8 +141,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.EnumerateDirectories(string, string)" />
 	public IEnumerable<string> EnumerateDirectories(string path, string searchPattern)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateDirectories),
-			path, searchPattern);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(EnumerateDirectories),
+				path, searchPattern);
 
 		return EnumerateDirectories(path, searchPattern, SearchOption.TopDirectoryOnly);
 	}
@@ -144,8 +153,9 @@ internal sealed class DirectoryMock : IDirectory
 		string searchPattern,
 		SearchOption searchOption)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateDirectories),
-			path, searchPattern, searchOption);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(EnumerateDirectories),
+				path, searchPattern, searchOption);
 
 		return EnumerateInternal(FileSystemTypes.Directory,
 			path,
@@ -159,8 +169,9 @@ internal sealed class DirectoryMock : IDirectory
 		string searchPattern,
 		EnumerationOptions enumerationOptions)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateDirectories),
-			path, searchPattern, enumerationOptions);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(EnumerateDirectories),
+				path, searchPattern, enumerationOptions);
 
 		return EnumerateInternal(FileSystemTypes.Directory,
 			path,
@@ -172,8 +183,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.EnumerateFiles(string)" />
 	public IEnumerable<string> EnumerateFiles(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFiles),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(EnumerateFiles),
+				path);
 
 		return EnumerateFiles(path,
 			EnumerationOptionsHelper.DefaultSearchPattern,
@@ -183,8 +195,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.EnumerateFiles(string, string)" />
 	public IEnumerable<string> EnumerateFiles(string path, string searchPattern)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFiles),
-			path, searchPattern);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(EnumerateFiles),
+				path, searchPattern);
 
 		return EnumerateFiles(path, searchPattern, SearchOption.TopDirectoryOnly);
 	}
@@ -194,8 +207,9 @@ internal sealed class DirectoryMock : IDirectory
 		string searchPattern,
 		SearchOption searchOption)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFiles),
-			path, searchPattern, searchOption);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(EnumerateFiles),
+				path, searchPattern, searchOption);
 
 		return EnumerateInternal(FileSystemTypes.File,
 			path,
@@ -209,8 +223,9 @@ internal sealed class DirectoryMock : IDirectory
 		string searchPattern,
 		EnumerationOptions enumerationOptions)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFiles),
-			path, searchPattern, enumerationOptions);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(EnumerateFiles),
+				path, searchPattern, enumerationOptions);
 
 		return EnumerateInternal(FileSystemTypes.File,
 			path,
@@ -222,8 +237,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.EnumerateFileSystemEntries(string)" />
 	public IEnumerable<string> EnumerateFileSystemEntries(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFileSystemEntries),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(EnumerateFileSystemEntries),
+				path);
 
 		return EnumerateFileSystemEntries(path,
 			EnumerationOptionsHelper.DefaultSearchPattern,
@@ -234,8 +250,9 @@ internal sealed class DirectoryMock : IDirectory
 	public IEnumerable<string> EnumerateFileSystemEntries(
 		string path, string searchPattern)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFileSystemEntries),
-			path, searchPattern);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(EnumerateFileSystemEntries),
+				path, searchPattern);
 
 		return EnumerateFileSystemEntries(path,
 			searchPattern,
@@ -247,8 +264,9 @@ internal sealed class DirectoryMock : IDirectory
 		string searchPattern,
 		SearchOption searchOption)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFileSystemEntries),
-			path, searchPattern, searchOption);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(EnumerateFileSystemEntries),
+				path, searchPattern, searchOption);
 
 		return EnumerateInternal(FileSystemTypes.DirectoryOrFile,
 			path,
@@ -262,8 +280,9 @@ internal sealed class DirectoryMock : IDirectory
 		string searchPattern,
 		EnumerationOptions enumerationOptions)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EnumerateFileSystemEntries),
-			path, searchPattern, enumerationOptions);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(EnumerateFileSystemEntries),
+				path, searchPattern, enumerationOptions);
 
 		return EnumerateInternal(FileSystemTypes.DirectoryOrFile,
 			path,
@@ -275,8 +294,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.Exists(string)" />
 	public bool Exists([NotNullWhen(true)] string? path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Exists),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(Exists),
+				path);
 
 		return DirectoryInfoMock.New(
 			_fileSystem.Storage.GetLocation(path),
@@ -286,8 +306,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetCreationTime(string)" />
 	public DateTime GetCreationTime(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetCreationTime),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetCreationTime),
+				path);
 
 		return _fileSystem.Storage.GetContainer(
 				_fileSystem.Storage.GetLocation(
@@ -298,8 +319,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetCreationTimeUtc(string)" />
 	public DateTime GetCreationTimeUtc(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetCreationTimeUtc),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetCreationTimeUtc),
+				path);
 
 		return _fileSystem.Storage.GetContainer(
 				_fileSystem.Storage.GetLocation(
@@ -310,7 +332,8 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetCurrentDirectory()" />
 	public string GetCurrentDirectory()
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetCurrentDirectory));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetCurrentDirectory));
 
 		return _fileSystem.Storage.CurrentDirectory;
 	}
@@ -318,8 +341,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetDirectories(string)" />
 	public string[] GetDirectories(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetDirectories),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetDirectories),
+				path);
 
 		return EnumerateDirectories(path).ToArray();
 	}
@@ -327,8 +351,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetDirectories(string, string)" />
 	public string[] GetDirectories(string path, string searchPattern)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetDirectories),
-			path, searchPattern);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetDirectories),
+				path, searchPattern);
 
 		return EnumerateDirectories(path, searchPattern).ToArray();
 	}
@@ -338,8 +363,9 @@ internal sealed class DirectoryMock : IDirectory
 		string searchPattern,
 		SearchOption searchOption)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetDirectories),
-			path, searchPattern, searchOption);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetDirectories),
+				path, searchPattern, searchOption);
 
 		return EnumerateDirectories(path, searchPattern, searchOption).ToArray();
 	}
@@ -350,8 +376,9 @@ internal sealed class DirectoryMock : IDirectory
 		string searchPattern,
 		EnumerationOptions enumerationOptions)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetDirectories),
-			path, searchPattern, enumerationOptions);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetDirectories),
+				path, searchPattern, enumerationOptions);
 
 		return EnumerateDirectories(path, searchPattern, enumerationOptions).ToArray();
 	}
@@ -360,8 +387,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetDirectoryRoot(string)" />
 	public string GetDirectoryRoot(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetDirectoryRoot),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetDirectoryRoot),
+				path);
 
 		return _fileSystem.Execute.Path.GetPathRoot(
 			       _fileSystem.Execute.Path.GetFullPath(path)) ??
@@ -371,8 +399,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetFiles(string)" />
 	public string[] GetFiles(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFiles),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetFiles),
+				path);
 
 		return EnumerateFiles(path).ToArray();
 	}
@@ -380,8 +409,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetFiles(string, string)" />
 	public string[] GetFiles(string path, string searchPattern)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFiles),
-			path, searchPattern);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetFiles),
+				path, searchPattern);
 
 		return EnumerateFiles(path, searchPattern).ToArray();
 	}
@@ -391,8 +421,9 @@ internal sealed class DirectoryMock : IDirectory
 		string searchPattern,
 		SearchOption searchOption)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFiles),
-			path, searchPattern, searchOption);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetFiles),
+				path, searchPattern, searchOption);
 
 		return EnumerateFiles(path, searchPattern, searchOption).ToArray();
 	}
@@ -403,8 +434,9 @@ internal sealed class DirectoryMock : IDirectory
 		string searchPattern,
 		EnumerationOptions enumerationOptions)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFiles),
-			path, searchPattern, enumerationOptions);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetFiles),
+				path, searchPattern, enumerationOptions);
 
 		return EnumerateFiles(path, searchPattern, enumerationOptions).ToArray();
 	}
@@ -413,8 +445,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetFileSystemEntries(string)" />
 	public string[] GetFileSystemEntries(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFileSystemEntries),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetFileSystemEntries),
+				path);
 
 		return EnumerateFileSystemEntries(path).ToArray();
 	}
@@ -422,8 +455,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetFileSystemEntries(string, string)" />
 	public string[] GetFileSystemEntries(string path, string searchPattern)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFileSystemEntries),
-			path, searchPattern);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetFileSystemEntries),
+				path, searchPattern);
 
 		return EnumerateFileSystemEntries(path, searchPattern).ToArray();
 	}
@@ -433,8 +467,9 @@ internal sealed class DirectoryMock : IDirectory
 		string searchPattern,
 		SearchOption searchOption)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFileSystemEntries),
-			path, searchPattern, searchOption);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetFileSystemEntries),
+				path, searchPattern, searchOption);
 
 		return EnumerateFileSystemEntries(path, searchPattern, searchOption).ToArray();
 	}
@@ -445,8 +480,9 @@ internal sealed class DirectoryMock : IDirectory
 		string searchPattern,
 		EnumerationOptions enumerationOptions)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetFileSystemEntries),
-			path, searchPattern, enumerationOptions);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetFileSystemEntries),
+				path, searchPattern, enumerationOptions);
 
 		return EnumerateFileSystemEntries(path, searchPattern, enumerationOptions)
 			.ToArray();
@@ -456,8 +492,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetLastAccessTime(string)" />
 	public DateTime GetLastAccessTime(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetLastAccessTime),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetLastAccessTime),
+				path);
 
 		return _fileSystem.Storage.GetContainer(
 				_fileSystem.Storage.GetLocation(
@@ -468,8 +505,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetLastAccessTimeUtc(string)" />
 	public DateTime GetLastAccessTimeUtc(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetLastAccessTimeUtc),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetLastAccessTimeUtc),
+				path);
 
 		return _fileSystem.Storage.GetContainer(
 				_fileSystem.Storage.GetLocation(
@@ -480,8 +518,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetLastWriteTime(string)" />
 	public DateTime GetLastWriteTime(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetLastWriteTime),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetLastWriteTime),
+				path);
 
 		return _fileSystem.Storage.GetContainer(
 				_fileSystem.Storage.GetLocation(
@@ -492,8 +531,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetLastWriteTimeUtc(string)" />
 	public DateTime GetLastWriteTimeUtc(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetLastWriteTimeUtc),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetLastWriteTimeUtc),
+				path);
 
 		return _fileSystem.Storage.GetContainer(
 				_fileSystem.Storage.GetLocation(
@@ -504,7 +544,8 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetLogicalDrives()" />
 	public string[] GetLogicalDrives()
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetLogicalDrives));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetLogicalDrives));
 
 		return _fileSystem.DriveInfo.GetDrives().Select(x => x.Name).ToArray();
 	}
@@ -512,8 +553,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.GetParent(string)" />
 	public IDirectoryInfo? GetParent(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetParent),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(GetParent),
+				path);
 
 		return _fileSystem.DirectoryInfo
 			.New(path.EnsureValidArgument(_fileSystem, nameof(path)))
@@ -523,8 +565,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.Move(string, string)" />
 	public void Move(string sourceDirName, string destDirName)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Move),
-			sourceDirName, destDirName);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(Move),
+				sourceDirName, destDirName);
 
 		_fileSystem.DirectoryInfo.New(sourceDirName
 				.EnsureValidFormat(_fileSystem, nameof(sourceDirName)))
@@ -537,8 +580,9 @@ internal sealed class DirectoryMock : IDirectory
 	public IFileSystemInfo? ResolveLinkTarget(
 		string linkPath, bool returnFinalTarget)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ResolveLinkTarget),
-			linkPath, returnFinalTarget);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(ResolveLinkTarget),
+				linkPath, returnFinalTarget);
 
 		try
 		{
@@ -558,8 +602,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.SetCreationTime(string, DateTime)" />
 	public void SetCreationTime(string path, DateTime creationTime)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetCreationTime),
-			path, creationTime);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(SetCreationTime),
+				path, creationTime);
 
 		LoadDirectoryInfoOrThrowNotFoundException(path, ThrowMissingFileCreatedTimeException)
 			.CreationTime = creationTime;
@@ -568,8 +613,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.SetCreationTimeUtc(string, DateTime)" />
 	public void SetCreationTimeUtc(string path, DateTime creationTimeUtc)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetCreationTimeUtc),
-			path, creationTimeUtc);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(SetCreationTimeUtc),
+				path, creationTimeUtc);
 
 		LoadDirectoryInfoOrThrowNotFoundException(path, ThrowMissingFileCreatedTimeException)
 			.CreationTimeUtc = creationTimeUtc;
@@ -578,8 +624,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.SetCurrentDirectory(string)" />
 	public void SetCurrentDirectory(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetCurrentDirectory),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(SetCurrentDirectory),
+				path);
 
 		IDirectoryInfo directoryInfo =
 			_fileSystem.DirectoryInfo.New(path);
@@ -595,8 +642,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.SetLastAccessTime(string, DateTime)" />
 	public void SetLastAccessTime(string path, DateTime lastAccessTime)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetLastAccessTime),
-			path, lastAccessTime);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(SetLastAccessTime),
+				path, lastAccessTime);
 
 		LoadDirectoryInfoOrThrowNotFoundException(path,
 				ThrowMissingFileLastAccessOrLastWriteTimeException)
@@ -606,8 +654,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.SetLastAccessTimeUtc(string, DateTime)" />
 	public void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetLastAccessTimeUtc),
-			path, lastAccessTimeUtc);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(SetLastAccessTimeUtc),
+				path, lastAccessTimeUtc);
 
 		LoadDirectoryInfoOrThrowNotFoundException(path,
 				ThrowMissingFileLastAccessOrLastWriteTimeException)
@@ -617,8 +666,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.SetLastWriteTime(string, DateTime)" />
 	public void SetLastWriteTime(string path, DateTime lastWriteTime)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetLastWriteTime),
-			path, lastWriteTime);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(SetLastWriteTime),
+				path, lastWriteTime);
 
 		LoadDirectoryInfoOrThrowNotFoundException(path,
 				ThrowMissingFileLastAccessOrLastWriteTimeException)
@@ -628,8 +678,9 @@ internal sealed class DirectoryMock : IDirectory
 	/// <inheritdoc cref="IDirectory.SetLastWriteTimeUtc(string, DateTime)" />
 	public void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetLastWriteTimeUtc),
-			path, lastWriteTimeUtc);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.Directory.RegisterMethod(nameof(SetLastWriteTimeUtc),
+				path, lastWriteTimeUtc);
 
 		LoadDirectoryInfoOrThrowNotFoundException(path,
 				ThrowMissingFileLastAccessOrLastWriteTimeException)
@@ -668,25 +719,6 @@ internal sealed class DirectoryMock : IDirectory
 
 		return directoryInfo;
 	}
-
-	private IDisposable RegisterMethod(string name)
-		=> _fileSystem.StatisticsRegistration.Directory.RegisterMethod(name);
-
-	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
-		=> _fileSystem.StatisticsRegistration.Directory.RegisterMethod(name,
-			parameter1);
-
-	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
-		=> _fileSystem.StatisticsRegistration.Directory.RegisterMethod(name,
-			parameter1,
-			parameter2);
-
-	private IDisposable RegisterMethod<T1, T2, T3>(string name, T1 parameter1, T2 parameter2,
-		T3 parameter3)
-		=> _fileSystem.StatisticsRegistration.Directory.RegisterMethod(name,
-			parameter1,
-			parameter2,
-			parameter3);
 
 	private static void ThrowMissingFileCreatedTimeException(MockFileSystem fileSystem, string path)
 	{

--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoFactoryMock.cs
@@ -24,7 +24,8 @@ internal sealed class DriveInfoFactoryMock : IDriveInfoFactory
 	/// <inheritdoc cref="IDriveInfoFactory.GetDrives()" />
 	public IDriveInfo[] GetDrives()
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetDrives));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DriveInfo.RegisterMethod(nameof(GetDrives));
 
 		return _fileSystem.Storage.GetDrives()
 			.Where(x => !x.IsUncPath)
@@ -36,8 +37,9 @@ internal sealed class DriveInfoFactoryMock : IDriveInfoFactory
 	/// <inheritdoc cref="IDriveInfoFactory.New(string)" />
 	public IDriveInfo New(string driveName)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			driveName);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DriveInfo.RegisterMethod(nameof(New),
+				driveName);
 
 		if (driveName == null)
 		{
@@ -53,8 +55,9 @@ internal sealed class DriveInfoFactoryMock : IDriveInfoFactory
 	[return: NotNullIfNotNull("driveInfo")]
 	public IDriveInfo? Wrap(DriveInfo? driveInfo)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Wrap),
-			driveInfo);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.DriveInfo.RegisterMethod(nameof(Wrap),
+				driveInfo);
 
 		if (_fileSystem.SimulationMode != SimulationMode.Native)
 		{
@@ -71,11 +74,4 @@ internal sealed class DriveInfoFactoryMock : IDriveInfoFactory
 	}
 
 	#endregion
-
-	private IDisposable RegisterMethod(string name)
-		=> _fileSystem.StatisticsRegistration.DriveInfo.RegisterMethod(name);
-
-	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
-		=> _fileSystem.StatisticsRegistration.DriveInfo.RegisterMethod(name,
-			parameter1);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoFactoryMock.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.FileSystem;
@@ -78,5 +77,5 @@ internal sealed class DriveInfoFactoryMock : IDriveInfoFactory
 
 	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
 		=> _fileSystem.StatisticsRegistration.DriveInfo.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1));
+			parameter1);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
@@ -68,8 +68,9 @@ internal sealed class DriveInfoMock : IStorageDrive
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(AvailableFreeSpace), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.DriveInfo
+				.RegisterPathProperty(_name, nameof(AvailableFreeSpace), PropertyAccess.Get);
 
 			return TotalFreeSpace;
 		}
@@ -80,8 +81,8 @@ internal sealed class DriveInfoMock : IStorageDrive
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(DriveFormat), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.DriveInfo.RegisterPathProperty(_name, nameof(DriveFormat), PropertyAccess.Get);
 
 			return _driveFormat;
 		}
@@ -92,8 +93,8 @@ internal sealed class DriveInfoMock : IStorageDrive
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(DriveType), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.DriveInfo.RegisterPathProperty(_name, nameof(DriveType), PropertyAccess.Get);
 
 			return _driveType;
 		}
@@ -108,7 +109,8 @@ internal sealed class DriveInfoMock : IStorageDrive
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(IsReady), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.DriveInfo.RegisterPathProperty(_name, nameof(IsReady), PropertyAccess.Get);
 
 			return _isReady;
 		}
@@ -124,7 +126,8 @@ internal sealed class DriveInfoMock : IStorageDrive
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Name), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.DriveInfo.RegisterPathProperty(_name, nameof(Name), PropertyAccess.Get);
 
 			return _name;
 		}
@@ -135,8 +138,8 @@ internal sealed class DriveInfoMock : IStorageDrive
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(RootDirectory), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.DriveInfo.RegisterPathProperty(_name, nameof(RootDirectory), PropertyAccess.Get);
 
 			return DirectoryInfoMock.New(_fileSystem.Storage.GetLocation(Name), _fileSystem);
 		}
@@ -147,8 +150,8 @@ internal sealed class DriveInfoMock : IStorageDrive
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(TotalFreeSpace), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.DriveInfo.RegisterPathProperty(_name, nameof(TotalFreeSpace), PropertyAccess.Get);
 
 			return _totalSize - _usedBytes;
 		}
@@ -159,8 +162,8 @@ internal sealed class DriveInfoMock : IStorageDrive
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(TotalSize), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.DriveInfo.RegisterPathProperty(_name, nameof(TotalSize), PropertyAccess.Get);
 
 			return _totalSize;
 		}
@@ -172,16 +175,16 @@ internal sealed class DriveInfoMock : IStorageDrive
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(VolumeLabel), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.DriveInfo.RegisterPathProperty(_name, nameof(VolumeLabel), PropertyAccess.Get);
 
 			return _volumeLabel;
 		}
 		[SupportedOSPlatform("windows")]
 		set
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(VolumeLabel), PropertyAccess.Set);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.DriveInfo.RegisterPathProperty(_name, nameof(VolumeLabel), PropertyAccess.Set);
 
 			// ReSharper disable once ConstantNullCoalescingCondition
 			_volumeLabel = value ?? _volumeLabel;
@@ -273,9 +276,6 @@ internal sealed class DriveInfoMock : IStorageDrive
 
 		return path;
 	}
-
-	private IDisposable RegisterProperty(string name, PropertyAccess access)
-		=> _fileSystem.StatisticsRegistration.DriveInfo.RegisterProperty(_name, name, access);
 
 	private static string ValidateDriveLetter(string driveName,
 		MockFileSystem fileSystem)

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoFactoryMock.cs
@@ -23,8 +23,9 @@ internal sealed class FileInfoFactoryMock : IFileInfoFactory
 	/// <inheritdoc cref="IFileInfoFactory.New(string)" />
 	public IFileInfo New(string fileName)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			fileName);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterMethod(nameof(New),
+				fileName);
 
 		if (fileName == null)
 		{
@@ -45,8 +46,9 @@ internal sealed class FileInfoFactoryMock : IFileInfoFactory
 	[return: NotNullIfNotNull("fileInfo")]
 	public IFileInfo? Wrap(FileInfo? fileInfo)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Wrap),
-			fileInfo);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterMethod(nameof(Wrap),
+				fileInfo);
 
 		if (_fileSystem.SimulationMode != SimulationMode.Native)
 		{
@@ -62,8 +64,4 @@ internal sealed class FileInfoFactoryMock : IFileInfoFactory
 	}
 
 	#endregion
-
-	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
-		=> _fileSystem.StatisticsRegistration.FileInfo.RegisterMethod(name,
-			parameter1);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoFactoryMock.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Testably.Abstractions.Testing.Helpers;
-using Testably.Abstractions.Testing.Statistics;
 
 namespace Testably.Abstractions.Testing.FileSystem;
 
@@ -66,5 +65,5 @@ internal sealed class FileInfoFactoryMock : IFileInfoFactory
 
 	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
 		=> _fileSystem.StatisticsRegistration.FileInfo.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1));
+			parameter1);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
@@ -29,8 +29,9 @@ internal sealed class FileInfoMock
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(Directory), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileInfo.RegisterPathProperty(Location.FullPath,
+					nameof(Directory), PropertyAccess.Get);
 
 			return DirectoryInfoMock.New(Location.GetParent(),
 				_fileSystem);
@@ -42,8 +43,9 @@ internal sealed class FileInfoMock
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(DirectoryName), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileInfo.RegisterPathProperty(Location.FullPath,
+					nameof(DirectoryName), PropertyAccess.Get);
 
 			return Directory?.FullName;
 		}
@@ -54,7 +56,9 @@ internal sealed class FileInfoMock
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Exists), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileInfo.RegisterPathProperty(Location.FullPath,
+					nameof(Exists), PropertyAccess.Get);
 
 			return base.Exists && FileSystemType == FileSystemTypes.File;
 		}
@@ -65,15 +69,17 @@ internal sealed class FileInfoMock
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(IsReadOnly), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileInfo.RegisterPathProperty(Location.FullPath,
+					nameof(IsReadOnly), PropertyAccess.Get);
 
 			return (Attributes & FileAttributes.ReadOnly) != 0;
 		}
 		set
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(IsReadOnly), PropertyAccess.Set);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileInfo.RegisterPathProperty(Location.FullPath,
+					nameof(IsReadOnly), PropertyAccess.Set);
 
 			if (value)
 			{
@@ -91,7 +97,9 @@ internal sealed class FileInfoMock
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Length), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileInfo.RegisterPathProperty(Location.FullPath,
+					nameof(Length), PropertyAccess.Get);
 
 			if (Container is NullContainer ||
 			    Container.Type != FileSystemTypes.File)
@@ -111,7 +119,9 @@ internal sealed class FileInfoMock
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Name), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileInfo.RegisterPathProperty(Location.FullPath,
+					nameof(Name), PropertyAccess.Get);
 
 			if (Location.FullPath.EndsWith(_fileSystem.Execute.Path.DirectorySeparatorChar))
 			{
@@ -125,7 +135,8 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.AppendText()" />
 	public StreamWriter AppendText()
 	{
-		using IDisposable registration = RegisterMethod(nameof(AppendText));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(AppendText));
 
 		return new StreamWriter(Open(FileMode.Append, FileAccess.Write));
 	}
@@ -133,8 +144,9 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.CopyTo(string)" />
 	public IFileInfo CopyTo(string destFileName)
 	{
-		using IDisposable registration = RegisterMethod(nameof(CopyTo),
-			destFileName);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(CopyTo),
+				destFileName);
 
 		destFileName.EnsureValidArgument(_fileSystem, nameof(destFileName));
 		IStorageLocation destinationLocation = _fileSystem.Storage.GetLocation(destFileName);
@@ -148,8 +160,9 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.CopyTo(string, bool)" />
 	public IFileInfo CopyTo(string destFileName, bool overwrite)
 	{
-		using IDisposable registration = RegisterMethod(nameof(CopyTo),
-			destFileName, overwrite);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(CopyTo),
+				destFileName, overwrite);
 
 		destFileName.EnsureValidArgument(_fileSystem, nameof(destFileName));
 		IStorageLocation location = _fileSystem.Storage.Copy(
@@ -163,7 +176,8 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.Create()" />
 	public FileSystemStream Create()
 	{
-		using IDisposable registration = RegisterMethod(nameof(Create));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(Create));
 
 		if (!_fileSystem.Execute.IsNetFramework)
 		{
@@ -176,7 +190,8 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.CreateText()" />
 	public StreamWriter CreateText()
 	{
-		using IDisposable registration = RegisterMethod(nameof(CreateText));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(CreateText));
 
 		StreamWriter streamWriter = new(_fileSystem.File.Create(FullName));
 #if NET8_0_OR_GREATER
@@ -189,7 +204,8 @@ internal sealed class FileInfoMock
 	[SupportedOSPlatform("windows")]
 	public void Decrypt()
 	{
-		using IDisposable registration = RegisterMethod(nameof(Decrypt));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(Decrypt));
 
 		Container.Decrypt();
 	}
@@ -198,7 +214,8 @@ internal sealed class FileInfoMock
 	[SupportedOSPlatform("windows")]
 	public void Encrypt()
 	{
-		using IDisposable registration = RegisterMethod(nameof(Encrypt));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(Encrypt));
 
 		Container.Encrypt();
 	}
@@ -206,8 +223,9 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.MoveTo(string)" />
 	public void MoveTo(string destFileName)
 	{
-		using IDisposable registration = RegisterMethod(nameof(MoveTo),
-			destFileName);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(MoveTo),
+				destFileName);
 
 		Location = _fileSystem.Storage.Move(
 			           Location,
@@ -220,8 +238,9 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.MoveTo(string, bool)" />
 	public void MoveTo(string destFileName, bool overwrite)
 	{
-		using IDisposable registration = RegisterMethod(nameof(MoveTo),
-			destFileName, overwrite);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(MoveTo),
+				destFileName, overwrite);
 
 		Location = _fileSystem.Storage.Move(
 			           Location,
@@ -235,8 +254,9 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.Open(FileMode)" />
 	public FileSystemStream Open(FileMode mode)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Open),
-			mode);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(Open),
+				mode);
 
 		if (_fileSystem.Execute.IsNetFramework && mode == FileMode.Append)
 		{
@@ -254,8 +274,9 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.Open(FileMode, FileAccess)" />
 	public FileSystemStream Open(FileMode mode, FileAccess access)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Open),
-			mode, access);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(Open),
+				mode, access);
 
 		return new FileStreamMock(
 			_fileSystem,
@@ -268,8 +289,9 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.Open(FileMode, FileAccess, FileShare)" />
 	public FileSystemStream Open(FileMode mode, FileAccess access, FileShare share)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Open),
-			mode, access, share);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(Open),
+				mode, access, share);
 
 		return new FileStreamMock(
 			_fileSystem,
@@ -283,8 +305,9 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.Open(FileStreamOptions)" />
 	public FileSystemStream Open(FileStreamOptions options)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Open),
-			options);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(Open),
+				options);
 
 		return _fileSystem.File.Open(FullName, options);
 	}
@@ -293,7 +316,8 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.OpenRead()" />
 	public FileSystemStream OpenRead()
 	{
-		using IDisposable registration = RegisterMethod(nameof(OpenRead));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(OpenRead));
 
 		return new FileStreamMock(
 			_fileSystem,
@@ -305,7 +329,8 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.OpenText()" />
 	public StreamReader OpenText()
 	{
-		using IDisposable registration = RegisterMethod(nameof(OpenText));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(OpenText));
 
 		return new StreamReader(OpenRead());
 	}
@@ -313,7 +338,8 @@ internal sealed class FileInfoMock
 	/// <inheritdoc cref="IFileInfo.OpenWrite()" />
 	public FileSystemStream OpenWrite()
 	{
-		using IDisposable registration = RegisterMethod(nameof(OpenWrite));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(OpenWrite));
 
 		return new FileStreamMock(
 			_fileSystem,
@@ -327,8 +353,9 @@ internal sealed class FileInfoMock
 	public IFileInfo Replace(string destinationFileName,
 		string? destinationBackupFileName)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Replace),
-			destinationFileName, destinationBackupFileName);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(Replace),
+				destinationFileName, destinationBackupFileName);
 
 		IStorageLocation location =
 			_fileSystem
@@ -382,8 +409,9 @@ internal sealed class FileInfoMock
 		string? destinationBackupFileName,
 		bool ignoreMetadataErrors)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Replace),
-			destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileInfo.RegisterPathMethod(Location.FullPath, nameof(Replace),
+				destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
 
 		IStorageLocation location = _fileSystem.Storage.Replace(
 			                            Location,
@@ -412,26 +440,14 @@ internal sealed class FileInfoMock
 		return new FileInfoMock(location, fileSystem);
 	}
 
-	protected override IDisposable RegisterMethod(string name)
-		=> _fileSystem.StatisticsRegistration.FileInfo.RegisterMethod(Location.FullPath, name);
+	protected override IDisposable RegisterPathMethod(string name)
+		=> _fileSystem.StatisticsRegistration.FileInfo.RegisterPathMethod(Location.FullPath, name);
 
-	protected override IDisposable RegisterMethod<T1>(string name, T1 parameter1)
-		=> _fileSystem.StatisticsRegistration.FileInfo.RegisterMethod(Location.FullPath, name,
+	protected override IDisposable RegisterPathMethod<T1>(string name, T1 parameter1)
+		=> _fileSystem.StatisticsRegistration.FileInfo.RegisterPathMethod(Location.FullPath, name,
 			parameter1);
 
-	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
-		=> _fileSystem.StatisticsRegistration.FileInfo.RegisterMethod(Location.FullPath, name,
-			parameter1,
-			parameter2);
-
-	private IDisposable RegisterMethod<T1, T2, T3>(string name, T1 parameter1, T2 parameter2,
-		T3 parameter3)
-		=> _fileSystem.StatisticsRegistration.FileInfo.RegisterMethod(Location.FullPath, name,
-			parameter1,
-			parameter2,
-			parameter3);
-
-	protected override IDisposable RegisterProperty(string name, PropertyAccess access)
-		=> _fileSystem.StatisticsRegistration.FileInfo.RegisterProperty(Location.FullPath, name,
+	protected override IDisposable RegisterPathProperty(string name, PropertyAccess access)
+		=> _fileSystem.StatisticsRegistration.FileInfo.RegisterPathProperty(Location.FullPath, name,
 			access);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileInfoMock.cs
@@ -417,19 +417,19 @@ internal sealed class FileInfoMock
 
 	protected override IDisposable RegisterMethod<T1>(string name, T1 parameter1)
 		=> _fileSystem.StatisticsRegistration.FileInfo.RegisterMethod(Location.FullPath, name,
-			ParameterDescription.FromParameter(parameter1));
+			parameter1);
 
 	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
 		=> _fileSystem.StatisticsRegistration.FileInfo.RegisterMethod(Location.FullPath, name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2));
+			parameter1,
+			parameter2);
 
 	private IDisposable RegisterMethod<T1, T2, T3>(string name, T1 parameter1, T2 parameter2,
 		T3 parameter3)
 		=> _fileSystem.StatisticsRegistration.FileInfo.RegisterMethod(Location.FullPath, name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3));
+			parameter1,
+			parameter2,
+			parameter3);
 
 	protected override IDisposable RegisterProperty(string name, PropertyAccess access)
 		=> _fileSystem.StatisticsRegistration.FileInfo.RegisterProperty(Location.FullPath, name,

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Testably.Abstractions.Testing.Helpers;
-using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Storage;
 #if FEATURE_FILESYSTEM_SAFEFILEHANDLE
 using Microsoft.Win32.SafeHandles;
@@ -1387,28 +1386,28 @@ internal sealed class FileMock : IFile
 	private IDisposable RegisterMethod<T1>(string name,
 		T1 parameter1)
 		=> _fileSystem.StatisticsRegistration.File.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1));
+			parameter1);
 
 	private IDisposable RegisterMethod<T1, T2>(string name,
 		T1 parameter1, T2 parameter2)
 		=> _fileSystem.StatisticsRegistration.File.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2));
+			parameter1,
+			parameter2);
 
 	private IDisposable RegisterMethod<T1, T2, T3>(string name,
 		T1 parameter1, T2 parameter2, T3 parameter3)
 		=> _fileSystem.StatisticsRegistration.File.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3));
+			parameter1,
+			parameter2,
+			parameter3);
 
 	private IDisposable RegisterMethod<T1, T2, T3, T4>(string name,
 		T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)
 		=> _fileSystem.StatisticsRegistration.File.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3),
-			ParameterDescription.FromParameter(parameter4));
+			parameter1,
+			parameter2,
+			parameter3,
+			parameter4);
 
 #if FEATURE_FILESYSTEM_ASYNC
 	private static void ThrowIfCancelled(CancellationToken cancellationToken)

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -12,7 +12,6 @@ using Microsoft.Win32.SafeHandles;
 #if FEATURE_FILESYSTEM_ASYNC
 using System.Threading;
 using System.Threading.Tasks;
-using System.ComponentModel;
 #endif
 
 // ReSharper disable PossibleMultipleEnumeration
@@ -36,8 +35,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.AppendAllLines(string, IEnumerable{string})" />
 	public void AppendAllLines(string path, IEnumerable<string> contents)
 	{
-		using IDisposable registration = RegisterMethod(nameof(AppendAllLines),
-			path, contents);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(AppendAllLines),
+				path, contents);
 
 		AppendAllLines(path, contents, Encoding.Default);
 	}
@@ -48,8 +48,9 @@ internal sealed class FileMock : IFile
 		IEnumerable<string> contents,
 		Encoding encoding)
 	{
-		using IDisposable registration = RegisterMethod(nameof(AppendAllLines),
-			path, contents, encoding);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(AppendAllLines),
+				path, contents, encoding);
 
 		_ = contents ?? throw new ArgumentNullException(nameof(contents));
 		_ = encoding ?? throw new ArgumentNullException(nameof(encoding));
@@ -64,8 +65,9 @@ internal sealed class FileMock : IFile
 	public Task AppendAllLinesAsync(string path, IEnumerable<string> contents,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(AppendAllLinesAsync),
-			path, contents, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(AppendAllLinesAsync),
+				path, contents, cancellationToken);
 
 		return AppendAllLinesAsync(path, contents, Encoding.Default, cancellationToken);
 	}
@@ -77,8 +79,9 @@ internal sealed class FileMock : IFile
 		Encoding encoding,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(AppendAllLinesAsync),
-			path, contents, encoding, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(AppendAllLinesAsync),
+				path, contents, encoding, cancellationToken);
 
 		ThrowIfCancelled(cancellationToken);
 		AppendAllLines(path, contents, encoding);
@@ -89,8 +92,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.AppendAllText(string, string?)" />
 	public void AppendAllText(string path, string? contents)
 	{
-		using IDisposable registration = RegisterMethod(nameof(AppendAllText),
-			path, contents);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(AppendAllText),
+				path, contents);
 
 		AppendAllText(path, contents, Encoding.Default);
 	}
@@ -98,8 +102,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.AppendAllText(string, string?, Encoding)" />
 	public void AppendAllText(string path, string? contents, Encoding encoding)
 	{
-		using IDisposable registration = RegisterMethod(nameof(AppendAllText),
-			path, contents, encoding);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(AppendAllText),
+				path, contents, encoding);
 
 		IStorageContainer container =
 			_fileSystem.Storage.GetOrCreateContainer(
@@ -133,8 +138,9 @@ internal sealed class FileMock : IFile
 	public Task AppendAllTextAsync(string path, string? contents,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(AppendAllTextAsync),
-			path, contents, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(AppendAllTextAsync),
+				path, contents, cancellationToken);
 
 		return AppendAllTextAsync(path, contents, Encoding.Default, cancellationToken);
 	}
@@ -145,8 +151,9 @@ internal sealed class FileMock : IFile
 	public Task AppendAllTextAsync(string path, string? contents, Encoding encoding,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(AppendAllTextAsync),
-			path, contents, encoding, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(AppendAllTextAsync),
+				path, contents, encoding, cancellationToken);
 
 		ThrowIfCancelled(cancellationToken);
 		AppendAllText(path, contents, encoding);
@@ -157,8 +164,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.AppendText(string)" />
 	public StreamWriter AppendText(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(AppendText),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(AppendText),
+				path);
 
 		return FileSystem.FileInfo
 			.New(path.EnsureValidFormat(_fileSystem))
@@ -168,8 +176,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.Copy(string, string)" />
 	public void Copy(string sourceFileName, string destFileName)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Copy),
-			sourceFileName, destFileName);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Copy),
+				sourceFileName, destFileName);
 
 		sourceFileName.EnsureValidFormat(_fileSystem, nameof(sourceFileName));
 		destFileName.EnsureValidFormat(_fileSystem, nameof(destFileName));
@@ -188,8 +197,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.Copy(string, string, bool)" />
 	public void Copy(string sourceFileName, string destFileName, bool overwrite)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Copy),
-			sourceFileName, destFileName, overwrite);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Copy),
+				sourceFileName, destFileName, overwrite);
 
 		if (_fileSystem.Execute.IsNetFramework)
 		{
@@ -218,8 +228,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.Create(string)" />
 	public FileSystemStream Create(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Create),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Create),
+				path);
 
 		return new FileStreamMock(
 			_fileSystem,
@@ -232,8 +243,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.Create(string, int)" />
 	public FileSystemStream Create(string path, int bufferSize)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Create),
-			path, bufferSize);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Create),
+				path, bufferSize);
 
 		return new FileStreamMock(
 			_fileSystem,
@@ -247,8 +259,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.Create(string, int, FileOptions)" />
 	public FileSystemStream Create(string path, int bufferSize, FileOptions options)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Create),
-			path, bufferSize, options);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Create),
+				path, bufferSize, options);
 
 		return new FileStreamMock(
 			_fileSystem,
@@ -265,8 +278,9 @@ internal sealed class FileMock : IFile
 	public IFileSystemInfo CreateSymbolicLink(
 		string path, string pathToTarget)
 	{
-		using IDisposable registration = RegisterMethod(nameof(CreateSymbolicLink),
-			path, pathToTarget);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(CreateSymbolicLink),
+				path, pathToTarget);
 
 		path.EnsureValidFormat(_fileSystem);
 		IFileInfo fileSystemInfo =
@@ -279,8 +293,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.CreateText(string)" />
 	public StreamWriter CreateText(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(CreateText),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(CreateText),
+				path);
 
 		return FileSystem.FileInfo
 			.New(path.EnsureValidFormat(_fileSystem))
@@ -291,8 +306,9 @@ internal sealed class FileMock : IFile
 	[SupportedOSPlatform("windows")]
 	public void Decrypt(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Decrypt),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Decrypt),
+				path);
 
 		IStorageContainer container = GetContainerFromPath(path);
 		container.Decrypt();
@@ -301,8 +317,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.Delete(string)" />
 	public void Delete(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Delete),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Delete),
+				path);
 
 		_fileSystem.Storage.DeleteContainer(
 			_fileSystem.Storage.GetLocation(
@@ -313,8 +330,9 @@ internal sealed class FileMock : IFile
 	[SupportedOSPlatform("windows")]
 	public void Encrypt(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Encrypt),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Encrypt),
+				path);
 
 		IStorageContainer container = GetContainerFromPath(path);
 		container.Encrypt();
@@ -323,8 +341,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.Exists(string?)" />
 	public bool Exists([NotNullWhen(true)] string? path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Exists),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Exists),
+				path);
 
 		if (string.IsNullOrEmpty(path))
 		{
@@ -340,8 +359,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.GetAttributes(string)" />
 	public FileAttributes GetAttributes(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetAttributes),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetAttributes),
+				path);
 
 		IStorageContainer container = _fileSystem.Storage
 			.GetContainer(_fileSystem.Storage.GetLocation(
@@ -355,8 +375,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.GetAttributes(SafeFileHandle)" />
 	public FileAttributes GetAttributes(SafeFileHandle fileHandle)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetAttributes),
-			fileHandle);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetAttributes),
+				fileHandle);
 
 		IStorageContainer container = GetContainerFromSafeFileHandle(fileHandle);
 		return container.Attributes;
@@ -366,8 +387,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.GetCreationTime(string)" />
 	public DateTime GetCreationTime(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetCreationTime),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetCreationTime),
+				path);
 
 		return _fileSystem.Storage.GetContainer(
 				_fileSystem.Storage.GetLocation(
@@ -379,8 +401,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.GetCreationTime(SafeFileHandle)" />
 	public DateTime GetCreationTime(SafeFileHandle fileHandle)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetCreationTime),
-			fileHandle);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetCreationTime),
+				fileHandle);
 
 		return GetContainerFromSafeFileHandle(fileHandle)
 			.CreationTime.Get(DateTimeKind.Local);
@@ -390,8 +413,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.GetCreationTimeUtc(string)" />
 	public DateTime GetCreationTimeUtc(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetCreationTimeUtc),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetCreationTimeUtc),
+				path);
 
 		return _fileSystem.Storage.GetContainer(
 				_fileSystem.Storage.GetLocation(
@@ -403,8 +427,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.GetCreationTimeUtc(SafeFileHandle)" />
 	public DateTime GetCreationTimeUtc(SafeFileHandle fileHandle)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetCreationTimeUtc),
-			fileHandle);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetCreationTimeUtc),
+				fileHandle);
 
 		return GetContainerFromSafeFileHandle(fileHandle)
 			.CreationTime.Get(DateTimeKind.Utc);
@@ -414,8 +439,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.GetLastAccessTime(string)" />
 	public DateTime GetLastAccessTime(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetLastAccessTime),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetLastAccessTime),
+				path);
 
 		return _fileSystem.Storage.GetContainer(
 				_fileSystem.Storage.GetLocation(
@@ -427,8 +453,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.GetLastAccessTime(SafeFileHandle)" />
 	public DateTime GetLastAccessTime(SafeFileHandle fileHandle)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetLastAccessTime),
-			fileHandle);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetLastAccessTime),
+				fileHandle);
 
 		return GetContainerFromSafeFileHandle(fileHandle)
 			.LastAccessTime.Get(DateTimeKind.Local);
@@ -438,8 +465,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.GetLastAccessTimeUtc(string)" />
 	public DateTime GetLastAccessTimeUtc(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetLastAccessTimeUtc),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetLastAccessTimeUtc),
+				path);
 
 		return _fileSystem.Storage.GetContainer(
 				_fileSystem.Storage.GetLocation(
@@ -451,8 +479,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.GetLastAccessTimeUtc(SafeFileHandle)" />
 	public DateTime GetLastAccessTimeUtc(SafeFileHandle fileHandle)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetLastAccessTimeUtc),
-			fileHandle);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetLastAccessTimeUtc),
+				fileHandle);
 
 		return GetContainerFromSafeFileHandle(fileHandle)
 			.LastAccessTime.Get(DateTimeKind.Utc);
@@ -462,8 +491,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.GetLastWriteTime(string)" />
 	public DateTime GetLastWriteTime(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetLastWriteTime),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetLastWriteTime),
+				path);
 
 		return _fileSystem.Storage.GetContainer(
 				_fileSystem.Storage.GetLocation(
@@ -475,8 +505,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.GetLastWriteTime(SafeFileHandle)" />
 	public DateTime GetLastWriteTime(SafeFileHandle fileHandle)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetLastWriteTime),
-			fileHandle);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetLastWriteTime),
+				fileHandle);
 
 		return GetContainerFromSafeFileHandle(fileHandle)
 			.LastWriteTime.Get(DateTimeKind.Local);
@@ -486,8 +517,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.GetLastWriteTimeUtc(string)" />
 	public DateTime GetLastWriteTimeUtc(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetLastWriteTimeUtc),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetLastWriteTimeUtc),
+				path);
 
 		return _fileSystem.Storage.GetContainer(
 				_fileSystem.Storage.GetLocation(
@@ -499,8 +531,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.GetLastWriteTimeUtc(SafeFileHandle)" />
 	public DateTime GetLastWriteTimeUtc(SafeFileHandle fileHandle)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetLastWriteTimeUtc),
-			fileHandle);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetLastWriteTimeUtc),
+				fileHandle);
 
 		return GetContainerFromSafeFileHandle(fileHandle)
 			.LastWriteTime.Get(DateTimeKind.Utc);
@@ -512,8 +545,9 @@ internal sealed class FileMock : IFile
 	[UnsupportedOSPlatform("windows")]
 	public UnixFileMode GetUnixFileMode(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetUnixFileMode),
-		path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetUnixFileMode),
+				path);
 
 		if (_fileSystem.Execute.IsWindows)
 		{
@@ -533,8 +567,9 @@ internal sealed class FileMock : IFile
 	[UnsupportedOSPlatform("windows")]
 	public UnixFileMode GetUnixFileMode(SafeFileHandle fileHandle)
 	{
-		using IDisposable registration = RegisterMethod(nameof(GetUnixFileMode),
-			fileHandle);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(GetUnixFileMode),
+				fileHandle);
 
 		if (_fileSystem.Execute.IsWindows)
 		{
@@ -548,8 +583,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.Move(string, string)" />
 	public void Move(string sourceFileName, string destFileName)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Move),
-			sourceFileName, destFileName);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Move),
+				sourceFileName, destFileName);
 
 		_fileSystem.FileInfo.New(sourceFileName
 				.EnsureValidFormat(_fileSystem, nameof(sourceFileName)))
@@ -561,8 +597,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.Move(string, string, bool)" />
 	public void Move(string sourceFileName, string destFileName, bool overwrite)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Move),
-			sourceFileName, destFileName, overwrite);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Move),
+				sourceFileName, destFileName, overwrite);
 
 		_fileSystem.FileInfo.New(sourceFileName
 				.EnsureValidFormat(_fileSystem, nameof(sourceFileName)))
@@ -574,8 +611,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.Open(string, FileMode)" />
 	public FileSystemStream Open(string path, FileMode mode)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Open),
-			path, mode);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Open),
+				path, mode);
 
 		return new FileStreamMock(
 			_fileSystem,
@@ -588,8 +626,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.Open(string, FileMode, FileAccess)" />
 	public FileSystemStream Open(string path, FileMode mode, FileAccess access)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Open),
-			path, mode, access);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Open),
+				path, mode, access);
 
 		return new FileStreamMock(
 			_fileSystem,
@@ -606,8 +645,9 @@ internal sealed class FileMock : IFile
 		FileAccess access,
 		FileShare share)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Open),
-			path, mode, access, share);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Open),
+				path, mode, access, share);
 
 		return new FileStreamMock(
 			_fileSystem,
@@ -621,8 +661,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.Open(string, FileStreamOptions)" />
 	public FileSystemStream Open(string path, FileStreamOptions options)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Open),
-			path, options);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Open),
+				path, options);
 
 		return new FileStreamMock(
 			_fileSystem,
@@ -638,8 +679,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.OpenRead(string)" />
 	public FileSystemStream OpenRead(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(OpenRead),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(OpenRead),
+				path);
 
 		return new FileStreamMock(
 			_fileSystem,
@@ -651,8 +693,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.OpenText(string)" />
 	public StreamReader OpenText(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(OpenText),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(OpenText),
+				path);
 
 		return FileSystem.FileInfo
 			.New(path.EnsureValidFormat(_fileSystem))
@@ -662,8 +705,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.OpenWrite(string)" />
 	public FileSystemStream OpenWrite(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(OpenWrite),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(OpenWrite),
+				path);
 
 		return new FileStreamMock(
 			_fileSystem,
@@ -676,8 +720,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.ReadAllBytes(string)" />
 	public byte[] ReadAllBytes(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadAllBytes),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ReadAllBytes),
+				path);
 
 		IStorageContainer container = GetContainerFromPath(path);
 		using (container.RequestAccess(
@@ -698,8 +743,9 @@ internal sealed class FileMock : IFile
 	public Task<byte[]> ReadAllBytesAsync(string path,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadAllBytesAsync),
-			path, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ReadAllBytesAsync),
+				path, cancellationToken);
 
 		ThrowIfCancelled(cancellationToken);
 		return Task.FromResult(ReadAllBytes(path));
@@ -709,8 +755,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.ReadAllLines(string)" />
 	public string[] ReadAllLines(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadAllLines),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ReadAllLines),
+				path);
 
 		return ReadAllLines(path, Encoding.Default);
 	}
@@ -718,8 +765,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.ReadAllLines(string, Encoding)" />
 	public string[] ReadAllLines(string path, Encoding encoding)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadAllLines),
-			path, encoding);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ReadAllLines),
+				path, encoding);
 
 		return ReadLines(path, encoding).ToArray();
 	}
@@ -730,8 +778,9 @@ internal sealed class FileMock : IFile
 		string path,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadAllLinesAsync),
-			path, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ReadAllLinesAsync),
+				path, cancellationToken);
 
 		return ReadAllLinesAsync(path, Encoding.Default, cancellationToken);
 	}
@@ -744,8 +793,9 @@ internal sealed class FileMock : IFile
 		Encoding encoding,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadAllLinesAsync),
-			path, encoding, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ReadAllLinesAsync),
+				path, encoding, cancellationToken);
 
 		ThrowIfCancelled(cancellationToken);
 		return Task.FromResult(ReadAllLines(path, encoding));
@@ -755,8 +805,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.ReadAllText(string)" />
 	public string ReadAllText(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadAllText),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ReadAllText),
+				path);
 
 		return ReadAllText(path, Encoding.Default);
 	}
@@ -764,8 +815,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.ReadAllText(string, Encoding)" />
 	public string ReadAllText(string path, Encoding encoding)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadAllText),
-			path, encoding);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ReadAllText),
+				path, encoding);
 
 		IStorageContainer container = GetContainerFromPath(path);
 		using (container.RequestAccess(
@@ -791,8 +843,9 @@ internal sealed class FileMock : IFile
 		string path,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadAllTextAsync),
-			path, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ReadAllTextAsync),
+				path, cancellationToken);
 
 		return ReadAllTextAsync(path, Encoding.Default, cancellationToken);
 	}
@@ -805,8 +858,9 @@ internal sealed class FileMock : IFile
 		Encoding encoding,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadAllTextAsync),
-			path, encoding, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ReadAllTextAsync),
+				path, encoding, cancellationToken);
 
 		ThrowIfCancelled(cancellationToken);
 		return Task.FromResult(ReadAllText(path, encoding));
@@ -816,8 +870,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.ReadLines(string)" />
 	public IEnumerable<string> ReadLines(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadLines),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ReadLines),
+				path);
 
 		return ReadLines(path, Encoding.Default);
 	}
@@ -825,8 +880,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.ReadLines(string, Encoding)" />
 	public IEnumerable<string> ReadLines(string path, Encoding encoding)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadLines),
-			path, encoding);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ReadLines),
+				path, encoding);
 
 		return EnumerateLines(ReadAllText(path, encoding));
 	}
@@ -836,8 +892,9 @@ internal sealed class FileMock : IFile
 	public IAsyncEnumerable<string> ReadLinesAsync(string path,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadLinesAsync),
-			path, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ReadLinesAsync),
+				path, cancellationToken);
 
 		ThrowIfCancelled(cancellationToken);
 		return ReadAllLines(path).ToAsyncEnumerable();
@@ -849,8 +906,9 @@ internal sealed class FileMock : IFile
 	public IAsyncEnumerable<string> ReadLinesAsync(string path, Encoding encoding,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadLinesAsync),
-			path, encoding, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ReadLinesAsync),
+				path, encoding, cancellationToken);
 
 		ThrowIfCancelled(cancellationToken);
 		return ReadAllLines(path, encoding).ToAsyncEnumerable();
@@ -862,8 +920,9 @@ internal sealed class FileMock : IFile
 		string destinationFileName,
 		string? destinationBackupFileName)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Replace),
-			sourceFileName, destinationFileName, destinationBackupFileName);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Replace),
+				sourceFileName, destinationFileName, destinationBackupFileName);
 
 		_fileSystem.FileInfo.New(sourceFileName
 				.EnsureValidFormat(_fileSystem, nameof(sourceFileName)))
@@ -878,8 +937,10 @@ internal sealed class FileMock : IFile
 		string? destinationBackupFileName,
 		bool ignoreMetadataErrors)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Replace),
-			sourceFileName, destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(Replace),
+				sourceFileName, destinationFileName, destinationBackupFileName,
+				ignoreMetadataErrors);
 
 		_fileSystem.FileInfo.New(sourceFileName
 				.EnsureValidFormat(_fileSystem, nameof(sourceFileName)))
@@ -894,8 +955,9 @@ internal sealed class FileMock : IFile
 	public IFileSystemInfo? ResolveLinkTarget(
 		string linkPath, bool returnFinalTarget)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ResolveLinkTarget),
-			linkPath, returnFinalTarget);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(ResolveLinkTarget),
+				linkPath, returnFinalTarget);
 
 		IStorageLocation location =
 			_fileSystem.Storage.GetLocation(linkPath
@@ -933,8 +995,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.SetAttributes(string, FileAttributes)" />
 	public void SetAttributes(string path, FileAttributes fileAttributes)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetAttributes),
-			path, fileAttributes);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetAttributes),
+				path, fileAttributes);
 
 		IStorageContainer container = GetContainerFromPath(path);
 		container.Attributes = fileAttributes;
@@ -944,8 +1007,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.SetAttributes(SafeFileHandle, FileAttributes)" />
 	public void SetAttributes(SafeFileHandle fileHandle, FileAttributes fileAttributes)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetAttributes),
-			fileHandle, fileAttributes);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetAttributes),
+				fileHandle, fileAttributes);
 
 		IStorageContainer container = GetContainerFromSafeFileHandle(fileHandle);
 		container.Attributes = fileAttributes;
@@ -955,8 +1019,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.SetCreationTime(string, DateTime)" />
 	public void SetCreationTime(string path, DateTime creationTime)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetCreationTime),
-			path, creationTime);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetCreationTime),
+				path, creationTime);
 
 		IStorageContainer container =
 			GetContainerFromPath(path, ExceptionMode.FileNotFoundExceptionOnLinuxAndMac);
@@ -967,8 +1032,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.SetCreationTime(SafeFileHandle, DateTime)" />
 	public void SetCreationTime(SafeFileHandle fileHandle, DateTime creationTime)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetCreationTime),
-			fileHandle, creationTime);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetCreationTime),
+				fileHandle, creationTime);
 
 		IStorageContainer container = GetContainerFromSafeFileHandle(fileHandle);
 		container.CreationTime.Set(creationTime, DateTimeKind.Local);
@@ -978,8 +1044,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.SetCreationTimeUtc(string, DateTime)" />
 	public void SetCreationTimeUtc(string path, DateTime creationTimeUtc)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetCreationTimeUtc),
-			path, creationTimeUtc);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetCreationTimeUtc),
+				path, creationTimeUtc);
 
 		IStorageContainer container =
 			GetContainerFromPath(path, ExceptionMode.FileNotFoundExceptionOnLinuxAndMac);
@@ -990,8 +1057,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.SetCreationTimeUtc(SafeFileHandle, DateTime)" />
 	public void SetCreationTimeUtc(SafeFileHandle fileHandle, DateTime creationTimeUtc)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetCreationTimeUtc),
-			fileHandle, creationTimeUtc);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetCreationTimeUtc),
+				fileHandle, creationTimeUtc);
 
 		IStorageContainer container = GetContainerFromSafeFileHandle(fileHandle);
 		container.CreationTime.Set(creationTimeUtc, DateTimeKind.Utc);
@@ -1001,8 +1069,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.SetLastAccessTime(string, DateTime)" />
 	public void SetLastAccessTime(string path, DateTime lastAccessTime)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetLastAccessTime),
-			path, lastAccessTime);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetLastAccessTime),
+				path, lastAccessTime);
 
 		IStorageContainer container =
 			GetContainerFromPath(path, ExceptionMode.FileNotFoundExceptionOnLinuxAndMac);
@@ -1013,8 +1082,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.SetLastAccessTime(SafeFileHandle, DateTime)" />
 	public void SetLastAccessTime(SafeFileHandle fileHandle, DateTime lastAccessTime)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetLastAccessTime),
-			fileHandle, lastAccessTime);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetLastAccessTime),
+				fileHandle, lastAccessTime);
 
 		IStorageContainer container = GetContainerFromSafeFileHandle(fileHandle);
 		container.LastAccessTime.Set(lastAccessTime, DateTimeKind.Local);
@@ -1024,8 +1094,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.SetLastAccessTimeUtc(string, DateTime)" />
 	public void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetLastAccessTimeUtc),
-			path, lastAccessTimeUtc);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetLastAccessTimeUtc),
+				path, lastAccessTimeUtc);
 
 		IStorageContainer container =
 			GetContainerFromPath(path, ExceptionMode.FileNotFoundExceptionOnLinuxAndMac);
@@ -1036,8 +1107,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.SetLastAccessTimeUtc(SafeFileHandle, DateTime)" />
 	public void SetLastAccessTimeUtc(SafeFileHandle fileHandle, DateTime lastAccessTimeUtc)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetLastAccessTimeUtc),
-			fileHandle, lastAccessTimeUtc);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetLastAccessTimeUtc),
+				fileHandle, lastAccessTimeUtc);
 
 		IStorageContainer container = GetContainerFromSafeFileHandle(fileHandle);
 		container.LastAccessTime.Set(lastAccessTimeUtc, DateTimeKind.Utc);
@@ -1047,8 +1119,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.SetLastWriteTime(string, DateTime)" />
 	public void SetLastWriteTime(string path, DateTime lastWriteTime)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetLastWriteTime),
-			path, lastWriteTime);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetLastWriteTime),
+				path, lastWriteTime);
 
 		IStorageContainer container =
 			GetContainerFromPath(path, ExceptionMode.FileNotFoundExceptionOnLinuxAndMac);
@@ -1059,8 +1132,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.SetLastWriteTime(SafeFileHandle, DateTime)" />
 	public void SetLastWriteTime(SafeFileHandle fileHandle, DateTime lastWriteTime)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetLastWriteTime),
-			fileHandle, lastWriteTime);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetLastWriteTime),
+				fileHandle, lastWriteTime);
 
 		IStorageContainer container = GetContainerFromSafeFileHandle(fileHandle);
 		container.LastWriteTime.Set(lastWriteTime, DateTimeKind.Local);
@@ -1070,8 +1144,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.SetLastWriteTimeUtc(string, DateTime)" />
 	public void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetLastWriteTimeUtc),
-			path, lastWriteTimeUtc);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetLastWriteTimeUtc),
+				path, lastWriteTimeUtc);
 
 		IStorageContainer container =
 			GetContainerFromPath(path, ExceptionMode.FileNotFoundExceptionOnLinuxAndMac);
@@ -1082,8 +1157,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.SetLastWriteTimeUtc(SafeFileHandle, DateTime)" />
 	public void SetLastWriteTimeUtc(SafeFileHandle fileHandle, DateTime lastWriteTimeUtc)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetLastWriteTimeUtc),
-			fileHandle, lastWriteTimeUtc);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetLastWriteTimeUtc),
+				fileHandle, lastWriteTimeUtc);
 
 		IStorageContainer container = GetContainerFromSafeFileHandle(fileHandle);
 		container.LastWriteTime.Set(lastWriteTimeUtc, DateTimeKind.Utc);
@@ -1095,8 +1171,9 @@ internal sealed class FileMock : IFile
 	[UnsupportedOSPlatform("windows")]
 	public void SetUnixFileMode(string path, UnixFileMode mode)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetUnixFileMode),
-			path, mode);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetUnixFileMode),
+				path, mode);
 
 		if (_fileSystem.Execute.IsWindows)
 		{
@@ -1113,8 +1190,9 @@ internal sealed class FileMock : IFile
 	[UnsupportedOSPlatform("windows")]
 	public void SetUnixFileMode(SafeFileHandle fileHandle, UnixFileMode mode)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetUnixFileMode),
-			fileHandle, mode);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(SetUnixFileMode),
+				fileHandle, mode);
 
 		if (_fileSystem.Execute.IsWindows)
 		{
@@ -1129,8 +1207,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.WriteAllBytes(string, byte[])" />
 	public void WriteAllBytes(string path, byte[] bytes)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteAllBytes),
-			path, bytes);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(WriteAllBytes),
+				path, bytes);
 
 		_ = bytes ?? throw new ArgumentNullException(nameof(bytes));
 		IStorageContainer container =
@@ -1167,8 +1246,9 @@ internal sealed class FileMock : IFile
 	public Task WriteAllBytesAsync(string path, byte[] bytes,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteAllBytesAsync),
-			path, bytes, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(WriteAllBytesAsync),
+				path, bytes, cancellationToken);
 
 		ThrowIfCancelled(cancellationToken);
 		WriteAllBytes(path, bytes);
@@ -1179,8 +1259,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.WriteAllLines(string, string[])" />
 	public void WriteAllLines(string path, string[] contents)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteAllLines),
-			path, contents);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(WriteAllLines),
+				path, contents);
 
 		WriteAllLines(path, contents, Encoding.Default);
 	}
@@ -1188,8 +1269,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.WriteAllLines(string, IEnumerable{string})" />
 	public void WriteAllLines(string path, IEnumerable<string> contents)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteAllLines),
-			path, contents);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(WriteAllLines),
+				path, contents);
 
 		WriteAllLines(path, contents, Encoding.Default);
 	}
@@ -1200,8 +1282,9 @@ internal sealed class FileMock : IFile
 		string[] contents,
 		Encoding encoding)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteAllLines),
-			path, contents, encoding);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(WriteAllLines),
+				path, contents, encoding);
 
 		WriteAllLines(path, contents.AsEnumerable(), encoding);
 	}
@@ -1212,8 +1295,9 @@ internal sealed class FileMock : IFile
 		IEnumerable<string> contents,
 		Encoding encoding)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteAllLines),
-			path, contents, encoding);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(WriteAllLines),
+				path, contents, encoding);
 
 		WriteAllText(
 			path,
@@ -1228,8 +1312,9 @@ internal sealed class FileMock : IFile
 		IEnumerable<string> contents,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteAllLinesAsync),
-			path, contents, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(WriteAllLinesAsync),
+				path, contents, cancellationToken);
 
 		return WriteAllLinesAsync(path, contents, Encoding.Default, cancellationToken);
 	}
@@ -1243,8 +1328,9 @@ internal sealed class FileMock : IFile
 		Encoding encoding,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteAllLinesAsync),
-			path, contents, encoding, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(WriteAllLinesAsync),
+				path, contents, encoding, cancellationToken);
 
 		ThrowIfCancelled(cancellationToken);
 		WriteAllLines(path, contents, encoding);
@@ -1255,8 +1341,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.WriteAllText(string, string?)" />
 	public void WriteAllText(string path, string? contents)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteAllText),
-			path, contents);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(WriteAllText),
+				path, contents);
 
 		WriteAllText(path, contents, Encoding.Default);
 	}
@@ -1264,8 +1351,9 @@ internal sealed class FileMock : IFile
 	/// <inheritdoc cref="IFile.WriteAllText(string, string?, Encoding)" />
 	public void WriteAllText(string path, string? contents, Encoding encoding)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteAllText),
-			path, contents, encoding);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(WriteAllText),
+				path, contents, encoding);
 
 		IStorageContainer container =
 			_fileSystem.Storage.GetOrCreateContainer(
@@ -1284,8 +1372,8 @@ internal sealed class FileMock : IFile
 
 		if (contents != null)
 		{
-
-			if (_fileSystem.Execute.IsWindows && container.Attributes.HasFlag(FileAttributes.Hidden))
+			if (_fileSystem.Execute.IsWindows &&
+			    container.Attributes.HasFlag(FileAttributes.Hidden))
 			{
 				throw ExceptionFactory.AccessToPathDenied();
 			}
@@ -1305,8 +1393,9 @@ internal sealed class FileMock : IFile
 	public Task WriteAllTextAsync(string path, string? contents,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteAllTextAsync),
-			path, contents, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(WriteAllTextAsync),
+				path, contents, cancellationToken);
 
 		return WriteAllTextAsync(path, contents, Encoding.Default, cancellationToken);
 	}
@@ -1317,8 +1406,9 @@ internal sealed class FileMock : IFile
 	public Task WriteAllTextAsync(string path, string? contents, Encoding encoding,
 		CancellationToken cancellationToken = default)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteAllTextAsync),
-			path, contents, encoding, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.File.RegisterMethod(nameof(WriteAllTextAsync),
+				path, contents, encoding, cancellationToken);
 
 		ThrowIfCancelled(cancellationToken);
 		WriteAllText(path, contents, encoding);
@@ -1382,32 +1472,6 @@ internal sealed class FileMock : IFile
 		return container;
 	}
 #endif
-
-	private IDisposable RegisterMethod<T1>(string name,
-		T1 parameter1)
-		=> _fileSystem.StatisticsRegistration.File.RegisterMethod(name,
-			parameter1);
-
-	private IDisposable RegisterMethod<T1, T2>(string name,
-		T1 parameter1, T2 parameter2)
-		=> _fileSystem.StatisticsRegistration.File.RegisterMethod(name,
-			parameter1,
-			parameter2);
-
-	private IDisposable RegisterMethod<T1, T2, T3>(string name,
-		T1 parameter1, T2 parameter2, T3 parameter3)
-		=> _fileSystem.StatisticsRegistration.File.RegisterMethod(name,
-			parameter1,
-			parameter2,
-			parameter3);
-
-	private IDisposable RegisterMethod<T1, T2, T3, T4>(string name,
-		T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)
-		=> _fileSystem.StatisticsRegistration.File.RegisterMethod(name,
-			parameter1,
-			parameter2,
-			parameter3,
-			parameter4);
 
 #if FEATURE_FILESYSTEM_ASYNC
 	private static void ThrowIfCancelled(CancellationToken cancellationToken)

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
@@ -200,7 +200,7 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 	/// <inheritdoc cref="IFileStreamFactory.Wrap(FileStream)" />
 	public FileSystemStream Wrap(FileStream fileStream)
 	{
-		using IDisposable registration = _fileSystem.StatisticsRegistration
+		_fileSystem.StatisticsRegistration
 			.FileStream.RegisterMethod(nameof(Wrap), fileStream);
 		throw ExceptionFactory.NotSupportedFileStreamWrapping();
 	}

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
@@ -2,7 +2,6 @@
 using System;
 using System.IO;
 using Testably.Abstractions.Testing.Helpers;
-using Testably.Abstractions.Testing.Statistics;
 #if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
@@ -199,44 +198,44 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 
 	private void RegisterMethod<T1>(string name, T1 parameter1)
 		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1));
+			parameter1);
 
 	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
 		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2));
+			parameter1,
+			parameter2);
 
 	private IDisposable RegisterMethod<T1, T2, T3>(string name, T1 parameter1, T2 parameter2,
 		T3 parameter3)
 		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3));
+			parameter1,
+			parameter2,
+			parameter3);
 
 	private IDisposable RegisterMethod<T1, T2, T3, T4>(string name, T1 parameter1, T2 parameter2,
 		T3 parameter3, T4 parameter4)
 		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3),
-			ParameterDescription.FromParameter(parameter4));
+			parameter1,
+			parameter2,
+			parameter3,
+			parameter4);
 
 	private IDisposable RegisterMethod<T1, T2, T3, T4, T5>(string name, T1 parameter1,
 		T2 parameter2, T3 parameter3, T4 parameter4, T5 parameter5)
 		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3),
-			ParameterDescription.FromParameter(parameter4),
-			ParameterDescription.FromParameter(parameter5));
+			parameter1,
+			parameter2,
+			parameter3,
+			parameter4,
+			parameter5);
 
 	private IDisposable RegisterMethod<T1, T2, T3, T4, T5, T6>(string name, T1 parameter1,
 		T2 parameter2, T3 parameter3, T4 parameter4, T5 parameter5, T6 parameter6)
 		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3),
-			ParameterDescription.FromParameter(parameter4),
-			ParameterDescription.FromParameter(parameter5),
-			ParameterDescription.FromParameter(parameter6));
+			parameter1,
+			parameter2,
+			parameter3,
+			parameter4,
+			parameter5,
+			parameter6);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
@@ -29,8 +29,9 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 	/// <inheritdoc cref="IFileStreamFactory.New(string, FileMode)" />
 	public FileSystemStream New(string path, FileMode mode)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			path, mode);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterMethod(nameof(New),
+				path, mode);
 
 		return New(path,
 			mode,
@@ -43,8 +44,9 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 	/// <inheritdoc cref="IFileStreamFactory.New(string, FileMode, FileAccess)" />
 	public FileSystemStream New(string path, FileMode mode, FileAccess access)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			path, mode, access);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterMethod(nameof(New),
+				path, mode, access);
 
 		return New(path, mode, access, DefaultShare, DefaultBufferSize, DefaultUseAsync);
 	}
@@ -55,8 +57,9 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 		FileAccess access,
 		FileShare share)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			path, mode, access, share);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterMethod(nameof(New),
+				path, mode, access, share);
 
 		return New(path, mode, access, share, DefaultBufferSize, DefaultUseAsync);
 	}
@@ -68,8 +71,9 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 		FileShare share,
 		int bufferSize)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			path, mode, access, share, bufferSize);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterMethod(nameof(New),
+				path, mode, access, share, bufferSize);
 
 		return New(path, mode, access, share, bufferSize, DefaultUseAsync);
 	}
@@ -82,8 +86,9 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 		int bufferSize,
 		bool useAsync)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			path, mode, access, share, bufferSize, useAsync);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterMethod(nameof(New),
+				path, mode, access, share, bufferSize, useAsync);
 
 		return New(path,
 			mode,
@@ -101,8 +106,9 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 		int bufferSize,
 		FileOptions options)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			path, mode, access, share, bufferSize, options);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterMethod(nameof(New),
+				path, mode, access, share, bufferSize, options);
 
 		return new FileStreamMock(_fileSystem,
 			path,
@@ -119,8 +125,9 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 #endif
 	public FileSystemStream New(SafeFileHandle handle, FileAccess access)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			handle, access);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterMethod(nameof(New),
+				handle, access);
 
 		SafeFileHandleMock safeFileHandleMock = _fileSystem
 			.SafeFileHandleStrategy.MapSafeFileHandle(handle);
@@ -137,8 +144,9 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 #endif
 	public FileSystemStream New(SafeFileHandle handle, FileAccess access, int bufferSize)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			handle, access, bufferSize);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterMethod(nameof(New),
+				handle, access, bufferSize);
 
 		SafeFileHandleMock safeFileHandleMock = _fileSystem
 			.SafeFileHandleStrategy.MapSafeFileHandle(handle);
@@ -157,8 +165,9 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 	public FileSystemStream New(SafeFileHandle handle, FileAccess access, int bufferSize,
 		bool isAsync)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			handle, access, bufferSize, isAsync);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterMethod(nameof(New),
+				handle, access, bufferSize, isAsync);
 
 		SafeFileHandleMock safeFileHandleMock = _fileSystem
 			.SafeFileHandleStrategy.MapSafeFileHandle(handle);
@@ -175,8 +184,9 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 	/// <inheritdoc cref="IFileStreamFactory.New(string, FileStreamOptions)" />
 	public FileSystemStream New(string path, FileStreamOptions options)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			path, options);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterMethod(nameof(New),
+				path, options);
 
 		return New(path,
 			options.Mode,
@@ -190,52 +200,10 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 	/// <inheritdoc cref="IFileStreamFactory.Wrap(FileStream)" />
 	public FileSystemStream Wrap(FileStream fileStream)
 	{
-		RegisterMethod(nameof(Wrap), fileStream);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterMethod(nameof(Wrap), fileStream);
 		throw ExceptionFactory.NotSupportedFileStreamWrapping();
 	}
 
 	#endregion
-
-	private void RegisterMethod<T1>(string name, T1 parameter1)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(name,
-			parameter1);
-
-	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(name,
-			parameter1,
-			parameter2);
-
-	private IDisposable RegisterMethod<T1, T2, T3>(string name, T1 parameter1, T2 parameter2,
-		T3 parameter3)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(name,
-			parameter1,
-			parameter2,
-			parameter3);
-
-	private IDisposable RegisterMethod<T1, T2, T3, T4>(string name, T1 parameter1, T2 parameter2,
-		T3 parameter3, T4 parameter4)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(name,
-			parameter1,
-			parameter2,
-			parameter3,
-			parameter4);
-
-	private IDisposable RegisterMethod<T1, T2, T3, T4, T5>(string name, T1 parameter1,
-		T2 parameter2, T3 parameter3, T4 parameter4, T5 parameter5)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(name,
-			parameter1,
-			parameter2,
-			parameter3,
-			parameter4,
-			parameter5);
-
-	private IDisposable RegisterMethod<T1, T2, T3, T4, T5, T6>(string name, T1 parameter1,
-		T2 parameter2, T3 parameter3, T4 parameter4, T5 parameter5, T6 parameter6)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(name,
-			parameter1,
-			parameter2,
-			parameter3,
-			parameter4,
-			parameter5,
-			parameter6);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -659,7 +659,7 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 
 	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
 		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(_location.FullPath, name,
-			ParameterDescription.FromParameter(parameter1));
+			parameter1);
 
 #if FEATURE_SPAN
 	private IDisposable RegisterMethod<T1>(string name, Span<T1> parameter1)
@@ -675,32 +675,32 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 
 	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
 		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(_location.FullPath, name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2));
+			parameter1,
+			parameter2);
 
 	private IDisposable RegisterMethod<T1, T2, T3>(string name, T1 parameter1, T2 parameter2,
 		T3 parameter3)
 		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(_location.FullPath, name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3));
+			parameter1,
+			parameter2,
+			parameter3);
 
 	private IDisposable RegisterMethod<T1, T2, T3, T4>(string name, T1 parameter1, T2 parameter2,
 		T3 parameter3, T4 parameter4)
 		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(_location.FullPath, name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3),
-			ParameterDescription.FromParameter(parameter4));
+			parameter1,
+			parameter2,
+			parameter3,
+			parameter4);
 
 	private IDisposable RegisterMethod<T1, T2, T3, T4, T5>(string name, T1 parameter1,
 		T2 parameter2, T3 parameter3, T4 parameter4, T5 parameter5)
 		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(_location.FullPath, name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3),
-			ParameterDescription.FromParameter(parameter4),
-			ParameterDescription.FromParameter(parameter5));
+			parameter1,
+			parameter2,
+			parameter3,
+			parameter4,
+			parameter5);
 
 	private IDisposable RegisterProperty(string name, PropertyAccess access)
 		=> _fileSystem.StatisticsRegistration.FileStream.RegisterProperty(_location.FullPath, name,

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -20,7 +20,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(CanRead), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileStream.RegisterPathProperty(_location.FullPath,
+					nameof(CanRead), PropertyAccess.Get);
 
 			return _access.HasFlag(FileAccess.Read);
 		}
@@ -31,7 +33,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(CanSeek), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileStream.RegisterPathProperty(_location.FullPath,
+					nameof(CanSeek), PropertyAccess.Get);
 
 			return base.CanSeek;
 		}
@@ -42,8 +46,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(CanTimeout), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileStream.RegisterPathProperty(_location.FullPath,
+					nameof(CanTimeout), PropertyAccess.Get);
 
 			return base.CanTimeout;
 		}
@@ -54,7 +59,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(CanWrite), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileStream.RegisterPathProperty(_location.FullPath,
+					nameof(CanWrite), PropertyAccess.Get);
 
 			return _access.HasFlag(FileAccess.Write);
 		}
@@ -65,7 +72,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(IsAsync), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileStream.RegisterPathProperty(_location.FullPath,
+					nameof(IsAsync), PropertyAccess.Get);
 
 			return base.IsAsync;
 		}
@@ -76,7 +85,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Length), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileStream.RegisterPathProperty(_location.FullPath,
+					nameof(Length), PropertyAccess.Get);
 
 			return base.Length;
 		}
@@ -87,7 +98,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Name), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileStream.RegisterPathProperty(_location.FullPath,
+					nameof(Name), PropertyAccess.Get);
 
 			return base.Name;
 		}
@@ -98,13 +111,17 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Position), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileStream.RegisterPathProperty(_location.FullPath,
+					nameof(Position), PropertyAccess.Get);
 
 			return base.Position;
 		}
 		set
 		{
-			using IDisposable registration = RegisterProperty(nameof(Position), PropertyAccess.Set);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileStream.RegisterPathProperty(_location.FullPath,
+					nameof(Position), PropertyAccess.Set);
 
 			base.Position = value;
 		}
@@ -115,15 +132,17 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(ReadTimeout), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileStream.RegisterPathProperty(_location.FullPath,
+					nameof(ReadTimeout), PropertyAccess.Get);
 
 			return base.ReadTimeout;
 		}
 		set
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(ReadTimeout), PropertyAccess.Set);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileStream.RegisterPathProperty(_location.FullPath,
+					nameof(ReadTimeout), PropertyAccess.Set);
 
 			base.ReadTimeout = value;
 		}
@@ -134,15 +153,17 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(WriteTimeout), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileStream.RegisterPathProperty(_location.FullPath,
+					nameof(WriteTimeout), PropertyAccess.Get);
 
 			return base.WriteTimeout;
 		}
 		set
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(WriteTimeout), PropertyAccess.Set);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileStream.RegisterPathProperty(_location.FullPath,
+					nameof(WriteTimeout), PropertyAccess.Set);
 
 			base.WriteTimeout = value;
 		}
@@ -271,8 +292,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 		AsyncCallback? callback,
 		object? state)
 	{
-		using IDisposable registration = RegisterMethod(nameof(BeginRead),
-			buffer, offset, count, callback, state);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(BeginRead),
+				buffer, offset, count, callback, state);
 
 		ThrowIfDisposed();
 		if (!CanRead)
@@ -290,8 +312,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 		AsyncCallback? callback,
 		object? state)
 	{
-		using IDisposable registration = RegisterMethod(nameof(BeginWrite),
-			buffer, offset, count, callback, state);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(BeginWrite),
+				buffer, offset, count, callback, state);
 
 		ThrowIfDisposed();
 		if (!CanWrite)
@@ -305,8 +328,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.CopyTo(Stream, int)" />
 	public override void CopyTo(Stream destination, int bufferSize)
 	{
-		using IDisposable registration = RegisterMethod(nameof(CopyTo),
-			destination, bufferSize);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(CopyTo),
+				destination, bufferSize);
 
 		if (!_fileSystem.Execute.IsWindows)
 		{
@@ -320,8 +344,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	public override Task CopyToAsync(Stream destination, int bufferSize,
 		CancellationToken cancellationToken)
 	{
-		using IDisposable registration = RegisterMethod(nameof(CopyToAsync),
-			destination, bufferSize, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(CopyToAsync),
+				destination, bufferSize, cancellationToken);
 
 		_container.AdjustTimes(TimeAdjustments.LastAccessTime);
 		return base.CopyToAsync(destination, bufferSize, cancellationToken);
@@ -330,8 +355,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.EndRead(IAsyncResult)" />
 	public override int EndRead(IAsyncResult asyncResult)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EndRead),
-			asyncResult);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(EndRead),
+				asyncResult);
 
 		return base.EndRead(asyncResult);
 	}
@@ -339,8 +365,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.EndWrite(IAsyncResult)" />
 	public override void EndWrite(IAsyncResult asyncResult)
 	{
-		using IDisposable registration = RegisterMethod(nameof(EndWrite),
-			asyncResult);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(EndWrite),
+				asyncResult);
 
 		_isContentChanged = true;
 		base.EndWrite(asyncResult);
@@ -349,7 +376,8 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.Flush()" />
 	public override void Flush()
 	{
-		using IDisposable registration = RegisterMethod(nameof(Flush));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(Flush));
 
 		ThrowIfDisposed();
 		InternalFlush();
@@ -358,8 +386,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.Flush(bool)" />
 	public override void Flush(bool flushToDisk)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Flush),
-			flushToDisk);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(Flush),
+				flushToDisk);
 
 		Flush();
 	}
@@ -367,8 +396,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.FlushAsync(CancellationToken)" />
 	public override Task FlushAsync(CancellationToken cancellationToken)
 	{
-		using IDisposable registration = RegisterMethod(nameof(FlushAsync),
-			cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(FlushAsync),
+				cancellationToken);
 
 		if (cancellationToken.IsCancellationRequested)
 		{
@@ -382,8 +412,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.Read(byte[], int, int)" />
 	public override int Read(byte[] buffer, int offset, int count)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Read),
-			buffer, offset, count);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(Read),
+				buffer, offset, count);
 
 		if (!CanRead)
 		{
@@ -402,8 +433,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.Read(Span{byte})" />
 	public override int Read(Span<byte> buffer)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Read),
-			buffer);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(Read),
+				buffer);
 
 		if (!CanRead)
 		{
@@ -423,8 +455,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	public override Task<int> ReadAsync(byte[] buffer, int offset, int count,
 		CancellationToken cancellationToken)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadAsync),
-			buffer, offset, count, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(ReadAsync),
+				buffer, offset, count, cancellationToken);
 
 		if (!CanRead)
 		{
@@ -444,8 +477,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	public override ValueTask<int> ReadAsync(Memory<byte> buffer,
 		CancellationToken cancellationToken = new())
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadAsync),
-			buffer, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(ReadAsync),
+				buffer, cancellationToken);
 
 		if (!CanRead)
 		{
@@ -464,7 +498,8 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.ReadByte()" />
 	public override int ReadByte()
 	{
-		using IDisposable registration = RegisterMethod(nameof(ReadByte));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(ReadByte));
 
 		if (!CanRead)
 		{
@@ -482,8 +517,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.Seek(long, SeekOrigin)" />
 	public override long Seek(long offset, SeekOrigin origin)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Seek),
-			offset, origin);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(Seek),
+				offset, origin);
 
 		if (_mode == FileMode.Append && offset <= _initialPosition)
 		{
@@ -496,8 +532,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.SetLength(long)" />
 	public override void SetLength(long value)
 	{
-		using IDisposable registration = RegisterMethod(nameof(SetLength),
-			value);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(SetLength),
+				value);
 
 		ThrowIfDisposed();
 		if (!CanWrite)
@@ -511,7 +548,8 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.ToString()" />
 	public override string? ToString()
 	{
-		using IDisposable registration = RegisterMethod(nameof(ToString));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(ToString));
 
 		return base.ToString();
 	}
@@ -519,8 +557,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.Write(byte[], int, int)" />
 	public override void Write(byte[] buffer, int offset, int count)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Write),
-			buffer, offset, count);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(Write),
+				buffer, offset, count);
 
 		if (!CanWrite)
 		{
@@ -535,8 +574,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.Write(ReadOnlySpan{byte})" />
 	public override void Write(ReadOnlySpan<byte> buffer)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Write),
-			buffer);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(Write),
+				buffer);
 
 		if (!CanWrite)
 		{
@@ -552,8 +592,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	public override Task WriteAsync(byte[] buffer, int offset, int count,
 		CancellationToken cancellationToken)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteAsync),
-			buffer, offset, count, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(WriteAsync),
+				buffer, offset, count, cancellationToken);
 
 		if (!CanWrite)
 		{
@@ -569,8 +610,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer,
 		CancellationToken cancellationToken = new())
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteAsync),
-			buffer, cancellationToken);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(WriteAsync),
+				buffer, cancellationToken);
 
 		if (!CanWrite)
 		{
@@ -585,8 +627,9 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	/// <inheritdoc cref="FileSystemStream.WriteByte(byte)" />
 	public override void WriteByte(byte value)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WriteByte),
-			value);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterPathMethod(_location.FullPath, nameof(WriteByte),
+				value);
 
 		if (!CanWrite)
 		{
@@ -653,58 +696,6 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 				_fileSystem.Storage.GetLocation(Name));
 		}
 	}
-
-	private IDisposable RegisterMethod(string name)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(_location.FullPath, name);
-
-	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(_location.FullPath, name,
-			parameter1);
-
-#if FEATURE_SPAN
-	private IDisposable RegisterMethod<T1>(string name, Span<T1> parameter1)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(_location.FullPath, name,
-			ParameterDescription.FromParameter(parameter1));
-#endif
-
-#if FEATURE_SPAN
-	private IDisposable RegisterMethod<T1>(string name, ReadOnlySpan<T1> parameter1)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(_location.FullPath, name,
-			ParameterDescription.FromParameter(parameter1));
-#endif
-
-	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(_location.FullPath, name,
-			parameter1,
-			parameter2);
-
-	private IDisposable RegisterMethod<T1, T2, T3>(string name, T1 parameter1, T2 parameter2,
-		T3 parameter3)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(_location.FullPath, name,
-			parameter1,
-			parameter2,
-			parameter3);
-
-	private IDisposable RegisterMethod<T1, T2, T3, T4>(string name, T1 parameter1, T2 parameter2,
-		T3 parameter3, T4 parameter4)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(_location.FullPath, name,
-			parameter1,
-			parameter2,
-			parameter3,
-			parameter4);
-
-	private IDisposable RegisterMethod<T1, T2, T3, T4, T5>(string name, T1 parameter1,
-		T2 parameter2, T3 parameter3, T4 parameter4, T5 parameter5)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterMethod(_location.FullPath, name,
-			parameter1,
-			parameter2,
-			parameter3,
-			parameter4,
-			parameter5);
-
-	private IDisposable RegisterProperty(string name, PropertyAccess access)
-		=> _fileSystem.StatisticsRegistration.FileStream.RegisterProperty(_location.FullPath, name,
-			access);
 
 	private void ThrowIfDisposed()
 	{

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
@@ -51,14 +51,14 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 		get
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(Attributes), PropertyAccess.Get);
+				RegisterPathProperty(nameof(Attributes), PropertyAccess.Get);
 
 			return Container.Attributes;
 		}
 		set
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(Attributes), PropertyAccess.Set);
+				RegisterPathProperty(nameof(Attributes), PropertyAccess.Set);
 
 			Container.Attributes = value;
 		}
@@ -68,7 +68,7 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 	/// <inheritdoc cref="IFileSystemInfo.CreateAsSymbolicLink(string)" />
 	public void CreateAsSymbolicLink(string pathToTarget)
 	{
-		using IDisposable registration = RegisterMethod(nameof(CreateAsSymbolicLink),
+		using IDisposable registration = RegisterPathMethod(nameof(CreateAsSymbolicLink),
 			pathToTarget);
 
 		if (!_fileSystem.Execute.IsWindows && string.IsNullOrWhiteSpace(FullName))
@@ -99,14 +99,14 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 		get
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(CreationTime), PropertyAccess.Get);
+				RegisterPathProperty(nameof(CreationTime), PropertyAccess.Get);
 
 			return Container.CreationTime.Get(DateTimeKind.Local);
 		}
 		set
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(CreationTime), PropertyAccess.Set);
+				RegisterPathProperty(nameof(CreationTime), PropertyAccess.Set);
 
 			Container.CreationTime.Set(value, DateTimeKind.Local);
 		}
@@ -118,14 +118,14 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 		get
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(CreationTimeUtc), PropertyAccess.Get);
+				RegisterPathProperty(nameof(CreationTimeUtc), PropertyAccess.Get);
 
 			return Container.CreationTime.Get(DateTimeKind.Utc);
 		}
 		set
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(CreationTimeUtc), PropertyAccess.Set);
+				RegisterPathProperty(nameof(CreationTimeUtc), PropertyAccess.Set);
 
 			Container.CreationTime.Set(value, DateTimeKind.Utc);
 		}
@@ -134,7 +134,7 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 	/// <inheritdoc cref="IFileSystemInfo.Delete()" />
 	public virtual void Delete()
 	{
-		using IDisposable registration = RegisterMethod(nameof(Delete));
+		using IDisposable registration = RegisterPathMethod(nameof(Delete));
 
 		_fileSystem.Storage.DeleteContainer(Location);
 		ResetCache(!_fileSystem.Execute.IsNetFramework);
@@ -158,7 +158,7 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 		get
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(Extension), PropertyAccess.Get);
+				RegisterPathProperty(nameof(Extension), PropertyAccess.Get);
 
 			if (Location.FullPath.EndsWith('.') &&
 			    !_fileSystem.Execute.IsWindows)
@@ -179,7 +179,8 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(FullName), PropertyAccess.Get);
+			using IDisposable registration =
+				RegisterPathProperty(nameof(FullName), PropertyAccess.Get);
 
 			return Location.FullPath;
 		}
@@ -191,14 +192,14 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 		get
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(LastAccessTime), PropertyAccess.Get);
+				RegisterPathProperty(nameof(LastAccessTime), PropertyAccess.Get);
 
 			return Container.LastAccessTime.Get(DateTimeKind.Local);
 		}
 		set
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(LastAccessTime), PropertyAccess.Set);
+				RegisterPathProperty(nameof(LastAccessTime), PropertyAccess.Set);
 
 			Container.LastAccessTime.Set(value, DateTimeKind.Local);
 		}
@@ -210,14 +211,14 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 		get
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(LastAccessTimeUtc), PropertyAccess.Get);
+				RegisterPathProperty(nameof(LastAccessTimeUtc), PropertyAccess.Get);
 
 			return Container.LastAccessTime.Get(DateTimeKind.Utc);
 		}
 		set
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(LastAccessTimeUtc), PropertyAccess.Set);
+				RegisterPathProperty(nameof(LastAccessTimeUtc), PropertyAccess.Set);
 
 			Container.LastAccessTime.Set(value, DateTimeKind.Utc);
 		}
@@ -229,14 +230,14 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 		get
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(LastWriteTime), PropertyAccess.Get);
+				RegisterPathProperty(nameof(LastWriteTime), PropertyAccess.Get);
 
 			return Container.LastWriteTime.Get(DateTimeKind.Local);
 		}
 		set
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(LastWriteTime), PropertyAccess.Set);
+				RegisterPathProperty(nameof(LastWriteTime), PropertyAccess.Set);
 
 			Container.LastWriteTime.Set(value, DateTimeKind.Local);
 		}
@@ -248,14 +249,14 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 		get
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(LastWriteTimeUtc), PropertyAccess.Get);
+				RegisterPathProperty(nameof(LastWriteTimeUtc), PropertyAccess.Get);
 
 			return Container.LastWriteTime.Get(DateTimeKind.Utc);
 		}
 		set
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(LastWriteTimeUtc), PropertyAccess.Set);
+				RegisterPathProperty(nameof(LastWriteTimeUtc), PropertyAccess.Set);
 
 			Container.LastWriteTime.Set(value, DateTimeKind.Utc);
 		}
@@ -268,7 +269,7 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 		get
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(LinkTarget), PropertyAccess.Get);
+				RegisterPathProperty(nameof(LinkTarget), PropertyAccess.Get);
 
 			return Container.LinkTarget;
 		}
@@ -280,7 +281,7 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Name), PropertyAccess.Get);
+			using IDisposable registration = RegisterPathProperty(nameof(Name), PropertyAccess.Get);
 
 			return string.Equals(
 				_fileSystem.Execute.Path.GetPathRoot(Location.FullPath),
@@ -300,7 +301,7 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 		get
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(UnixFileMode), PropertyAccess.Get);
+				RegisterPathProperty(nameof(UnixFileMode), PropertyAccess.Get);
 
 			return Container.UnixFileMode;
 		}
@@ -308,7 +309,7 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 		set
 		{
 			using IDisposable registration =
-				RegisterProperty(nameof(UnixFileMode), PropertyAccess.Set);
+				RegisterPathProperty(nameof(UnixFileMode), PropertyAccess.Set);
 
 			if (_fileSystem.Execute.IsWindows)
 			{
@@ -323,7 +324,7 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 	/// <inheritdoc cref="IFileSystemInfo.Refresh()" />
 	public void Refresh()
 	{
-		using IDisposable registration = RegisterMethod(nameof(Refresh));
+		using IDisposable registration = RegisterPathMethod(nameof(Refresh));
 
 		ResetCache(true);
 	}
@@ -332,7 +333,7 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 	/// <inheritdoc cref="IFileSystemInfo.ResolveLinkTarget(bool)" />
 	public IFileSystemInfo? ResolveLinkTarget(bool returnFinalTarget)
 	{
-		using IDisposable registration = RegisterMethod(nameof(ResolveLinkTarget),
+		using IDisposable registration = RegisterPathMethod(nameof(ResolveLinkTarget),
 			returnFinalTarget);
 
 		try
@@ -417,12 +418,12 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 		_isInitialized = true;
 	}
 
-	protected virtual IDisposable RegisterProperty(string name, PropertyAccess access)
+	protected virtual IDisposable RegisterPathProperty(string name, PropertyAccess access)
 		=> new NoOpDisposable();
 
-	protected virtual IDisposable RegisterMethod(string name)
+	protected virtual IDisposable RegisterPathMethod(string name)
 		=> new NoOpDisposable();
 
-	protected virtual IDisposable RegisterMethod<T1>(string name, T1 parameter1)
+	protected virtual IDisposable RegisterPathMethod<T1>(string name, T1 parameter1)
 		=> new NoOpDisposable();
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherFactoryMock.cs
@@ -24,7 +24,8 @@ internal sealed class FileSystemWatcherFactoryMock
 	/// <inheritdoc cref="IFileSystemWatcherFactory.New()" />
 	public IFileSystemWatcher New()
 	{
-		using IDisposable registration = RegisterMethod(nameof(New));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileSystemWatcher.RegisterMethod(nameof(New));
 
 		return FileSystemWatcherMock.New(_fileSystem);
 	}
@@ -32,8 +33,9 @@ internal sealed class FileSystemWatcherFactoryMock
 	/// <inheritdoc cref="IFileSystemWatcherFactory.New(string)" />
 	public IFileSystemWatcher New(string path)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			path);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileSystemWatcher.RegisterMethod(nameof(New),
+				path);
 
 		FileSystemWatcherMock fileSystemWatcherMock =
 			FileSystemWatcherMock.New(_fileSystem);
@@ -44,8 +46,9 @@ internal sealed class FileSystemWatcherFactoryMock
 	/// <inheritdoc cref="IFileSystemWatcherFactory.New(string, string)" />
 	public IFileSystemWatcher New(string path, string filter)
 	{
-		using IDisposable registration = RegisterMethod(nameof(New),
-			path, filter);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileSystemWatcher.RegisterMethod(nameof(New),
+				path, filter);
 
 		FileSystemWatcherMock fileSystemWatcherMock =
 			FileSystemWatcherMock.New(_fileSystem);
@@ -59,8 +62,9 @@ internal sealed class FileSystemWatcherFactoryMock
 	// ReSharper disable once ReturnTypeCanBeNotNullable
 	public IFileSystemWatcher? Wrap(FileSystemWatcher? fileSystemWatcher)
 	{
-		using IDisposable registration = RegisterMethod(nameof(Wrap),
-			fileSystemWatcher);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileSystemWatcher.RegisterMethod(nameof(Wrap),
+				fileSystemWatcher);
 
 		if (fileSystemWatcher == null)
 		{
@@ -89,16 +93,4 @@ internal sealed class FileSystemWatcherFactoryMock
 	}
 
 	#endregion
-
-	private IDisposable RegisterMethod(string name)
-		=> _fileSystem.StatisticsRegistration.FileSystemWatcher.RegisterMethod(name);
-
-	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
-		=> _fileSystem.StatisticsRegistration.FileSystemWatcher.RegisterMethod(name,
-			parameter1);
-
-	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
-		=> _fileSystem.StatisticsRegistration.FileSystemWatcher.RegisterMethod(name,
-			parameter1,
-			parameter2);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherFactoryMock.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Testably.Abstractions.Testing.Helpers;
-using Testably.Abstractions.Testing.Statistics;
 
 namespace Testably.Abstractions.Testing.FileSystem;
 
@@ -96,10 +95,10 @@ internal sealed class FileSystemWatcherFactoryMock
 
 	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
 		=> _fileSystem.StatisticsRegistration.FileSystemWatcher.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1));
+			parameter1);
 
 	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
 		=> _fileSystem.StatisticsRegistration.FileSystemWatcher.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2));
+			parameter1,
+			parameter2);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
@@ -388,12 +388,12 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 
 	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
 		=> _fileSystem.StatisticsRegistration.FileSystemWatcher.RegisterMethod(_path, name,
-			ParameterDescription.FromParameter(parameter1));
+			parameter1);
 
 	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
 		=> _fileSystem.StatisticsRegistration.FileSystemWatcher.RegisterMethod(_path, name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2));
+			parameter1,
+			parameter2);
 
 	private IDisposable RegisterProperty(string name, PropertyAccess access)
 		=> _fileSystem.StatisticsRegistration.FileSystemWatcher.RegisterProperty(_path, name,

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
@@ -55,15 +55,17 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(EnableRaisingEvents), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(EnableRaisingEvents), PropertyAccess.Get);
 
 			return _enableRaisingEvents;
 		}
 		set
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(EnableRaisingEvents), PropertyAccess.Set);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(EnableRaisingEvents), PropertyAccess.Set);
 
 			_enableRaisingEvents = value;
 			if (_enableRaisingEvents)
@@ -86,7 +88,9 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Filter), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(Filter), PropertyAccess.Get);
 
 			if (_filters.Count == 0)
 			{
@@ -97,7 +101,9 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 		}
 		set
 		{
-			using IDisposable registration = RegisterProperty(nameof(Filter), PropertyAccess.Set);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(Filter), PropertyAccess.Set);
 
 			_filters.Clear();
 			_filters.Add(value);
@@ -110,7 +116,9 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Filters), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(Filters), PropertyAccess.Get);
 
 			return _filters;
 		}
@@ -122,15 +130,17 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(IncludeSubdirectories), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(IncludeSubdirectories), PropertyAccess.Get);
 
 			return _includeSubdirectories;
 		}
 		set
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(IncludeSubdirectories), PropertyAccess.Set);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(IncludeSubdirectories), PropertyAccess.Set);
 
 			_includeSubdirectories = value;
 		}
@@ -141,15 +151,17 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(InternalBufferSize), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(InternalBufferSize), PropertyAccess.Get);
 
 			return _internalBufferSize;
 		}
 		set
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(InternalBufferSize), PropertyAccess.Set);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(InternalBufferSize), PropertyAccess.Set);
 
 			_internalBufferSize = Math.Max(value, 4096);
 			Restart();
@@ -161,15 +173,17 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(NotifyFilter), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(NotifyFilter), PropertyAccess.Get);
 
 			return _notifyFilter;
 		}
 		set
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(NotifyFilter), PropertyAccess.Set);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(NotifyFilter), PropertyAccess.Set);
 
 			_notifyFilter = value;
 		}
@@ -180,14 +194,17 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Path), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(Path), PropertyAccess.Get);
 
 			return _path;
 		}
 		set
 		{
-			using IDisposable registration =
-				RegisterProperty(value, nameof(Path), PropertyAccess.Set);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(value,
+					nameof(Path), PropertyAccess.Set);
 
 			if (!string.IsNullOrEmpty(value) &&
 			    !_fileSystem.Directory.Exists(value))
@@ -204,13 +221,17 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	{
 		get
 		{
-			using IDisposable registration = RegisterProperty(nameof(Site), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(Site), PropertyAccess.Get);
 
 			return base.Site;
 		}
 		set
 		{
-			using IDisposable registration = RegisterProperty(nameof(Site), PropertyAccess.Set);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(Site), PropertyAccess.Set);
 
 			base.Site = value;
 		}
@@ -221,15 +242,17 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	{
 		get
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(SynchronizingObject), PropertyAccess.Get);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(SynchronizingObject), PropertyAccess.Get);
 
 			return _synchronizingObject;
 		}
 		set
 		{
-			using IDisposable registration =
-				RegisterProperty(nameof(SynchronizingObject), PropertyAccess.Set);
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileSystemWatcher.RegisterPathProperty(_path,
+					nameof(SynchronizingObject), PropertyAccess.Set);
 
 			_synchronizingObject = value;
 		}
@@ -238,7 +261,8 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	/// <inheritdoc cref="IFileSystemWatcher.BeginInit()" />
 	public void BeginInit()
 	{
-		using IDisposable registration = RegisterMethod(nameof(BeginInit));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileSystemWatcher.RegisterPathMethod(_path, nameof(BeginInit));
 
 		_isInitializing = true;
 		Stop();
@@ -256,7 +280,8 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	/// <inheritdoc cref="IFileSystemWatcher.EndInit()" />
 	public void EndInit()
 	{
-		using IDisposable registration = RegisterMethod(nameof(EndInit));
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileSystemWatcher.RegisterPathMethod(_path, nameof(EndInit));
 
 		_isInitializing = false;
 		Restart();
@@ -273,8 +298,9 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	public IWaitForChangedResult WaitForChanged(
 		WatcherChangeTypes changeType)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WaitForChanged),
-			changeType);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileSystemWatcher.RegisterPathMethod(_path, nameof(WaitForChanged),
+				changeType);
 
 		return WaitForChanged(changeType, Timeout.Infinite);
 	}
@@ -283,8 +309,9 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	public IWaitForChangedResult WaitForChanged(
 		WatcherChangeTypes changeType, int timeout)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WaitForChanged),
-			changeType, timeout);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileSystemWatcher.RegisterPathMethod(_path, nameof(WaitForChanged),
+				changeType, timeout);
 
 		return WaitForChangedInternal(changeType, TimeSpan.FromMilliseconds(timeout));
 	}
@@ -294,8 +321,9 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	public IWaitForChangedResult WaitForChanged(
 		WatcherChangeTypes changeType, TimeSpan timeout)
 	{
-		using IDisposable registration = RegisterMethod(nameof(WaitForChanged),
-			changeType, timeout);
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileSystemWatcher.RegisterPathMethod(_path, nameof(WaitForChanged),
+				changeType, timeout);
 
 		return WaitForChangedInternal(changeType, timeout);
 	}
@@ -382,26 +410,6 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 			}
 		}
 	}
-
-	private IDisposable RegisterMethod(string name)
-		=> _fileSystem.StatisticsRegistration.FileSystemWatcher.RegisterMethod(_path, name);
-
-	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
-		=> _fileSystem.StatisticsRegistration.FileSystemWatcher.RegisterMethod(_path, name,
-			parameter1);
-
-	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
-		=> _fileSystem.StatisticsRegistration.FileSystemWatcher.RegisterMethod(_path, name,
-			parameter1,
-			parameter2);
-
-	private IDisposable RegisterProperty(string name, PropertyAccess access)
-		=> _fileSystem.StatisticsRegistration.FileSystemWatcher.RegisterProperty(_path, name,
-			access);
-
-	private IDisposable RegisterProperty(string path, string name, PropertyAccess access)
-		=> _fileSystem.StatisticsRegistration.FileSystemWatcher
-			.RegisterProperty(path, name, access);
 
 	private void Restart()
 	{

--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -20,7 +20,8 @@ internal sealed class PathMock : IPath
 	{
 		get
 		{
-			using IDisposable register = RegisterProperty(nameof(AltDirectorySeparatorChar));
+			using IDisposable register = _fileSystem.StatisticsRegistration
+				.Path.RegisterProperty(nameof(AltDirectorySeparatorChar), PropertyAccess.Get);
 
 			return _fileSystem.Execute.Path.AltDirectorySeparatorChar;
 		}
@@ -31,7 +32,8 @@ internal sealed class PathMock : IPath
 	{
 		get
 		{
-			using IDisposable register = RegisterProperty(nameof(DirectorySeparatorChar));
+			using IDisposable register = _fileSystem.StatisticsRegistration
+				.Path.RegisterProperty(nameof(DirectorySeparatorChar), PropertyAccess.Get);
 
 			return _fileSystem.Execute.Path.DirectorySeparatorChar;
 		}
@@ -46,7 +48,8 @@ internal sealed class PathMock : IPath
 	{
 		get
 		{
-			using IDisposable register = RegisterProperty(nameof(PathSeparator));
+			using IDisposable register = _fileSystem.StatisticsRegistration
+				.Path.RegisterProperty(nameof(PathSeparator), PropertyAccess.Get);
 
 			return _fileSystem.Execute.Path.PathSeparator;
 		}
@@ -57,7 +60,8 @@ internal sealed class PathMock : IPath
 	{
 		get
 		{
-			using IDisposable register = RegisterProperty(nameof(VolumeSeparatorChar));
+			using IDisposable register = _fileSystem.StatisticsRegistration
+				.Path.RegisterProperty(nameof(VolumeSeparatorChar), PropertyAccess.Get);
 
 			return _fileSystem.Execute.Path.VolumeSeparatorChar;
 		}
@@ -67,8 +71,9 @@ internal sealed class PathMock : IPath
 	[return: NotNullIfNotNull("path")]
 	public string? ChangeExtension(string? path, string? extension)
 	{
-		using IDisposable register = RegisterMethod(nameof(ChangeExtension),
-			path, extension);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(ChangeExtension),
+				path, extension);
 
 		return _fileSystem.Execute.Path.ChangeExtension(path, extension);
 	}
@@ -76,8 +81,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.Combine(string, string)" />
 	public string Combine(string path1, string path2)
 	{
-		using IDisposable register = RegisterMethod(nameof(Combine),
-			path1, path2);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(Combine),
+				path1, path2);
 
 		return _fileSystem.Execute.Path.Combine(path1, path2);
 	}
@@ -85,8 +91,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.Combine(string, string, string)" />
 	public string Combine(string path1, string path2, string path3)
 	{
-		using IDisposable register = RegisterMethod(nameof(Combine),
-			path1, path2, path3);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(Combine),
+				path1, path2, path3);
 
 		return _fileSystem.Execute.Path.Combine(path1, path2, path3);
 	}
@@ -94,8 +101,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.Combine(string, string, string, string)" />
 	public string Combine(string path1, string path2, string path3, string path4)
 	{
-		using IDisposable register = RegisterMethod(nameof(Combine),
-			path1, path2, path3, path4);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(Combine),
+				path1, path2, path3, path4);
 
 		return _fileSystem.Execute.Path.Combine(path1, path2, path3, path4);
 	}
@@ -103,8 +111,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.Combine(string[])" />
 	public string Combine(params string[] paths)
 	{
-		using IDisposable register = RegisterMethod(nameof(Combine),
-			paths);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(Combine),
+				paths);
 
 		return _fileSystem.Execute.Path.Combine(paths);
 	}
@@ -113,8 +122,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.EndsInDirectorySeparator(ReadOnlySpan{char})" />
 	public bool EndsInDirectorySeparator(ReadOnlySpan<char> path)
 	{
-		using IDisposable register = RegisterMethod(nameof(EndsInDirectorySeparator),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(EndsInDirectorySeparator),
+				path);
 
 		return _fileSystem.Execute.Path.EndsInDirectorySeparator(path);
 	}
@@ -124,8 +134,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.EndsInDirectorySeparator(string)" />
 	public bool EndsInDirectorySeparator(string path)
 	{
-		using IDisposable register = RegisterMethod(nameof(EndsInDirectorySeparator),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(EndsInDirectorySeparator),
+				path);
 
 		return _fileSystem.Execute.Path.EndsInDirectorySeparator(path);
 	}
@@ -135,8 +146,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.Exists(string)" />
 	public bool Exists([NotNullWhen(true)] string? path)
 	{
-		using IDisposable register = RegisterMethod(nameof(Exists),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(Exists),
+				path);
 
 		return _fileSystem.Execute.Path.Exists(path);
 	}
@@ -146,8 +158,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.GetDirectoryName(ReadOnlySpan{char})" />
 	public ReadOnlySpan<char> GetDirectoryName(ReadOnlySpan<char> path)
 	{
-		using IDisposable register = RegisterMethod(nameof(GetDirectoryName),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetDirectoryName),
+				path);
 
 		return _fileSystem.Execute.Path.GetDirectoryName(path);
 	}
@@ -156,8 +169,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.GetDirectoryName(string)" />
 	public string? GetDirectoryName(string? path)
 	{
-		using IDisposable register = RegisterMethod(nameof(GetDirectoryName),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetDirectoryName),
+				path);
 
 		return _fileSystem.Execute.Path.GetDirectoryName(path);
 	}
@@ -166,8 +180,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.GetExtension(ReadOnlySpan{char})" />
 	public ReadOnlySpan<char> GetExtension(ReadOnlySpan<char> path)
 	{
-		using IDisposable register = RegisterMethod(nameof(GetExtension),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetExtension),
+				path);
 
 		return _fileSystem.Execute.Path.GetExtension(path);
 	}
@@ -177,8 +192,9 @@ internal sealed class PathMock : IPath
 	[return: NotNullIfNotNull("path")]
 	public string? GetExtension(string? path)
 	{
-		using IDisposable register = RegisterMethod(nameof(GetExtension),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetExtension),
+				path);
 
 		return _fileSystem.Execute.Path.GetExtension(path);
 	}
@@ -187,8 +203,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.GetFileName(ReadOnlySpan{char})" />
 	public ReadOnlySpan<char> GetFileName(ReadOnlySpan<char> path)
 	{
-		using IDisposable register = RegisterMethod(nameof(GetFileName),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetFileName),
+				path);
 
 		return _fileSystem.Execute.Path.GetFileName(path);
 	}
@@ -198,8 +215,9 @@ internal sealed class PathMock : IPath
 	[return: NotNullIfNotNull("path")]
 	public string? GetFileName(string? path)
 	{
-		using IDisposable register = RegisterMethod(nameof(GetFileName),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetFileName),
+				path);
 
 		return _fileSystem.Execute.Path.GetFileName(path);
 	}
@@ -208,8 +226,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.GetFileNameWithoutExtension(ReadOnlySpan{char})" />
 	public ReadOnlySpan<char> GetFileNameWithoutExtension(ReadOnlySpan<char> path)
 	{
-		using IDisposable register = RegisterMethod(nameof(GetFileNameWithoutExtension),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetFileNameWithoutExtension),
+				path);
 
 		return _fileSystem.Execute.Path.GetFileNameWithoutExtension(path);
 	}
@@ -219,8 +238,9 @@ internal sealed class PathMock : IPath
 	[return: NotNullIfNotNull("path")]
 	public string? GetFileNameWithoutExtension(string? path)
 	{
-		using IDisposable register = RegisterMethod(nameof(GetFileNameWithoutExtension),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetFileNameWithoutExtension),
+				path);
 
 		return _fileSystem.Execute.Path.GetFileNameWithoutExtension(path);
 	}
@@ -228,8 +248,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.GetFullPath(string)" />
 	public string GetFullPath(string path)
 	{
-		using IDisposable register = RegisterMethod(nameof(GetFullPath),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetFullPath),
+				path);
 
 		return _fileSystem.Execute.Path.GetFullPath(path);
 	}
@@ -238,8 +259,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.GetFullPath(string, string)" />
 	public string GetFullPath(string path, string basePath)
 	{
-		using IDisposable register = RegisterMethod(nameof(GetFullPath),
-			path, basePath);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetFullPath),
+				path, basePath);
 
 		return _fileSystem.Execute.Path.GetFullPath(path, basePath);
 	}
@@ -248,7 +270,8 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.GetInvalidFileNameChars()" />
 	public char[] GetInvalidFileNameChars()
 	{
-		using IDisposable register = RegisterMethod(nameof(GetInvalidFileNameChars));
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetInvalidFileNameChars));
 
 		return _fileSystem.Execute.Path.GetInvalidFileNameChars();
 	}
@@ -256,7 +279,8 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.GetInvalidPathChars()" />
 	public char[] GetInvalidPathChars()
 	{
-		using IDisposable register = RegisterMethod(nameof(GetInvalidPathChars));
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetInvalidPathChars));
 
 		return _fileSystem.Execute.Path.GetInvalidPathChars();
 	}
@@ -265,8 +289,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.GetPathRoot(ReadOnlySpan{char})" />
 	public ReadOnlySpan<char> GetPathRoot(ReadOnlySpan<char> path)
 	{
-		using IDisposable register = RegisterMethod(nameof(GetPathRoot),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetPathRoot),
+				path);
 
 		return _fileSystem.Execute.Path.GetPathRoot(path);
 	}
@@ -275,8 +300,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.GetPathRoot(string?)" />
 	public string? GetPathRoot(string? path)
 	{
-		using IDisposable register = RegisterMethod(nameof(GetPathRoot),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetPathRoot),
+				path);
 
 		return _fileSystem.Execute.Path.GetPathRoot(path);
 	}
@@ -284,7 +310,8 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.GetRandomFileName()" />
 	public string GetRandomFileName()
 	{
-		using IDisposable register = RegisterMethod(nameof(GetRandomFileName));
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetRandomFileName));
 
 		return _fileSystem.Execute.Path.GetRandomFileName();
 	}
@@ -293,8 +320,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.GetRelativePath(string, string)" />
 	public string GetRelativePath(string relativeTo, string path)
 	{
-		using IDisposable register = RegisterMethod(nameof(GetRelativePath),
-			relativeTo, path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetRelativePath),
+				relativeTo, path);
 
 		return _fileSystem.Execute.Path.GetRelativePath(relativeTo, path);
 	}
@@ -308,7 +336,8 @@ internal sealed class PathMock : IPath
 #endif
 	public string GetTempFileName()
 	{
-		using IDisposable register = RegisterMethod(nameof(GetTempFileName));
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetTempFileName));
 
 		return _fileSystem.Execute.Path.GetTempFileName();
 	}
@@ -316,7 +345,8 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.GetTempPath()" />
 	public string GetTempPath()
 	{
-		using IDisposable register = RegisterMethod(nameof(GetTempPath));
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(GetTempPath));
 
 		return _fileSystem.Execute.Path.GetTempPath();
 	}
@@ -325,8 +355,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.HasExtension(ReadOnlySpan{char})" />
 	public bool HasExtension(ReadOnlySpan<char> path)
 	{
-		using IDisposable register = RegisterMethod(nameof(HasExtension),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(HasExtension),
+				path);
 
 		return _fileSystem.Execute.Path.HasExtension(path);
 	}
@@ -335,8 +366,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.HasExtension(string)" />
 	public bool HasExtension([NotNullWhen(true)] string? path)
 	{
-		using IDisposable register = RegisterMethod(nameof(HasExtension),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(HasExtension),
+				path);
 
 		return _fileSystem.Execute.Path.HasExtension(path);
 	}
@@ -345,8 +377,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.IsPathFullyQualified(ReadOnlySpan{char})" />
 	public bool IsPathFullyQualified(ReadOnlySpan<char> path)
 	{
-		using IDisposable register = RegisterMethod(nameof(IsPathFullyQualified),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(IsPathFullyQualified),
+				path);
 
 		return _fileSystem.Execute.Path.IsPathFullyQualified(path);
 	}
@@ -356,8 +389,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.IsPathFullyQualified(string)" />
 	public bool IsPathFullyQualified(string path)
 	{
-		using IDisposable register = RegisterMethod(nameof(IsPathFullyQualified),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(IsPathFullyQualified),
+				path);
 
 		return _fileSystem.Execute.Path.IsPathFullyQualified(path);
 	}
@@ -367,8 +401,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.IsPathRooted(ReadOnlySpan{char})" />
 	public bool IsPathRooted(ReadOnlySpan<char> path)
 	{
-		using IDisposable register = RegisterMethod(nameof(IsPathRooted),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(IsPathRooted),
+				path);
 
 		return _fileSystem.Execute.Path.IsPathRooted(path);
 	}
@@ -377,8 +412,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.IsPathRooted(string)" />
 	public bool IsPathRooted(string? path)
 	{
-		using IDisposable register = RegisterMethod(nameof(IsPathRooted),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(IsPathRooted),
+				path);
 
 		return _fileSystem.Execute.Path.IsPathRooted(path);
 	}
@@ -387,8 +423,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.Join(ReadOnlySpan{char}, ReadOnlySpan{char})" />
 	public string Join(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2)
 	{
-		using IDisposable register = RegisterMethod(nameof(Join),
-			path1, path2);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(Join),
+				path1, path2);
 
 		return _fileSystem.Execute.Path.Join(path1, path2);
 	}
@@ -400,10 +437,11 @@ internal sealed class PathMock : IPath
 		ReadOnlySpan<char> path2,
 		ReadOnlySpan<char> path3)
 	{
-		using IDisposable register = RegisterMethod(nameof(Join),
-			path1,
-			path2,
-			path3);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(Join),
+				path1,
+				path2,
+				path3);
 
 		return _fileSystem.Execute.Path.Join(path1, path2, path3);
 	}
@@ -416,11 +454,12 @@ internal sealed class PathMock : IPath
 		ReadOnlySpan<char> path3,
 		ReadOnlySpan<char> path4)
 	{
-		using IDisposable register = RegisterMethod(nameof(Join),
-			path1,
-			path2,
-			path3,
-			path4);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(Join),
+				path1,
+				path2,
+				path3,
+				path4);
 
 		return _fileSystem.Execute.Path.Join(path1, path2, path3, path4);
 	}
@@ -430,8 +469,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.Join(string, string)" />
 	public string Join(string? path1, string? path2)
 	{
-		using IDisposable register = RegisterMethod(nameof(Join),
-			path1, path2);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(Join),
+				path1, path2);
 
 		return _fileSystem.Execute.Path.Join(path1, path2);
 	}
@@ -441,8 +481,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.Join(string, string, string)" />
 	public string Join(string? path1, string? path2, string? path3)
 	{
-		using IDisposable register = RegisterMethod(nameof(Join),
-			path1, path2, path3);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(Join),
+				path1, path2, path3);
 
 		return _fileSystem.Execute.Path.Join(path1, path2, path3);
 	}
@@ -452,8 +493,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.Join(string, string, string, string)" />
 	public string Join(string? path1, string? path2, string? path3, string? path4)
 	{
-		using IDisposable register = RegisterMethod(nameof(Join),
-			path1, path2, path3, path4);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(Join),
+				path1, path2, path3, path4);
 
 		return _fileSystem.Execute.Path.Join(path1, path2, path3, path4);
 	}
@@ -463,8 +505,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.Join(string[])" />
 	public string Join(params string?[] paths)
 	{
-		using IDisposable register = RegisterMethod(nameof(Join),
-			paths);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(Join),
+				paths);
 
 		return _fileSystem.Execute.Path.Join(paths);
 	}
@@ -474,8 +517,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.TrimEndingDirectorySeparator(ReadOnlySpan{char})" />
 	public ReadOnlySpan<char> TrimEndingDirectorySeparator(ReadOnlySpan<char> path)
 	{
-		using IDisposable register = RegisterMethod(nameof(TrimEndingDirectorySeparator),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(TrimEndingDirectorySeparator),
+				path);
 
 		return _fileSystem.Execute.Path.TrimEndingDirectorySeparator(path);
 	}
@@ -485,8 +529,9 @@ internal sealed class PathMock : IPath
 	/// <inheritdoc cref="IPath.TrimEndingDirectorySeparator(string)" />
 	public string TrimEndingDirectorySeparator(string path)
 	{
-		using IDisposable register = RegisterMethod(nameof(TrimEndingDirectorySeparator),
-			path);
+		using IDisposable register = _fileSystem.StatisticsRegistration
+			.Path.RegisterMethod(nameof(TrimEndingDirectorySeparator),
+				path);
 
 		return _fileSystem.Execute.Path.TrimEndingDirectorySeparator(path);
 	}
@@ -548,67 +593,4 @@ internal sealed class PathMock : IPath
 #endif
 
 	#endregion
-
-	private IDisposable RegisterMethod(string name)
-		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name);
-
-	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
-		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name,
-			parameter1);
-
-#if FEATURE_SPAN
-	private IDisposable RegisterMethod<T1>(string name, ReadOnlySpan<T1> parameter1)
-		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1));
-#endif
-
-#if FEATURE_PATH_JOIN
-	private IDisposable RegisterMethod<T1, T2>(string name, ReadOnlySpan<T1> parameter1,
-		ReadOnlySpan<T2> parameter2)
-		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2));
-#endif
-
-#if FEATURE_PATH_JOIN
-	private IDisposable RegisterMethod<T1, T2, T3>(string name, ReadOnlySpan<T1> parameter1,
-		ReadOnlySpan<T2> parameter2, ReadOnlySpan<T3> parameter3)
-		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3));
-#endif
-
-#if FEATURE_PATH_ADVANCED
-	private IDisposable RegisterMethod<T1, T2, T3, T4>(string name, ReadOnlySpan<T1> parameter1,
-		ReadOnlySpan<T2> parameter2, ReadOnlySpan<T3> parameter3, ReadOnlySpan<T4> parameter4)
-		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3),
-			ParameterDescription.FromParameter(parameter4));
-#endif
-
-	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
-		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name,
-			parameter1,
-			parameter2);
-
-	private IDisposable RegisterMethod<T1, T2, T3>(string name, T1 parameter1, T2 parameter2,
-		T3 parameter3)
-		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name,
-			parameter1,
-			parameter2,
-			parameter3);
-
-	private IDisposable RegisterMethod<T1, T2, T3, T4>(string name, T1 parameter1, T2 parameter2,
-		T3 parameter3, T4 parameter4)
-		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name,
-			parameter1,
-			parameter2,
-			parameter3,
-			parameter4);
-
-	private IDisposable RegisterProperty(string name, PropertyAccess access = PropertyAccess.Get)
-		=> _fileSystem.StatisticsRegistration.Path.RegisterProperty(name, access);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/PathMock.cs
@@ -554,7 +554,7 @@ internal sealed class PathMock : IPath
 
 	private IDisposable RegisterMethod<T1>(string name, T1 parameter1)
 		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1));
+			parameter1);
 
 #if FEATURE_SPAN
 	private IDisposable RegisterMethod<T1>(string name, ReadOnlySpan<T1> parameter1)
@@ -591,23 +591,23 @@ internal sealed class PathMock : IPath
 
 	private IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
 		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2));
+			parameter1,
+			parameter2);
 
 	private IDisposable RegisterMethod<T1, T2, T3>(string name, T1 parameter1, T2 parameter2,
 		T3 parameter3)
 		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3));
+			parameter1,
+			parameter2,
+			parameter3);
 
 	private IDisposable RegisterMethod<T1, T2, T3, T4>(string name, T1 parameter1, T2 parameter2,
 		T3 parameter3, T4 parameter4)
 		=> _fileSystem.StatisticsRegistration.Path.RegisterMethod(name,
-			ParameterDescription.FromParameter(parameter1),
-			ParameterDescription.FromParameter(parameter2),
-			ParameterDescription.FromParameter(parameter3),
-			ParameterDescription.FromParameter(parameter4));
+			parameter1,
+			parameter2,
+			parameter3,
+			parameter4);
 
 	private IDisposable RegisterProperty(string name, PropertyAccess access = PropertyAccess.Get)
 		=> _fileSystem.StatisticsRegistration.Path.RegisterProperty(name, access);

--- a/Source/Testably.Abstractions.Testing/Statistics/CallStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/CallStatistics.cs
@@ -181,6 +181,90 @@ internal class CallStatistics<TType> : IStatistics<TType>
 		return release;
 	}
 
+#if FEATURE_SPAN
+	/// <summary>
+	///     Registers the method <paramref name="name" /> with <paramref name="parameter1" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1>(string name, ReadOnlySpan<T1> parameter1)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			int counter = _statisticsGate.GetCounter();
+			_methods.Enqueue(new MethodStatistic(counter, name,
+				ParameterDescription.FromParameter(parameter1)));
+		}
+
+		return release;
+	}
+#endif
+
+#if FEATURE_SPAN
+	/// <summary>
+	///     Registers the method <paramref name="name" /> with <paramref name="parameter1" /> and
+	///     <paramref name="parameter2" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1, T2>(string name, ReadOnlySpan<T1> parameter1,
+		ReadOnlySpan<T2> parameter2)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			int counter = _statisticsGate.GetCounter();
+			_methods.Enqueue(new MethodStatistic(counter, name,
+				ParameterDescription.FromParameter(parameter1),
+				ParameterDescription.FromParameter(parameter2)));
+		}
+
+		return release;
+	}
+#endif
+
+#if FEATURE_SPAN
+	/// <summary>
+	///     Registers the method <paramref name="name" /> with <paramref name="parameter1" />, <paramref name="parameter2" />
+	///     and <paramref name="parameter3" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1, T2, T3>(string name, ReadOnlySpan<T1> parameter1,
+		ReadOnlySpan<T2> parameter2, ReadOnlySpan<T3> parameter3)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			int counter = _statisticsGate.GetCounter();
+			_methods.Enqueue(new MethodStatistic(counter, name,
+				ParameterDescription.FromParameter(parameter1),
+				ParameterDescription.FromParameter(parameter2),
+				ParameterDescription.FromParameter(parameter3)));
+		}
+
+		return release;
+	}
+#endif
+
+#if FEATURE_SPAN
+	/// <summary>
+	///     Registers the method <paramref name="name" /> with <paramref name="parameter1" />, <paramref name="parameter2" />,
+	///     <paramref name="parameter3" /> and <paramref name="parameter4" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1, T2, T3, T4>(string name, ReadOnlySpan<T1> parameter1,
+		ReadOnlySpan<T2> parameter2, ReadOnlySpan<T3> parameter3, ReadOnlySpan<T4> parameter4)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			int counter = _statisticsGate.GetCounter();
+			_methods.Enqueue(new MethodStatistic(counter, name,
+				ParameterDescription.FromParameter(parameter1),
+				ParameterDescription.FromParameter(parameter2),
+				ParameterDescription.FromParameter(parameter3),
+				ParameterDescription.FromParameter(parameter4)));
+		}
+
+		return release;
+	}
+#endif
+
 	/// <summary>
 	///     Registers the method <paramref name="name" /> with <paramref name="parameters" />.
 	/// </summary>

--- a/Source/Testably.Abstractions.Testing/Statistics/CallStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/CallStatistics.cs
@@ -54,10 +54,23 @@ internal class CallStatistics<TType> : IStatistics<TType>
 		if (_statisticsGate.TryGetLock(out IDisposable release))
 		{
 			int counter = _statisticsGate.GetCounter();
-			_methods.Enqueue(new MethodStatistic(counter, name, new[]
-			{
-				ParameterDescription.FromParameter(parameter1)
-			}));
+			_methods.Enqueue(new MethodStatistic(counter, name,
+				ParameterDescription.FromParameter(parameter1)));
+		}
+
+		return release;
+	}
+
+	/// <summary>
+	///     Registers the method <paramref name="name" /> without parameters.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod(string name)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			int counter = _statisticsGate.GetCounter();
+			_methods.Enqueue(new MethodStatistic(counter, name));
 		}
 
 		return release;
@@ -73,11 +86,9 @@ internal class CallStatistics<TType> : IStatistics<TType>
 		if (_statisticsGate.TryGetLock(out IDisposable release))
 		{
 			int counter = _statisticsGate.GetCounter();
-			_methods.Enqueue(new MethodStatistic(counter, name, new[]
-			{
+			_methods.Enqueue(new MethodStatistic(counter, name,
 				ParameterDescription.FromParameter(parameter1),
-				ParameterDescription.FromParameter(parameter2)
-			}));
+				ParameterDescription.FromParameter(parameter2)));
 		}
 
 		return release;
@@ -94,12 +105,10 @@ internal class CallStatistics<TType> : IStatistics<TType>
 		if (_statisticsGate.TryGetLock(out IDisposable release))
 		{
 			int counter = _statisticsGate.GetCounter();
-			_methods.Enqueue(new MethodStatistic(counter, name, new[]
-			{
+			_methods.Enqueue(new MethodStatistic(counter, name,
 				ParameterDescription.FromParameter(parameter1),
 				ParameterDescription.FromParameter(parameter2),
-				ParameterDescription.FromParameter(parameter3)
-			}));
+				ParameterDescription.FromParameter(parameter3)));
 		}
 
 		return release;
@@ -116,13 +125,11 @@ internal class CallStatistics<TType> : IStatistics<TType>
 		if (_statisticsGate.TryGetLock(out IDisposable release))
 		{
 			int counter = _statisticsGate.GetCounter();
-			_methods.Enqueue(new MethodStatistic(counter, name, new[]
-			{
+			_methods.Enqueue(new MethodStatistic(counter, name,
 				ParameterDescription.FromParameter(parameter1),
 				ParameterDescription.FromParameter(parameter2),
 				ParameterDescription.FromParameter(parameter3),
-				ParameterDescription.FromParameter(parameter4)
-			}));
+				ParameterDescription.FromParameter(parameter4)));
 		}
 
 		return release;
@@ -139,14 +146,12 @@ internal class CallStatistics<TType> : IStatistics<TType>
 		if (_statisticsGate.TryGetLock(out IDisposable release))
 		{
 			int counter = _statisticsGate.GetCounter();
-			_methods.Enqueue(new MethodStatistic(counter, name, new[]
-			{
+			_methods.Enqueue(new MethodStatistic(counter, name,
 				ParameterDescription.FromParameter(parameter1),
 				ParameterDescription.FromParameter(parameter2),
 				ParameterDescription.FromParameter(parameter3),
 				ParameterDescription.FromParameter(parameter4),
-				ParameterDescription.FromParameter(parameter5)
-			}));
+				ParameterDescription.FromParameter(parameter5)));
 		}
 
 		return release;
@@ -164,15 +169,13 @@ internal class CallStatistics<TType> : IStatistics<TType>
 		if (_statisticsGate.TryGetLock(out IDisposable release))
 		{
 			int counter = _statisticsGate.GetCounter();
-			_methods.Enqueue(new MethodStatistic(counter, name, new[]
-			{
+			_methods.Enqueue(new MethodStatistic(counter, name,
 				ParameterDescription.FromParameter(parameter1),
 				ParameterDescription.FromParameter(parameter2),
 				ParameterDescription.FromParameter(parameter3),
 				ParameterDescription.FromParameter(parameter4),
 				ParameterDescription.FromParameter(parameter5),
-				ParameterDescription.FromParameter(parameter6)
-			}));
+				ParameterDescription.FromParameter(parameter6)));
 		}
 
 		return release;

--- a/Source/Testably.Abstractions.Testing/Statistics/CallStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/CallStatistics.cs
@@ -46,6 +46,151 @@ internal class CallStatistics<TType> : IStatistics<TType>
 	}
 
 	/// <summary>
+	///     Registers the method <paramref name="name" /> with <paramref name="parameter1" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1>(string name, T1 parameter1)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			int counter = _statisticsGate.GetCounter();
+			_methods.Enqueue(new MethodStatistic(counter, name, new[]
+			{
+				ParameterDescription.FromParameter(parameter1)
+			}));
+		}
+
+		return release;
+	}
+
+	/// <summary>
+	///     Registers the method <paramref name="name" /> with <paramref name="parameter1" /> and
+	///     <paramref name="parameter2" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1, T2>(string name, T1 parameter1, T2 parameter2)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			int counter = _statisticsGate.GetCounter();
+			_methods.Enqueue(new MethodStatistic(counter, name, new[]
+			{
+				ParameterDescription.FromParameter(parameter1),
+				ParameterDescription.FromParameter(parameter2)
+			}));
+		}
+
+		return release;
+	}
+
+	/// <summary>
+	///     Registers the method <paramref name="name" /> with <paramref name="parameter1" />, <paramref name="parameter2" />
+	///     and <paramref name="parameter3" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1, T2, T3>(string name, T1 parameter1, T2 parameter2,
+		T3 parameter3)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			int counter = _statisticsGate.GetCounter();
+			_methods.Enqueue(new MethodStatistic(counter, name, new[]
+			{
+				ParameterDescription.FromParameter(parameter1),
+				ParameterDescription.FromParameter(parameter2),
+				ParameterDescription.FromParameter(parameter3)
+			}));
+		}
+
+		return release;
+	}
+
+	/// <summary>
+	///     Registers the method <paramref name="name" /> with <paramref name="parameter1" />, <paramref name="parameter2" />,
+	///     <paramref name="parameter3" /> and <paramref name="parameter4" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1, T2, T3, T4>(string name, T1 parameter1, T2 parameter2,
+		T3 parameter3, T4 parameter4)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			int counter = _statisticsGate.GetCounter();
+			_methods.Enqueue(new MethodStatistic(counter, name, new[]
+			{
+				ParameterDescription.FromParameter(parameter1),
+				ParameterDescription.FromParameter(parameter2),
+				ParameterDescription.FromParameter(parameter3),
+				ParameterDescription.FromParameter(parameter4)
+			}));
+		}
+
+		return release;
+	}
+
+	/// <summary>
+	///     Registers the method <paramref name="name" /> with <paramref name="parameter1" />, <paramref name="parameter2" />,
+	///     <paramref name="parameter3" />, <paramref name="parameter4" /> and <paramref name="parameter5" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1, T2, T3, T4, T5>(string name, T1 parameter1,
+		T2 parameter2, T3 parameter3, T4 parameter4, T5 parameter5)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			int counter = _statisticsGate.GetCounter();
+			_methods.Enqueue(new MethodStatistic(counter, name, new[]
+			{
+				ParameterDescription.FromParameter(parameter1),
+				ParameterDescription.FromParameter(parameter2),
+				ParameterDescription.FromParameter(parameter3),
+				ParameterDescription.FromParameter(parameter4),
+				ParameterDescription.FromParameter(parameter5)
+			}));
+		}
+
+		return release;
+	}
+
+	/// <summary>
+	///     Registers the method <paramref name="name" /> with <paramref name="parameter1" />, <paramref name="parameter2" />,
+	///     <paramref name="parameter3" />, <paramref name="parameter4" />, <paramref name="parameter5" /> and
+	///     <paramref name="parameter6" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1, T2, T3, T4, T5, T6>(string name, T1 parameter1,
+		T2 parameter2, T3 parameter3, T4 parameter4, T5 parameter5, T6 parameter6)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			int counter = _statisticsGate.GetCounter();
+			_methods.Enqueue(new MethodStatistic(counter, name, new[]
+			{
+				ParameterDescription.FromParameter(parameter1),
+				ParameterDescription.FromParameter(parameter2),
+				ParameterDescription.FromParameter(parameter3),
+				ParameterDescription.FromParameter(parameter4),
+				ParameterDescription.FromParameter(parameter5),
+				ParameterDescription.FromParameter(parameter6)
+			}));
+		}
+
+		return release;
+	}
+
+	/// <summary>
+	///     Registers the method <paramref name="name" /> with <paramref name="parameters" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethodWithoutLock(IDisposable release, string name,
+		params ParameterDescription[] parameters)
+	{
+		int counter = _statisticsGate.GetCounter();
+		_methods.Enqueue(new MethodStatistic(counter, name, parameters));
+		return release;
+	}
+
+	/// <summary>
 	///     Registers the property <paramref name="name" /> callback with <paramref name="access" /> access.
 	/// </summary>
 	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
@@ -57,6 +202,18 @@ internal class CallStatistics<TType> : IStatistics<TType>
 			_properties.Enqueue(new PropertyStatistic(counter, name, access));
 		}
 
+		return release;
+	}
+
+	/// <summary>
+	///     Registers the property <paramref name="name" /> callback with <paramref name="access" /> access.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterPropertyWithoutLock(IDisposable release, string name,
+		PropertyAccess access)
+	{
+		int counter = _statisticsGate.GetCounter();
+		_properties.Enqueue(new PropertyStatistic(counter, name, access));
 		return release;
 	}
 }

--- a/Source/Testably.Abstractions.Testing/Statistics/MethodStatistic.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/MethodStatistic.cs
@@ -22,7 +22,7 @@ public sealed class MethodStatistic
 	/// </summary>
 	public ParameterDescription[] Parameters { get; }
 
-	internal MethodStatistic(int counter, string name, ParameterDescription[] parameters)
+	internal MethodStatistic(int counter, string name, params ParameterDescription[] parameters)
 	{
 		Counter = counter;
 		Name = name;

--- a/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
@@ -49,11 +49,137 @@ internal class PathStatistics<TFactory, TType> : CallStatistics<TFactory>,
 	internal IDisposable RegisterMethod(string path, string name,
 		params ParameterDescription[] parameters)
 	{
-		string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
-		CallStatistics<TType> callStatistics =
-			_statistics.GetOrAdd(key,
-				k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
-		return callStatistics.RegisterMethod(name, parameters);
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
+			CallStatistics<TType> callStatistics =
+				_statistics.GetOrAdd(key,
+					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
+			return callStatistics.RegisterMethodWithoutLock(release, name, parameters);
+		}
+
+		return release;
+	}
+
+	/// <summary>
+	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" /> under <paramref name="path" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1>(string path, string name,
+		T1 parameter1)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
+			CallStatistics<TType> callStatistics =
+				_statistics.GetOrAdd(key,
+					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
+			return callStatistics.RegisterMethodWithoutLock(release, name, new[]
+			{
+				ParameterDescription.FromParameter(parameter1)
+			});
+		}
+
+		return release;
+	}
+
+	/// <summary>
+	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" /> and <paramref name="parameter2" /> under <paramref name="path" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1, T2>(string path, string name,
+		T1 parameter1, T2 parameter2)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
+			CallStatistics<TType> callStatistics =
+				_statistics.GetOrAdd(key,
+					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
+			return callStatistics.RegisterMethodWithoutLock(release, name, new[]
+			{
+				ParameterDescription.FromParameter(parameter1),
+				ParameterDescription.FromParameter(parameter2)
+			});
+		}
+
+		return release;
+	}
+
+	/// <summary>
+	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" />, <paramref name="parameter2" /> and <paramref name="parameter3" /> under <paramref name="path" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1, T2, T3>(string path, string name,
+		T1 parameter1, T2 parameter2, T3 parameter3)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
+			CallStatistics<TType> callStatistics =
+				_statistics.GetOrAdd(key,
+					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
+			return callStatistics.RegisterMethodWithoutLock(release, name, new[]
+			{
+				ParameterDescription.FromParameter(parameter1),
+				ParameterDescription.FromParameter(parameter2),
+				ParameterDescription.FromParameter(parameter3)
+			});
+		}
+
+		return release;
+	}
+
+	/// <summary>
+	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" />, <paramref name="parameter2" />, <paramref name="parameter3" /> and <paramref name="parameter4" /> under <paramref name="path" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1, T2, T3, T4>(string path, string name,
+		T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
+			CallStatistics<TType> callStatistics =
+				_statistics.GetOrAdd(key,
+					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
+			return callStatistics.RegisterMethodWithoutLock(release, name, new[]
+			{
+				ParameterDescription.FromParameter(parameter1),
+				ParameterDescription.FromParameter(parameter2),
+				ParameterDescription.FromParameter(parameter3),
+				ParameterDescription.FromParameter(parameter4)
+			});
+		}
+
+		return release;
+	}
+
+
+	/// <summary>
+	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" />, <paramref name="parameter2" />, <paramref name="parameter3" />, <paramref name="parameter4" /> and <paramref name="parameter5" /> under <paramref name="path" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1, T2, T3, T4, T5>(string path, string name,
+		T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4, T5 parameter5)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
+			CallStatistics<TType> callStatistics =
+				_statistics.GetOrAdd(key,
+					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
+			return callStatistics.RegisterMethodWithoutLock(release, name, new[]
+			{
+				ParameterDescription.FromParameter(parameter1),
+				ParameterDescription.FromParameter(parameter2),
+				ParameterDescription.FromParameter(parameter3),
+				ParameterDescription.FromParameter(parameter4),
+				ParameterDescription.FromParameter(parameter5)
+			});
+		}
+
+		return release;
 	}
 
 	/// <summary>
@@ -63,11 +189,15 @@ internal class PathStatistics<TFactory, TType> : CallStatistics<TFactory>,
 	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
 	internal IDisposable RegisterProperty(string path, string name, PropertyAccess access)
 	{
-		string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
-		CallStatistics<TType> callStatistics =
-			_statistics.GetOrAdd(key,
-				k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
-		return callStatistics.RegisterProperty(name, access);
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
+			CallStatistics<TType> callStatistics =
+				_statistics.GetOrAdd(key,
+					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
+			return callStatistics.RegisterPropertyWithoutLock(release, name, access);
+		}
+		return release;
 	}
 
 	private static string CreateKey(string currentDirectory, string path)

--- a/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
@@ -46,8 +46,8 @@ internal class PathStatistics<TFactory, TType> : CallStatistics<TFactory>,
 	///     Registers the <paramref name="name" /> callback with <paramref name="parameters" /> under <paramref name="path" />.
 	/// </summary>
 	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
-	internal IDisposable RegisterMethod(string path, string name,
-		params ParameterDescription[] parameters)
+	internal IDisposable RegisterPathMethod(string path, string name,
+		ParameterDescription[] parameters)
 	{
 		if (_statisticsGate.TryGetLock(out IDisposable release))
 		{
@@ -62,10 +62,28 @@ internal class PathStatistics<TFactory, TType> : CallStatistics<TFactory>,
 	}
 
 	/// <summary>
+	///     Registers the <paramref name="name" /> callback without parameters under <paramref name="path" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterPathMethod(string path, string name)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
+			CallStatistics<TType> callStatistics =
+				_statistics.GetOrAdd(key,
+					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
+			return callStatistics.RegisterMethodWithoutLock(release, name);
+		}
+
+		return release;
+	}
+
+	/// <summary>
 	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" /> under <paramref name="path" />.
 	/// </summary>
 	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
-	internal IDisposable RegisterMethod<T1>(string path, string name,
+	internal IDisposable RegisterPathMethod<T1>(string path, string name,
 		T1 parameter1)
 	{
 		if (_statisticsGate.TryGetLock(out IDisposable release))
@@ -74,20 +92,63 @@ internal class PathStatistics<TFactory, TType> : CallStatistics<TFactory>,
 			CallStatistics<TType> callStatistics =
 				_statistics.GetOrAdd(key,
 					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
-			return callStatistics.RegisterMethodWithoutLock(release, name, new[]
-			{
-				ParameterDescription.FromParameter(parameter1)
-			});
+			return callStatistics.RegisterMethodWithoutLock(release, name,
+				ParameterDescription.FromParameter(parameter1));
 		}
 
 		return release;
 	}
 
+#if FEATURE_SPAN
 	/// <summary>
-	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" /> and <paramref name="parameter2" /> under <paramref name="path" />.
+	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" /> under <paramref name="path" />.
 	/// </summary>
 	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
-	internal IDisposable RegisterMethod<T1, T2>(string path, string name,
+	internal IDisposable RegisterPathMethod<T1>(string path, string name,
+		ReadOnlySpan<T1> parameter1)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
+			CallStatistics<TType> callStatistics =
+				_statistics.GetOrAdd(key,
+					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
+			return callStatistics.RegisterMethodWithoutLock(release, name,
+				ParameterDescription.FromParameter(parameter1));
+		}
+
+		return release;
+	}
+#endif
+
+#if FEATURE_SPAN
+	/// <summary>
+	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" /> under <paramref name="path" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterPathMethod<T1>(string path, string name,
+		Span<T1> parameter1)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			string key = CreateKey(_fileSystem.Storage.CurrentDirectory, path);
+			CallStatistics<TType> callStatistics =
+				_statistics.GetOrAdd(key,
+					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
+			return callStatistics.RegisterMethodWithoutLock(release, name,
+				ParameterDescription.FromParameter(parameter1));
+		}
+
+		return release;
+	}
+#endif
+
+	/// <summary>
+	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" /> and
+	///     <paramref name="parameter2" /> under <paramref name="path" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterPathMethod<T1, T2>(string path, string name,
 		T1 parameter1, T2 parameter2)
 	{
 		if (_statisticsGate.TryGetLock(out IDisposable release))
@@ -96,21 +157,20 @@ internal class PathStatistics<TFactory, TType> : CallStatistics<TFactory>,
 			CallStatistics<TType> callStatistics =
 				_statistics.GetOrAdd(key,
 					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
-			return callStatistics.RegisterMethodWithoutLock(release, name, new[]
-			{
+			return callStatistics.RegisterMethodWithoutLock(release, name,
 				ParameterDescription.FromParameter(parameter1),
-				ParameterDescription.FromParameter(parameter2)
-			});
+				ParameterDescription.FromParameter(parameter2));
 		}
 
 		return release;
 	}
 
 	/// <summary>
-	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" />, <paramref name="parameter2" /> and <paramref name="parameter3" /> under <paramref name="path" />.
+	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" />, <paramref name="parameter2" />
+	///     and <paramref name="parameter3" /> under <paramref name="path" />.
 	/// </summary>
 	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
-	internal IDisposable RegisterMethod<T1, T2, T3>(string path, string name,
+	internal IDisposable RegisterPathMethod<T1, T2, T3>(string path, string name,
 		T1 parameter1, T2 parameter2, T3 parameter3)
 	{
 		if (_statisticsGate.TryGetLock(out IDisposable release))
@@ -119,22 +179,21 @@ internal class PathStatistics<TFactory, TType> : CallStatistics<TFactory>,
 			CallStatistics<TType> callStatistics =
 				_statistics.GetOrAdd(key,
 					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
-			return callStatistics.RegisterMethodWithoutLock(release, name, new[]
-			{
+			return callStatistics.RegisterMethodWithoutLock(release, name,
 				ParameterDescription.FromParameter(parameter1),
 				ParameterDescription.FromParameter(parameter2),
-				ParameterDescription.FromParameter(parameter3)
-			});
+				ParameterDescription.FromParameter(parameter3));
 		}
 
 		return release;
 	}
 
 	/// <summary>
-	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" />, <paramref name="parameter2" />, <paramref name="parameter3" /> and <paramref name="parameter4" /> under <paramref name="path" />.
+	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" />, <paramref name="parameter2" />
+	///     , <paramref name="parameter3" /> and <paramref name="parameter4" /> under <paramref name="path" />.
 	/// </summary>
 	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
-	internal IDisposable RegisterMethod<T1, T2, T3, T4>(string path, string name,
+	internal IDisposable RegisterPathMethod<T1, T2, T3, T4>(string path, string name,
 		T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)
 	{
 		if (_statisticsGate.TryGetLock(out IDisposable release))
@@ -143,24 +202,23 @@ internal class PathStatistics<TFactory, TType> : CallStatistics<TFactory>,
 			CallStatistics<TType> callStatistics =
 				_statistics.GetOrAdd(key,
 					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
-			return callStatistics.RegisterMethodWithoutLock(release, name, new[]
-			{
+			return callStatistics.RegisterMethodWithoutLock(release, name,
 				ParameterDescription.FromParameter(parameter1),
 				ParameterDescription.FromParameter(parameter2),
 				ParameterDescription.FromParameter(parameter3),
-				ParameterDescription.FromParameter(parameter4)
-			});
+				ParameterDescription.FromParameter(parameter4));
 		}
 
 		return release;
 	}
 
-
 	/// <summary>
-	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" />, <paramref name="parameter2" />, <paramref name="parameter3" />, <paramref name="parameter4" /> and <paramref name="parameter5" /> under <paramref name="path" />.
+	///     Registers the <paramref name="name" /> callback with <paramref name="parameter1" />, <paramref name="parameter2" />
+	///     , <paramref name="parameter3" />, <paramref name="parameter4" /> and <paramref name="parameter5" /> under
+	///     <paramref name="path" />.
 	/// </summary>
 	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
-	internal IDisposable RegisterMethod<T1, T2, T3, T4, T5>(string path, string name,
+	internal IDisposable RegisterPathMethod<T1, T2, T3, T4, T5>(string path, string name,
 		T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4, T5 parameter5)
 	{
 		if (_statisticsGate.TryGetLock(out IDisposable release))
@@ -169,14 +227,12 @@ internal class PathStatistics<TFactory, TType> : CallStatistics<TFactory>,
 			CallStatistics<TType> callStatistics =
 				_statistics.GetOrAdd(key,
 					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
-			return callStatistics.RegisterMethodWithoutLock(release, name, new[]
-			{
+			return callStatistics.RegisterMethodWithoutLock(release, name,
 				ParameterDescription.FromParameter(parameter1),
 				ParameterDescription.FromParameter(parameter2),
 				ParameterDescription.FromParameter(parameter3),
 				ParameterDescription.FromParameter(parameter4),
-				ParameterDescription.FromParameter(parameter5)
-			});
+				ParameterDescription.FromParameter(parameter5));
 		}
 
 		return release;
@@ -187,7 +243,7 @@ internal class PathStatistics<TFactory, TType> : CallStatistics<TFactory>,
 	///     <paramref name="path" />.
 	/// </summary>
 	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
-	internal IDisposable RegisterProperty(string path, string name, PropertyAccess access)
+	internal IDisposable RegisterPathProperty(string path, string name, PropertyAccess access)
 	{
 		if (_statisticsGate.TryGetLock(out IDisposable release))
 		{
@@ -197,6 +253,7 @@ internal class PathStatistics<TFactory, TType> : CallStatistics<TFactory>,
 					k => new CallStatistics<TType>(_statisticsGate, $"{ToString()}[{k}]"));
 			return callStatistics.RegisterPropertyWithoutLock(release, name, access);
 		}
+
 		return release;
 	}
 


### PR DESCRIPTION
Currently all calls during the initialization result in an initialized `ConcurrentDictionary` for each path. This PR changes the behaviour, that the entries of `PathStatistics` are only added, during a normal statistic registration.