### PR TITLE
feat: Add initial `FileVersionInfo` support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 		<PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageVersion Include="System.Linq.Async" Version="6.0.1" />
 		<PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
-		<PackageVersion Include="TestableIO.System.IO.Abstractions" Version="21.1.7" />
+		<PackageVersion Include="TestableIO.System.IO.Abstractions" Version="21.2.1" />
 		<PackageVersion Include="System.IO.Compression" Version="4.3.0" />
 		<PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
 	</ItemGroup>

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileVersionInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileVersionInfoFactoryMock.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Testably.Abstractions.Testing.FileSystem;
+
+internal sealed class FileVersionInfoFactoryMock
+	: IFileVersionInfoFactory
+{
+	private readonly MockFileSystem _fileSystem;
+
+	internal FileVersionInfoFactoryMock(MockFileSystem fileSystem)
+	{
+		_fileSystem = fileSystem;
+	}
+
+	#region IFileVersionInfoFactory Members
+
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
+	public IFileSystem FileSystem
+		=> _fileSystem;
+
+	/// <inheritdoc cref="IFileVersionInfoFactory.GetVersionInfo(string)" />
+	public IFileVersionInfo GetVersionInfo(string fileName)
+	{
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileVersionInfo.RegisterMethod(nameof(GetVersionInfo), fileName);
+
+		return FileVersionInfoMock.New(_fileSystem.Storage.GetLocation(fileName), _fileSystem);
+	}
+
+	#endregion
+}

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileVersionInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileVersionInfoMock.cs
@@ -1,0 +1,382 @@
+﻿using System;
+using Testably.Abstractions.Testing.Statistics;
+using Testably.Abstractions.Testing.Storage;
+
+namespace Testably.Abstractions.Testing.FileSystem;
+
+/// <summary>
+///     Mocked instance of a <see cref="IFileVersionInfo" />
+/// </summary>
+internal sealed class FileVersionInfoMock : IFileVersionInfo
+{
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
+	public IFileSystem FileSystem
+		=> _fileSystem;
+
+	private readonly MockFileSystem _fileSystem;
+	private readonly string _path;
+
+	private FileVersionInfoMock(IStorageLocation location, MockFileSystem fileSystem)
+	{
+		_fileSystem = fileSystem;
+		_path = location.FullPath;
+	}
+
+	#region IFileVersionInfo Members
+
+	/// <inheritdoc cref="IFileVersionInfo.Comments" />
+	public string? Comments
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(Comments), PropertyAccess.Get);
+
+			return "";
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.CompanyName" />
+	public string? CompanyName
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(CompanyName), PropertyAccess.Get);
+
+			return "";
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.FileBuildPart" />
+	public int FileBuildPart
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(FileBuildPart), PropertyAccess.Get);
+
+			return 0;
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.FileDescription" />
+	public string? FileDescription
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(FileDescription), PropertyAccess.Get);
+
+			return "";
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.FileMajorPart" />
+	public int FileMajorPart
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(FileMajorPart), PropertyAccess.Get);
+
+			return 0;
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.FileMinorPart" />
+	public int FileMinorPart
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(FileMinorPart), PropertyAccess.Get);
+
+			return 0;
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.FileName" />
+	public string FileName
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(FileName), PropertyAccess.Get);
+
+			return "";
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.FilePrivatePart" />
+	public int FilePrivatePart
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(FilePrivatePart), PropertyAccess.Get);
+
+			return 0;
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.FileVersion" />
+	public string? FileVersion
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(FileVersion), PropertyAccess.Get);
+
+			return "";
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.InternalName" />
+	public string? InternalName
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(InternalName), PropertyAccess.Get);
+
+			return "";
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.IsDebug" />
+	public bool IsDebug
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(IsDebug), PropertyAccess.Get);
+
+			return false;
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.IsPatched" />
+	public bool IsPatched
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(IsPatched), PropertyAccess.Get);
+
+			return false;
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.IsPreRelease" />
+	public bool IsPreRelease
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(IsPreRelease), PropertyAccess.Get);
+
+			return false;
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.IsPrivateBuild" />
+	public bool IsPrivateBuild
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(IsPrivateBuild), PropertyAccess.Get);
+
+			return false;
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.IsSpecialBuild" />
+	public bool IsSpecialBuild
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(IsSpecialBuild), PropertyAccess.Get);
+
+			return false;
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.Language" />
+	public string? Language
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(Language), PropertyAccess.Get);
+
+			return "";
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.LegalCopyright" />
+	public string? LegalCopyright
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(LegalCopyright), PropertyAccess.Get);
+
+			return "";
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.LegalTrademarks" />
+	public string? LegalTrademarks
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(LegalTrademarks), PropertyAccess.Get);
+
+			return "";
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.OriginalFilename" />
+	public string? OriginalFilename
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(OriginalFilename), PropertyAccess.Get);
+
+			return "";
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.PrivateBuild" />
+	public string? PrivateBuild
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(PrivateBuild), PropertyAccess.Get);
+
+			return "";
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductBuildPart" />
+	public int ProductBuildPart
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(ProductBuildPart), PropertyAccess.Get);
+
+			return 0;
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductMajorPart" />
+	public int ProductMajorPart
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(ProductMajorPart), PropertyAccess.Get);
+
+			return 0;
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductMinorPart" />
+	public int ProductMinorPart
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(ProductMinorPart), PropertyAccess.Get);
+
+			return 0;
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductName" />
+	public string? ProductName
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(ProductName), PropertyAccess.Get);
+
+			return "";
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductPrivatePart" />
+	public int ProductPrivatePart
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(ProductPrivatePart), PropertyAccess.Get);
+
+			return 0;
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductVersion" />
+	public string? ProductVersion
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(ProductVersion), PropertyAccess.Get);
+
+			return "";
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.SpecialBuild" />
+	public string? SpecialBuild
+	{
+		get
+		{
+			using IDisposable registration = _fileSystem.StatisticsRegistration
+				.FileVersionInfo.RegisterPathProperty(_path,
+					nameof(SpecialBuild), PropertyAccess.Get);
+
+			return "";
+		}
+	}
+
+	#endregion
+
+	internal static FileVersionInfoMock New(IStorageLocation location, MockFileSystem fileSystem)
+		=> new(location, fileSystem);
+}

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -138,6 +138,7 @@ public sealed class MockFileSystem : IFileSystem
 		FileInfo = new FileInfoFactoryMock(this);
 		FileStream = new FileStreamFactoryMock(this);
 		FileSystemWatcher = new FileSystemWatcherFactoryMock(this);
