### PR TITLE
feat: Add `TotalCount` to Statistics

### DIFF
--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
@@ -129,7 +129,7 @@ internal static class FileSystemExtensions
 	{
 		if (fileSystem is MockFileSystem mockFileSystem)
 		{
-			return mockFileSystem.StatisticsRegistration.Ignore();
+			return mockFileSystem.Registration.Ignore();
 		}
 
 		return new NoOpDisposable();

--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemRegistration.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemRegistration.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Threading;
-using Testably.Abstractions.Testing.Helpers;
+using Testably.Abstractions.Testing.Statistics;
 
-namespace Testably.Abstractions.Testing.Statistics;
+namespace Testably.Abstractions.Testing.Helpers;
 
 internal sealed class FileSystemRegistration : IStatisticsGate
 {

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -80,6 +80,8 @@ public sealed class MockFileSystem : IFileSystem
 		private set;
 	}
 
+	internal FileSystemStatistics StatisticsRegistration { get; }
+
 	/// <summary>
 	///     The underlying storage of directories and files.
 	/// </summary>
@@ -91,7 +93,7 @@ public sealed class MockFileSystem : IFileSystem
 	internal IReadOnlyList<IStorageContainer> StorageContainers
 		=> _storage.GetContainers();
 
-	internal readonly FileSystemStatistics StatisticsRegistration;
+	internal FileSystemRegistration Registration { get; }
 
 	private readonly DirectoryMock _directoryMock;
 	private readonly FileMock _fileMock;
@@ -120,8 +122,9 @@ public sealed class MockFileSystem : IFileSystem
 		SimulationMode = SimulationMode.Native;
 		Execute = new Execute(this);
 #endif
+		Registration = new FileSystemRegistration();
 		StatisticsRegistration = new FileSystemStatistics(this);
-		using IDisposable release = StatisticsRegistration.Ignore();
+		using IDisposable release = Registration.Ignore();
 		RandomSystem =
 			new MockRandomSystem(initialization.RandomProvider ?? RandomProvider.Default());
 		TimeSystem = new MockTimeSystem(TimeProvider.Now());

--- a/Source/Testably.Abstractions.Testing/Statistics/FileSystemRegistration.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/FileSystemRegistration.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Threading;
+using Testably.Abstractions.Testing.Helpers;
+
+namespace Testably.Abstractions.Testing.Statistics;
+
+internal sealed class FileSystemRegistration : IStatisticsGate
+{
+	private static readonly AsyncLocal<bool> IsDisabled = new();
+	private static readonly AsyncLocal<bool> IsInit = new();
+
+	/// <summary>
+	///     The total count of registered statistic calls.
+	/// </summary>
+	public int TotalCount => _counter;
+
+	private int _counter;
+
+	#region IStatisticsGate Members
+
+	/// <inheritdoc cref="IStatisticsGate.GetCounter()" />
+	public int GetCounter()
+	{
+		return Interlocked.Increment(ref _counter);
+	}
+
+	/// <inheritdoc cref="IStatisticsGate.TryGetLock(out IDisposable)" />
+	public bool TryGetLock(out IDisposable release)
+	{
+		if (IsDisabled.Value)
+		{
+			release = TemporaryDisable.None;
+			return false;
+		}
+
+		IsDisabled.Value = true;
+		release = new TemporaryDisable(() => IsDisabled.Value = false);
+		return true;
+	}
+
+	#endregion
+
+	/// <summary>
+	///     Ignores all registrations until the return value is disposed.
+	/// </summary>
+	internal IDisposable Ignore()
+	{
+		if (IsDisabled.Value)
+		{
+			return TemporaryDisable.None;
+		}
+
+		IsDisabled.Value = true;
+		IsInit.Value = true;
+		return new TemporaryDisable(() =>
+		{
+			IsDisabled.Value = false;
+			IsInit.Value = false;
+		});
+	}
+
+	internal bool IsInitializing()
+		=> IsInit.Value;
+
+	private sealed class TemporaryDisable : IDisposable
+	{
+		public static IDisposable None { get; } = new NoOpDisposable();
+
+		private readonly Action _onDispose;
+
+		public TemporaryDisable(Action onDispose)
+		{
+			_onDispose = onDispose;
+		}
+
+		#region IDisposable Members
+
+		/// <inheritdoc cref="IDisposable.Dispose()" />
+		public void Dispose() => _onDispose();
+
+		#endregion
+	}
+}

--- a/Source/Testably.Abstractions.Testing/Statistics/FileSystemStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/FileSystemStatistics.cs
@@ -1,19 +1,7 @@
-﻿using System;
-using System.Threading;
-using Testably.Abstractions.Testing.Helpers;
+﻿namespace Testably.Abstractions.Testing.Statistics;
 
-namespace Testably.Abstractions.Testing.Statistics;
-
-internal sealed class FileSystemStatistics : IFileSystemStatistics, IStatisticsGate
+internal sealed class FileSystemStatistics : IFileSystemStatistics
 {
-	private static readonly AsyncLocal<bool> IsDisabled = new();
-	private static readonly AsyncLocal<bool> IsInit = new();
-
-	/// <summary>
-	///     The total count of registered statistic calls.
-	/// </summary>
-	public int TotalCount => _counter;
-
 	internal readonly CallStatistics<IDirectory> Directory;
 	internal readonly PathStatistics<IDirectoryInfoFactory, IDirectoryInfo> DirectoryInfo;
 	internal readonly PathStatistics<IDriveInfoFactory, IDriveInfo> DriveInfo;
@@ -25,118 +13,69 @@ internal sealed class FileSystemStatistics : IFileSystemStatistics, IStatisticsG
 		FileSystemWatcher;
 
 	internal readonly CallStatistics<IPath> Path;
-	private int _counter;
+	private readonly MockFileSystem _fileSystem;
 
 	public FileSystemStatistics(MockFileSystem fileSystem)
 	{
-		Directory = new CallStatistics<IDirectory>(this, nameof(IFileSystem.Directory));
+		_fileSystem = fileSystem;
+		IStatisticsGate statisticsGate = fileSystem.Registration;
+
+		Directory = new CallStatistics<IDirectory>(
+			statisticsGate, nameof(IFileSystem.Directory));
 		DirectoryInfo = new PathStatistics<IDirectoryInfoFactory, IDirectoryInfo>(
-			this, fileSystem, nameof(IFileSystem.DirectoryInfo));
+			statisticsGate, fileSystem, nameof(IFileSystem.DirectoryInfo));
 		DriveInfo = new PathStatistics<IDriveInfoFactory, IDriveInfo>(
-			this, fileSystem, nameof(IFileSystem.DriveInfo));
-		File = new CallStatistics<IFile>(this, nameof(IFileSystem.File));
+			statisticsGate, fileSystem, nameof(IFileSystem.DriveInfo));
+		File = new CallStatistics<IFile>(
+			statisticsGate, nameof(IFileSystem.File));
 		FileInfo = new PathStatistics<IFileInfoFactory, IFileInfo>(
-			this, fileSystem, nameof(IFileSystem.FileInfo));
+			statisticsGate, fileSystem, nameof(IFileSystem.FileInfo));
 		FileStream = new PathStatistics<IFileStreamFactory, FileSystemStream>(
-			this, fileSystem, nameof(IFileSystem.FileStream));
+			statisticsGate, fileSystem, nameof(IFileSystem.FileStream));
 		FileSystemWatcher = new PathStatistics<IFileSystemWatcherFactory, IFileSystemWatcher>(
-			this, fileSystem, nameof(IFileSystem.FileSystemWatcher));
-		Path = new CallStatistics<IPath>(this, nameof(IFileSystem.Path));
+			statisticsGate, fileSystem, nameof(IFileSystem.FileSystemWatcher));
+		Path = new CallStatistics<IPath>(
+			statisticsGate, nameof(IFileSystem.Path));
 	}
 
 	#region IFileSystemStatistics Members
 
+	/// <inheritdoc cref="IFileSystemStatistics.TotalCount" />
+	public int TotalCount
+		=> _fileSystem.Registration.TotalCount;
+
 	/// <inheritdoc cref="IFileSystemStatistics.Directory" />
-	IStatistics<IDirectory> IFileSystemStatistics.Directory => Directory;
+	IStatistics<IDirectory> IFileSystemStatistics.Directory
+		=> Directory;
 
 	/// <inheritdoc cref="IFileSystemStatistics.DirectoryInfo" />
 	IPathStatistics<IDirectoryInfoFactory, IDirectoryInfo> IFileSystemStatistics.DirectoryInfo
 		=> DirectoryInfo;
 
 	/// <inheritdoc cref="IFileSystemStatistics.DriveInfo" />
-	IPathStatistics<IDriveInfoFactory, IDriveInfo> IFileSystemStatistics.DriveInfo => DriveInfo;
+	IPathStatistics<IDriveInfoFactory, IDriveInfo> IFileSystemStatistics.DriveInfo
+		=> DriveInfo;
 
 	/// <inheritdoc cref="IFileSystemStatistics.File" />
-	IStatistics<IFile> IFileSystemStatistics.File => File;
+	IStatistics<IFile> IFileSystemStatistics.File
+		=> File;
 
 	/// <inheritdoc cref="IFileSystemStatistics.FileInfo" />
-	IPathStatistics<IFileInfoFactory, IFileInfo> IFileSystemStatistics.FileInfo => FileInfo;
+	IPathStatistics<IFileInfoFactory, IFileInfo> IFileSystemStatistics.FileInfo
+		=> FileInfo;
 
 	/// <inheritdoc cref="IFileSystemStatistics.FileStream" />
 	IPathStatistics<IFileStreamFactory, FileSystemStream> IFileSystemStatistics.FileStream
 		=> FileStream;
 
 	/// <inheritdoc cref="IFileSystemStatistics.FileSystemWatcher" />
