### PR TITLE
refactor: skip release message for pull requests with "dependencies" label

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -361,6 +361,7 @@ jobs:
             state: released
           skip-label: |
             state: released
+            dependencies
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
Use "skip-label" in [apexskier/github-release-commenter](https://github.com/apexskier/github-release-commenter) to exclude dependabot PRs