+		FileVersionInfo = new FileVersionInfoFactoryMock(this);
 		SafeFileHandleStrategy = new NullSafeFileHandleStrategy();
 		AccessControlStrategy = new NullAccessControlStrategy();
 		InitializeFileSystem(initialization);
@@ -167,6 +168,9 @@ public sealed class MockFileSystem : IFileSystem
 
 	/// <inheritdoc cref="IFileSystem.FileSystemWatcher" />
 	public IFileSystemWatcherFactory FileSystemWatcher { get; }
+
+	/// <inheritdoc cref="IFileSystem.FileVersionInfo" />
+	public IFileVersionInfoFactory FileVersionInfo { get; }
 
 	/// <inheritdoc cref="IFileSystem.Path" />
 	public IPath Path

--- a/Source/Testably.Abstractions.Testing/Statistics/FileSystemStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/FileSystemStatistics.cs
@@ -11,6 +11,8 @@ internal sealed class FileSystemStatistics : IFileSystemStatistics
 
 	internal readonly PathStatistics<IFileSystemWatcherFactory, IFileSystemWatcher>
 		FileSystemWatcher;
+	internal readonly PathStatistics<IFileVersionInfoFactory, IFileVersionInfo>
+		FileVersionInfo;
 
 	internal readonly CallStatistics<IPath> Path;
 	private readonly MockFileSystem _fileSystem;
@@ -34,6 +36,8 @@ internal sealed class FileSystemStatistics : IFileSystemStatistics
 			statisticsGate, fileSystem, nameof(IFileSystem.FileStream));
 		FileSystemWatcher = new PathStatistics<IFileSystemWatcherFactory, IFileSystemWatcher>(
 			statisticsGate, fileSystem, nameof(IFileSystem.FileSystemWatcher));