-	IPathStatistics<IFileSystemWatcherFactory, IFileSystemWatcher> IFileSystemStatistics.
-		FileSystemWatcher => FileSystemWatcher;
+	IPathStatistics<IFileSystemWatcherFactory, IFileSystemWatcher>
+		IFileSystemStatistics.FileSystemWatcher
+		=> FileSystemWatcher;
 
 	/// <inheritdoc cref="IFileSystemStatistics.Path" />
-	IStatistics<IPath> IFileSystemStatistics.Path => Path;
+	IStatistics<IPath> IFileSystemStatistics.Path
+		=> Path;
 
 	#endregion
-
-	#region IStatisticsGate Members
-
-	/// <inheritdoc cref="IStatisticsGate.GetCounter()" />
-	public int GetCounter()
-	{
-		return Interlocked.Increment(ref _counter);
-	}
-
-	/// <inheritdoc cref="IStatisticsGate.TryGetLock(out IDisposable)" />
-	public bool TryGetLock(out IDisposable release)
-	{
-		if (IsDisabled.Value)
-		{
-			release = TemporaryDisable.None;
-			return false;
-		}
-
-		IsDisabled.Value = true;
-		release = new TemporaryDisable(() => IsDisabled.Value = false);
-		return true;
-	}
-
-	#endregion
-
-	/// <summary>
-	///     Ignores all registrations until the return value is disposed.
-	/// </summary>
-	internal IDisposable Ignore()
-	{
-		if (IsDisabled.Value)
-		{
-			return TemporaryDisable.None;
-		}
-
-		IsDisabled.Value = true;
-		IsInit.Value = true;
-		return new TemporaryDisable(() =>
-		{
-			IsDisabled.Value = false;
-			IsInit.Value = false;
-		});
-	}
-
-	internal bool IsInitializing()
-		=> IsInit.Value;
-
-	private sealed class TemporaryDisable : IDisposable
-	{
-		public static IDisposable None { get; } = new NoOpDisposable();
-
-		private readonly Action _onDispose;
-
-		public TemporaryDisable(Action onDispose)
-		{
-			_onDispose = onDispose;
-		}
-
-		#region IDisposable Members
-
-		/// <inheritdoc cref="IDisposable.Dispose()" />
-		public void Dispose() => _onDispose();
-
-		#endregion
-	}
 }

--- a/Source/Testably.Abstractions.Testing/Statistics/IFileSystemStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/IFileSystemStatistics.cs
@@ -44,4 +44,9 @@ public interface IFileSystemStatistics
 	///     Statistical information about calls to <see cref="IFileSystem.Path" />.
 	/// </summary>
 	IStatistics<IPath> Path { get; }
+
+	/// <summary>
+	///     The sum of all registered statistic calls.
+	/// </summary>
+	int TotalCount { get; }
 }

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -148,7 +148,7 @@ internal class InMemoryContainer : IStorageContainer
 		bool ignoreMetadataErrors = true,
 		int? hResult = null)
 	{
-		if (_fileSystem.StatisticsRegistration.IsInitializing())
+		if (_fileSystem.Registration.IsInitializing())
 		{
 			return FileHandle.Ignore;
 		}

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -294,6 +294,7 @@ namespace Testably.Abstractions.Testing.Statistics
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
         Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
+        int TotalCount { get; }
     }
     public interface IPathStatistics<TFactory, TType> : Testably.Abstractions.Testing.Statistics.IStatistics, Testably.Abstractions.Testing.Statistics.IStatistics<TFactory>
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
@@ -294,6 +294,7 @@ namespace Testably.Abstractions.Testing.Statistics
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
         Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
+        int TotalCount { get; }
     }
     public interface IPathStatistics<TFactory, TType> : Testably.Abstractions.Testing.Statistics.IStatistics, Testably.Abstractions.Testing.Statistics.IStatistics<TFactory>
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -292,6 +292,7 @@ namespace Testably.Abstractions.Testing.Statistics
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
         Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
+        int TotalCount { get; }
     }
     public interface IPathStatistics<TFactory, TType> : Testably.Abstractions.Testing.Statistics.IStatistics, Testably.Abstractions.Testing.Statistics.IStatistics<TFactory>
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -291,6 +291,7 @@ namespace Testably.Abstractions.Testing.Statistics
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
         Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
+        int TotalCount { get; }
     }
     public interface IPathStatistics<TFactory, TType> : Testably.Abstractions.Testing.Statistics.IStatistics, Testably.Abstractions.Testing.Statistics.IStatistics<TFactory>
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -291,6 +291,7 @@ namespace Testably.Abstractions.Testing.Statistics
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
         Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
+        int TotalCount { get; }
     }
     public interface IPathStatistics<TFactory, TType> : Testably.Abstractions.Testing.Statistics.IStatistics, Testably.Abstractions.Testing.Statistics.IStatistics<TFactory>
     {

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/DirectoryCleanerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/DirectoryCleanerTests.cs
@@ -113,7 +113,7 @@ public class DirectoryCleanerTests
 		using IDirectoryCleaner directoryCleaner =
 			sut.SetCurrentDirectoryToEmptyTemporaryDirectory(logger: t => receivedLogs.Add(t));
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(0);
+		sut.Statistics.TotalCount.Should().Be(0);
 		string currentDirectory = sut.Directory.GetCurrentDirectory();
 		sut.Should().HaveDirectory(currentDirectory);
 		receivedLogs.Should().Contain(m => m.Contains($"'{currentDirectory}'"));

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
@@ -16,7 +16,7 @@ public class FileSystemInitializerTests
 
 		sut.With(directories);
 
-		fileSystem.StatisticsRegistration.TotalCount.Should().Be(0);
+		fileSystem.Statistics.TotalCount.Should().Be(0);
 		foreach (DirectoryDescription directory in directories)
 		{
 			fileSystem.Should().HaveDirectory(directory.Name);
@@ -35,7 +35,7 @@ public class FileSystemInitializerTests
 
 		sut.With(directoryDescription);
 
-		fileSystem.StatisticsRegistration.TotalCount.Should().Be(0);
+		fileSystem.Statistics.TotalCount.Should().Be(0);
 		foreach (DirectoryDescription directory in directories)
 		{
 			fileSystem.Should().HaveDirectory(Path.Combine(parent, directory.Name));
@@ -52,7 +52,7 @@ public class FileSystemInitializerTests
 
 		sut.With(description);
 
-		fileSystem.StatisticsRegistration.TotalCount.Should().Be(0);
+		fileSystem.Statistics.TotalCount.Should().Be(0);
 		fileSystem.Should().HaveFile(name)
 			.Which.HasContent(bytes);
 	}
@@ -68,7 +68,7 @@ public class FileSystemInitializerTests
 
 		sut.With(description);
 
-		fileSystem.StatisticsRegistration.TotalCount.Should().Be(0);
+		fileSystem.Statistics.TotalCount.Should().Be(0);
 		fileSystem.Should().HaveFile(name)
 			.Which.HasContent(content);
 	}
@@ -82,7 +82,7 @@ public class FileSystemInitializerTests
 
 		sut.With(files);
 
-		fileSystem.StatisticsRegistration.TotalCount.Should().Be(0);
+		fileSystem.Statistics.TotalCount.Should().Be(0);
 		foreach (FileDescription file in files)
 		{
 			fileSystem.Should().HaveFile(file.Name);
@@ -103,7 +103,7 @@ public class FileSystemInitializerTests
 
 		sut.With(description);
 
-		fileSystem.StatisticsRegistration.TotalCount.Should().Be(0);
+		fileSystem.Statistics.TotalCount.Should().Be(0);
 		fileSystem.Should().HaveFile(name);
 		fileSystem.FileInfo.New(name).IsReadOnly.Should().Be(isReadOnly);
 	}
@@ -119,7 +119,7 @@ public class FileSystemInitializerTests
 
 		sut.With(fileDescription, directoryDescription);
 
-		fileSystem.StatisticsRegistration.TotalCount.Should().Be(0);
+		fileSystem.Statistics.TotalCount.Should().Be(0);
 		fileSystem.Should().HaveFile(fileName);
 		fileSystem.Should().HaveDirectory(directoryName);
 	}
@@ -165,7 +165,7 @@ public class FileSystemInitializerTests
 
 		sut.WithFile(path).Which(f => f.HasStringContent("foo"));
 
-		fileSystem.StatisticsRegistration.TotalCount.Should().Be(0);
+		fileSystem.Statistics.TotalCount.Should().Be(0);
 		fileSystem.Should().HaveFile(path)
 			.Which.HasContent("foo");
 	}
@@ -181,7 +181,7 @@ public class FileSystemInitializerTests
 
 		sut.WithFile(path);
 
-		fileSystem.StatisticsRegistration.TotalCount.Should().Be(0);
+		fileSystem.Statistics.TotalCount.Should().Be(0);
 		fileSystem.Should().HaveFile(path);
 		fileSystem.Should().HaveDirectory(directoryPath);
 	}
@@ -196,7 +196,7 @@ public class FileSystemInitializerTests
 		IFileSystemInitializer<MockFileSystem> result = sut
 			.WithSubdirectories(paths);
 
