### PR TITLE
fix: update buffer when accessing a `FileStream` in parallel

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -648,6 +648,7 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 			return;
 		}
 
+		_container.BytesChanged -= OnBytesChanged;
 		_accessLock.Dispose();
 		InternalFlush();
 		base.Dispose(disposing);
@@ -657,6 +658,7 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 
 	private void InitializeStream()
 	{
+		_container.BytesChanged += OnBytesChanged;
 		if (_mode != FileMode.Create &&
 		    _mode != FileMode.Truncate)
 		{
@@ -686,6 +688,15 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 		_ = _stream.Read(data, 0, (int)Length);
 		_stream.Seek(position, SeekOrigin.Begin);
 		_container.WriteBytes(data);
+	}
+
+	private void OnBytesChanged(object? sender, EventArgs e)
+	{
+		byte[] existingContents = _container.GetBytes();
+		long position = _stream.Position;
+		_stream.Position = 0;
+		_stream.Write(existingContents, 0, existingContents.Length);
+		_stream.Position = position;
 	}
 
 	private void OnClose()

--- a/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
@@ -47,6 +47,11 @@ internal interface IStorageContainer : IFileSystemEntity, ITimeSystemEntity
 #endif
 
 	/// <summary>
+	///     An event triggered, when the underlying buffer is changed.
+	/// </summary>
+	event EventHandler? BytesChanged;
+
+	/// <summary>
 	///     Appends the <paramref name="bytes" /> to the <see cref="IFileInfo" />.
 	/// </summary>
 	void AppendBytes(byte[] bytes);

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -101,11 +101,15 @@ internal class InMemoryContainer : IStorageContainer
 		WriteBytes(_bytes.Concat(bytes).ToArray());
 	}
 
+	/// <inheritdoc cref="IStorageContainer.BytesChanged" />
+	public event EventHandler? BytesChanged;
+
 	/// <inheritdoc cref="IStorageContainer.ClearBytes()" />
 	public void ClearBytes()
 	{
 		_location.Drive?.ChangeUsedBytes(0 - _bytes.Length);
 		_bytes = Array.Empty<byte>();
+		BytesChanged?.Invoke(this, EventArgs.Empty);
 	}
 
 	/// <inheritdoc cref="IStorageContainer.Decrypt()" />
@@ -232,6 +236,7 @@ internal class InMemoryContainer : IStorageContainer
 		}
 
 		_fileSystem.ChangeHandler.NotifyCompletedChange(fileSystemChange);
+		BytesChanged?.Invoke(this, EventArgs.Empty);
 	}
 
 	#endregion

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -69,6 +69,11 @@ internal sealed class NullContainer : IStorageContainer
 		// Do nothing in NullContainer
 	}
 
+	#pragma warning disable CS0067 // Event is never used
+	/// <inheritdoc cref="IStorageContainer.BytesChanged" />
+	public event EventHandler? BytesChanged;
+	#pragma warning restore CS0067
+
 	/// <inheritdoc cref="IStorageContainer.ClearBytes()" />
 	public void ClearBytes()
 	{

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
@@ -73,9 +73,15 @@ internal sealed class LockableContainer(
 	public void AppendBytes(byte[] bytes)
 		=> WriteBytes(_bytes.Concat(bytes).ToArray());
 
+	/// <inheritdoc cref="IStorageContainer.BytesChanged" />
+	public event EventHandler? BytesChanged;
+
 	/// <inheritdoc cref="IStorageContainer.ClearBytes()" />
 	public void ClearBytes()
-		=> _bytes = Array.Empty<byte>();
+	{
+		_bytes = Array.Empty<byte>();
+		BytesChanged?.Invoke(this, EventArgs.Empty);
+	}
 
 	/// <inheritdoc cref="IStorageContainer.Decrypt()" />
 	public void Decrypt()
@@ -106,7 +112,10 @@ internal sealed class LockableContainer(
 
 	/// <inheritdoc cref="IStorageContainer.WriteBytes(byte[])" />
 	public void WriteBytes(byte[] bytes)
-		=> _bytes = bytes;
+	{
+		_bytes = bytes;
+		BytesChanged?.Invoke(this, EventArgs.Empty);
+	}
 
 	#endregion
 


### PR DESCRIPTION
As reported in https://github.com/TestableIO/System.IO.Abstractions/issues/1131:
Update underlying memory stream, when the buffer in a shared `InMemoryContainer` changes.