+		FileVersionInfo = new PathStatistics<IFileVersionInfoFactory, IFileVersionInfo>(
+			statisticsGate, fileSystem, nameof(IFileSystem.FileVersionInfo));
 		Path = new CallStatistics<IPath>(
 			statisticsGate, nameof(IFileSystem.Path));
 	}
@@ -72,6 +76,11 @@ internal sealed class FileSystemStatistics : IFileSystemStatistics
 	IPathStatistics<IFileSystemWatcherFactory, IFileSystemWatcher>
 		IFileSystemStatistics.FileSystemWatcher
 		=> FileSystemWatcher;
+
+	/// <inheritdoc cref="IFileSystemStatistics.FileSystemWatcher" />
+	IPathStatistics<IFileVersionInfoFactory, IFileVersionInfo>
+		IFileSystemStatistics.FileVersionInfo 
+		=> FileVersionInfo;
 
 	/// <inheritdoc cref="IFileSystemStatistics.Path" />
 	IStatistics<IPath> IFileSystemStatistics.Path

--- a/Source/Testably.Abstractions.Testing/Statistics/IFileSystemStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/IFileSystemStatistics.cs
@@ -41,6 +41,11 @@ public interface IFileSystemStatistics
 	IPathStatistics<IFileSystemWatcherFactory, IFileSystemWatcher> FileSystemWatcher { get; }
 
 	/// <summary>
+	///     Statistical information about calls to <see cref="IFileSystem.FileVersionInfo" />.
+	/// </summary>
+	IPathStatistics<IFileVersionInfoFactory, IFileVersionInfo> FileVersionInfo { get; }
+
+	/// <summary>
 	///     Statistical information about calls to <see cref="IFileSystem.Path" />.
 	/// </summary>
 	IStatistics<IPath> Path { get; }

--- a/Source/Testably.Abstractions/FileSystem/FileVersionInfoFactory.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileVersionInfoFactory.cs
@@ -1,0 +1,26 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+namespace Testably.Abstractions.FileSystem;
+
+internal sealed class FileVersionInfoFactory : IFileVersionInfoFactory
+{
+	internal FileVersionInfoFactory(RealFileSystem fileSystem)
+	{
+		FileSystem = fileSystem;
+	}
+
+	#region IFileSystemWatcherFactory Members
+
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
+	public IFileSystem FileSystem { get; }
+
+	/// <inheritdoc cref="IFileVersionInfoFactory.GetVersionInfo(string)" />
+	public IFileVersionInfo GetVersionInfo(string fileName)
+		=> FileVersionInfoWrapper.FromFileVersionInfo(
+			FileVersionInfo.GetVersionInfo(fileName),
+			FileSystem);
+
+	#endregion
+}