-		fileSystem.StatisticsRegistration.TotalCount.Should().Be(0);
+		fileSystem.Statistics.TotalCount.Should().Be(0);
 		foreach (string path in paths)
 		{
 			fileSystem.Should().HaveDirectory(path);
@@ -246,7 +246,7 @@ public class FileSystemInitializerTests
 		IFileSystemDirectoryInitializer<MockFileSystem> result = sut
 			.WithSubdirectory(path);
 
-		fileSystem.StatisticsRegistration.TotalCount.Should().Be(0);
+		fileSystem.Statistics.TotalCount.Should().Be(0);
 		fileSystem.Should().HaveDirectory(path);
 		result.FileSystem.Should().BeSameAs(fileSystem);
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
@@ -15,7 +15,7 @@ public class FileSystemInitializerExtensionsTests
 		MockFileSystem sut = new();
 		sut.Initialize().WithAFile();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(0);
+		sut.Statistics.TotalCount.Should().Be(0);
 		sut.Directory.EnumerateFiles(".").Should().ContainSingle();
 	}
 
@@ -27,7 +27,7 @@ public class FileSystemInitializerExtensionsTests
 		MockFileSystem sut = new();
 		sut.Initialize().WithAFile(extension);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(0);
+		sut.Statistics.TotalCount.Should().Be(0);
 		sut.Directory.EnumerateFiles(".", $"*.{extension}").Should().ContainSingle();
 	}
 
@@ -37,7 +37,7 @@ public class FileSystemInitializerExtensionsTests
 		MockFileSystem sut = new();
 		sut.InitializeIn("base-directory").WithASubdirectory();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(0);
+		sut.Statistics.TotalCount.Should().Be(0);
 		sut.Directory.EnumerateDirectories(".").Should().ContainSingle();
 	}
 
@@ -66,7 +66,7 @@ public class FileSystemInitializerExtensionsTests
 			.WithFile(fileName).Which(f => f
 				.HasBytesContent(fileContent));
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(0);
+		sut.Statistics.TotalCount.Should().Be(0);
 		byte[] result = sut.File.ReadAllBytes(fileName);
 
 		result.Should().BeEquivalentTo(fileContent);
@@ -82,7 +82,7 @@ public class FileSystemInitializerExtensionsTests
 			.WithFile(fileName).Which(f => f
 				.HasStringContent(fileContent));
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(0);
+		sut.Statistics.TotalCount.Should().Be(0);
 		string result = sut.File.ReadAllText(fileName);
 
 		result.Should().Be(fileContent);
@@ -95,7 +95,7 @@ public class FileSystemInitializerExtensionsTests
 		MockFileSystem sut = new();
 		sut.Initialize().WithFile(fileName);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(0);
+		sut.Statistics.TotalCount.Should().Be(0);
 		sut.Directory.EnumerateFiles(".", fileName).Should().ContainSingle();
 	}
 
@@ -108,7 +108,7 @@ public class FileSystemInitializerExtensionsTests
 				.WithSubdirectory("bar").Initialized(s => s
 					.WithSubdirectory("xyz")));
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(0);
+		sut.Statistics.TotalCount.Should().Be(0);
 		List<string> result = sut.Directory
 			.EnumerateDirectories(".", "*", SearchOption.AllDirectories).ToList();
 
@@ -128,7 +128,7 @@ public class FileSystemInitializerExtensionsTests
 
 		sut.Initialize(options => options.InitializeTempDirectory = initializeTempDirectory);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(0);
+		sut.Statistics.TotalCount.Should().Be(0);
 		sut.Directory.Exists(sut.Path.GetTempPath()).Should().Be(initializeTempDirectory);
 	}
 
@@ -156,7 +156,7 @@ public class FileSystemInitializerExtensionsTests
 		MockFileSystem sut = new();
 		sut.Initialize().WithSubdirectory(directoryName);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(0);
+		sut.Statistics.TotalCount.Should().Be(0);
 		sut.Directory.EnumerateDirectories(".", directoryName).Should().ContainSingle();
 	}
 
@@ -169,7 +169,7 @@ public class FileSystemInitializerExtensionsTests
 			MockFileSystem> result =
 			sut.Initialize().WithSubdirectory(directoryName);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(0);
+		sut.Statistics.TotalCount.Should().Be(0);
 		result.Directory.Should().Exist();
 	}
 
@@ -187,7 +187,7 @@ public class FileSystemInitializerExtensionsTests
 			Assembly.GetExecutingAssembly(),
 			searchPattern: "*.txt");
 
-		fileSystem.StatisticsRegistration.TotalCount.Should().Be(0);
+		fileSystem.Statistics.TotalCount.Should().Be(0);
 		string[] result = fileSystem.Directory.GetFiles(Path.Combine(path, "TestResources"));
 		string[] result2 =
 			fileSystem.Directory.GetFiles(Path.Combine(path, "TestResources", "SubResource"));
@@ -214,7 +214,7 @@ public class FileSystemInitializerExtensionsTests
 			searchPattern: "*.txt",
 			SearchOption.TopDirectoryOnly);
 
-		fileSystem.StatisticsRegistration.TotalCount.Should().Be(0);
+		fileSystem.Statistics.TotalCount.Should().Be(0);
 		string[] result = fileSystem.Directory.GetFiles(path);
 		result.Length.Should().Be(2);
 		result.Should().Contain(x => x.EndsWith("TestFile1.txt"));
@@ -237,7 +237,7 @@ public class FileSystemInitializerExtensionsTests
 			"TestResources/SubResource",
 			searchPattern: "*.txt");
 
-		fileSystem.StatisticsRegistration.TotalCount.Should().Be(0);
+		fileSystem.Statistics.TotalCount.Should().Be(0);
 		string[] result = fileSystem.Directory.GetFiles(path);
 		result.Length.Should().Be(1);
 		result.Should().Contain(x => x.EndsWith("SubResourceFile1.txt"));
@@ -277,7 +277,7 @@ public class FileSystemInitializerExtensionsTests
 
 		sut.InitializeIn(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(0);
+		sut.Statistics.TotalCount.Should().Be(0);
 		sut.Directory.GetCurrentDirectory().Should().Be(expectedPath);
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryInfoFactoryStatisticsTests.cs
@@ -14,7 +14,7 @@ public sealed class DirectoryInfoFactoryStatisticsTests
 
 		sut.DirectoryInfo.New(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.DirectoryInfo.ShouldOnlyContainMethodCall(nameof(IDirectoryInfoFactory.New),
 			path);
 	}
@@ -27,7 +27,7 @@ public sealed class DirectoryInfoFactoryStatisticsTests
 
 		sut.DirectoryInfo.Wrap(directoryInfo);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.DirectoryInfo.ShouldOnlyContainMethodCall(nameof(IDirectoryInfoFactory.Wrap),
 			directoryInfo);
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryInfoStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryInfoStatisticsTests.cs
@@ -13,7 +13,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").Create();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.Create));
 	}
@@ -27,7 +27,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").CreateAsSymbolicLink(pathToTarget);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.CreateAsSymbolicLink),
 				pathToTarget);
@@ -42,7 +42,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").CreateSubdirectory(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.CreateSubdirectory),
 				path);
@@ -57,7 +57,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").Delete(recursive);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.Delete),
 				recursive);
@@ -71,7 +71,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").Delete();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.Delete));
 	}
@@ -83,7 +83,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateDirectories();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateDirectories));
 	}
@@ -98,7 +98,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateDirectories(searchPattern, enumerationOptions);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateDirectories),
 				searchPattern, enumerationOptions);
@@ -114,7 +114,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateDirectories(searchPattern, searchOption);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateDirectories),
 				searchPattern, searchOption);
@@ -128,7 +128,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateDirectories(searchPattern);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateDirectories),
 				searchPattern);
@@ -141,7 +141,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFiles();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFiles));
 	}
@@ -156,7 +156,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFiles(searchPattern, enumerationOptions);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFiles),
 				searchPattern, enumerationOptions);
@@ -172,7 +172,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFiles(searchPattern, searchOption);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFiles),
 				searchPattern, searchOption);
@@ -186,7 +186,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFiles(searchPattern);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFiles),
 				searchPattern);
@@ -199,7 +199,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFileSystemInfos();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFileSystemInfos));
 	}
@@ -214,7 +214,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFileSystemInfos(searchPattern, enumerationOptions);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFileSystemInfos),
 				searchPattern, enumerationOptions);
@@ -230,7 +230,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFileSystemInfos(searchPattern, searchOption);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFileSystemInfos),
 				searchPattern, searchOption);
@@ -244,7 +244,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").EnumerateFileSystemInfos(searchPattern);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.EnumerateFileSystemInfos),
 				searchPattern);
@@ -258,7 +258,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetDirectories();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetDirectories));
 	}
@@ -274,7 +274,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetDirectories(searchPattern, enumerationOptions);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetDirectories),
 				searchPattern, enumerationOptions);
@@ -291,7 +291,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetDirectories(searchPattern, searchOption);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetDirectories),
 				searchPattern, searchOption);
@@ -306,7 +306,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetDirectories(searchPattern);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetDirectories),
 				searchPattern);
@@ -320,7 +320,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFiles();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFiles));
 	}
@@ -336,7 +336,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFiles(searchPattern, enumerationOptions);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFiles),
 				searchPattern, enumerationOptions);
@@ -353,7 +353,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFiles(searchPattern, searchOption);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFiles),
 				searchPattern, searchOption);
@@ -368,7 +368,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFiles(searchPattern);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFiles),
 				searchPattern);
@@ -382,7 +382,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFileSystemInfos();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFileSystemInfos));
 	}
@@ -398,7 +398,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFileSystemInfos(searchPattern, enumerationOptions);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFileSystemInfos),
 				searchPattern, enumerationOptions);
@@ -415,7 +415,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFileSystemInfos(searchPattern, searchOption);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFileSystemInfos),
 				searchPattern, searchOption);
@@ -430,7 +430,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").GetFileSystemInfos(searchPattern);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.GetFileSystemInfos),
 				searchPattern);
