### PR TITLE
refactor: use aweXpect for Compression project

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,8 @@
 	<ItemGroup>
 		<PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
 		<PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
-		<PackageVersion Include="aweXpect" Version="0.7.0" />
+		<PackageVersion Include="aweXpect" Version="0.10.0" />
+		<PackageVersion Include="aweXpect.Testably" Version="0.2.0" />
 		<PackageVersion Include="FluentAssertions" Version="7.0.0" />
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 		<PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -25,6 +25,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="aweXpect" />
+		<PackageReference Include="aweXpect.Testably" />
 		<PackageReference Include="AutoFixture.Xunit2" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Xunit.SkippableFact" />

--- a/Tests/Testably.Abstractions.Compression.Tests/Internal/ExecuteTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/Internal/ExecuteTests.cs
@@ -5,7 +5,7 @@ namespace Testably.Abstractions.Compression.Tests.Internal;
 public sealed class ExecuteTests
 {
 	[Fact]
-	public void WhenRealFileSystem_MockFileSystem_WithActionCallback_ShouldExecuteOnMockFileSystem()
+	public async Task WhenRealFileSystem_MockFileSystem_WithActionCallback_ShouldExecuteOnMockFileSystem()
 	{
 		bool onRealFileSystemExecuted = false;
 		bool onMockFileSystemExecuted = false;
@@ -20,12 +20,12 @@ public sealed class ExecuteTests
 				onMockFileSystemExecuted = true;
 			});
 
-		onRealFileSystemExecuted.Should().BeFalse();
-		onMockFileSystemExecuted.Should().BeTrue();
+		await That(onRealFileSystemExecuted).Should().BeFalse();
+		await That(onMockFileSystemExecuted).Should().BeTrue();
 	}
 
 	[Fact]
-	public void WhenRealFileSystem_MockFileSystem_WithFuncCallback_ShouldExecuteOnMockFileSystem()
+	public async Task WhenRealFileSystem_MockFileSystem_WithFuncCallback_ShouldExecuteOnMockFileSystem()
 	{
 		bool onRealFileSystemExecuted = false;
 		bool onMockFileSystemExecuted = false;
@@ -40,12 +40,12 @@ public sealed class ExecuteTests
 				return onMockFileSystemExecuted = true;
 			});
 
-		onRealFileSystemExecuted.Should().BeFalse();
-		onMockFileSystemExecuted.Should().BeTrue();
+		await That(onRealFileSystemExecuted).Should().BeFalse();
+		await That(onMockFileSystemExecuted).Should().BeTrue();
 	}
 
 	[Fact]
-	public void WhenRealFileSystem_RealFileSystem_WithActionCallback_ShouldExecuteOnRealFileSystem()
+	public async Task WhenRealFileSystem_RealFileSystem_WithActionCallback_ShouldExecuteOnRealFileSystem()
 	{
 		bool onRealFileSystemExecuted = false;
 		bool onMockFileSystemExecuted = false;
@@ -60,12 +60,12 @@ public sealed class ExecuteTests
 				onMockFileSystemExecuted = true;
 			});
 
-		onRealFileSystemExecuted.Should().BeTrue();
-		onMockFileSystemExecuted.Should().BeFalse();
+		await That(onRealFileSystemExecuted).Should().BeTrue();
+		await That(onMockFileSystemExecuted).Should().BeFalse();
 	}
 
 	[Fact]
-	public void WhenRealFileSystem_RealFileSystem_WithFuncCallback_ShouldExecuteOnRealFileSystem()
+	public async Task WhenRealFileSystem_RealFileSystem_WithFuncCallback_ShouldExecuteOnRealFileSystem()
 	{
 		bool onRealFileSystemExecuted = false;
 		bool onMockFileSystemExecuted = false;
@@ -80,7 +80,7 @@ public sealed class ExecuteTests
 				return onMockFileSystemExecuted = true;
 			});
 
-		onRealFileSystemExecuted.Should().BeTrue();
-		onMockFileSystemExecuted.Should().BeFalse();
+		await That(onRealFileSystemExecuted).Should().BeTrue();
+		await That(onMockFileSystemExecuted).Should().BeFalse();
 	}
 }

--- a/Tests/Testably.Abstractions.Compression.Tests/TestHelpers/Usings.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/TestHelpers/Usings.cs
@@ -1,7 +1,11 @@
 ﻿global using AutoFixture.Xunit2;
 global using FluentAssertions;
 global using System;
+global using System.Threading.Tasks;
 global using System.IO.Abstractions;
 global using Testably.Abstractions.TestHelpers;
 global using Testably.Abstractions.Testing;
 global using Xunit;