--- a/Source/Testably.Abstractions/FileSystem/FileVersionInfoWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileVersionInfoWrapper.cs
@@ -1,0 +1,143 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Testably.Abstractions.FileSystem;
+
+internal sealed class FileVersionInfoWrapper : IFileVersionInfo
+{
+	private readonly FileVersionInfo _instance;
+
+	private FileVersionInfoWrapper(FileVersionInfo fileSystemWatcher,
+		IFileSystem fileSystem)
+	{
+		_instance = fileSystemWatcher;
+		FileSystem = fileSystem;
+	}
+
+	#region IFileVersionInfo Members
+
+	/// <inheritdoc cref="IFileVersionInfo.Comments" />
+	public string? Comments
+		=> _instance.Comments;
+
+	/// <inheritdoc cref="IFileVersionInfo.CompanyName" />
+	public string? CompanyName
+		=> _instance.CompanyName;
+
+	/// <inheritdoc cref="IFileVersionInfo.FileBuildPart" />
+	public int FileBuildPart
+		=> _instance.FileBuildPart;
+
+	/// <inheritdoc cref="IFileVersionInfo.FileDescription" />
+	public string? FileDescription
+		=> _instance.FileDescription;
+
+	/// <inheritdoc cref="IFileVersionInfo.FileMajorPart" />
+	public int FileMajorPart
+		=> _instance.FileMajorPart;
+
+	/// <inheritdoc cref="IFileVersionInfo.FileMinorPart" />
+	public int FileMinorPart
+		=> _instance.FileMinorPart;
+
+	/// <inheritdoc cref="IFileVersionInfo.FileName" />
+	public string FileName
+		=> _instance.FileName;
+
+	/// <inheritdoc cref="IFileVersionInfo.FilePrivatePart" />
+	public int FilePrivatePart
+		=> _instance.FilePrivatePart;
+
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
+	public IFileSystem FileSystem { get; }
+
+	/// <inheritdoc cref="IFileVersionInfo.FileVersion" />
+	public string? FileVersion
+		=> _instance.FileVersion;
+
+	/// <inheritdoc cref="IFileVersionInfo.InternalName" />
+	public string? InternalName
+		=> _instance.InternalName;
+
+	/// <inheritdoc cref="IFileVersionInfo.IsDebug" />
+	public bool IsDebug
+		=> _instance.IsDebug;
+
+	/// <inheritdoc cref="IFileVersionInfo.IsPatched" />
+	public bool IsPatched
+		=> _instance.IsPatched;
+
+	/// <inheritdoc cref="IFileVersionInfo.IsPreRelease" />
+	public bool IsPreRelease
+		=> _instance.IsPreRelease;
+
+	/// <inheritdoc cref="IFileVersionInfo.IsPrivateBuild" />
+	public bool IsPrivateBuild
+		=> _instance.IsPrivateBuild;
+
+	/// <inheritdoc cref="IFileVersionInfo.IsSpecialBuild" />
+	public bool IsSpecialBuild
+		=> _instance.IsSpecialBuild;
+
+	/// <inheritdoc cref="IFileVersionInfo.Language" />
+	public string? Language
+		=> _instance.Language;
+
+	/// <inheritdoc cref="IFileVersionInfo.LegalCopyright" />
+	public string? LegalCopyright
+		=> _instance.LegalCopyright;
+
+	/// <inheritdoc cref="IFileVersionInfo.LegalTrademarks" />
+	public string? LegalTrademarks
+		=> _instance.LegalTrademarks;
+
+	/// <inheritdoc cref="IFileVersionInfo.OriginalFilename" />
+	public string? OriginalFilename
+		=> _instance.OriginalFilename;
+
+	/// <inheritdoc cref="IFileVersionInfo.PrivateBuild" />
+	public string? PrivateBuild
+		=> _instance.PrivateBuild;
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductBuildPart" />
+	public int ProductBuildPart
+		=> _instance.ProductBuildPart;
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductMajorPart" />
+	public int ProductMajorPart
+		=> _instance.ProductMajorPart;
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductMinorPart" />
+	public int ProductMinorPart
+		=> _instance.ProductMinorPart;
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductName" />
+	public string? ProductName
+		=> _instance.ProductName;
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductPrivatePart" />
+	public int ProductPrivatePart
+		=> _instance.ProductPrivatePart;
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductVersion" />
+	public string? ProductVersion
+		=> _instance.ProductVersion;
+
+	/// <inheritdoc cref="IFileVersionInfo.SpecialBuild" />
+	public string? SpecialBuild
+		=> _instance.SpecialBuild;
+
+	#endregion
+
+	[return: NotNullIfNotNull("instance")]
+	internal static FileVersionInfoWrapper? FromFileVersionInfo(
+		FileVersionInfo? instance, IFileSystem fileSystem)
+	{
+		if (instance == null)
+		{
+			return null;
+		}
+
+		return new FileVersionInfoWrapper(instance, fileSystem);
+	}
+}

--- a/Source/Testably.Abstractions/RealFileSystem.cs
+++ b/Source/Testably.Abstractions/RealFileSystem.cs
@@ -22,6 +22,7 @@ public sealed class RealFileSystem : IFileSystem
 		FileInfo = new FileInfoFactory(this);
 		FileStream = new FileStreamFactory(this);
 		FileSystemWatcher = new FileSystemWatcherFactory(this);
+		FileVersionInfo = new FileVersionInfoFactory(this);
 		Path = new PathWrapper(this);
 	}
 