@@ -445,7 +445,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").MoveTo(destDirName);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.MoveTo),
 				destDirName);
@@ -458,7 +458,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").Refresh();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.Refresh));
 	}
@@ -472,7 +472,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").ResolveLinkTarget(returnFinalTarget);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IDirectoryInfo.ResolveLinkTarget),
 				returnFinalTarget);
@@ -486,7 +486,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").Attributes;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.Attributes));
 	}
@@ -500,7 +500,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").Attributes = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.Attributes));
 	}
@@ -513,7 +513,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").CreationTime;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.CreationTime));
 	}
@@ -527,7 +527,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").CreationTime = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.CreationTime));
 	}
@@ -540,7 +540,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").CreationTimeUtc;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.CreationTimeUtc));
 	}
@@ -554,7 +554,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").CreationTimeUtc = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.CreationTimeUtc));
 	}
@@ -567,7 +567,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").Exists;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.Exists));
 	}
@@ -580,7 +580,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").Extension;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.Extension));
 	}
@@ -593,7 +593,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").FullName;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.FullName));
 	}
@@ -606,7 +606,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").LastAccessTime;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.LastAccessTime));
 	}
@@ -620,7 +620,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").LastAccessTime = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.LastAccessTime));
 	}
@@ -633,7 +633,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").LastAccessTimeUtc;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.LastAccessTimeUtc));
 	}
@@ -647,7 +647,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").LastAccessTimeUtc = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.LastAccessTimeUtc));
 	}
@@ -660,7 +660,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").LastWriteTime;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.LastWriteTime));
 	}
@@ -674,7 +674,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").LastWriteTime = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.LastWriteTime));
 	}
@@ -687,7 +687,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").LastWriteTimeUtc;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.LastWriteTimeUtc));
 	}
@@ -701,7 +701,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		sut.DirectoryInfo.New("foo").LastWriteTimeUtc = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.LastWriteTimeUtc));
 	}
@@ -715,7 +715,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").LinkTarget;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.LinkTarget));
 	}
@@ -729,7 +729,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").Name;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.Name));
 	}
@@ -742,7 +742,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").Parent;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.Parent));
 	}
@@ -755,7 +755,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").Root;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.Root));
 	}
@@ -769,7 +769,7 @@ public sealed class DirectoryInfoStatisticsTests
 
 		_ = sut.DirectoryInfo.New("foo").UnixFileMode;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDirectoryInfo.UnixFileMode));
 	}
@@ -789,7 +789,7 @@ public sealed class DirectoryInfoStatisticsTests
 		sut.DirectoryInfo.New("foo").UnixFileMode = value;
 		#pragma warning restore CA1416
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DirectoryInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDirectoryInfo.UnixFileMode));
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DirectoryStatisticsTests.cs
@@ -14,7 +14,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.CreateDirectory(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.CreateDirectory),
 			path);
 	}
@@ -31,7 +31,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.CreateDirectory(path, unixCreateMode);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.CreateDirectory),
 			path, unixCreateMode);
 	}
@@ -47,7 +47,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.CreateSymbolicLink(path, pathToTarget);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.CreateSymbolicLink),
 			path, pathToTarget);
 	}
@@ -62,7 +62,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.CreateTempSubdirectory(prefix);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.CreateTempSubdirectory),
 			prefix);
@@ -79,7 +79,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.Delete(path, recursive);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.Delete),
 			path, recursive);
 	}
@@ -93,7 +93,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.Delete(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.Delete),
 			path);
 	}
@@ -106,7 +106,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateDirectories(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateDirectories),
 			path);
@@ -123,7 +123,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateDirectories(path, searchPattern, enumerationOptions);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateDirectories),
 			path, searchPattern, enumerationOptions);
@@ -140,7 +140,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateDirectories(path, searchPattern, searchOption);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateDirectories),
 			path, searchPattern, searchOption);
@@ -155,7 +155,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateDirectories(path, searchPattern);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateDirectories),
 			path, searchPattern);
@@ -169,7 +169,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFiles(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.EnumerateFiles),
 			path);
 	}
@@ -185,7 +185,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFiles(path, searchPattern, enumerationOptions);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.EnumerateFiles),
 			path, searchPattern, enumerationOptions);
 	}
@@ -201,7 +201,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFiles(path, searchPattern, searchOption);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.EnumerateFiles),
 			path, searchPattern, searchOption);
 	}
@@ -215,7 +215,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFiles(path, searchPattern);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.EnumerateFiles),
 			path, searchPattern);
 	}
@@ -228,7 +228,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFileSystemEntries(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateFileSystemEntries),
 			path);
@@ -246,7 +246,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFileSystemEntries(path, searchPattern, enumerationOptions);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateFileSystemEntries),
 			path, searchPattern, enumerationOptions);
@@ -263,7 +263,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFileSystemEntries(path, searchPattern, searchOption);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateFileSystemEntries),
 			path, searchPattern, searchOption);
@@ -278,7 +278,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.EnumerateFileSystemEntries(path, searchPattern);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.EnumerateFileSystemEntries),
 			path, searchPattern);
@@ -292,7 +292,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.Exists(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.Exists),
 			path);
 	}
@@ -305,7 +305,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetCreationTime(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetCreationTime),
 			path);
 	}
@@ -318,7 +318,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetCreationTimeUtc(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetCreationTimeUtc),
 			path);
 	}
@@ -330,7 +330,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetCurrentDirectory();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.GetCurrentDirectory));
 	}
@@ -344,7 +344,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetDirectories(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetDirectories),
 			path);
 	}
@@ -361,7 +361,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetDirectories(path, searchPattern, enumerationOptions);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetDirectories),
 			path, searchPattern, enumerationOptions);
 	}
@@ -378,7 +378,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetDirectories(path, searchPattern, searchOption);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetDirectories),
 			path, searchPattern, searchOption);
 	}
@@ -393,7 +393,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetDirectories(path, searchPattern);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetDirectories),
 			path, searchPattern);
 	}
@@ -406,7 +406,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetDirectoryRoot(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetDirectoryRoot),
 			path);
 	}
@@ -420,7 +420,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFiles(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetFiles),
 			path);
 	}
@@ -437,7 +437,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFiles(path, searchPattern, enumerationOptions);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetFiles),
 			path, searchPattern, enumerationOptions);
 	}
@@ -454,7 +454,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFiles(path, searchPattern, searchOption);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetFiles),
 			path, searchPattern, searchOption);
 	}
@@ -469,7 +469,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFiles(path, searchPattern);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetFiles),
 			path, searchPattern);
 	}
@@ -483,7 +483,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFileSystemEntries(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.GetFileSystemEntries),
 			path);
@@ -501,7 +501,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFileSystemEntries(path, searchPattern, enumerationOptions);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.GetFileSystemEntries),
 			path, searchPattern, enumerationOptions);
@@ -519,7 +519,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFileSystemEntries(path, searchPattern, searchOption);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.GetFileSystemEntries),
 			path, searchPattern, searchOption);
@@ -535,7 +535,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetFileSystemEntries(path, searchPattern);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.GetFileSystemEntries),
 			path, searchPattern);
@@ -549,7 +549,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetLastAccessTime(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetLastAccessTime),
 			path);
 	}
@@ -562,7 +562,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetLastAccessTimeUtc(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.GetLastAccessTimeUtc),
 			path);
@@ -576,7 +576,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetLastWriteTime(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetLastWriteTime),
 			path);
 	}
@@ -589,7 +589,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetLastWriteTimeUtc(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetLastWriteTimeUtc),
 			path);
 	}
@@ -601,7 +601,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetLogicalDrives();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetLogicalDrives));
 	}
 
@@ -613,7 +613,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.GetParent(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.GetParent),
 			path);
 	}
@@ -628,7 +628,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.Move(sourceDirName, destDirName);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.Move),
 			sourceDirName, destDirName);
 	}
@@ -643,7 +643,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.ResolveLinkTarget(linkPath, returnFinalTarget);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.ResolveLinkTarget),
 			linkPath, returnFinalTarget);
 	}
@@ -659,7 +659,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.SetCreationTime(path, creationTime);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.SetCreationTime),
 			path, creationTime);
 	}
@@ -674,7 +674,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.SetCreationTimeUtc(path, creationTimeUtc);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.SetCreationTimeUtc),
 			path, creationTimeUtc);
 	}
@@ -688,7 +688,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.SetCurrentDirectory(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.SetCurrentDirectory),
 			path);
 	}
@@ -703,7 +703,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.SetLastAccessTime(path, lastAccessTime);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.SetLastAccessTime),
 			path, lastAccessTime);
 	}
@@ -718,7 +718,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.SetLastAccessTimeUtc(path, lastAccessTimeUtc);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(
 			nameof(IDirectory.SetLastAccessTimeUtc),
 			path, lastAccessTimeUtc);
@@ -734,7 +734,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.SetLastWriteTime(path, lastWriteTime);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.SetLastWriteTime),
 			path, lastWriteTime);
 	}
@@ -749,7 +749,7 @@ public sealed class DirectoryStatisticsTests
 
 		sut.Directory.SetLastWriteTimeUtc(path, lastWriteTimeUtc);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Directory.ShouldOnlyContainMethodCall(nameof(IDirectory.SetLastWriteTimeUtc),
 			path, lastWriteTimeUtc);
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoFactoryStatisticsTests.cs
@@ -14,7 +14,7 @@ public sealed class DriveInfoFactoryStatisticsTests
 
 		sut.DriveInfo.GetDrives();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.DriveInfo.ShouldOnlyContainMethodCall(nameof(IDriveInfoFactory.GetDrives));
 	}
 
