### PR TITLE
fix: test classes are not source generated anymore

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,14 +21,14 @@
 		<PackageVersion Include="SharpCompress" Version="0.38.0"/>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
 		<PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
 		<PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
-		<PackageVersion Include="aweXpect" Version="0.10.0" />
+		<PackageVersion Include="aweXpect" Version="0.11.1" />
 		<PackageVersion Include="aweXpect.Testably" Version="0.2.0" />
 		<PackageVersion Include="FluentAssertions" Version="7.0.0" />
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
 		<PackageVersion Include="SharpCompress" Version="0.38.0"/>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
 		<PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
 	</ItemGroup>


### PR DESCRIPTION
Revert #684, as it deactivates the generation of the unit test classes.