+global using aweXpect;
+global using aweXpect.Testably;
+global using static aweXpect.Expect;

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/Tests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/Tests.cs
@@ -10,7 +10,7 @@ public abstract partial class Tests<TFileSystem>
 {
 #if FEATURE_ZIPFILE_NET7
 	[SkippableFact]
-	public void Comment_ShouldBeInitializedEmpty()
+	public async Task Comment_ShouldBeInitializedEmpty()
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
@@ -23,13 +23,13 @@ public abstract partial class Tests<TFileSystem>
 
 		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
 
-		archive.Comment.Should().Be("");
+		await That(archive.Comment).Should().Be("");
 	}
 #endif
 #if FEATURE_ZIPFILE_NET7
 	[SkippableTheory]
 	[AutoData]
-	public void Comment_ShouldBeSettable(string comment)
+	public async Task Comment_ShouldBeSettable(string comment)
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
@@ -43,12 +43,12 @@ public abstract partial class Tests<TFileSystem>
 		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
 		archive.Comment = comment;
 
-		archive.Comment.Should().Be(comment);
+		await That(archive.Comment).Should().Be(comment);
 	}
 #endif
 
 	[SkippableFact]
-	public void Entries_CreateMode_ShouldThrowNotSupportedException()
+	public async Task Entries_CreateMode_ShouldThrowNotSupportedException()
 	{
 		using FileSystemStream stream =
 			FileSystem.File.Open("destination.zip", FileMode.Create, FileAccess.ReadWrite);
@@ -62,7 +62,7 @@ public abstract partial class Tests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void FileSystem_ShouldBeSet(
+	public async Task FileSystem_ShouldBeSet(
 		CompressionLevel compressionLevel)
 	{
 		FileSystem.Initialize()
@@ -78,7 +78,7 @@ public abstract partial class Tests<TFileSystem>
 	}
 
 	[SkippableFact]
-	public void GetEntry_WhenNameIsNotFound_ShouldReturnNull()
+	public async Task GetEntry_WhenNameIsNotFound_ShouldReturnNull()
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
@@ -97,7 +97,7 @@ public abstract partial class Tests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void Mode_ShouldBeSetCorrectly(ZipArchiveMode mode)
+	public async Task Mode_ShouldBeSetCorrectly(ZipArchiveMode mode)
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
@@ -14,7 +14,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 {
 	[SkippableTheory]
 	[AutoData]
-	public void
+	public async Task
 		CreateFromDirectory_EmptyDirectory_ShouldBeIncluded(
 			CompressionLevel compressionLevel)
 	{
@@ -34,7 +34,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void CreateFromDirectory_EmptySource_DoNotIncludeBaseDirectory_ShouldBeEmpty(
+	public async Task CreateFromDirectory_EmptySource_DoNotIncludeBaseDirectory_ShouldBeEmpty(
 		CompressionLevel compressionLevel)
 	{
 		FileSystem.Initialize()
@@ -51,7 +51,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void
+	public async Task
 		CreateFromDirectory_EmptySource_IncludeBaseDirectory_ShouldPrependDirectoryName(
 			CompressionLevel compressionLevel)
 	{
@@ -70,7 +70,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 
 	[SkippableTheory]
 	[MemberData(nameof(EntryNameEncoding))]
-	public void CreateFromDirectory_EntryNameEncoding_ShouldUseEncoding(
+	public async Task CreateFromDirectory_EntryNameEncoding_ShouldUseEncoding(
 		string entryName, Encoding encoding, bool encodedCorrectly)
 	{
 		FileSystem.Initialize()
@@ -97,7 +97,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void CreateFromDirectory_IncludeBaseDirectory_ShouldPrependDirectoryName(
+	public async Task CreateFromDirectory_IncludeBaseDirectory_ShouldPrependDirectoryName(
 		CompressionLevel compressionLevel)
 	{
 		FileSystem.Initialize()
@@ -117,7 +117,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 #if FEATURE_COMPRESSION_OVERWRITE
 	[SkippableTheory]
 	[AutoData]
-	public void CreateFromDirectory_Overwrite_WithEncoding_ShouldOverwriteFile(
+	public async Task CreateFromDirectory_Overwrite_WithEncoding_ShouldOverwriteFile(
 		string contents, Encoding encoding)
 	{
 		FileSystem.Initialize()
@@ -140,7 +140,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 #endif
 
 	[SkippableFact]
-	public void CreateFromDirectory_ShouldZipDirectoryContent()
+	public async Task CreateFromDirectory_ShouldZipDirectoryContent()
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("destination")
@@ -161,7 +161,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableFact]
-	public void CreateFromDirectory_WithReadOnlyStream_ShouldThrowArgumentException()
+	public async Task CreateFromDirectory_WithReadOnlyStream_ShouldThrowArgumentException()
 	{
 		FileSystem.Initialize()
 			.WithFile("target.zip")
@@ -186,7 +186,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableTheory]
 	[AutoData]
-	public void
+	public async Task
 		CreateFromDirectory_WithStream_EmptyDirectory_ShouldBeIncluded(
 			CompressionLevel compressionLevel)
 	{
@@ -208,7 +208,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableTheory]
 	[AutoData]
-	public void CreateFromDirectory_WithStream_EmptySource_DoNotIncludeBaseDirectory_ShouldBeEmpty(
+	public async Task CreateFromDirectory_WithStream_EmptySource_DoNotIncludeBaseDirectory_ShouldBeEmpty(
 		CompressionLevel compressionLevel)
 	{
 		FileSystem.Initialize()
@@ -227,7 +227,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableTheory]
 	[AutoData]
-	public void
+	public async Task
 		CreateFromDirectory_WithStream_EmptySource_IncludeBaseDirectory_ShouldPrependDirectoryName(
 			CompressionLevel compressionLevel)
 	{
@@ -248,7 +248,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableTheory]
 	[MemberData(nameof(EntryNameEncoding))]
-	public void CreateFromDirectory_WithStream_EntryNameEncoding_ShouldUseEncoding(
+	public async Task CreateFromDirectory_WithStream_EntryNameEncoding_ShouldUseEncoding(
 		string entryName, Encoding encoding, bool encodedCorrectly)
 	{
 		FileSystem.Initialize()
@@ -277,7 +277,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableTheory]
 	[AutoData]
-	public void CreateFromDirectory_WithStream_IncludeBaseDirectory_ShouldPrependDirectoryName(
+	public async Task CreateFromDirectory_WithStream_IncludeBaseDirectory_ShouldPrependDirectoryName(
 		CompressionLevel compressionLevel)
 	{
 		FileSystem.Initialize()
@@ -297,7 +297,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableFact]
-	public void
+	public async Task
 		CreateFromDirectory_WithStream_NotWritable_ShouldThrowArgumentException()
 	{
 		Stream stream = new MemoryStreamMock(canWrite: false);
@@ -314,7 +314,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableFact]
-	public void
+	public async Task
 		CreateFromDirectory_WithStream_Null_ShouldThrowArgumentNullException()
 	{
 		Stream stream = null!;
@@ -332,7 +332,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableTheory]
 	[AutoData]
-	public void CreateFromDirectory_WithStream_Overwrite_WithEncoding_ShouldOverwriteFile(
+	public async Task CreateFromDirectory_WithStream_Overwrite_WithEncoding_ShouldOverwriteFile(
 		string contents, Encoding encoding)
 	{
 		FileSystem.Initialize()
@@ -357,7 +357,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableFact]
-	public void CreateFromDirectory_WithStream_ShouldZipDirectoryContent()
+	public async Task CreateFromDirectory_WithStream_ShouldZipDirectoryContent()
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("destination")

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
@@ -13,7 +13,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
 	[SkippableFact]
-	public void ExtractToDirectory_MissingDestinationDirectory_ShouldCreateDirectory()
+	public async Task ExtractToDirectory_MissingDestinationDirectory_ShouldCreateDirectory()
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("foo").Initialized(s => s
@@ -31,7 +31,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 	}
 
 	[SkippableFact]
-	public void
+	public async Task
 		ExtractToDirectory_MissingSourceFileName_ShouldThrowArgumentNullException()
 	{
 		FileSystem.Initialize();
@@ -48,7 +48,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 	}
 
 	[SkippableFact]
-	public void
+	public async Task
 		ExtractToDirectory_NullAsSourceFileName_ShouldThrowArgumentNullException()
 	{
 		FileSystem.Initialize();
@@ -66,7 +66,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 #if FEATURE_COMPRESSION_OVERWRITE
 	[SkippableTheory]
 	[AutoData]
-	public void ExtractToDirectory_Overwrite_ShouldOverwriteFile(
+	public async Task ExtractToDirectory_Overwrite_ShouldOverwriteFile(
 		string contents)
 	{
 		FileSystem.Initialize()
@@ -91,7 +91,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 #if FEATURE_COMPRESSION_OVERWRITE
 	[SkippableTheory]
 	[AutoData]
-	public void ExtractToDirectory_WithEncoding_Overwrite_ShouldOverwriteFile(
+	public async Task ExtractToDirectory_WithEncoding_Overwrite_ShouldOverwriteFile(
 		string contents,
 		Encoding encoding)
 	{
@@ -116,7 +116,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void ExtractToDirectory_WithEncoding_ShouldZipDirectoryContent(
+	public async Task ExtractToDirectory_WithEncoding_ShouldZipDirectoryContent(
 		Encoding encoding)
 	{
 		FileSystem.Initialize()
@@ -138,7 +138,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 
 	[SkippableTheory]
 	[AutoData]
-	public void ExtractToDirectory_WithoutOverwriteAndExistingFile_ShouldOverwriteFile(
+	public async Task ExtractToDirectory_WithoutOverwriteAndExistingFile_ShouldOverwriteFile(
 		string contents)
 	{
 		FileSystem.Initialize()
@@ -166,7 +166,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableFact]
-	public void ExtractToDirectory_WithStream_MissingDestinationDirectory_ShouldCreateDirectory()
+	public async Task ExtractToDirectory_WithStream_MissingDestinationDirectory_ShouldCreateDirectory()
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("foo").Initialized(s => s
@@ -187,7 +187,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableFact]
-	public void
+	public async Task
 		ExtractToDirectory_WithStream_NotReadable_ShouldThrowArgumentNullException()
 	{
 		FileSystem.Initialize();
@@ -205,7 +205,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableFact]
-	public void
+	public async Task
 		ExtractToDirectory_WithStream_Null_ShouldThrowArgumentNullException()
 	{
 		FileSystem.Initialize();
@@ -224,7 +224,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableTheory]
 	[AutoData]
-	public void ExtractToDirectory_WithStream_Overwrite_ShouldOverwriteFile(
+	public async Task ExtractToDirectory_WithStream_Overwrite_ShouldOverwriteFile(
 		string contents)
 	{
 		FileSystem.Initialize()
@@ -250,7 +250,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableTheory]
 	[AutoData]
-	public void ExtractToDirectory_WithStream_WithEncoding_Overwrite_ShouldOverwriteFile(
+	public async Task ExtractToDirectory_WithStream_WithEncoding_Overwrite_ShouldOverwriteFile(
 		string contents,
 		Encoding encoding)
 	{
@@ -277,7 +277,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableTheory]
 	[AutoData]
-	public void ExtractToDirectory_WithStream_WithEncoding_ShouldZipDirectoryContent(
+	public async Task ExtractToDirectory_WithStream_WithEncoding_ShouldZipDirectoryContent(
 		Encoding encoding)
 	{
 		FileSystem.Initialize()
@@ -302,7 +302,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableTheory]
 	[AutoData]
-	public void ExtractToDirectory_WithStream_WithoutOverwriteAndExistingFile_ShouldOverwriteFile(
+	public async Task ExtractToDirectory_WithStream_WithoutOverwriteAndExistingFile_ShouldOverwriteFile(
 		string contents)
 	{
 		FileSystem.Initialize()
@@ -333,7 +333,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 
 #if FEATURE_COMPRESSION_STREAM
 	[SkippableFact]
-	public void ExtractToDirectory_WithWriteOnlyStream_ShouldThrowArgumentException()
+	public async Task ExtractToDirectory_WithWriteOnlyStream_ShouldThrowArgumentException()
 	{
 		FileSystem.Initialize()
 			.WithFile("target.zip")

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/OpenTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/OpenTests.cs
@@ -8,7 +8,7 @@ public abstract partial class OpenTests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
 	[SkippableFact]
-	public void Open_CreateMode_ShouldInitializeEmptyArchive()
+	public async Task Open_CreateMode_ShouldInitializeEmptyArchive()
 	{
 		IZipArchive archive = FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Create);
 
@@ -16,7 +16,7 @@ public abstract partial class OpenTests<TFileSystem>
 	}
 
 	[SkippableFact]
-	public void Open_InvalidMode_ShouldThrowArgumentOutOfRangeException()
+	public async Task Open_InvalidMode_ShouldThrowArgumentOutOfRangeException()
 	{
 		ZipArchiveMode invalidMode = (ZipArchiveMode)(-1);
 
@@ -32,7 +32,7 @@ public abstract partial class OpenTests<TFileSystem>
 	[SkippableTheory]
 	[InlineData(ZipArchiveMode.Read)]
 	[InlineData(ZipArchiveMode.Update)]
-	public void Open_ShouldOpenExistingArchive(ZipArchiveMode mode)
+	public async Task Open_ShouldOpenExistingArchive(ZipArchiveMode mode)
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
@@ -48,7 +48,7 @@ public abstract partial class OpenTests<TFileSystem>
 	}
 
 	[SkippableFact]
-	public void OpenRead_ShouldOpenExistingArchiveInReadMode()
+	public async Task OpenRead_ShouldOpenExistingArchiveInReadMode()
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/Tests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/Tests.cs
@@ -6,7 +6,7 @@ public abstract partial class Tests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
 	[SkippableFact]
-	public void FileSystemExtension_ShouldBeSet()
+	public async Task FileSystemExtension_ShouldBeSet()
 	{
 		IZipFile result = FileSystem.ZipFile();
 


### PR DESCRIPTION
Use [aweXpect](https://github.com/aweXpect/aweXpect) as an assertion library for Testably.Abstractions.Compression.Tests