@@ -26,7 +26,7 @@ public sealed class DriveInfoFactoryStatisticsTests
 
 		sut.DriveInfo.New(driveName);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.DriveInfo.ShouldOnlyContainMethodCall(nameof(IDriveInfoFactory.New),
 			driveName);
 	}
@@ -39,7 +39,7 @@ public sealed class DriveInfoFactoryStatisticsTests
 
 		sut.DriveInfo.Wrap(driveInfo);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.DriveInfo.ShouldOnlyContainMethodCall(nameof(IDriveInfoFactory.Wrap),
 			driveInfo);
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoStatisticsTests.cs
@@ -14,7 +14,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").AvailableFreeSpace;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.AvailableFreeSpace));
 	}
@@ -28,7 +28,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").DriveFormat;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.DriveFormat));
 	}
@@ -42,7 +42,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").DriveType;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.DriveType));
 	}
@@ -56,7 +56,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").IsReady;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.IsReady));
 	}
@@ -70,7 +70,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").Name;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"].ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.Name));
 	}
 
@@ -83,7 +83,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").RootDirectory;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.RootDirectory));
 	}
@@ -97,7 +97,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").TotalFreeSpace;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.TotalFreeSpace));
 	}
@@ -111,7 +111,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").TotalSize;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.TotalSize));
 	}
@@ -125,7 +125,7 @@ public sealed class DriveInfoStatisticsTests
 
 		_ = sut.DriveInfo.New("F:").VolumeLabel;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IDriveInfo.VolumeLabel));
 	}
@@ -142,7 +142,7 @@ public sealed class DriveInfoStatisticsTests
 		sut.DriveInfo.New("F:").VolumeLabel = value;
 		#pragma warning restore CA1416
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.DriveInfo["F:"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IDriveInfo.VolumeLabel));
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoFactoryStatisticsTests.cs
@@ -14,7 +14,7 @@ public class FileInfoFactoryStatisticsTests
 
 		sut.FileInfo.New(fileName);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileInfo.ShouldOnlyContainMethodCall(nameof(IFileInfoFactory.New),
 			fileName);
 	}
@@ -27,7 +27,7 @@ public class FileInfoFactoryStatisticsTests
 
 		sut.FileInfo.Wrap(fileInfo);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileInfo.ShouldOnlyContainMethodCall(nameof(IFileInfoFactory.Wrap),
 			fileInfo);
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileInfoStatisticsTests.cs
@@ -13,7 +13,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").AppendText();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.AppendText));
 	}
@@ -28,7 +28,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").CopyTo(destFileName, overwrite);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.CopyTo),
 				destFileName, overwrite);
@@ -43,7 +43,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").CopyTo(destFileName);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.CopyTo),
 				destFileName);
@@ -56,7 +56,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Create();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Create));
 	}
@@ -70,7 +70,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").CreateAsSymbolicLink(pathToTarget);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.CreateAsSymbolicLink),
 				pathToTarget);
@@ -84,7 +84,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").CreateText();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.CreateText));
 	}
@@ -100,7 +100,7 @@ public class FileInfoStatisticsTests
 		sut.FileInfo.New("foo").Decrypt();
 		#pragma warning restore CA1416
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Decrypt));
 	}
@@ -113,7 +113,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Delete();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Delete));
 	}
@@ -129,7 +129,7 @@ public class FileInfoStatisticsTests
 		sut.FileInfo.New("foo").Encrypt();
 		#pragma warning restore CA1416
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Encrypt));
 	}
@@ -145,7 +145,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").MoveTo(destFileName, overwrite);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.MoveTo),
 				destFileName, overwrite);
@@ -161,7 +161,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").MoveTo(destFileName);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.MoveTo),
 				destFileName);
@@ -177,7 +177,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Open(mode, access, share);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Open),
 				mode, access, share);
@@ -192,7 +192,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Open(mode, access);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Open),
 				mode, access);
@@ -206,7 +206,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Open(mode);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Open),
 				mode);
@@ -222,7 +222,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Open(options);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Open),
 				options);
@@ -237,7 +237,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").OpenRead();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.OpenRead));
 	}
@@ -250,7 +250,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").OpenText();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.OpenText));
 	}
@@ -262,7 +262,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").OpenWrite();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.OpenWrite));
 	}
@@ -274,7 +274,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Refresh();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Refresh));
 	}
@@ -291,7 +291,7 @@ public class FileInfoStatisticsTests
 		sut.FileInfo.New("foo").Replace(destinationFileName, destinationBackupFileName,
 			ignoreMetadataErrors);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Replace),
 				destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
@@ -307,7 +307,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Replace(destinationFileName, destinationBackupFileName);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileInfo.Replace),
 				destinationFileName, destinationBackupFileName);
@@ -322,7 +322,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").ResolveLinkTarget(returnFinalTarget);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainMethodCall(
 				nameof(IFileInfo.ResolveLinkTarget),
@@ -338,7 +338,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").Attributes;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.Attributes));
 	}
@@ -352,7 +352,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").Attributes = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.Attributes));
 	}
@@ -365,7 +365,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").CreationTime;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.CreationTime));
 	}
@@ -379,7 +379,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").CreationTime = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.CreationTime));
 	}
@@ -392,7 +392,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").CreationTimeUtc;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.CreationTimeUtc));
 	}
@@ -406,7 +406,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").CreationTimeUtc = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.CreationTimeUtc));
 	}
@@ -419,7 +419,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").Directory;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.Directory));
 	}
@@ -432,7 +432,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").DirectoryName;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.DirectoryName));
 	}
@@ -445,7 +445,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").Exists;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"].ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.Exists));
 	}
 
@@ -457,7 +457,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").Extension;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.Extension));
 	}
@@ -470,7 +470,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").FullName;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.FullName));
 	}
@@ -483,7 +483,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").IsReadOnly;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.IsReadOnly));
 	}
@@ -497,7 +497,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").IsReadOnly = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.IsReadOnly));
 	}
@@ -510,7 +510,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").LastAccessTime;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.LastAccessTime));
 	}
@@ -524,7 +524,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").LastAccessTime = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.LastAccessTime));
 	}
@@ -537,7 +537,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").LastAccessTimeUtc;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.LastAccessTimeUtc));
 	}
@@ -551,7 +551,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").LastAccessTimeUtc = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.LastAccessTimeUtc));
 	}
@@ -564,7 +564,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").LastWriteTime;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.LastWriteTime));
 	}
@@ -578,7 +578,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").LastWriteTime = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.LastWriteTime));
 	}
@@ -591,7 +591,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").LastWriteTimeUtc;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.LastWriteTimeUtc));
 	}
@@ -605,7 +605,7 @@ public class FileInfoStatisticsTests
 
 		sut.FileInfo.New("foo").LastWriteTimeUtc = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.LastWriteTimeUtc));
 	}
@@ -618,7 +618,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").Length;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"].ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.Length));
 	}
 
@@ -631,7 +631,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").LinkTarget;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.LinkTarget));
 	}
@@ -645,7 +645,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").Name;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"].ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.Name));
 	}
 
@@ -658,7 +658,7 @@ public class FileInfoStatisticsTests
 
 		_ = sut.FileInfo.New("foo").UnixFileMode;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileInfo.UnixFileMode));
 	}
@@ -678,7 +678,7 @@ public class FileInfoStatisticsTests
 		sut.FileInfo.New("foo").UnixFileMode = value;
 		#pragma warning restore CA1416
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileInfo["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileInfo.UnixFileMode));
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStatisticsTests.cs
@@ -27,7 +27,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.AppendAllLines(path, contents, encoding);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllLines),
 			path, contents, encoding);
 	}
@@ -41,7 +41,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.AppendAllLines(path, contents);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllLines),
 			path, contents);
 	}
@@ -58,7 +58,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.AppendAllLinesAsync(path, contents, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllLinesAsync),
 			path, contents, cancellationToken);
 	}
@@ -77,7 +77,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.AppendAllLinesAsync(path, contents, encoding, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllLinesAsync),
 			path, contents, encoding, cancellationToken);
 	}
@@ -93,7 +93,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.AppendAllText(path, contents, encoding);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllText),
 			path, contents, encoding);
 	}
@@ -107,7 +107,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.AppendAllText(path, contents);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllText),
 			path, contents);
 	}
@@ -123,7 +123,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.AppendAllTextAsync(path, contents, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllTextAsync),
 			path, contents, cancellationToken);
 	}
@@ -142,7 +142,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.AppendAllTextAsync(path, contents, encoding, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendAllTextAsync),
 			path, contents, encoding, cancellationToken);
 	}
@@ -156,7 +156,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.AppendText(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.AppendText),
 			path);
 	}
@@ -172,7 +172,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Copy(sourceFileName, destFileName, overwrite);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Copy),
 			sourceFileName, destFileName, overwrite);
 	}
@@ -187,7 +187,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Copy(sourceFileName, destFileName);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Copy),
 			sourceFileName, destFileName);
 	}
@@ -202,7 +202,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Create(path, bufferSize, options);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Create),
 			path, bufferSize, options);
 	}
@@ -216,7 +216,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Create(path, bufferSize);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Create),
 			path, bufferSize);
 	}
@@ -229,7 +229,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Create(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Create),
 			path);
 	}
@@ -244,7 +244,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.CreateSymbolicLink(path, pathToTarget);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.CreateSymbolicLink),
 			path, pathToTarget);
 	}
@@ -258,7 +258,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.CreateText(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.CreateText),
 			path);
 	}
@@ -276,7 +276,7 @@ public sealed class FileStatisticsTests
 		sut.File.Decrypt(path);
 		#pragma warning restore CA1416
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Decrypt),
 			path);
 	}
