### PR TITLE
fix: Throw correct exception when using `File.Replace` with case-only changes on MacOS

### DIFF
--- a/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
@@ -207,7 +207,7 @@ internal static class ExceptionFactory
 		string sourcePath, string destinationPath)
 		=> new($"The source '{sourcePath}' and destination '{destinationPath}' are the same file.", -2146232800);
 
-#pragma warning disable MA0015 // Specify the parameter name
+	#pragma warning disable MA0015 // Specify the parameter name
 	internal static ArgumentException SearchPatternCannotContainTwoDots()
 		=> new(
 			"Search pattern cannot contain \"..\" to move up directories and can be contained only internally in file/directory names, as in \"a..b\".");

--- a/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
@@ -203,7 +203,11 @@ internal static class ExceptionFactory
 			$"The process cannot access the file '{path}' because it is being used by another process.",
 			hResult);
 
-	#pragma warning disable MA0015 // Specify the parameter name
+	internal static IOException ReplaceSourceMustBeDifferentThanDestination(
+		string sourcePath, string destinationPath)
+		=> new($"The source '{sourcePath}' and destination '{destinationPath}' are the same file.", -2146232800);
+
+#pragma warning disable MA0015 // Specify the parameter name
 	internal static ArgumentException SearchPatternCannotContainTwoDots()
 		=> new(
 			"Search pattern cannot contain \"..\" to move up directories and can be contained only internally in file/directory names, as in \"a..b\".");

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -444,7 +444,7 @@ internal sealed class InMemoryStorage : IStorage
 		if (_fileSystem.Execute.IsMac &&
 		    source.FullPath.Equals(destination.FullPath, StringComparison.OrdinalIgnoreCase))
 		{
-			throw ExceptionFactory.MoveSourceMustBeDifferentThanDestination();
+			throw ExceptionFactory.ReplaceSourceMustBeDifferentThanDestination(source.FullPath, destination.FullPath);
 		}
 
 		using (_ = sourceContainer.RequestAccess(

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -441,6 +441,12 @@ internal sealed class InMemoryStorage : IStorage
 			throw ExceptionFactory.AccessToPathDenied(source.FullPath);
 		}
 
+		if (_fileSystem.Execute.IsMac &&
+		    source.FullPath.Equals(destination.FullPath, StringComparison.OrdinalIgnoreCase))
+		{
+			throw ExceptionFactory.MoveSourceMustBeDifferentThanDestination();
+		}
+
 		using (_ = sourceContainer.RequestAccess(
 			FileAccess.ReadWrite,
 			FileShare.None,

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/MoveTests.cs
@@ -29,7 +29,7 @@ public abstract partial class MoveTests<TFileSystem>
 		FileSystem.Directory.Exists(source).Should().Be(!Test.RunsOnLinux);
 		FileSystem.Should().HaveDirectory(destination);
 		FileSystem.Directory.GetDirectories(".").Should()
-			.ContainSingle(d => d.Contains(destination));
+			.ContainSingle(d => d.Contains(destination, StringComparison.Ordinal));
 		FileSystem.Directory.GetFiles(destination, initialized[1].Name)
 			.Should().ContainSingle();
 		FileSystem.Directory.GetDirectories(destination, initialized[2].Name)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
@@ -26,6 +26,8 @@ public abstract partial class MoveTests<TFileSystem>
 
 		FileSystem.Should().HaveFile(destinationName)
 			.Which.HasContent(contents);
+		FileSystem.Directory.GetFiles(".").Should()
+			.ContainSingle(d => d.Contains(destinationName, StringComparison.Ordinal));
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
@@ -15,13 +15,25 @@ public abstract partial class ReplaceTests<TFileSystem>
 		string sourceName = name.ToLowerInvariant();
 		string destinationName = name.ToUpperInvariant();
 		FileSystem.File.WriteAllText(sourceName, contents);
+		FileSystem.File.WriteAllText(destinationName, "other-content");
 
 		Exception? exception = Record.Exception(() =>
 		{
 			FileSystem.File.Replace(sourceName, destinationName, null);
 		});
 
-		exception.Should().BeException<IOException>(hResult: -2147024864);
+
+		if (Test.RunsOnLinux)
+		{
+			exception.Should().BeNull();
+			FileSystem.File.Exists(sourceName).Should().BeFalse();
+			FileSystem.File.Exists(destinationName).Should().BeTrue();
+		}
+		else
+		{
+			exception.Should().BeException<IOException>(
+				hResult: Test.RunsOnWindows ? -2147024864 : -2147024894);
+		}
 	}
 
 	[SkippableTheory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
@@ -33,7 +33,7 @@ public abstract partial class ReplaceTests<TFileSystem>
 		{
 			exception.Should().BeException<IOException>(
 				hResult: -2146232800,
-				messageContains: "Source and destination path must be different");
+				messageContains: $"The source '{FileSystem.Path.GetFullPath(sourceName)}' and destination '{FileSystem.Path.GetFullPath(destinationName)}' are the same file");
 		}
 		else
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
@@ -9,6 +9,23 @@ public abstract partial class ReplaceTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
+	public void Replace_CaseOnlyChange_ShouldThrowIOException(
+		string name, string contents)
+	{
+		string sourceName = name.ToLowerInvariant();
+		string destinationName = name.ToUpperInvariant();
+		FileSystem.File.WriteAllText(sourceName, contents);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			FileSystem.File.Replace(sourceName, destinationName, null);
+		});
+
+		exception.Should().BeException<IOException>(hResult: -2147024864);
+	}
+
+	[SkippableTheory]
+	[AutoData]
 	public void
 		Replace_DestinationDirectoryDoesNotExist_ShouldThrowCorrectException(
 			string source)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
@@ -29,10 +29,17 @@ public abstract partial class ReplaceTests<TFileSystem>
 			FileSystem.File.Exists(sourceName).Should().BeFalse();
 			FileSystem.File.Exists(destinationName).Should().BeTrue();
 		}
+		else if (Test.RunsOnMac)
+		{
+			exception.Should().BeException<IOException>(
+				hResult: -2146232800,
+				messageContains: "Source and destination path must be different");
+		}
 		else
 		{
 			exception.Should().BeException<IOException>(
-				hResult: Test.RunsOnWindows ? -2147024864 : -2147024894);
+				hResult:  -2147024864,
+				messageContains: "The process cannot access the file");
 		}
 	}
 


### PR DESCRIPTION
When calling `File.Replace` with source and destination only differing in casing, on MacOS the file system throws an exception that "Source and destination path must be different". Consider this case also in the `MockFileSystem`.

Also add tests for correct handling of case-only changes in `File.Move` and `File.Copy`.

*Note: This fix was inspired by https://github.com/TestableIO/System.IO.Abstractions/issues/1140 and https://github.com/TestableIO/System.IO.Abstractions/issues/1138.*