@@ -47,6 +48,9 @@ public sealed class RealFileSystem : IFileSystem
 
 	/// <inheritdoc cref="IFileSystem.FileSystemWatcher" />
 	public IFileSystemWatcherFactory FileSystemWatcher { get; }
+
+	/// <inheritdoc cref="IFileSystem.FileVersionInfo" />
+	public IFileVersionInfoFactory FileVersionInfo { get; }
 
 	/// <inheritdoc cref="IFileSystem.Path" />
 	public IPath Path { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -101,6 +101,7 @@ namespace Testably.Abstractions.Testing
         public System.IO.Abstractions.IFileInfoFactory FileInfo { get; }
         public System.IO.Abstractions.IFileStreamFactory FileStream { get; }
         public System.IO.Abstractions.IFileSystemWatcherFactory FileSystemWatcher { get; }
+        public System.IO.Abstractions.IFileVersionInfoFactory FileVersionInfo { get; }
         public Testably.Abstractions.Testing.FileSystem.IInterceptionHandler Intercept { get; }
         public Testably.Abstractions.Testing.FileSystem.INotificationHandler Notify { get; }
         public System.IO.Abstractions.IPath Path { get; }
@@ -293,6 +294,7 @@ namespace Testably.Abstractions.Testing.Statistics
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileInfoFactory, System.IO.Abstractions.IFileInfo> FileInfo { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileVersionInfoFactory, System.IO.Abstractions.IFileVersionInfo> FileVersionInfo { get; }
         Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
         int TotalCount { get; }
     }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
@@ -101,6 +101,7 @@ namespace Testably.Abstractions.Testing
         public System.IO.Abstractions.IFileInfoFactory FileInfo { get; }
         public System.IO.Abstractions.IFileStreamFactory FileStream { get; }
         public System.IO.Abstractions.IFileSystemWatcherFactory FileSystemWatcher { get; }
+        public System.IO.Abstractions.IFileVersionInfoFactory FileVersionInfo { get; }
         public Testably.Abstractions.Testing.FileSystem.IInterceptionHandler Intercept { get; }
         public Testably.Abstractions.Testing.FileSystem.INotificationHandler Notify { get; }
         public System.IO.Abstractions.IPath Path { get; }
@@ -293,6 +294,7 @@ namespace Testably.Abstractions.Testing.Statistics
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileInfoFactory, System.IO.Abstractions.IFileInfo> FileInfo { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileVersionInfoFactory, System.IO.Abstractions.IFileVersionInfo> FileVersionInfo { get; }
         Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
         int TotalCount { get; }
     }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -101,6 +101,7 @@ namespace Testably.Abstractions.Testing
         public System.IO.Abstractions.IFileInfoFactory FileInfo { get; }
         public System.IO.Abstractions.IFileStreamFactory FileStream { get; }
         public System.IO.Abstractions.IFileSystemWatcherFactory FileSystemWatcher { get; }
+        public System.IO.Abstractions.IFileVersionInfoFactory FileVersionInfo { get; }
         public Testably.Abstractions.Testing.FileSystem.IInterceptionHandler Intercept { get; }
         public Testably.Abstractions.Testing.FileSystem.INotificationHandler Notify { get; }
         public System.IO.Abstractions.IPath Path { get; }
@@ -291,6 +292,7 @@ namespace Testably.Abstractions.Testing.Statistics
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileInfoFactory, System.IO.Abstractions.IFileInfo> FileInfo { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileVersionInfoFactory, System.IO.Abstractions.IFileVersionInfo> FileVersionInfo { get; }
         Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
         int TotalCount { get; }
     }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -99,6 +99,7 @@ namespace Testably.Abstractions.Testing
         public System.IO.Abstractions.IFileInfoFactory FileInfo { get; }
         public System.IO.Abstractions.IFileStreamFactory FileStream { get; }
         public System.IO.Abstractions.IFileSystemWatcherFactory FileSystemWatcher { get; }
+        public System.IO.Abstractions.IFileVersionInfoFactory FileVersionInfo { get; }
         public Testably.Abstractions.Testing.FileSystem.IInterceptionHandler Intercept { get; }
         public Testably.Abstractions.Testing.FileSystem.INotificationHandler Notify { get; }
         public System.IO.Abstractions.IPath Path { get; }
@@ -290,6 +291,7 @@ namespace Testably.Abstractions.Testing.Statistics
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileInfoFactory, System.IO.Abstractions.IFileInfo> FileInfo { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileVersionInfoFactory, System.IO.Abstractions.IFileVersionInfo> FileVersionInfo { get; }
         Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
         int TotalCount { get; }
     }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -99,6 +99,7 @@ namespace Testably.Abstractions.Testing
         public System.IO.Abstractions.IFileInfoFactory FileInfo { get; }
         public System.IO.Abstractions.IFileStreamFactory FileStream { get; }
         public System.IO.Abstractions.IFileSystemWatcherFactory FileSystemWatcher { get; }
+        public System.IO.Abstractions.IFileVersionInfoFactory FileVersionInfo { get; }
         public Testably.Abstractions.Testing.FileSystem.IInterceptionHandler Intercept { get; }
         public Testably.Abstractions.Testing.FileSystem.INotificationHandler Notify { get; }
         public System.IO.Abstractions.IPath Path { get; }
@@ -290,6 +291,7 @@ namespace Testably.Abstractions.Testing.Statistics
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileInfoFactory, System.IO.Abstractions.IFileInfo> FileInfo { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileStreamFactory, System.IO.Abstractions.FileSystemStream> FileStream { get; }
         Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileSystemWatcherFactory, System.IO.Abstractions.IFileSystemWatcher> FileSystemWatcher { get; }
+        Testably.Abstractions.Testing.Statistics.IPathStatistics<System.IO.Abstractions.IFileVersionInfoFactory, System.IO.Abstractions.IFileVersionInfo> FileVersionInfo { get; }
         Testably.Abstractions.Testing.Statistics.IStatistics<System.IO.Abstractions.IPath> Path { get; }
         int TotalCount { get; }
     }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net6.0.txt
@@ -14,6 +14,7 @@ namespace Testably.Abstractions
         public System.IO.Abstractions.IFileInfoFactory FileInfo { get; }
         public System.IO.Abstractions.IFileStreamFactory FileStream { get; }
         public System.IO.Abstractions.IFileSystemWatcherFactory FileSystemWatcher { get; }
+        public System.IO.Abstractions.IFileVersionInfoFactory FileVersionInfo { get; }
         public System.IO.Abstractions.IPath Path { get; }
     }
     public sealed class RealRandomSystem : Testably.Abstractions.IRandomSystem

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net7.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net7.0.txt
@@ -14,6 +14,7 @@ namespace Testably.Abstractions
         public System.IO.Abstractions.IFileInfoFactory FileInfo { get; }
         public System.IO.Abstractions.IFileStreamFactory FileStream { get; }
         public System.IO.Abstractions.IFileSystemWatcherFactory FileSystemWatcher { get; }