@@ -290,7 +290,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Delete(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Delete),
 			path);
 	}
@@ -308,7 +308,7 @@ public sealed class FileStatisticsTests
 		sut.File.Encrypt(path);
 		#pragma warning restore CA1416
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Encrypt),
 			path);
 	}
@@ -321,7 +321,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Exists(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Exists),
 			path);
 	}
@@ -338,7 +338,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetAttributes(fileHandle);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetAttributes),
 			fileHandle);
 	}
@@ -353,7 +353,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetAttributes(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetAttributes),
 			path);
 	}
@@ -370,7 +370,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetCreationTime(fileHandle);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetCreationTime),
 			fileHandle);
 	}
@@ -385,7 +385,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetCreationTime(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetCreationTime),
 			path);
 	}
@@ -402,7 +402,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetCreationTimeUtc(fileHandle);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetCreationTimeUtc),
 			fileHandle);
 	}
@@ -417,7 +417,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetCreationTimeUtc(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetCreationTimeUtc),
 			path);
 	}
@@ -434,7 +434,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastAccessTime(fileHandle);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastAccessTime),
 			fileHandle);
 	}
@@ -449,7 +449,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastAccessTime(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastAccessTime),
 			path);
 	}
@@ -466,7 +466,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastAccessTimeUtc(fileHandle);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastAccessTimeUtc),
 			fileHandle);
 	}
@@ -481,7 +481,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastAccessTimeUtc(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastAccessTimeUtc),
 			path);
 	}
@@ -498,7 +498,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastWriteTime(fileHandle);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastWriteTime),
 			fileHandle);
 	}
@@ -513,7 +513,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastWriteTime(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastWriteTime),
 			path);
 	}
@@ -530,7 +530,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastWriteTimeUtc(fileHandle);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastWriteTimeUtc),
 			fileHandle);
 	}
@@ -545,7 +545,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.GetLastWriteTimeUtc(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetLastWriteTimeUtc),
 			path);
 	}
@@ -566,7 +566,7 @@ public sealed class FileStatisticsTests
 		sut.File.GetUnixFileMode(fileHandle);
 		#pragma warning restore CA1416
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetUnixFileMode),
 			fileHandle);
 	}
@@ -586,7 +586,7 @@ public sealed class FileStatisticsTests
 		sut.File.GetUnixFileMode(path);
 		#pragma warning restore CA1416
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.GetUnixFileMode),
 			path);
 	}
@@ -604,7 +604,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Move(sourceFileName, destFileName, overwrite);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Move),
 			sourceFileName, destFileName, overwrite);
 	}
@@ -620,7 +620,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Move(sourceFileName, destFileName);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Move),
 			sourceFileName, destFileName);
 	}
@@ -636,7 +636,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Open(path, mode, access, share);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Open),
 			path, mode, access, share);
 	}
@@ -651,7 +651,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Open(path, mode, access);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Open),
 			path, mode, access);
 	}
@@ -665,7 +665,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Open(path, mode);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Open),
 			path, mode);
 	}
@@ -681,7 +681,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Open(path, options);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Open),
 			path, options);
 	}
@@ -696,7 +696,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.OpenRead(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.OpenRead),
 			path);
 	}
@@ -710,7 +710,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.OpenText(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.OpenText),
 			path);
 	}
@@ -723,7 +723,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.OpenWrite(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.OpenWrite),
 			path);
 	}
@@ -737,7 +737,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadAllBytes(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllBytes),
 			path);
 	}
@@ -753,7 +753,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.ReadAllBytesAsync(path, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllBytesAsync),
 			path, cancellationToken);
 	}
@@ -769,7 +769,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadAllLines(path, encoding);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllLines),
 			path, encoding);
 	}
@@ -783,7 +783,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadAllLines(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllLines),
 			path);
 	}
@@ -799,7 +799,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.ReadAllLinesAsync(path, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllLinesAsync),
 			path, cancellationToken);
 	}
@@ -818,7 +818,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.ReadAllLinesAsync(path, encoding, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllLinesAsync),
 			path, encoding, cancellationToken);
 	}
@@ -834,7 +834,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadAllText(path, encoding);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllText),
 			path, encoding);
 	}
@@ -848,7 +848,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadAllText(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllText),
 			path);
 	}
@@ -864,7 +864,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.ReadAllTextAsync(path, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllTextAsync),
 			path, cancellationToken);
 	}
@@ -882,7 +882,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.ReadAllTextAsync(path, encoding, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadAllTextAsync),
 			path, encoding, cancellationToken);
 	}
@@ -898,7 +898,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadLines(path, encoding);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadLines),
 			path, encoding);
 	}
@@ -912,7 +912,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadLines(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadLines),
 			path);
 	}
@@ -928,7 +928,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadLinesAsync(path, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadLinesAsync),
 			path, cancellationToken);
 	}
@@ -946,7 +946,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ReadLinesAsync(path, encoding, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ReadLinesAsync),
 			path, encoding, cancellationToken);
 	}
@@ -965,7 +965,7 @@ public sealed class FileStatisticsTests
 		sut.File.Replace(sourceFileName, destinationFileName, destinationBackupFileName,
 			ignoreMetadataErrors);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Replace),
 			sourceFileName, destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
 	}
@@ -981,7 +981,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.Replace(sourceFileName, destinationFileName, destinationBackupFileName);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.Replace),
 			sourceFileName, destinationFileName, destinationBackupFileName);
 	}
@@ -997,7 +997,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.ResolveLinkTarget(linkPath, returnFinalTarget);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.ResolveLinkTarget),
 			linkPath, returnFinalTarget);
 	}
@@ -1016,7 +1016,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetAttributes(fileHandle, fileAttributes);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetAttributes),
 			fileHandle, fileAttributes);
 	}
@@ -1032,7 +1032,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetAttributes(path, fileAttributes);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetAttributes),
 			path, fileAttributes);
 	}
@@ -1050,7 +1050,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetCreationTime(fileHandle, creationTime);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetCreationTime),
 			fileHandle, creationTime);
 	}
@@ -1066,7 +1066,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetCreationTime(path, creationTime);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetCreationTime),
 			path, creationTime);
 	}
@@ -1084,7 +1084,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetCreationTimeUtc(fileHandle, creationTimeUtc);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetCreationTimeUtc),
 			fileHandle, creationTimeUtc);
 	}
@@ -1100,7 +1100,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetCreationTimeUtc(path, creationTimeUtc);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetCreationTimeUtc),
 			path, creationTimeUtc);
 	}
@@ -1118,7 +1118,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastAccessTime(fileHandle, lastAccessTime);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastAccessTime),
 			fileHandle, lastAccessTime);
 	}
@@ -1134,7 +1134,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastAccessTime(path, lastAccessTime);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastAccessTime),
 			path, lastAccessTime);
 	}
@@ -1152,7 +1152,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastAccessTimeUtc(fileHandle, lastAccessTimeUtc);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastAccessTimeUtc),
 			fileHandle, lastAccessTimeUtc);
 	}
@@ -1168,7 +1168,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastAccessTimeUtc(path, lastAccessTimeUtc);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastAccessTimeUtc),
 			path, lastAccessTimeUtc);
 	}
@@ -1186,7 +1186,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastWriteTime(fileHandle, lastWriteTime);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastWriteTime),
 			fileHandle, lastWriteTime);
 	}
@@ -1202,7 +1202,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastWriteTime(path, lastWriteTime);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastWriteTime),
 			path, lastWriteTime);
 	}
@@ -1220,7 +1220,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastWriteTimeUtc(fileHandle, lastWriteTimeUtc);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastWriteTimeUtc),
 			fileHandle, lastWriteTimeUtc);
 	}
@@ -1236,7 +1236,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.SetLastWriteTimeUtc(path, lastWriteTimeUtc);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetLastWriteTimeUtc),
 			path, lastWriteTimeUtc);
 	}
@@ -1258,7 +1258,7 @@ public sealed class FileStatisticsTests
 		sut.File.SetUnixFileMode(fileHandle, mode);
 		#pragma warning restore CA1416
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetUnixFileMode),
 			fileHandle, mode);
 	}
@@ -1279,7 +1279,7 @@ public sealed class FileStatisticsTests
 		sut.File.SetUnixFileMode(path, mode);
 		#pragma warning restore CA1416
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.SetUnixFileMode),
 			path, mode);
 	}
@@ -1294,7 +1294,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.WriteAllBytes(path, bytes);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllBytes),
 			path, bytes);
 	}
@@ -1311,7 +1311,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.WriteAllBytesAsync(path, bytes, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllBytesAsync),
 			path, bytes, cancellationToken);
 	}
@@ -1327,7 +1327,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.WriteAllLines(path, contents, encoding);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllLines),
 			path, contents, encoding);
 	}
@@ -1341,7 +1341,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.WriteAllLines(path, contents);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllLines),
 			path, contents);
 	}
@@ -1356,7 +1356,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.WriteAllLines(path, contents, encoding);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllLines),
 			path, contents, encoding);
 	}
@@ -1370,7 +1370,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.WriteAllLines(path, contents);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllLines),
 			path, contents);
 	}
@@ -1387,7 +1387,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.WriteAllLinesAsync(path, contents, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllLinesAsync),
 			path, contents, cancellationToken);
 	}
@@ -1406,7 +1406,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.WriteAllLinesAsync(path, contents, encoding, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllLinesAsync),
 			path, contents, encoding, cancellationToken);
 	}
@@ -1422,7 +1422,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.WriteAllText(path, contents, encoding);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllText),
 			path, contents, encoding);
 	}
@@ -1436,7 +1436,7 @@ public sealed class FileStatisticsTests
 
 		sut.File.WriteAllText(path, contents);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllText),
 			path, contents);
 	}
