### PR TITLE
fix: tests are not generated/executed

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
 		<PackageVersion Include="SharpCompress" Version="0.38.0"/>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
 		<PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
 	</ItemGroup>

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
@@ -307,7 +307,7 @@ public abstract partial class CreateFromDirectoryTests<TFileSystem>
 		}
 
 		await That(Act).Should().Throw<ArgumentException>()
-			.WithMessage("The stream is unwritable").And
+			.WithMessage("The stream is unwritable*").AsWildcard().And
 			.WithParamName("destination").And
 			.WithHResult(-2147024809);
 	}

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
@@ -188,7 +188,7 @@ public abstract partial class ExtractToDirectoryTests<TFileSystem>
 		}
 
 		await That(Act).Should().Throw<ArgumentException>()
-			.WithMessage("The stream is unreadable").And
+			.WithMessage("The stream is unreadable*").AsWildcard().And
 			.WithParamName("source").And
 			.WithHResult(-2147024809);
 	}


### PR DESCRIPTION
Revert Microsoft.CodeAnalysis.CSharp to 4.11.0 as 4.12.0 does not generate tests correctly