### PR TITLE
refactor: add test to ensure, that `GetTempPath` ends with a directory separator

### DIFF
--- a/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetTempPathTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Path/GetTempPathTests.cs
@@ -26,6 +26,16 @@ public abstract partial class GetTempPathTests<TFileSystem>
 	}
 
 	[SkippableFact]
+	public void GetTempPath_ShouldEndWithDirectorySeparator()
+	{
+		string directorySeparator = FileSystem.Path.DirectorySeparatorChar.ToString();
+
+		string result = FileSystem.Path.GetTempPath();
+
+		result.Should().EndWith(directorySeparator);
+	}
+
+	[SkippableFact]
 	public void GetTempPath_ShouldRemainTheSame()
 	{
 		string result1 = FileSystem.Path.GetTempPath();


### PR DESCRIPTION
See https://github.com/TestableIO/System.IO.Abstractions/issues/1171