@@ -1452,7 +1452,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.WriteAllTextAsync(path, contents, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllTextAsync),
 			path, contents, cancellationToken);
 	}
@@ -1471,7 +1471,7 @@ public sealed class FileStatisticsTests
 
 		await sut.File.WriteAllTextAsync(path, contents, encoding, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.File.ShouldOnlyContainMethodCall(nameof(IFile.WriteAllTextAsync),
 			path, contents, encoding, cancellationToken);
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamFactoryStatisticsTests.cs
@@ -25,7 +25,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(handle, access, bufferSize, isAsync);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			handle, access, bufferSize, isAsync);
 	}
@@ -45,7 +45,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(handle, access, bufferSize);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			handle, access, bufferSize);
 	}
@@ -63,7 +63,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(handle, access);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			handle, access);
 	}
@@ -83,7 +83,7 @@ public class FileStreamFactoryStatisticsTests
 		using FileSystemStream result =
 			sut.FileStream.New(path, mode, access, share, bufferSize, useAsync);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			path, mode, access, share, bufferSize, useAsync);
 	}
@@ -102,7 +102,7 @@ public class FileStreamFactoryStatisticsTests
 		using FileSystemStream result =
 			sut.FileStream.New(path, mode, access, share, bufferSize, options);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			path, mode, access, share, bufferSize, options);
 	}
@@ -119,7 +119,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(path, mode, access, share, bufferSize);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			path, mode, access, share, bufferSize);
 	}
@@ -135,7 +135,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(path, mode, access, share);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			path, mode, access, share);
 	}
@@ -150,7 +150,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(path, mode, access);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			path, mode, access);
 	}
@@ -164,7 +164,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(path, mode);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			path, mode);
 	}
@@ -180,7 +180,7 @@ public class FileStreamFactoryStatisticsTests
 
 		using FileSystemStream result = sut.FileStream.New(path, options);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.New),
 			path, options);
 	}
@@ -204,7 +204,7 @@ public class FileStreamFactoryStatisticsTests
 				// Wrap is not possible on the MockFileSystem, but should still be registered!
 			}
 
-			sut.StatisticsRegistration.TotalCount.Should().Be(1);
+			sut.Statistics.TotalCount.Should().Be(1);
 			sut.Statistics.FileStream.ShouldOnlyContainMethodCall(nameof(IFileStreamFactory.Wrap),
 				fileStream);
 		}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileStreamStatisticsTests.cs
@@ -22,7 +22,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.BeginRead(buffer, offset, count, callback, state);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.BeginRead),
 				buffer, offset, count, callback, state);
@@ -41,7 +41,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.BeginWrite(buffer, offset, count, callback, state);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.BeginWrite),
 				buffer, offset, count, callback, state);
@@ -57,7 +57,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.CopyTo(destination, bufferSize);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.CopyTo),
 				destination, bufferSize);
@@ -74,7 +74,7 @@ public class FileStreamStatisticsTests
 
 		await fileStream.CopyToAsync(destination, bufferSize, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.CopyToAsync),
 				destination, bufferSize, cancellationToken);
@@ -90,7 +90,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.EndRead(asyncResult);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(3);
+		sut.Statistics.TotalCount.Should().Be(3);
 		sut.Statistics.FileStream["foo"].Methods.Length.Should().Be(2);
 		sut.Statistics.FileStream["foo"].Methods.Should()
 			.ContainSingle(c => c.Name == nameof(FileSystemStream.EndRead) &&
@@ -108,7 +108,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.EndWrite(asyncResult);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(3);
+		sut.Statistics.TotalCount.Should().Be(3);
 		sut.Statistics.FileStream["foo"].Methods.Length.Should().Be(2);
 		sut.Statistics.FileStream["foo"].Methods.Should()
 			.ContainSingle(c => c.Name == nameof(FileSystemStream.EndWrite) &&
@@ -125,7 +125,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.Flush(flushToDisk);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.Flush),
 				flushToDisk);
@@ -139,7 +139,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.Flush();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.Flush));
 	}
@@ -153,7 +153,7 @@ public class FileStreamStatisticsTests
 
 		await fileStream.FlushAsync(cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.FlushAsync),
 				cancellationToken);
@@ -170,7 +170,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.Read(buffer, offset, count);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.Read),
 				buffer, offset, count);
@@ -186,7 +186,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.Read(buffer);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.Read),
 				buffer);
@@ -205,7 +205,7 @@ public class FileStreamStatisticsTests
 
 		_ = await fileStream.ReadAsync(buffer, offset, count, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.ReadAsync),
 				buffer, offset, count, cancellationToken);
@@ -222,7 +222,7 @@ public class FileStreamStatisticsTests
 
 		_ = await fileStream.ReadAsync(buffer, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.ReadAsync),
 				buffer, cancellationToken);
@@ -237,7 +237,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.ReadByte();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.ReadByte));
 	}
@@ -252,7 +252,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.Seek(offset, origin);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.Seek),
 				offset, origin);
@@ -267,7 +267,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.SetLength(value);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.SetLength),
 				value);
@@ -281,7 +281,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.ToString();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.ToString));
 	}
@@ -297,7 +297,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.Write(buffer, offset, count);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.Write),
 				buffer, offset, count);
@@ -313,7 +313,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.Write(buffer);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.Write),
 				buffer);
@@ -332,7 +332,7 @@ public class FileStreamStatisticsTests
 
 		await fileStream.WriteAsync(buffer, offset, count, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.WriteAsync),
 				buffer, offset, count, cancellationToken);
@@ -349,7 +349,7 @@ public class FileStreamStatisticsTests
 
 		await fileStream.WriteAsync(buffer, cancellationToken);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.WriteAsync),
 				buffer, cancellationToken);
@@ -365,7 +365,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.WriteByte(value);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainMethodCall(nameof(FileSystemStream.WriteByte),
 				value);
@@ -379,7 +379,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.CanRead;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.CanRead));
 	}
@@ -392,7 +392,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.CanSeek;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.CanSeek));
 	}
@@ -405,7 +405,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.CanTimeout;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.CanTimeout));
 	}
@@ -418,7 +418,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.CanWrite;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.CanWrite));
 	}
@@ -431,7 +431,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.IsAsync;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.IsAsync));
 	}
@@ -444,7 +444,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.Length;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.Length));
 	}
@@ -457,7 +457,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.Name;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.Name));
 	}
@@ -470,7 +470,7 @@ public class FileStreamStatisticsTests
 
 		_ = fileStream.Position;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.Position));
 	}
@@ -484,7 +484,7 @@ public class FileStreamStatisticsTests
 
 		fileStream.Position = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(FileSystemStream.Position));
 	}
@@ -504,7 +504,7 @@ public class FileStreamStatisticsTests
 			// Timeouts are not supported on this stream.
 		}
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.ReadTimeout));
 	}
@@ -525,7 +525,7 @@ public class FileStreamStatisticsTests
 			// Timeouts are not supported on this stream.
 		}
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(FileSystemStream.ReadTimeout));
 	}
@@ -545,7 +545,7 @@ public class FileStreamStatisticsTests
 			// Timeouts are not supported on this stream.
 		}
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(FileSystemStream.WriteTimeout));
 	}
@@ -566,7 +566,7 @@ public class FileStreamStatisticsTests
 			// Timeouts are not supported on this stream.
 		}
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileStream["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(FileSystemStream.WriteTimeout));
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherFactoryStatisticsTests.cs
@@ -13,7 +13,7 @@ public class FileSystemWatcherFactoryStatisticsTests
 
 		using IFileSystemWatcher result = sut.FileSystemWatcher.New();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileSystemWatcher.ShouldOnlyContainMethodCall(
 			nameof(IFileSystemWatcherFactory.New));
 	}
@@ -27,7 +27,7 @@ public class FileSystemWatcherFactoryStatisticsTests
 
 		using IFileSystemWatcher result = sut.FileSystemWatcher.New(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileSystemWatcher.ShouldOnlyContainMethodCall(
 			nameof(IFileSystemWatcherFactory.New),
 			path);
@@ -43,7 +43,7 @@ public class FileSystemWatcherFactoryStatisticsTests
 
 		using IFileSystemWatcher result = sut.FileSystemWatcher.New(path, filter);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileSystemWatcher.ShouldOnlyContainMethodCall(
 			nameof(IFileSystemWatcherFactory.New),
 			path, filter);
@@ -58,7 +58,7 @@ public class FileSystemWatcherFactoryStatisticsTests
 
 		using IFileSystemWatcher result = sut.FileSystemWatcher.Wrap(fileSystemWatcher);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.FileSystemWatcher.ShouldOnlyContainMethodCall(
 			nameof(IFileSystemWatcherFactory.Wrap),
 			fileSystemWatcher);

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileSystemWatcherStatisticsTests.cs
@@ -18,7 +18,7 @@ public class FileSystemWatcherStatisticsTests
 
 		fileSystemWatcher.BeginInit();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileSystemWatcher.BeginInit));
 	}
@@ -32,7 +32,7 @@ public class FileSystemWatcherStatisticsTests
 
 		fileSystemWatcher.EndInit();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainMethodCall(nameof(IFileSystemWatcher.EndInit));
 	}
@@ -135,7 +135,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").EnableRaisingEvents;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.EnableRaisingEvents));
 	}
@@ -149,7 +149,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").EnableRaisingEvents = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.EnableRaisingEvents));
 	}
@@ -162,7 +162,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").Filter;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.Filter));
 	}
@@ -176,7 +176,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").Filter = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.Filter));
 	}