+        public System.IO.Abstractions.IFileVersionInfoFactory FileVersionInfo { get; }
         public System.IO.Abstractions.IPath Path { get; }
     }
     public sealed class RealRandomSystem : Testably.Abstractions.IRandomSystem

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net8.0.txt
@@ -14,6 +14,7 @@ namespace Testably.Abstractions
         public System.IO.Abstractions.IFileInfoFactory FileInfo { get; }
         public System.IO.Abstractions.IFileStreamFactory FileStream { get; }
         public System.IO.Abstractions.IFileSystemWatcherFactory FileSystemWatcher { get; }
+        public System.IO.Abstractions.IFileVersionInfoFactory FileVersionInfo { get; }
         public System.IO.Abstractions.IPath Path { get; }
     }
     public sealed class RealRandomSystem : Testably.Abstractions.IRandomSystem

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.0.txt
@@ -14,6 +14,7 @@ namespace Testably.Abstractions
         public System.IO.Abstractions.IFileInfoFactory FileInfo { get; }
         public System.IO.Abstractions.IFileStreamFactory FileStream { get; }
         public System.IO.Abstractions.IFileSystemWatcherFactory FileSystemWatcher { get; }
+        public System.IO.Abstractions.IFileVersionInfoFactory FileVersionInfo { get; }
         public System.IO.Abstractions.IPath Path { get; }
     }
     public sealed class RealRandomSystem : Testably.Abstractions.IRandomSystem

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.1.txt
@@ -14,6 +14,7 @@ namespace Testably.Abstractions
         public System.IO.Abstractions.IFileInfoFactory FileInfo { get; }
         public System.IO.Abstractions.IFileStreamFactory FileStream { get; }
         public System.IO.Abstractions.IFileSystemWatcherFactory FileSystemWatcher { get; }