@@ -190,7 +190,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").Filters;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.Filters));
 	}
@@ -204,7 +204,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").IncludeSubdirectories;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.IncludeSubdirectories));
 	}
@@ -218,7 +218,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").IncludeSubdirectories = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.IncludeSubdirectories));
 	}
@@ -231,7 +231,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").InternalBufferSize;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.InternalBufferSize));
 	}
@@ -245,7 +245,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").InternalBufferSize = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.InternalBufferSize));
 	}
@@ -258,7 +258,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").NotifyFilter;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.NotifyFilter));
 	}
@@ -272,7 +272,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").NotifyFilter = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.NotifyFilter));
 	}
@@ -285,7 +285,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").Path;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.Path));
 	}
@@ -299,7 +299,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").Path = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.Path));
 	}
@@ -312,7 +312,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").Site;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.Site));
 	}
@@ -326,7 +326,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").Site = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.Site));
 	}
@@ -339,7 +339,7 @@ public class FileSystemWatcherStatisticsTests
 
 		_ = sut.FileSystemWatcher.New("foo").SynchronizingObject;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertyGetAccess(nameof(IFileSystemWatcher.SynchronizingObject));
 	}
@@ -353,7 +353,7 @@ public class FileSystemWatcherStatisticsTests
 
 		sut.FileSystemWatcher.New("foo").SynchronizingObject = value;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(2);
+		sut.Statistics.TotalCount.Should().Be(2);
 		sut.Statistics.FileSystemWatcher["foo"]
 			.ShouldOnlyContainPropertySetAccess(nameof(IFileSystemWatcher.SynchronizingObject));
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/PathStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/PathStatisticsTests.cs
@@ -17,7 +17,7 @@ public class PathStatisticsTests
 
 		sut.Path.ChangeExtension(path, extension);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.ChangeExtension),
 			path, extension);
 	}
@@ -31,7 +31,7 @@ public class PathStatisticsTests
 
 		sut.Path.Combine(path1, path2);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Combine),
 			path1, path2);
 	}
@@ -46,7 +46,7 @@ public class PathStatisticsTests
 
 		sut.Path.Combine(path1, path2, path3);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Combine),
 			path1, path2, path3);
 	}
@@ -62,7 +62,7 @@ public class PathStatisticsTests
 
 		sut.Path.Combine(path1, path2, path3, path4);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Combine),
 			path1, path2, path3, path4);
 	}
@@ -75,7 +75,7 @@ public class PathStatisticsTests
 
 		sut.Path.Combine(paths);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Combine),
 			paths);
 	}
@@ -89,7 +89,7 @@ public class PathStatisticsTests
 
 		sut.Path.EndsInDirectorySeparator(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.EndsInDirectorySeparator),
 			path);
 	}
@@ -104,7 +104,7 @@ public class PathStatisticsTests
 
 		sut.Path.EndsInDirectorySeparator(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.EndsInDirectorySeparator),
 			path);
 	}
@@ -119,7 +119,7 @@ public class PathStatisticsTests
 
 		sut.Path.Exists(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Exists),
 			path);
 	}
@@ -134,7 +134,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetDirectoryName(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetDirectoryName),
 			path);
 	}
@@ -148,7 +148,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetDirectoryName(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetDirectoryName),
 			path);
 	}
@@ -162,7 +162,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetExtension(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetExtension),
 			path);
 	}
@@ -176,7 +176,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetExtension(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetExtension),
 			path);
 	}
@@ -190,7 +190,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetFileName(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetFileName),
 			path);
 	}
@@ -204,7 +204,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetFileName(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetFileName),
 			path);
 	}
@@ -218,7 +218,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetFileNameWithoutExtension(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetFileNameWithoutExtension),
 			path);
 	}
@@ -232,7 +232,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetFileNameWithoutExtension(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetFileNameWithoutExtension),
 			path);
 	}
@@ -245,7 +245,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetFullPath(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetFullPath),
 			path);
 	}
@@ -260,7 +260,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetFullPath(path, basePath);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetFullPath),
 			path, basePath);
 	}
@@ -273,7 +273,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetInvalidFileNameChars();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetInvalidFileNameChars));
 	}
 
@@ -284,7 +284,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetInvalidPathChars();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetInvalidPathChars));
 	}
 
@@ -297,7 +297,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetPathRoot(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetPathRoot),
 			path);
 	}
@@ -311,7 +311,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetPathRoot(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetPathRoot),
 			path);
 	}
@@ -323,7 +323,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetRandomFileName();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetRandomFileName));
 	}
 
@@ -337,7 +337,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetRelativePath(relativeTo, path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetRelativePath),
 			relativeTo, path);
 	}
@@ -350,7 +350,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetTempFileName();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetTempFileName));
 	}
 
@@ -361,7 +361,7 @@ public class PathStatisticsTests
 
 		sut.Path.GetTempPath();
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.GetTempPath));
 	}
 
@@ -374,7 +374,7 @@ public class PathStatisticsTests
 
 		sut.Path.HasExtension(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.HasExtension),
 			path);
 	}
@@ -388,7 +388,7 @@ public class PathStatisticsTests
 
 		sut.Path.HasExtension(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.HasExtension),
 			path);
 	}
@@ -402,7 +402,7 @@ public class PathStatisticsTests
 
 		sut.Path.IsPathFullyQualified(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.IsPathFullyQualified),
 			path);
 	}
@@ -417,7 +417,7 @@ public class PathStatisticsTests
 
 		sut.Path.IsPathFullyQualified(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.IsPathFullyQualified),
 			path);
 	}
@@ -432,7 +432,7 @@ public class PathStatisticsTests
 
 		sut.Path.IsPathRooted(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.IsPathRooted),
 			path);
 	}
@@ -446,7 +446,7 @@ public class PathStatisticsTests
 
 		sut.Path.IsPathRooted(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.IsPathRooted),
 			path);
 	}
@@ -464,7 +464,7 @@ public class PathStatisticsTests
 
 		sut.Path.Join(path1, path2, path3, path4);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Join),
 			path1, path2, path3, path4);
 	}
@@ -481,7 +481,7 @@ public class PathStatisticsTests
 
 		sut.Path.Join(path1, path2, path3);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Join),
 			path1, path2, path3);
 	}
@@ -497,7 +497,7 @@ public class PathStatisticsTests
 
 		sut.Path.Join(path1, path2);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Join),
 			path1, path2);
 	}
@@ -513,7 +513,7 @@ public class PathStatisticsTests
 
 		sut.Path.Join(path1, path2);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Join),
 			path1, path2);
 	}
@@ -530,7 +530,7 @@ public class PathStatisticsTests
 
 		sut.Path.Join(path1, path2, path3);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Join),
 			path1, path2, path3);
 	}
@@ -548,7 +548,7 @@ public class PathStatisticsTests
 
 		sut.Path.Join(path1, path2, path3, path4);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Join),
 			path1, path2, path3, path4);
 	}
@@ -563,7 +563,7 @@ public class PathStatisticsTests
 
 		sut.Path.Join(paths);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.Join),
 			paths);
 	}
@@ -578,7 +578,7 @@ public class PathStatisticsTests
 
 		sut.Path.TrimEndingDirectorySeparator(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.TrimEndingDirectorySeparator),
 			path);
 	}
@@ -593,7 +593,7 @@ public class PathStatisticsTests
 
 		sut.Path.TrimEndingDirectorySeparator(path);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.TrimEndingDirectorySeparator),
 			path);
 	}
@@ -612,7 +612,7 @@ public class PathStatisticsTests
 
 		sut.Path.TryJoin(path1, path2, path3, destination, out int charsWritten);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.TryJoin),
 			path1, path2, path3, destination, charsWritten);
 	}
@@ -630,7 +630,7 @@ public class PathStatisticsTests
 
 		sut.Path.TryJoin(path1, path2, destination, out int charsWritten);
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainMethodCall(nameof(IPath.TryJoin),
 			path1, path2, destination, charsWritten);
 	}
@@ -643,7 +643,7 @@ public class PathStatisticsTests
 
 		_ = sut.Path.AltDirectorySeparatorChar;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainPropertyGetAccess(
 			nameof(IPath.AltDirectorySeparatorChar));
 	}
@@ -655,7 +655,7 @@ public class PathStatisticsTests
 
 		_ = sut.Path.DirectorySeparatorChar;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainPropertyGetAccess(
 			nameof(IPath.DirectorySeparatorChar));
 	}
@@ -667,7 +667,7 @@ public class PathStatisticsTests
 
 		_ = sut.Path.PathSeparator;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainPropertyGetAccess(nameof(IPath.PathSeparator));
 	}
 
@@ -678,7 +678,7 @@ public class PathStatisticsTests
 
 		_ = sut.Path.VolumeSeparatorChar;
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(1);
+		sut.Statistics.TotalCount.Should().Be(1);
 		sut.Statistics.Path.ShouldOnlyContainPropertyGetAccess(nameof(IPath.VolumeSeparatorChar));
 	}
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/StatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/StatisticsTests.cs
@@ -20,7 +20,7 @@ public sealed partial class StatisticsTests
 			.WithFile("f0").Which(f => f.HasBytesContent(Encoding.UTF8.GetBytes("bar")))
 			.WithAFile().Which(f => f.HasStringContent("foo"));
 
-		sut.StatisticsRegistration.TotalCount.Should().Be(0);
+		sut.Statistics.TotalCount.Should().Be(0);
 		sut.Statistics.Directory.Methods.Should().BeEmpty();
 		sut.Statistics.File.Methods.Should().BeEmpty();
 	}


### PR DESCRIPTION
Add a public property `TotalCount` to the statistics which contains the total number of registered statistic calls.