+        public System.IO.Abstractions.IFileVersionInfoFactory FileVersionInfo { get; }
         public System.IO.Abstractions.IPath Path { get; }
     }
     public sealed class RealRandomSystem : Testably.Abstractions.IRandomSystem

--- a/Tests/Testably.Abstractions.Parity.Tests/ParityTests.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/ParityTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Threading;
@@ -93,6 +94,18 @@ public abstract class ParityTests(
 		List<string> parityErrors = Parity.FileSystemWatcher
 			.GetErrorsToInstanceType<IFileSystemWatcher, IFileSystemWatcherFactory>(
 				typeof(FileSystemWatcher),
+				testOutputHelper);
+
+		await That(parityErrors).Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task
+		IFileVersionInfoAndIFileVersionInfoFactory_EnsureParityWith_FileVersionInfo()
+	{
+		List<string> parityErrors = Parity.FileVersionInfo
+			.GetErrorsToInstanceType<IFileVersionInfo, IFileVersionInfoFactory>(
+				typeof(FileVersionInfo),
 				testOutputHelper);
 
 		await That(parityErrors).Should().BeEmpty();

--- a/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/Parity.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/Parity.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Threading;
@@ -55,6 +56,12 @@ public class Parity
 	[
 		typeof(FileSystemWatcher).GetMethod(
 			nameof(System.IO.FileSystemWatcher.ToString))
+	]);
+
+	public ParityCheck FileVersionInfo { get; } = new(excludeMethods:
+	[
+		typeof(FileVersionInfo).GetMethod(
+			nameof(System.Diagnostics.FileVersionInfo.ToString))
 	]);
 
 	public ParityCheck Guid { get; } = new();

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileVersionInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileVersionInfoFactoryStatisticsTests.cs
@@ -1,0 +1,19 @@
+﻿using Testably.Abstractions.Testing.Tests.TestHelpers;
+
+namespace Testably.Abstractions.Testing.Tests.Statistics.FileSystem;
+
+public class FileVersionInfoFactoryStatisticsTests
+{
+	[SkippableFact]
+	public void Method_GetVersionInfo_String_ShouldRegisterCall()
+	{
+		MockFileSystem sut = new();
+		string fileName = "foo";
+
+		sut.FileVersionInfo.GetVersionInfo(fileName);
+
+		sut.Statistics.FileVersionInfo.ShouldOnlyContainMethodCall(
+			nameof(IFileVersionInfoFactory.GetVersionInfo),
+			fileName);
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileVersionInfoStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileVersionInfoStatisticsTests.cs
@@ -1,0 +1,304 @@
+﻿using Testably.Abstractions.Testing.Tests.TestHelpers;
+// ReSharper disable MethodSupportsCancellation
+
+namespace Testably.Abstractions.Testing.Tests.Statistics.FileSystem;
+
+public class FileVersionInfoStatisticsTests
+{
+	[SkippableFact]
+	public void Property_Comments_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").Comments;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.Comments));
+	}
+
+	[SkippableFact]
+	public void Property_CompanyName_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").CompanyName;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.CompanyName));
+	}
+
+	[SkippableFact]
+	public void Property_FileBuildPart_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").FileBuildPart;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.FileBuildPart));
+	}
+
+	[SkippableFact]
+	public void Property_FileDescription_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").FileDescription;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.FileDescription));
+	}
+
+	[SkippableFact]
+	public void Property_FileMajorPart_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").FileMajorPart;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.FileMajorPart));
+	}
+
+	[SkippableFact]
+	public void Property_FileMinorPart_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").FileMinorPart;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.FileMinorPart));
+	}
+
+	[SkippableFact]
+	public void Property_FileName_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").FileName;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.FileName));
+	}
+
+	[SkippableFact]
+	public void Property_FilePrivatePart_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").FilePrivatePart;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.FilePrivatePart));
+	}
+
+	[SkippableFact]
+	public void Property_FileVersion_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").FileVersion;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.FileVersion));
+	}
+
+	[SkippableFact]
+	public void Property_InternalName_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").InternalName;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.InternalName));
+	}
+
+	[SkippableFact]
+	public void Property_IsDebug_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").IsDebug;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.IsDebug));
+	}
+
+	[SkippableFact]
+	public void Property_IsPatched_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").IsPatched;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.IsPatched));
+	}
+
+	[SkippableFact]
+	public void Property_IsPreRelease_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").IsPreRelease;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.IsPreRelease));
+	}
+
+	[SkippableFact]
+	public void Property_IsPrivateBuild_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").IsPrivateBuild;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.IsPrivateBuild));
+	}
+
+	[SkippableFact]
+	public void Property_IsSpecialBuild_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").IsSpecialBuild;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.IsSpecialBuild));
+	}
+
+	[SkippableFact]
+	public void Property_Language_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").Language;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.Language));
+	}
+
+	[SkippableFact]
+	public void Property_LegalCopyright_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").LegalCopyright;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.LegalCopyright));
+	}
+
+	[SkippableFact]
+	public void Property_LegalTrademarks_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").LegalTrademarks;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.LegalTrademarks));
+	}
+
+	[SkippableFact]
+	public void Property_OriginalFilename_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").OriginalFilename;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.OriginalFilename));
+	}
+
+	[SkippableFact]
+	public void Property_PrivateBuild_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").PrivateBuild;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.PrivateBuild));
+	}
+
+	[SkippableFact]
+	public void Property_ProductBuildPart_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").ProductBuildPart;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.ProductBuildPart));
+	}
+
+	[SkippableFact]
+	public void Property_ProductMajorPart_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").ProductMajorPart;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.ProductMajorPart));
+	}
+
+	[SkippableFact]
+	public void Property_ProductMinorPart_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").ProductMinorPart;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.ProductMinorPart));
+	}
+
+	[SkippableFact]
+	public void Property_ProductName_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").ProductName;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.ProductName));
+	}
+
+	[SkippableFact]
+	public void Property_ProductPrivatePart_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").ProductPrivatePart;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.ProductPrivatePart));
+	}
+
+	[SkippableFact]
+	public void Property_ProductVersion_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").ProductVersion;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.ProductVersion));
+	}
+
+	[SkippableFact]
+	public void Property_SpecialBuild_Get_ShouldRegisterPropertyAccess()
+	{
+		MockFileSystem sut = new();
+
+		_ = sut.FileVersionInfo.GetVersionInfo("foo").SpecialBuild;
+
+		sut.Statistics.FileVersionInfo["foo"]
+			.ShouldOnlyContainPropertyGetAccess(nameof(IFileVersionInfo.SpecialBuild));
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/StatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/StatisticsTests.cs
@@ -50,6 +50,10 @@ public sealed partial class StatisticsTests
 		typeof(IFileSystemWatcherFactory), typeof(FileSystemWatcherFactoryStatisticsTests))]
 	[InlineData(nameof(MockFileSystem.FileSystemWatcher), true,
 		typeof(IFileSystemWatcher), typeof(FileSystemWatcherStatisticsTests))]
+	[InlineData(nameof(MockFileSystem.FileVersionInfo), false,
+		typeof(IFileVersionInfoFactory), typeof(FileVersionInfoFactoryStatisticsTests))]
+	[InlineData(nameof(MockFileSystem.FileVersionInfo), true,
+		typeof(IFileVersionInfo), typeof(FileVersionInfoStatisticsTests))]
 	[InlineData(nameof(MockFileSystem.Path), false,
 		typeof(IPath), typeof(FileSystem.PathStatisticsTests))]
 	public void ShouldHaveTestedAllFileSystemMethods(string className, bool requireInstance,


### PR DESCRIPTION
Support for `FileVersionInfo` was added in https://github.com/TestableIO/System.IO.Abstractions/pull/1177. Add basic support for the updated interfaces.
*It is not yet possible to influence the mocked `IFileVersionInfo` in any way...*