### PR TITLE
feat: enable mocking the `IFileVersionInfo`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
     unit-tests:
         name: "Unit tests"
         strategy:
+            fail-fast: false
             matrix:
                 os: [ ubuntu-latest, windows-latest, macos-latest ]
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     unit-tests:
         name: "Unit tests"
         strategy:
+            fail-fast: false
             matrix:
                 os: [ ubuntu-latest, windows-latest, macos-latest ]
         runs-on: ${{ matrix.os }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
 		<PackageVersion Include="SharpCompress" Version="0.38.0"/>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
 		<PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
 	</ItemGroup>

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileVersionInfoFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileVersionInfoFactoryMock.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Testably.Abstractions.Testing.Helpers;
+using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.FileSystem;
 
@@ -24,7 +26,15 @@ internal sealed class FileVersionInfoFactoryMock
 		using IDisposable registration = _fileSystem.StatisticsRegistration
 			.FileVersionInfo.RegisterMethod(nameof(GetVersionInfo), fileName);
 
-		return FileVersionInfoMock.New(_fileSystem.Storage.GetLocation(fileName), _fileSystem);
+		fileName.EnsureValidFormat(_fileSystem, nameof(fileName));
+		IStorageLocation location = _fileSystem.Storage.GetLocation(fileName);
+		location.ThrowExceptionIfNotFound(_fileSystem);
+
+		FileVersionInfoContainer container = _fileSystem.Storage.GetVersionInfo(location)
+		                                     ?? FileVersionInfoContainer.None;
+
+		return FileVersionInfoMock.New(_fileSystem.Storage.GetLocation(fileName), container,
+			_fileSystem);
 	}
 
 	#endregion

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileVersionInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileVersionInfoMock.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Storage;
 
@@ -381,6 +382,29 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 	}
 
 	#endregion
+
+	/// <inheritdoc cref="object.ToString()" />
+	public override string ToString()
+	{
+		// An initial capacity of 512 was chosen because it is large enough to cover
+		// the size of the static strings with enough capacity left over to cover
+		// average length property values.
+		StringBuilder sb = new(512);
+		sb.Append("File:             ").AppendLine(FileName);
+		sb.Append("InternalName:     ").AppendLine(InternalName);
+		sb.Append("OriginalFilename: ").AppendLine(OriginalFilename);
+		sb.Append("FileVersion:      ").AppendLine(FileVersion);
+		sb.Append("FileDescription:  ").AppendLine(FileDescription);
+		sb.Append("Product:          ").AppendLine(ProductName);
+		sb.Append("ProductVersion:   ").AppendLine(ProductVersion);
+		sb.Append("Debug:            ").AppendLine(IsDebug.ToString());
+		sb.Append("Patched:          ").AppendLine(IsPatched.ToString());
+		sb.Append("PreRelease:       ").AppendLine(IsPreRelease.ToString());
+		sb.Append("PrivateBuild:     ").AppendLine(IsPrivateBuild.ToString());
+		sb.Append("SpecialBuild:     ").AppendLine(IsSpecialBuild.ToString());
+		sb.Append("Language:         ").AppendLine(Language);
+		return sb.ToString();
+	}
 
 	internal static FileVersionInfoMock New(
 		IStorageLocation location,

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileVersionInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileVersionInfoMock.cs
@@ -13,11 +13,16 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 	public IFileSystem FileSystem
 		=> _fileSystem;
 
+	private readonly FileVersionInfoContainer _container;
 	private readonly MockFileSystem _fileSystem;
 	private readonly string _path;
 
-	private FileVersionInfoMock(IStorageLocation location, MockFileSystem fileSystem)
+	private FileVersionInfoMock(
+		IStorageLocation location,
+		FileVersionInfoContainer container,
+		MockFileSystem fileSystem)
 	{
+		_container = container;
 		_fileSystem = fileSystem;
 		_path = location.FullPath;
 	}
@@ -33,7 +38,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(Comments), PropertyAccess.Get);
 
-			return "";
+			return _container.Comments;
 		}
 	}
 
@@ -46,7 +51,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(CompanyName), PropertyAccess.Get);
 
-			return "";
+			return _container.CompanyName;
 		}
 	}
 
@@ -59,7 +64,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(FileBuildPart), PropertyAccess.Get);
 
-			return 0;
+			return _container.FileBuildPart;
 		}
 	}
 
@@ -72,7 +77,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(FileDescription), PropertyAccess.Get);
 
-			return "";
+			return _container.FileDescription;
 		}
 	}
 
@@ -85,7 +90,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(FileMajorPart), PropertyAccess.Get);
 
-			return 0;
+			return _container.FileMajorPart;
 		}
 	}
 
@@ -98,7 +103,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(FileMinorPart), PropertyAccess.Get);
 
-			return 0;
+			return _container.FileMinorPart;
 		}
 	}
 
@@ -111,7 +116,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(FileName), PropertyAccess.Get);
 
-			return "";
+			return _path;
 		}
 	}
 
@@ -124,7 +129,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(FilePrivatePart), PropertyAccess.Get);
 
-			return 0;
+			return _container.FilePrivatePart;
 		}
 	}
 
@@ -137,7 +142,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(FileVersion), PropertyAccess.Get);
 
-			return "";
+			return _container.FileVersion;
 		}
 	}
 
@@ -150,7 +155,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(InternalName), PropertyAccess.Get);
 
-			return "";
+			return _container.InternalName;
 		}
 	}
 
@@ -163,7 +168,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(IsDebug), PropertyAccess.Get);
 
-			return false;
+			return _container.IsDebug;
 		}
 	}
 
@@ -176,7 +181,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(IsPatched), PropertyAccess.Get);
 
-			return false;
+			return _container.IsPatched;
 		}
 	}
 
@@ -189,7 +194,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(IsPreRelease), PropertyAccess.Get);
 
-			return false;
+			return _container.IsPreRelease;
 		}
 	}
 
@@ -202,7 +207,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(IsPrivateBuild), PropertyAccess.Get);
 
-			return false;
+			return _container.IsPrivateBuild;
 		}
 	}
 
@@ -215,7 +220,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(IsSpecialBuild), PropertyAccess.Get);
 
-			return false;
+			return _container.IsSpecialBuild;
 		}
 	}
 
@@ -228,7 +233,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(Language), PropertyAccess.Get);
 
-			return "";
+			return _container.Language;
 		}
 	}
 
@@ -241,7 +246,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(LegalCopyright), PropertyAccess.Get);
 
-			return "";
+			return _container.LegalCopyright;
 		}
 	}
 
@@ -254,7 +259,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(LegalTrademarks), PropertyAccess.Get);
 
-			return "";
+			return _container.LegalTrademarks;
 		}
 	}
 
@@ -267,7 +272,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(OriginalFilename), PropertyAccess.Get);
 
-			return "";
+			return _container.OriginalFilename;
 		}
 	}
 
@@ -280,7 +285,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(PrivateBuild), PropertyAccess.Get);
 
-			return "";
+			return _container.PrivateBuild;
 		}
 	}
 
@@ -293,7 +298,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(ProductBuildPart), PropertyAccess.Get);
 
-			return 0;
+			return _container.ProductBuildPart;
 		}
 	}
 
@@ -306,7 +311,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(ProductMajorPart), PropertyAccess.Get);
 
-			return 0;
+			return _container.ProductMajorPart;
 		}
 	}
 
@@ -319,7 +324,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(ProductMinorPart), PropertyAccess.Get);
 
-			return 0;
+			return _container.ProductMinorPart;
 		}
 	}
 
@@ -332,7 +337,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(ProductName), PropertyAccess.Get);
 
-			return "";
+			return _container.ProductName;
 		}
 	}
 
@@ -345,7 +350,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(ProductPrivatePart), PropertyAccess.Get);
 
-			return 0;
+			return _container.ProductPrivatePart;
 		}
 	}
 
@@ -358,7 +363,7 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(ProductVersion), PropertyAccess.Get);
 
-			return "";
+			return _container.ProductVersion;
 		}
 	}
 
@@ -371,12 +376,15 @@ internal sealed class FileVersionInfoMock : IFileVersionInfo
 				.FileVersionInfo.RegisterPathProperty(_path,
 					nameof(SpecialBuild), PropertyAccess.Get);
 
-			return "";
+			return _container.SpecialBuild;
 		}
 	}
 
 	#endregion
 
-	internal static FileVersionInfoMock New(IStorageLocation location, MockFileSystem fileSystem)
-		=> new(location, fileSystem);
+	internal static FileVersionInfoMock New(
+		IStorageLocation location,
+		FileVersionInfoContainer container,
+		MockFileSystem fileSystem)
+		=> new(location, container, fileSystem);
 }

--- a/Source/Testably.Abstractions.Testing/Initializer/FileVersionInfoBuilder.cs
+++ b/Source/Testably.Abstractions.Testing/Initializer/FileVersionInfoBuilder.cs
@@ -1,0 +1,176 @@
+using Testably.Abstractions.Testing.Storage;
+
+namespace Testably.Abstractions.Testing.Initializer;
+
+/// <summary>
+///     The builder for registering a <see cref="IFileVersionInfo" /> on the <see cref="MockFileSystem" />.
+/// </summary>
+public sealed class FileVersionInfoBuilder
+{
+	private readonly FileVersionInfoContainer _container = new();
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.Comments" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithComments(string? comments)
+	{
+		_container.Comments = comments;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.CompanyName" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithCompanyName(string? companyName)
+	{
+		_container.CompanyName = companyName;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.FileDescription" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithFileDescription(string? fileDescription)
+	{
+		_container.FileDescription = fileDescription;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.FileVersion" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithFileVersion(string? fileVersion)
+	{
+		_container.FileVersion = fileVersion;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.InternalName" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithInternalName(string? internalName)
+	{
+		_container.InternalName = internalName;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.IsDebug" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithIsDebug(bool isDebug)
+	{
+		_container.IsDebug = isDebug;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.IsPatched" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithIsPatched(bool isPatched)
+	{
+		_container.IsPatched = isPatched;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.IsPreRelease" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithIsPreRelease(bool isPreRelease)
+	{
+		_container.IsPreRelease = isPreRelease;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.IsPrivateBuild" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithIsPrivateBuild(bool isPrivateBuild)
+	{
+		_container.IsPrivateBuild = isPrivateBuild;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.IsSpecialBuild" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithIsSpecialBuild(bool isSpecialBuild)
+	{
+		_container.IsSpecialBuild = isSpecialBuild;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.Language" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithLanguage(string? language)
+	{
+		_container.Language = language;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.LegalCopyright" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithLegalCopyright(string? legalCopyright)
+	{
+		_container.LegalCopyright = legalCopyright;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.LegalTrademarks" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithLegalTrademarks(string? legalTrademarks)
+	{
+		_container.LegalTrademarks = legalTrademarks;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.OriginalFilename" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithOriginalFilename(string? originalFilename)
+	{
+		_container.OriginalFilename = originalFilename;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.PrivateBuild" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithPrivateBuild(string? privateBuild)
+	{
+		_container.PrivateBuild = privateBuild;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.ProductName" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithProductName(string? productName)
+	{
+		_container.ProductName = productName;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.ProductVersion" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithProductVersion(string? productVersion)
+	{
+		_container.ProductVersion = productVersion;
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="IFileVersionInfo.SpecialBuild" />.
+	/// </summary>
+	public FileVersionInfoBuilder WithSpecialBuild(string? specialBuild)
+	{
+		_container.SpecialBuild = specialBuild;
+		return this;
+	}
+
+	internal FileVersionInfoContainer Create()
+		=> _container;
+}

--- a/Source/Testably.Abstractions.Testing/Initializer/FileVersionInfoBuilder.cs
+++ b/Source/Testably.Abstractions.Testing/Initializer/FileVersionInfoBuilder.cs
@@ -12,7 +12,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.Comments" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithComments(string? comments)
+	public FileVersionInfoBuilder SetComments(string? comments)
 	{
 		_container.Comments = comments;
 		return this;
@@ -21,7 +21,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.CompanyName" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithCompanyName(string? companyName)
+	public FileVersionInfoBuilder SetCompanyName(string? companyName)
 	{
 		_container.CompanyName = companyName;
 		return this;
@@ -30,7 +30,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.FileDescription" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithFileDescription(string? fileDescription)
+	public FileVersionInfoBuilder SetFileDescription(string? fileDescription)
 	{
 		_container.FileDescription = fileDescription;
 		return this;
@@ -39,7 +39,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.FileVersion" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithFileVersion(string? fileVersion)
+	public FileVersionInfoBuilder SetFileVersion(string? fileVersion)
 	{
 		_container.FileVersion = fileVersion;
 		return this;
@@ -48,7 +48,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.InternalName" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithInternalName(string? internalName)
+	public FileVersionInfoBuilder SetInternalName(string? internalName)
 	{
 		_container.InternalName = internalName;
 		return this;
@@ -57,7 +57,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.IsDebug" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithIsDebug(bool isDebug)
+	public FileVersionInfoBuilder SetIsDebug(bool isDebug)
 	{
 		_container.IsDebug = isDebug;
 		return this;
@@ -66,7 +66,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.IsPatched" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithIsPatched(bool isPatched)
+	public FileVersionInfoBuilder SetIsPatched(bool isPatched)
 	{
 		_container.IsPatched = isPatched;
 		return this;
@@ -75,7 +75,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.IsPreRelease" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithIsPreRelease(bool isPreRelease)
+	public FileVersionInfoBuilder SetIsPreRelease(bool isPreRelease)
 	{
 		_container.IsPreRelease = isPreRelease;
 		return this;
@@ -84,7 +84,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.IsPrivateBuild" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithIsPrivateBuild(bool isPrivateBuild)
+	public FileVersionInfoBuilder SetIsPrivateBuild(bool isPrivateBuild)
 	{
 		_container.IsPrivateBuild = isPrivateBuild;
 		return this;
@@ -93,7 +93,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.IsSpecialBuild" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithIsSpecialBuild(bool isSpecialBuild)
+	public FileVersionInfoBuilder SetIsSpecialBuild(bool isSpecialBuild)
 	{
 		_container.IsSpecialBuild = isSpecialBuild;
 		return this;
@@ -102,7 +102,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.Language" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithLanguage(string? language)
+	public FileVersionInfoBuilder SetLanguage(string? language)
 	{
 		_container.Language = language;
 		return this;
@@ -111,7 +111,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.LegalCopyright" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithLegalCopyright(string? legalCopyright)
+	public FileVersionInfoBuilder SetLegalCopyright(string? legalCopyright)
 	{
 		_container.LegalCopyright = legalCopyright;
 		return this;
@@ -120,7 +120,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.LegalTrademarks" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithLegalTrademarks(string? legalTrademarks)
+	public FileVersionInfoBuilder SetLegalTrademarks(string? legalTrademarks)
 	{
 		_container.LegalTrademarks = legalTrademarks;
 		return this;
@@ -129,7 +129,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.OriginalFilename" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithOriginalFilename(string? originalFilename)
+	public FileVersionInfoBuilder SetOriginalFilename(string? originalFilename)
 	{
 		_container.OriginalFilename = originalFilename;
 		return this;
@@ -138,7 +138,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.PrivateBuild" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithPrivateBuild(string? privateBuild)
+	public FileVersionInfoBuilder SetPrivateBuild(string? privateBuild)
 	{
 		_container.PrivateBuild = privateBuild;
 		return this;
@@ -147,7 +147,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.ProductName" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithProductName(string? productName)
+	public FileVersionInfoBuilder SetProductName(string? productName)
 	{
 		_container.ProductName = productName;
 		return this;
@@ -156,7 +156,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.ProductVersion" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithProductVersion(string? productVersion)
+	public FileVersionInfoBuilder SetProductVersion(string? productVersion)
 	{
 		_container.ProductVersion = productVersion;
 		return this;
@@ -165,7 +165,7 @@ public sealed class FileVersionInfoBuilder
 	/// <summary>
 	///     Sets the <see cref="IFileVersionInfo.SpecialBuild" />.
 	/// </summary>
-	public FileVersionInfoBuilder WithSpecialBuild(string? specialBuild)
+	public FileVersionInfoBuilder SetSpecialBuild(string? specialBuild)
 	{
 		_container.SpecialBuild = specialBuild;
 		return this;

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -218,7 +218,7 @@ public sealed class MockFileSystem : IFileSystem
 	///     the <paramref name="fileVersionInfoBuilder" /> returned for
 	///     all files matching the <paramref name="searchPattern" />.
 	/// </summary>
-	public MockFileSystem WithFileVersion(string searchPattern,
+	public MockFileSystem WithFileVersionInfo(string searchPattern,
 		Action<FileVersionInfoBuilder> fileVersionInfoBuilder)
 	{
 		FileVersionInfoBuilder builder = new();

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using Testably.Abstractions.Testing.FileSystem;
 using Testably.Abstractions.Testing.Helpers;
+using Testably.Abstractions.Testing.Initializer;
 using Testably.Abstractions.Testing.RandomSystem;
 using Testably.Abstractions.Testing.Statistics;
 using Testably.Abstractions.Testing.Storage;
@@ -74,6 +75,8 @@ public sealed class MockFileSystem : IFileSystem
 	/// </summary>
 	internal Execute Execute { get; }
 
+	internal FileSystemRegistration Registration { get; }
+
 	internal ISafeFileHandleStrategy SafeFileHandleStrategy
 	{
 		get;
@@ -92,8 +95,6 @@ public sealed class MockFileSystem : IFileSystem
 	/// </summary>
 	internal IReadOnlyList<IStorageContainer> StorageContainers
 		=> _storage.GetContainers();
-
-	internal FileSystemRegistration Registration { get; }
 
 	private readonly DirectoryMock _directoryMock;
 	private readonly FileMock _fileMock;
@@ -213,6 +214,21 @@ public sealed class MockFileSystem : IFileSystem
 	}
 
 	/// <summary>
+	///     Registers a new <see cref="IFileVersionInfo" /> with values from
+	///     the <paramref name="fileVersionInfoBuilder" /> returned for
+	///     all files matching the <paramref name="searchPattern" />.
+	/// </summary>
+	public MockFileSystem WithFileVersion(string searchPattern,
+		Action<FileVersionInfoBuilder> fileVersionInfoBuilder)
+	{
+		FileVersionInfoBuilder builder = new();
+		fileVersionInfoBuilder(builder);
+		FileVersionInfoContainer container = builder.Create();
+		_storage.AddFileVersion(searchPattern, container);
+		return this;
+	}
+
+	/// <summary>
 	///     Registers the strategy how to deal with <see cref="SafeFileHandle" />s in the <see cref="MockFileSystem" />.
 	///     <para />
 	///     Defaults to <see cref="NullSafeFileHandleStrategy" />, if nothing is provided.
@@ -240,7 +256,7 @@ public sealed class MockFileSystem : IFileSystem
 		catch (IOException)
 		{
 			// Ignore any IOException, when trying to read the current directory
-			// due to brittle tests on MacOS
+			// due to brittle tests on macOS
 		}
 	}
 

--- a/Source/Testably.Abstractions.Testing/Storage/FileVersionInfoContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/FileVersionInfoContainer.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+
+namespace Testably.Abstractions.Testing.Storage;
+
+internal sealed class FileVersionInfoContainer
+{
+	/// <inheritdoc cref="IFileVersionInfo.Comments" />
+	public string? Comments { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.CompanyName" />
+	public string? CompanyName { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.FileBuildPart" />
+	public int FileBuildPart { get; private set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.FileDescription" />
+	public string? FileDescription { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.FileMajorPart" />
+	public int FileMajorPart { get; private set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.FileMinorPart" />
+	public int FileMinorPart { get; private set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.FilePrivatePart" />
+	public int FilePrivatePart { get; private set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.FileVersion" />
+	public string? FileVersion
+	{
+		get => _fileVersion;
+		set
+		{
+			_fileVersion = value;
+			if (value != null)
+			{
+				string cleanedFileVersion = CleanVersion(value);
+				if (Version.TryParse(cleanedFileVersion, out Version? version))
+				{
+					FileMajorPart = Math.Max(0, version.Major);
+					FileMinorPart = Math.Max(0, version.Minor);
+					FileBuildPart = Math.Max(0, version.Build);
+					FilePrivatePart = Math.Max(0, version.Revision);
+				}
+				else if (int.TryParse(cleanedFileVersion, NumberStyles.Integer,
+					CultureInfo.InvariantCulture, out int majorPart))
+				{
+					FileMajorPart = Math.Max(0, majorPart);
+					FileMinorPart = 0;
+					FileBuildPart = 0;
+					FilePrivatePart = 0;
+				}
+				else
+				{
+					FileMajorPart = 0;
+					FileMinorPart = 0;
+					FileBuildPart = 0;
+					FilePrivatePart = 0;
+				}
+			}
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.InternalName" />
+	public string? InternalName { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.IsDebug" />
+	public bool IsDebug { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.IsPatched" />
+	public bool IsPatched { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.IsPreRelease" />
+	public bool IsPreRelease { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.IsPrivateBuild" />
+	public bool IsPrivateBuild { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.IsSpecialBuild" />
+	public bool IsSpecialBuild { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.Language" />
+	public string? Language { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.LegalCopyright" />
+	public string? LegalCopyright { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.LegalTrademarks" />
+	public string? LegalTrademarks { get; set; }
+
+	public static FileVersionInfoContainer None => new();
+
+	/// <inheritdoc cref="IFileVersionInfo.OriginalFilename" />
+	public string? OriginalFilename { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.PrivateBuild" />
+	public string? PrivateBuild { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductBuildPart" />
+	public int ProductBuildPart { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductMajorPart" />
+	public int ProductMajorPart { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductMinorPart" />
+	public int ProductMinorPart { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductName" />
+	public string? ProductName { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductPrivatePart" />
+	public int ProductPrivatePart { get; set; }
+
+	/// <inheritdoc cref="IFileVersionInfo.ProductVersion" />
+	public string? ProductVersion
+	{
+		get => _productVersion;
+		set
+		{
+			_productVersion = value;
+			if (value != null)
+			{
+				string cleanedFileVersion = CleanVersion(value);
+				if (Version.TryParse(cleanedFileVersion, out Version? version))
+				{
+					ProductMajorPart = Math.Max(0, version.Major);
+					ProductMinorPart = Math.Max(0, version.Minor);
+					ProductBuildPart = Math.Max(0, version.Build);
+					ProductPrivatePart = Math.Max(0, version.Revision);
+				}
+				else if (int.TryParse(cleanedFileVersion, NumberStyles.Integer,
+					CultureInfo.InvariantCulture, out int majorPart))
+				{
+					ProductMajorPart = Math.Max(0, majorPart);
+					ProductMinorPart = 0;
+					ProductBuildPart = 0;
+					ProductPrivatePart = 0;
+				}
+				else
+				{
+					ProductMajorPart = 0;
+					ProductMinorPart = 0;
+					ProductBuildPart = 0;
+					ProductPrivatePart = 0;
+				}
+			}
+		}
+	}
+
+	/// <inheritdoc cref="IFileVersionInfo.SpecialBuild" />
+	public string? SpecialBuild { get; set; }
+
+	private string? _fileVersion;
+	private string? _productVersion;
+
+	private static string CleanVersion(string version)
+	{
+		char[] validVersionChars = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.'];
+		for (int i = 0; i < version.Length; i++)
+		{
+			if (!validVersionChars.Contains(version[i]))
+			{
+				return version.Substring(0, i);
+			}
+		}
+
+		return version;
+	}
+}

--- a/Source/Testably.Abstractions.Testing/Storage/IStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorage.cs
@@ -129,6 +129,13 @@ internal interface IStorage
 		IFileSystemExtensibility? fileSystemExtensibility = null);
 
 	/// <summary>
+	///     Get an associated <see cref="FileVersionInfoContainer" /> for the given <paramref name="location" />.
+	/// </summary>
+	/// <param name="location">The location of the <see cref="FileVersionInfoContainer" />.</param>
+	/// <returns>The <see cref="FileVersionInfoContainer" /> if one was registered; or <see langword="null" /> otherwise.</returns>
+	FileVersionInfoContainer? GetVersionInfo(IStorageLocation location);
+
+	/// <summary>
 	///     Moves a specified file or directory to a new location and potentially a new file name.<br />
 	///     This method does work across volumes.
 	/// </summary>

--- a/Source/Testably.Abstractions/FileSystem/FileVersionInfoWrapper.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileVersionInfoWrapper.cs
@@ -5,6 +5,9 @@ namespace Testably.Abstractions.FileSystem;
 
 internal sealed class FileVersionInfoWrapper : IFileVersionInfo
 {
+	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
+	public IFileSystem FileSystem { get; }
+
 	private readonly FileVersionInfo _instance;
 
 	private FileVersionInfoWrapper(FileVersionInfo fileSystemWatcher,
@@ -47,9 +50,6 @@ internal sealed class FileVersionInfoWrapper : IFileVersionInfo
 	/// <inheritdoc cref="IFileVersionInfo.FilePrivatePart" />
 	public int FilePrivatePart
 		=> _instance.FilePrivatePart;
-
-	/// <inheritdoc cref="IFileSystemEntity.FileSystem" />
-	public IFileSystem FileSystem { get; }
 
 	/// <inheritdoc cref="IFileVersionInfo.FileVersion" />
 	public string? FileVersion
@@ -128,6 +128,10 @@ internal sealed class FileVersionInfoWrapper : IFileVersionInfo
 		=> _instance.SpecialBuild;
 
 	#endregion
+
+	/// <inheritdoc cref="object.ToString()" />
+	public override string ToString()
+		=> _instance.ToString();
 
 	[return: NotNullIfNotNull("instance")]
 	internal static FileVersionInfoWrapper? FromFileVersionInfo(

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -112,7 +112,7 @@ namespace Testably.Abstractions.Testing
         public override string ToString() { }
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
-        public Testably.Abstractions.Testing.MockFileSystem WithFileVersion(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
+        public Testably.Abstractions.Testing.MockFileSystem WithFileVersionInfo(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
         public class MockFileSystemOptions
         {
@@ -234,24 +234,24 @@ namespace Testably.Abstractions.Testing.Initializer
     public sealed class FileVersionInfoBuilder
     {
         public FileVersionInfoBuilder() { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithComments(string? comments) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithCompanyName(string? companyName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileDescription(string? fileDescription) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileVersion(string? fileVersion) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithInternalName(string? internalName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsDebug(bool isDebug) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPatched(bool isPatched) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPreRelease(bool isPreRelease) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPrivateBuild(bool isPrivateBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsSpecialBuild(bool isSpecialBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLanguage(string? language) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalCopyright(string? legalCopyright) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalTrademarks(string? legalTrademarks) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithOriginalFilename(string? originalFilename) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithPrivateBuild(string? privateBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductName(string? productName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductVersion(string? productVersion) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithSpecialBuild(string? specialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetComments(string? comments) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetCompanyName(string? companyName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetFileDescription(string? fileDescription) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetFileVersion(string? fileVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetInternalName(string? internalName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsDebug(bool isDebug) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPatched(bool isPatched) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPreRelease(bool isPreRelease) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPrivateBuild(bool isPrivateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsSpecialBuild(bool isSpecialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLanguage(string? language) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLegalCopyright(string? legalCopyright) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLegalTrademarks(string? legalTrademarks) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetOriginalFilename(string? originalFilename) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetPrivateBuild(string? privateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetProductName(string? productName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetProductVersion(string? productVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetSpecialBuild(string? specialBuild) { }
     }
     public interface IDirectoryCleaner : System.IDisposable
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -112,6 +112,7 @@ namespace Testably.Abstractions.Testing
         public override string ToString() { }
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
+        public Testably.Abstractions.Testing.MockFileSystem WithFileVersion(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
         public class MockFileSystemOptions
         {
@@ -229,6 +230,28 @@ namespace Testably.Abstractions.Testing.Initializer
         protected FileSystemInfoDescription(string name) { }
         public abstract Testably.Abstractions.Testing.Initializer.FileSystemInfoDescription this[string path] { get; }
         public string Name { get; }
+    }
+    public sealed class FileVersionInfoBuilder
+    {
+        public FileVersionInfoBuilder() { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithComments(string? comments) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithCompanyName(string? companyName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileDescription(string? fileDescription) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileVersion(string? fileVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithInternalName(string? internalName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsDebug(bool isDebug) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPatched(bool isPatched) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPreRelease(bool isPreRelease) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPrivateBuild(bool isPrivateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsSpecialBuild(bool isSpecialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLanguage(string? language) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalCopyright(string? legalCopyright) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalTrademarks(string? legalTrademarks) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithOriginalFilename(string? originalFilename) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithPrivateBuild(string? privateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductName(string? productName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductVersion(string? productVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithSpecialBuild(string? specialBuild) { }
     }
     public interface IDirectoryCleaner : System.IDisposable
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
@@ -112,7 +112,7 @@ namespace Testably.Abstractions.Testing
         public override string ToString() { }
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
-        public Testably.Abstractions.Testing.MockFileSystem WithFileVersion(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
+        public Testably.Abstractions.Testing.MockFileSystem WithFileVersionInfo(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
         public class MockFileSystemOptions
         {
@@ -234,24 +234,24 @@ namespace Testably.Abstractions.Testing.Initializer
     public sealed class FileVersionInfoBuilder
     {
         public FileVersionInfoBuilder() { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithComments(string? comments) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithCompanyName(string? companyName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileDescription(string? fileDescription) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileVersion(string? fileVersion) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithInternalName(string? internalName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsDebug(bool isDebug) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPatched(bool isPatched) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPreRelease(bool isPreRelease) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPrivateBuild(bool isPrivateBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsSpecialBuild(bool isSpecialBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLanguage(string? language) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalCopyright(string? legalCopyright) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalTrademarks(string? legalTrademarks) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithOriginalFilename(string? originalFilename) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithPrivateBuild(string? privateBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductName(string? productName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductVersion(string? productVersion) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithSpecialBuild(string? specialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetComments(string? comments) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetCompanyName(string? companyName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetFileDescription(string? fileDescription) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetFileVersion(string? fileVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetInternalName(string? internalName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsDebug(bool isDebug) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPatched(bool isPatched) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPreRelease(bool isPreRelease) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPrivateBuild(bool isPrivateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsSpecialBuild(bool isSpecialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLanguage(string? language) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLegalCopyright(string? legalCopyright) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLegalTrademarks(string? legalTrademarks) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetOriginalFilename(string? originalFilename) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetPrivateBuild(string? privateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetProductName(string? productName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetProductVersion(string? productVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetSpecialBuild(string? specialBuild) { }
     }
     public interface IDirectoryCleaner : System.IDisposable
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
@@ -112,6 +112,7 @@ namespace Testably.Abstractions.Testing
         public override string ToString() { }
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
+        public Testably.Abstractions.Testing.MockFileSystem WithFileVersion(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
         public class MockFileSystemOptions
         {
@@ -229,6 +230,28 @@ namespace Testably.Abstractions.Testing.Initializer
         protected FileSystemInfoDescription(string name) { }
         public abstract Testably.Abstractions.Testing.Initializer.FileSystemInfoDescription this[string path] { get; }
         public string Name { get; }
+    }
+    public sealed class FileVersionInfoBuilder
+    {
+        public FileVersionInfoBuilder() { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithComments(string? comments) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithCompanyName(string? companyName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileDescription(string? fileDescription) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileVersion(string? fileVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithInternalName(string? internalName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsDebug(bool isDebug) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPatched(bool isPatched) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPreRelease(bool isPreRelease) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPrivateBuild(bool isPrivateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsSpecialBuild(bool isSpecialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLanguage(string? language) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalCopyright(string? legalCopyright) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalTrademarks(string? legalTrademarks) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithOriginalFilename(string? originalFilename) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithPrivateBuild(string? privateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductName(string? productName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductVersion(string? productVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithSpecialBuild(string? specialBuild) { }
     }
     public interface IDirectoryCleaner : System.IDisposable
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -112,7 +112,7 @@ namespace Testably.Abstractions.Testing
         public override string ToString() { }
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
-        public Testably.Abstractions.Testing.MockFileSystem WithFileVersion(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
+        public Testably.Abstractions.Testing.MockFileSystem WithFileVersionInfo(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
         public class MockFileSystemOptions
         {
@@ -234,24 +234,24 @@ namespace Testably.Abstractions.Testing.Initializer
     public sealed class FileVersionInfoBuilder
     {
         public FileVersionInfoBuilder() { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithComments(string? comments) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithCompanyName(string? companyName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileDescription(string? fileDescription) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileVersion(string? fileVersion) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithInternalName(string? internalName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsDebug(bool isDebug) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPatched(bool isPatched) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPreRelease(bool isPreRelease) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPrivateBuild(bool isPrivateBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsSpecialBuild(bool isSpecialBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLanguage(string? language) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalCopyright(string? legalCopyright) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalTrademarks(string? legalTrademarks) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithOriginalFilename(string? originalFilename) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithPrivateBuild(string? privateBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductName(string? productName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductVersion(string? productVersion) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithSpecialBuild(string? specialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetComments(string? comments) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetCompanyName(string? companyName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetFileDescription(string? fileDescription) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetFileVersion(string? fileVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetInternalName(string? internalName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsDebug(bool isDebug) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPatched(bool isPatched) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPreRelease(bool isPreRelease) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPrivateBuild(bool isPrivateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsSpecialBuild(bool isSpecialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLanguage(string? language) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLegalCopyright(string? legalCopyright) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLegalTrademarks(string? legalTrademarks) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetOriginalFilename(string? originalFilename) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetPrivateBuild(string? privateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetProductName(string? productName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetProductVersion(string? productVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetSpecialBuild(string? specialBuild) { }
     }
     public interface IDirectoryCleaner : System.IDisposable
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -112,6 +112,7 @@ namespace Testably.Abstractions.Testing
         public override string ToString() { }
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
+        public Testably.Abstractions.Testing.MockFileSystem WithFileVersion(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
         public class MockFileSystemOptions
         {
@@ -229,6 +230,28 @@ namespace Testably.Abstractions.Testing.Initializer
         protected FileSystemInfoDescription(string name) { }
         public abstract Testably.Abstractions.Testing.Initializer.FileSystemInfoDescription this[string path] { get; }
         public string Name { get; }
+    }
+    public sealed class FileVersionInfoBuilder
+    {
+        public FileVersionInfoBuilder() { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithComments(string? comments) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithCompanyName(string? companyName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileDescription(string? fileDescription) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileVersion(string? fileVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithInternalName(string? internalName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsDebug(bool isDebug) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPatched(bool isPatched) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPreRelease(bool isPreRelease) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPrivateBuild(bool isPrivateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsSpecialBuild(bool isSpecialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLanguage(string? language) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalCopyright(string? legalCopyright) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalTrademarks(string? legalTrademarks) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithOriginalFilename(string? originalFilename) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithPrivateBuild(string? privateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductName(string? productName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductVersion(string? productVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithSpecialBuild(string? specialBuild) { }
     }
     public interface IDirectoryCleaner : System.IDisposable
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -110,6 +110,7 @@ namespace Testably.Abstractions.Testing
         public override string ToString() { }
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
+        public Testably.Abstractions.Testing.MockFileSystem WithFileVersion(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
         public class MockFileSystemOptions
         {
@@ -226,6 +227,28 @@ namespace Testably.Abstractions.Testing.Initializer
         protected FileSystemInfoDescription(string name) { }
         public abstract Testably.Abstractions.Testing.Initializer.FileSystemInfoDescription this[string path] { get; }
         public string Name { get; }
+    }
+    public sealed class FileVersionInfoBuilder
+    {
+        public FileVersionInfoBuilder() { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithComments(string? comments) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithCompanyName(string? companyName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileDescription(string? fileDescription) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileVersion(string? fileVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithInternalName(string? internalName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsDebug(bool isDebug) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPatched(bool isPatched) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPreRelease(bool isPreRelease) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPrivateBuild(bool isPrivateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsSpecialBuild(bool isSpecialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLanguage(string? language) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalCopyright(string? legalCopyright) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalTrademarks(string? legalTrademarks) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithOriginalFilename(string? originalFilename) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithPrivateBuild(string? privateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductName(string? productName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductVersion(string? productVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithSpecialBuild(string? specialBuild) { }
     }
     public interface IDirectoryCleaner : System.IDisposable
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -110,7 +110,7 @@ namespace Testably.Abstractions.Testing
         public override string ToString() { }
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
-        public Testably.Abstractions.Testing.MockFileSystem WithFileVersion(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
+        public Testably.Abstractions.Testing.MockFileSystem WithFileVersionInfo(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
         public class MockFileSystemOptions
         {
@@ -231,24 +231,24 @@ namespace Testably.Abstractions.Testing.Initializer
     public sealed class FileVersionInfoBuilder
     {
         public FileVersionInfoBuilder() { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithComments(string? comments) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithCompanyName(string? companyName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileDescription(string? fileDescription) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileVersion(string? fileVersion) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithInternalName(string? internalName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsDebug(bool isDebug) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPatched(bool isPatched) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPreRelease(bool isPreRelease) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPrivateBuild(bool isPrivateBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsSpecialBuild(bool isSpecialBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLanguage(string? language) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalCopyright(string? legalCopyright) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalTrademarks(string? legalTrademarks) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithOriginalFilename(string? originalFilename) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithPrivateBuild(string? privateBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductName(string? productName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductVersion(string? productVersion) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithSpecialBuild(string? specialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetComments(string? comments) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetCompanyName(string? companyName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetFileDescription(string? fileDescription) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetFileVersion(string? fileVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetInternalName(string? internalName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsDebug(bool isDebug) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPatched(bool isPatched) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPreRelease(bool isPreRelease) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPrivateBuild(bool isPrivateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsSpecialBuild(bool isSpecialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLanguage(string? language) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLegalCopyright(string? legalCopyright) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLegalTrademarks(string? legalTrademarks) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetOriginalFilename(string? originalFilename) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetPrivateBuild(string? privateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetProductName(string? productName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetProductVersion(string? productVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetSpecialBuild(string? specialBuild) { }
     }
     public interface IDirectoryCleaner : System.IDisposable
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -110,6 +110,7 @@ namespace Testably.Abstractions.Testing
         public override string ToString() { }
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
+        public Testably.Abstractions.Testing.MockFileSystem WithFileVersion(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
         public class MockFileSystemOptions
         {
@@ -226,6 +227,28 @@ namespace Testably.Abstractions.Testing.Initializer
         protected FileSystemInfoDescription(string name) { }
         public abstract Testably.Abstractions.Testing.Initializer.FileSystemInfoDescription this[string path] { get; }
         public string Name { get; }
+    }
+    public sealed class FileVersionInfoBuilder
+    {
+        public FileVersionInfoBuilder() { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithComments(string? comments) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithCompanyName(string? companyName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileDescription(string? fileDescription) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileVersion(string? fileVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithInternalName(string? internalName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsDebug(bool isDebug) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPatched(bool isPatched) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPreRelease(bool isPreRelease) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPrivateBuild(bool isPrivateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsSpecialBuild(bool isSpecialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLanguage(string? language) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalCopyright(string? legalCopyright) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalTrademarks(string? legalTrademarks) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithOriginalFilename(string? originalFilename) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithPrivateBuild(string? privateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductName(string? productName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductVersion(string? productVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithSpecialBuild(string? specialBuild) { }
     }
     public interface IDirectoryCleaner : System.IDisposable
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -110,7 +110,7 @@ namespace Testably.Abstractions.Testing
         public override string ToString() { }
         public Testably.Abstractions.Testing.MockFileSystem WithAccessControlStrategy(Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy accessControlStrategy) { }
         public Testably.Abstractions.Testing.MockFileSystem WithDrive(string? drive, System.Action<Testably.Abstractions.Testing.Storage.IStorageDrive>? driveCallback = null) { }
-        public Testably.Abstractions.Testing.MockFileSystem WithFileVersion(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
+        public Testably.Abstractions.Testing.MockFileSystem WithFileVersionInfo(string searchPattern, System.Action<Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder> fileVersionInfoBuilder) { }
         public Testably.Abstractions.Testing.MockFileSystem WithSafeFileHandleStrategy(Testably.Abstractions.Testing.FileSystem.ISafeFileHandleStrategy safeFileHandleStrategy) { }
         public class MockFileSystemOptions
         {
@@ -231,24 +231,24 @@ namespace Testably.Abstractions.Testing.Initializer
     public sealed class FileVersionInfoBuilder
     {
         public FileVersionInfoBuilder() { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithComments(string? comments) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithCompanyName(string? companyName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileDescription(string? fileDescription) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithFileVersion(string? fileVersion) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithInternalName(string? internalName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsDebug(bool isDebug) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPatched(bool isPatched) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPreRelease(bool isPreRelease) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsPrivateBuild(bool isPrivateBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithIsSpecialBuild(bool isSpecialBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLanguage(string? language) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalCopyright(string? legalCopyright) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithLegalTrademarks(string? legalTrademarks) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithOriginalFilename(string? originalFilename) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithPrivateBuild(string? privateBuild) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductName(string? productName) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithProductVersion(string? productVersion) { }
-        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder WithSpecialBuild(string? specialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetComments(string? comments) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetCompanyName(string? companyName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetFileDescription(string? fileDescription) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetFileVersion(string? fileVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetInternalName(string? internalName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsDebug(bool isDebug) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPatched(bool isPatched) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPreRelease(bool isPreRelease) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsPrivateBuild(bool isPrivateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetIsSpecialBuild(bool isSpecialBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLanguage(string? language) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLegalCopyright(string? legalCopyright) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetLegalTrademarks(string? legalTrademarks) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetOriginalFilename(string? originalFilename) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetPrivateBuild(string? privateBuild) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetProductName(string? productName) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetProductVersion(string? productVersion) { }
+        public Testably.Abstractions.Testing.Initializer.FileVersionInfoBuilder SetSpecialBuild(string? specialBuild) { }
     }
     public interface IDirectoryCleaner : System.IDisposable
     {

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileVersionInfoFactoryMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileVersionInfoFactoryMockTests.cs
@@ -11,7 +11,7 @@ public sealed class FileVersionInfoFactoryMockTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize().WithFile("abc.foo");
-		fileSystem.WithFileVersion("*.foo", b => b.WithComments(comments));
+		fileSystem.WithFileVersionInfo("*.foo", b => b.SetComments(comments));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("abc.foo");
 
@@ -25,7 +25,7 @@ public sealed class FileVersionInfoFactoryMockTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize().WithFile("abc.bar");
-		fileSystem.WithFileVersion("*.foo", b => b.WithComments(comments));
+		fileSystem.WithFileVersionInfo("*.foo", b => b.SetComments(comments));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("abc.bar");
 

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileVersionInfoFactoryMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileVersionInfoFactoryMockTests.cs
@@ -10,6 +10,7 @@ public sealed class FileVersionInfoFactoryMockTests
 		string comments)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.Initialize().WithFile("abc.foo");
 		fileSystem.WithFileVersion("*.foo", b => b.WithComments(comments));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("abc.foo");
@@ -23,6 +24,7 @@ public sealed class FileVersionInfoFactoryMockTests
 		string comments)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.Initialize().WithFile("abc.bar");
 		fileSystem.WithFileVersion("*.foo", b => b.WithComments(comments));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("abc.bar");

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileVersionInfoFactoryMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileVersionInfoFactoryMockTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Diagnostics;
+
+namespace Testably.Abstractions.Testing.Tests.FileSystem;
+
+public sealed class FileVersionInfoFactoryMockTests
+{
+	[Theory]
+	[AutoData]
+	public void WhenRegistered_ShouldReturnFileVersionInfoWithRegisteredValues(
+		string comments)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*.foo", b => b.WithComments(comments));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("abc.foo");
+
+		result.Comments.Should().Be(comments);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WhenRegisteredUnderDifferentName_ShouldReturnDefaultValues(
+		string comments)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*.foo", b => b.WithComments(comments));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("abc.bar");
+
+		result.Comments.Should().BeNull();
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileVersionInfoBuilderTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileVersionInfoBuilderTests.cs
@@ -8,7 +8,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithComments(comments));
+		fileSystem.WithFileVersionInfo("*", b => b.SetComments(comments));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -21,7 +21,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithCompanyName(companyName));
+		fileSystem.WithFileVersionInfo("*", b => b.SetCompanyName(companyName));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -34,7 +34,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithFileDescription(fileDescription));
+		fileSystem.WithFileVersionInfo("*", b => b.SetFileDescription(fileDescription));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -53,7 +53,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithFileVersion("9.8.7.6").WithFileVersion(fileVersion));
+		fileSystem.WithFileVersionInfo("*", b => b.SetFileVersion("9.8.7.6").SetFileVersion(fileVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 		result.FileVersion.Should().Be(fileVersion);
@@ -85,7 +85,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithFileVersion(fileVersion));
+		fileSystem.WithFileVersionInfo("*", b => b.SetFileVersion(fileVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 		result.FileVersion.Should().Be(fileVersion);
@@ -105,8 +105,8 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithFileVersion("1.2.3.4")
-			.WithFileVersion(fileVersion));
+		fileSystem.WithFileVersionInfo("*", b => b.SetFileVersion("1.2.3.4")
+			.SetFileVersion(fileVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 		result.FileVersion.Should().Be(fileVersion);
@@ -122,7 +122,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithInternalName(internalName));
+		fileSystem.WithFileVersionInfo("*", b => b.SetInternalName(internalName));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -135,7 +135,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithIsDebug(isDebug));
+		fileSystem.WithFileVersionInfo("*", b => b.SetIsDebug(isDebug));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -148,7 +148,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithIsPatched(isPatched));
+		fileSystem.WithFileVersionInfo("*", b => b.SetIsPatched(isPatched));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -161,7 +161,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithIsPreRelease(isPreRelease));
+		fileSystem.WithFileVersionInfo("*", b => b.SetIsPreRelease(isPreRelease));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -174,7 +174,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithIsPrivateBuild(isPrivateBuild));
+		fileSystem.WithFileVersionInfo("*", b => b.SetIsPrivateBuild(isPrivateBuild));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -187,7 +187,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithIsSpecialBuild(isSpecialBuild));
+		fileSystem.WithFileVersionInfo("*", b => b.SetIsSpecialBuild(isSpecialBuild));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -200,7 +200,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithLanguage(language));
+		fileSystem.WithFileVersionInfo("*", b => b.SetLanguage(language));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -213,7 +213,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithLegalCopyright(legalCopyright));
+		fileSystem.WithFileVersionInfo("*", b => b.SetLegalCopyright(legalCopyright));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -226,7 +226,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithLegalTrademarks(legalTrademarks));
+		fileSystem.WithFileVersionInfo("*", b => b.SetLegalTrademarks(legalTrademarks));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -239,7 +239,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithOriginalFilename(originalFilename));
+		fileSystem.WithFileVersionInfo("*", b => b.SetOriginalFilename(originalFilename));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -252,7 +252,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithPrivateBuild(privateBuild));
+		fileSystem.WithFileVersionInfo("*", b => b.SetPrivateBuild(privateBuild));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -265,7 +265,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithProductName(productName));
+		fileSystem.WithFileVersionInfo("*", b => b.SetProductName(productName));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
@@ -284,7 +284,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithProductVersion("9.8.7.6").WithProductVersion(productVersion));
+		fileSystem.WithFileVersionInfo("*", b => b.SetProductVersion("9.8.7.6").SetProductVersion(productVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 		result.ProductVersion.Should().Be(productVersion);
@@ -316,7 +316,7 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithProductVersion(productVersion));
+		fileSystem.WithFileVersionInfo("*", b => b.SetProductVersion(productVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 		result.ProductVersion.Should().Be(productVersion);
@@ -336,8 +336,8 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithProductVersion("1.2.3.4")
-			.WithProductVersion(productVersion));
+		fileSystem.WithFileVersionInfo("*", b => b.SetProductVersion("1.2.3.4")
+			.SetProductVersion(productVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 		result.ProductVersion.Should().Be(productVersion);
@@ -353,10 +353,76 @@ public class FileVersionInfoBuilderTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "");
-		fileSystem.WithFileVersion("*", b => b.WithSpecialBuild(specialBuild));
+		fileSystem.WithFileVersionInfo("*", b => b.SetSpecialBuild(specialBuild));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
+		result.SpecialBuild.Should().Be(specialBuild);
+	}
+	
+	[Theory]
+	[AutoData]
+	public void ShouldBePossibleToChainMethods(
+		string comments,
+		string companyName,
+		string fileDescription,
+		string internalName,
+		bool isDebug,
+		bool isPatched,
+		bool isPreRelease,
+		bool isPrivateBuild,
+		bool isSpecialBuild,
+		string language,
+		string legalCopyright,
+		string legalTrademarks,
+		string originalFilename,
+		string privateBuild,
+		string productName,
+		string specialBuild)
+	{
+		string fileVersion = "1.2.3.4-foo";
+		string productVersion = "255.255.255.65432+bar";
+		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
+		fileSystem.WithFileVersionInfo("*", b => b
+			.SetComments(comments)
+			.SetCompanyName(companyName)
+			.SetFileDescription(fileDescription)
+			.SetFileVersion(fileVersion)
+			.SetInternalName(internalName)
+			.SetIsDebug(isDebug)
+			.SetIsPatched(isPatched)
+			.SetIsPreRelease(isPreRelease)
+			.SetIsPrivateBuild(isPrivateBuild)
+			.SetIsSpecialBuild(isSpecialBuild)
+			.SetLanguage(language)
+			.SetLegalCopyright(legalCopyright)
+			.SetLegalTrademarks(legalTrademarks)
+			.SetOriginalFilename(originalFilename)
+			.SetPrivateBuild(privateBuild)
+			.SetProductName(productName)
+			.SetProductVersion(productVersion)
+			.SetSpecialBuild(specialBuild)
+			.SetComments(comments));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.Comments.Should().Be(comments);
+		result.CompanyName.Should().Be(companyName);
+		result.FileDescription.Should().Be(fileDescription);
+		result.FileVersion.Should().Be(fileVersion);
+		result.InternalName.Should().Be(internalName);
+		result.IsDebug.Should().Be(isDebug);
+		result.IsPatched.Should().Be(isPatched);
+		result.IsPreRelease.Should().Be(isPreRelease);
+		result.IsSpecialBuild.Should().Be(isSpecialBuild);
+		result.Language.Should().Be(language);
+		result.LegalCopyright.Should().Be(legalCopyright);
+		result.LegalTrademarks.Should().Be(legalTrademarks);
+		result.OriginalFilename.Should().Be(originalFilename);
+		result.PrivateBuild.Should().Be(privateBuild);
+		result.ProductName.Should().Be(productName);
+		result.ProductVersion.Should().Be(productVersion);
 		result.SpecialBuild.Should().Be(specialBuild);
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileVersionInfoBuilderTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileVersionInfoBuilderTests.cs
@@ -7,6 +7,7 @@ public class FileVersionInfoBuilderTests
 	public void WithComments_ShouldSetComments(string comments)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithComments(comments));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -19,6 +20,7 @@ public class FileVersionInfoBuilderTests
 	public void WithCompanyName_ShouldSetCompanyName(string? companyName)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithCompanyName(companyName));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -31,6 +33,7 @@ public class FileVersionInfoBuilderTests
 	public void WithFileDescription_ShouldSetFileDescription(string? fileDescription)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithFileDescription(fileDescription));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -49,6 +52,7 @@ public class FileVersionInfoBuilderTests
 		int fileMajorPart, int fileMinorPart, int fileBuildPart = 0, int filePrivatePart = 0)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithFileVersion("9.8.7.6").WithFileVersion(fileVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -80,6 +84,7 @@ public class FileVersionInfoBuilderTests
 		int fileMajorPart, int fileMinorPart, int fileBuildPart = 0, int filePrivatePart = 0)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithFileVersion(fileVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -99,6 +104,7 @@ public class FileVersionInfoBuilderTests
 		string? fileVersion)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithFileVersion("1.2.3.4")
 			.WithFileVersion(fileVersion));
 
@@ -115,6 +121,7 @@ public class FileVersionInfoBuilderTests
 	public void WithInternalName_ShouldSetInternalName(string? internalName)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithInternalName(internalName));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -127,6 +134,7 @@ public class FileVersionInfoBuilderTests
 	public void WithIsDebug_ShouldSetIsDebug(bool isDebug)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithIsDebug(isDebug));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -139,6 +147,7 @@ public class FileVersionInfoBuilderTests
 	public void WithIsPatched_ShouldSetIsPatched(bool isPatched)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithIsPatched(isPatched));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -151,6 +160,7 @@ public class FileVersionInfoBuilderTests
 	public void WithIsPreRelease_ShouldSetIsPreRelease(bool isPreRelease)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithIsPreRelease(isPreRelease));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -163,6 +173,7 @@ public class FileVersionInfoBuilderTests
 	public void WithIsPrivateBuild_ShouldSetIsPrivateBuild(bool isPrivateBuild)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithIsPrivateBuild(isPrivateBuild));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -175,6 +186,7 @@ public class FileVersionInfoBuilderTests
 	public void WithIsSpecialBuild_ShouldSetIsSpecialBuild(bool isSpecialBuild)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithIsSpecialBuild(isSpecialBuild));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -187,6 +199,7 @@ public class FileVersionInfoBuilderTests
 	public void WithLanguage_ShouldSetLanguage(string? language)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithLanguage(language));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -199,6 +212,7 @@ public class FileVersionInfoBuilderTests
 	public void WithLegalCopyright_ShouldSetLegalCopyright(string? legalCopyright)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithLegalCopyright(legalCopyright));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -211,6 +225,7 @@ public class FileVersionInfoBuilderTests
 	public void WithLegalTrademarks_ShouldSetLegalTrademarks(string? legalTrademarks)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithLegalTrademarks(legalTrademarks));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -223,6 +238,7 @@ public class FileVersionInfoBuilderTests
 	public void WithOriginalFilename_ShouldSetOriginalFilename(string? originalFilename)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithOriginalFilename(originalFilename));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -235,6 +251,7 @@ public class FileVersionInfoBuilderTests
 	public void WithPrivateBuild_ShouldSetPrivateBuild(string? privateBuild)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithPrivateBuild(privateBuild));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -247,6 +264,7 @@ public class FileVersionInfoBuilderTests
 	public void WithProductName_ShouldSetProductName(string? productName)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithProductName(productName));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -265,6 +283,7 @@ public class FileVersionInfoBuilderTests
 		int fileMajorPart, int fileMinorPart, int fileBuildPart = 0, int filePrivatePart = 0)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithProductVersion("9.8.7.6").WithProductVersion(productVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -296,6 +315,7 @@ public class FileVersionInfoBuilderTests
 		int fileMajorPart, int fileMinorPart, int fileBuildPart = 0, int filePrivatePart = 0)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithProductVersion(productVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
@@ -315,6 +335,7 @@ public class FileVersionInfoBuilderTests
 		string? productVersion)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithProductVersion("1.2.3.4")
 			.WithProductVersion(productVersion));
 
@@ -331,6 +352,7 @@ public class FileVersionInfoBuilderTests
 	public void WithSpecialBuild_ShouldSetSpecialBuild(string? specialBuild)
 	{
 		MockFileSystem fileSystem = new();
+		fileSystem.File.WriteAllText("foo", "");
 		fileSystem.WithFileVersion("*", b => b.WithSpecialBuild(specialBuild));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileVersionInfoBuilderTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileVersionInfoBuilderTests.cs
@@ -1,0 +1,340 @@
+﻿namespace Testably.Abstractions.Testing.Tests.FileSystemInitializer;
+
+public class FileVersionInfoBuilderTests
+{
+	[Theory]
+	[AutoData]
+	public void WithComments_ShouldSetComments(string comments)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithComments(comments));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.Comments.Should().Be(comments);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithCompanyName_ShouldSetCompanyName(string? companyName)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithCompanyName(companyName));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.CompanyName.Should().Be(companyName);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithFileDescription_ShouldSetFileDescription(string? fileDescription)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithFileDescription(fileDescription));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.FileDescription.Should().Be(fileDescription);
+	}
+
+	[Theory]
+	[InlineData("1", 1, 0)]
+	[InlineData("0.1", 0, 1)]
+	[InlineData("1.2", 1, 2)]
+	[InlineData("1.2.3", 1, 2, 3)]
+	[InlineData("1.2.3.4", 1, 2, 3, 4)]
+	public void WithFileVersion_ShouldSetFileVersion(
+		string? fileVersion,
+		int fileMajorPart, int fileMinorPart, int fileBuildPart = 0, int filePrivatePart = 0)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithFileVersion("9.8.7.6").WithFileVersion(fileVersion));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+		result.FileVersion.Should().Be(fileVersion);
+		result.FileMajorPart.Should().Be(fileMajorPart);
+		result.FileMinorPart.Should().Be(fileMinorPart);
+		result.FileBuildPart.Should().Be(fileBuildPart);
+		result.FilePrivatePart.Should().Be(filePrivatePart);
+	}
+
+	[Theory]
+	[InlineData("1-foo", 1, 0)]
+	[InlineData("1+bar", 1, 0)]
+	[InlineData("1some-text", 1, 0)]
+	[InlineData("0.1-foo", 0, 1)]
+	[InlineData("0.1+bar", 0, 1)]
+	[InlineData("0.1some-text", 0, 1)]
+	[InlineData("1.2-foo", 1, 2)]
+	[InlineData("1.2+bar", 1, 2)]
+	[InlineData("1.2some-text", 1, 2)]
+	[InlineData("1.2.3-foo", 1, 2, 3)]
+	[InlineData("1.2.3+bar", 1, 2, 3)]
+	[InlineData("1.2.3some-text", 1, 2, 3)]
+	[InlineData("1.2.3.4-foo", 1, 2, 3, 4)]
+	[InlineData("1.2.3.4+bar", 1, 2, 3, 4)]
+	[InlineData("1.2.3.4some-text", 1, 2, 3, 4)]
+	public void WithFileVersion_WhenContainsPreReleaseInfo_ShouldIgnorePreReleaseInfo(
+		string? fileVersion,
+		int fileMajorPart, int fileMinorPart, int fileBuildPart = 0, int filePrivatePart = 0)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithFileVersion(fileVersion));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+		result.FileVersion.Should().Be(fileVersion);
+		result.FileMajorPart.Should().Be(fileMajorPart);
+		result.FileMinorPart.Should().Be(fileMinorPart);
+		result.FileBuildPart.Should().Be(fileBuildPart);
+		result.FilePrivatePart.Should().Be(filePrivatePart);
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("-1")]
+	[InlineData("+1.2.3-bar")]
+	[InlineData("abc")]
+	public void WithFileVersion_WhenStringIsInvalid_ShouldNotSetFileVersionParts(
+		string? fileVersion)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithFileVersion("1.2.3.4")
+			.WithFileVersion(fileVersion));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+		result.FileVersion.Should().Be(fileVersion);
+		result.FileMajorPart.Should().Be(0);
+		result.FileMinorPart.Should().Be(0);
+		result.FileBuildPart.Should().Be(0);
+		result.FilePrivatePart.Should().Be(0);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithInternalName_ShouldSetInternalName(string? internalName)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithInternalName(internalName));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.InternalName.Should().Be(internalName);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithIsDebug_ShouldSetIsDebug(bool isDebug)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithIsDebug(isDebug));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.IsDebug.Should().Be(isDebug);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithIsPatched_ShouldSetIsPatched(bool isPatched)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithIsPatched(isPatched));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.IsPatched.Should().Be(isPatched);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithIsPreRelease_ShouldSetIsPreRelease(bool isPreRelease)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithIsPreRelease(isPreRelease));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.IsPreRelease.Should().Be(isPreRelease);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithIsPrivateBuild_ShouldSetIsPrivateBuild(bool isPrivateBuild)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithIsPrivateBuild(isPrivateBuild));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.IsPrivateBuild.Should().Be(isPrivateBuild);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithIsSpecialBuild_ShouldSetIsSpecialBuild(bool isSpecialBuild)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithIsSpecialBuild(isSpecialBuild));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.IsSpecialBuild.Should().Be(isSpecialBuild);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithLanguage_ShouldSetLanguage(string? language)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithLanguage(language));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.Language.Should().Be(language);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithLegalCopyright_ShouldSetLegalCopyright(string? legalCopyright)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithLegalCopyright(legalCopyright));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.LegalCopyright.Should().Be(legalCopyright);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithLegalTrademarks_ShouldSetLegalTrademarks(string? legalTrademarks)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithLegalTrademarks(legalTrademarks));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.LegalTrademarks.Should().Be(legalTrademarks);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithOriginalFilename_ShouldSetOriginalFilename(string? originalFilename)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithOriginalFilename(originalFilename));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.OriginalFilename.Should().Be(originalFilename);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithPrivateBuild_ShouldSetPrivateBuild(string? privateBuild)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithPrivateBuild(privateBuild));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.PrivateBuild.Should().Be(privateBuild);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithProductName_ShouldSetProductName(string? productName)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithProductName(productName));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.ProductName.Should().Be(productName);
+	}
+
+	[Theory]
+	[InlineData("1", 1, 0)]
+	[InlineData("0.1", 0, 1)]
+	[InlineData("1.2", 1, 2)]
+	[InlineData("1.2.3", 1, 2, 3)]
+	[InlineData("1.2.3.4", 1, 2, 3, 4)]
+	public void WithProductVersion_ShouldSetProductVersion(
+		string? productVersion,
+		int fileMajorPart, int fileMinorPart, int fileBuildPart = 0, int filePrivatePart = 0)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithProductVersion("9.8.7.6").WithProductVersion(productVersion));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+		result.ProductVersion.Should().Be(productVersion);
+		result.ProductMajorPart.Should().Be(fileMajorPart);
+		result.ProductMinorPart.Should().Be(fileMinorPart);
+		result.ProductBuildPart.Should().Be(fileBuildPart);
+		result.ProductPrivatePart.Should().Be(filePrivatePart);
+	}
+
+	[Theory]
+	[InlineData("1-foo", 1, 0)]
+	[InlineData("1+bar", 1, 0)]
+	[InlineData("1some-text", 1, 0)]
+	[InlineData("0.1-foo", 0, 1)]
+	[InlineData("0.1+bar", 0, 1)]
+	[InlineData("0.1some-text", 0, 1)]
+	[InlineData("1.2-foo", 1, 2)]
+	[InlineData("1.2+bar", 1, 2)]
+	[InlineData("1.2some-text", 1, 2)]
+	[InlineData("1.2.3-foo", 1, 2, 3)]
+	[InlineData("1.2.3+bar", 1, 2, 3)]
+	[InlineData("1.2.3some-text", 1, 2, 3)]
+	[InlineData("1.2.3.4-foo", 1, 2, 3, 4)]
+	[InlineData("1.2.3.4+bar", 1, 2, 3, 4)]
+	[InlineData("1.2.3.4some-text", 1, 2, 3, 4)]
+	public void WithProductVersion_WhenContainsPreReleaseInfo_ShouldIgnorePreReleaseInfo(
+		string? productVersion,
+		int fileMajorPart, int fileMinorPart, int fileBuildPart = 0, int filePrivatePart = 0)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithProductVersion(productVersion));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+		result.ProductVersion.Should().Be(productVersion);
+		result.ProductMajorPart.Should().Be(fileMajorPart);
+		result.ProductMinorPart.Should().Be(fileMinorPart);
+		result.ProductBuildPart.Should().Be(fileBuildPart);
+		result.ProductPrivatePart.Should().Be(filePrivatePart);
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("-1")]
+	[InlineData("+1.2.3-bar")]
+	[InlineData("abc")]
+	public void WithProductVersion_WhenStringIsInvalid_ShouldNotSetProductVersionParts(
+		string? productVersion)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithProductVersion("1.2.3.4")
+			.WithProductVersion(productVersion));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+		result.ProductVersion.Should().Be(productVersion);
+		result.ProductMajorPart.Should().Be(0);
+		result.ProductMinorPart.Should().Be(0);
+		result.ProductBuildPart.Should().Be(0);
+		result.ProductPrivatePart.Should().Be(0);
+	}
+
+	[Theory]
+	[AutoData]
+	public void WithSpecialBuild_ShouldSetSpecialBuild(string? specialBuild)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.WithFileVersion("*", b => b.WithSpecialBuild(specialBuild));
+
+		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
+
+		result.SpecialBuild.Should().Be(specialBuild);
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileVersionInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileVersionInfoFactoryStatisticsTests.cs
@@ -9,6 +9,7 @@ public class FileVersionInfoFactoryStatisticsTests
 	{
 		MockFileSystem sut = new();
 		string fileName = "foo";
+		sut.Initialize().WithFile(fileName);
 
 		sut.FileVersionInfo.GetVersionInfo(fileName);
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileVersionInfoStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/FileVersionInfoStatisticsTests.cs
@@ -9,6 +9,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_Comments_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").Comments;
 
@@ -20,6 +21,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_CompanyName_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").CompanyName;
 
@@ -31,6 +33,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_FileBuildPart_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").FileBuildPart;
 
@@ -42,6 +45,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_FileDescription_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").FileDescription;
 
@@ -53,6 +57,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_FileMajorPart_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").FileMajorPart;
 
@@ -64,6 +69,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_FileMinorPart_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").FileMinorPart;
 
@@ -75,6 +81,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_FileName_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").FileName;
 
@@ -86,6 +93,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_FilePrivatePart_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").FilePrivatePart;
 
@@ -97,6 +105,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_FileVersion_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").FileVersion;
 
@@ -108,6 +117,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_InternalName_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").InternalName;
 
@@ -119,6 +129,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_IsDebug_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").IsDebug;
 
@@ -130,6 +141,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_IsPatched_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").IsPatched;
 
@@ -141,6 +153,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_IsPreRelease_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").IsPreRelease;
 
@@ -152,6 +165,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_IsPrivateBuild_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").IsPrivateBuild;
 
@@ -163,6 +177,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_IsSpecialBuild_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").IsSpecialBuild;
 
@@ -174,6 +189,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_Language_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").Language;
 
@@ -185,6 +201,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_LegalCopyright_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").LegalCopyright;
 
@@ -196,6 +213,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_LegalTrademarks_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").LegalTrademarks;
 
@@ -207,6 +225,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_OriginalFilename_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").OriginalFilename;
 
@@ -218,6 +237,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_PrivateBuild_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").PrivateBuild;
 
@@ -229,6 +249,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_ProductBuildPart_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").ProductBuildPart;
 
@@ -240,6 +261,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_ProductMajorPart_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").ProductMajorPart;
 
@@ -251,6 +273,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_ProductMinorPart_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").ProductMinorPart;
 
@@ -262,6 +285,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_ProductName_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").ProductName;
 
@@ -273,6 +297,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_ProductPrivatePart_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").ProductPrivatePart;
 
@@ -284,6 +309,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_ProductVersion_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").ProductVersion;
 
@@ -295,6 +321,7 @@ public class FileVersionInfoStatisticsTests
 	public void Property_SpecialBuild_Get_ShouldRegisterPropertyAccess()
 	{
 		MockFileSystem sut = new();
+		sut.Initialize().WithFile("foo");
 
 		_ = sut.FileVersionInfo.GetVersionInfo("foo").SpecialBuild;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfo/Tests.cs
@@ -1,0 +1,20 @@
+namespace Testably.Abstractions.Tests.FileSystem.FileVersionInfo;
+
+// ReSharper disable once PartialTypeWithSinglePart
+public abstract partial class Tests<TFileSystem>
+	: FileSystemTestBase<TFileSystem>
+	where TFileSystem : IFileSystem
+{
+	[SkippableTheory]
+	[InlineData("/foo")]
+	[InlineData("./foo")]
+	[InlineData("foo")]
+	public void ToString_ShouldReturnProvidedPath(string path)
+	{
+		IFileVersionInfo fileInfo = FileSystem.FileVersionInfo.GetVersionInfo(path);
+
+		string? result = fileInfo.ToString();
+
+		result.Should().Be(path);
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfo/Tests.cs
@@ -11,7 +11,7 @@ public abstract partial class Tests<TFileSystem>
 	{
 		FileSystem.File.WriteAllText(fileName, "");
 		string fullPath = FileSystem.Path.GetFullPath(fileName);
-		IFileVersionInfo fileInfo = FileSystem.FileVersionInfo.GetVersionInfo(fileName);
+		IFileVersionInfo fileInfo = FileSystem.FileVersionInfo.GetVersionInfo(fullPath);
 
 		string? result = fileInfo.ToString();
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfo/Tests.cs
@@ -6,15 +6,15 @@ public abstract partial class Tests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
 	[SkippableTheory]
-	[InlineData("/foo")]
-	[InlineData("./foo")]
-	[InlineData("foo")]
-	public void ToString_ShouldReturnProvidedPath(string path)
+	[AutoData]
+	public void ToString_ShouldReturnProvidedPath(string fileName)
 	{
-		IFileVersionInfo fileInfo = FileSystem.FileVersionInfo.GetVersionInfo(path);
+		FileSystem.File.WriteAllText(fileName, "");
+		string fullPath = FileSystem.Path.GetFullPath(fileName);
+		IFileVersionInfo fileInfo = FileSystem.FileVersionInfo.GetVersionInfo(fileName);
 
 		string? result = fileInfo.ToString();
 
-		result.Should().Be(path);
+		result.Should().Contain(fullPath);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/ExceptionTests.cs
@@ -126,7 +126,7 @@ public abstract partial class ExceptionTests<TFileSystem>
 			Expression<Action<IFileVersionInfoFactory>> Callback)>
 		GetFileVersionInfoFactoryCallbackTestParameters(string value)
 	{
-		yield return (ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "fileName", fileVersionInfoFactory
+		yield return (ExceptionTestHelper.TestTypes.IgnoreParamNameCheck | ExceptionTestHelper.TestTypes.All, "fileName", fileVersionInfoFactory
 			=> fileVersionInfoFactory.GetVersionInfo(value));
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/ExceptionTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -10,7 +11,7 @@ public abstract partial class ExceptionTests<TFileSystem>
 	where TFileSystem : IFileSystem
 {
 	[SkippableTheory]
-	[MemberData(nameof(GetFileInfoFactoryCallbacks),
+	[MemberData(nameof(GetFileVersionInfoFactoryCallbacks),
 		parameters: "Illegal\tCharacter?InPath")]
 	public void
 		Operations_WhenValueContainsIllegalPathCharacters_ShouldThrowArgumentException_OnNetFramework(
@@ -31,14 +32,14 @@ public abstract partial class ExceptionTests<TFileSystem>
 		}
 		else
 		{
-			exception.Should()
-				.BeNull(
-					$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
+			exception.Should().BeException<IOException>(
+				hResult: -2147024773,
+				because: $"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 	}
 
 	[SkippableTheory]
-	[MemberData(nameof(GetFileInfoFactoryCallbacks), parameters: "")]
+	[MemberData(nameof(GetFileVersionInfoFactoryCallbacks), parameters: "")]
 	public void Operations_WhenValueIsEmpty_ShouldThrowArgumentException(
 		Expression<Action<IFileVersionInfoFactory>> callback, string paramName,
 		bool ignoreParamCheck)
@@ -56,7 +57,7 @@ public abstract partial class ExceptionTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[MemberData(nameof(GetFileInfoFactoryCallbacks), parameters: (string?)null)]
+	[MemberData(nameof(GetFileVersionInfoFactoryCallbacks), parameters: (string?)null)]
 	public void Operations_WhenValueIsNull_ShouldThrowArgumentNullException(
 		Expression<Action<IFileVersionInfoFactory>> callback, string paramName,
 		bool ignoreParamCheck)
@@ -73,7 +74,7 @@ public abstract partial class ExceptionTests<TFileSystem>
 	}
 
 	[SkippableTheory]
-	[MemberData(nameof(GetFileInfoFactoryCallbacks), parameters: "  ")]
+	[MemberData(nameof(GetFileVersionInfoFactoryCallbacks), parameters: "  ")]
 	public void Operations_WhenValueIsWhitespace_ShouldThrowArgumentException(
 		Expression<Action<IFileVersionInfoFactory>> callback, string paramName,
 		bool ignoreParamCheck)
@@ -96,13 +97,13 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	#pragma warning disable MA0018
 	public static TheoryData<Expression<Action<IFileVersionInfoFactory>>, string, bool>
-		GetFileInfoFactoryCallbacks(string? path)
+		GetFileVersionInfoFactoryCallbacks(string? path)
 	{
 		TheoryData<Expression<Action<IFileVersionInfoFactory>>, string, bool> theoryData = new();
 		foreach ((ExceptionTestHelper.TestTypes TestType,
 			string ParamName,
 			Expression<Action<IFileVersionInfoFactory>> Callback) item in
-			GetFileInfoFactoryCallbackTestParameters(path!)
+			GetFileVersionInfoFactoryCallbackTestParameters(path!)
 				.Where(item => item.TestType.HasFlag(path.ToTestType())))
 		{
 			theoryData.Add(
@@ -117,10 +118,10 @@ public abstract partial class ExceptionTests<TFileSystem>
 
 	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string ParamName,
 			Expression<Action<IFileVersionInfoFactory>> Callback)>
-		GetFileInfoFactoryCallbackTestParameters(string value)
+		GetFileVersionInfoFactoryCallbackTestParameters(string value)
 	{
-		yield return (ExceptionTestHelper.TestTypes.All, "fileName", fileInfoFactory
-			=> fileInfoFactory.GetVersionInfo(value));
+		yield return (ExceptionTestHelper.TestTypes.All, "fileName", fileVersionInfoFactory
+			=> fileVersionInfoFactory.GetVersionInfo(value));
 	}
 
 	#endregion

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/ExceptionTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -10,34 +9,6 @@ public abstract partial class ExceptionTests<TFileSystem>
 	: FileSystemTestBase<TFileSystem>
 	where TFileSystem : IFileSystem
 {
-	[SkippableTheory]
-	[MemberData(nameof(GetFileVersionInfoFactoryCallbacks),
-		parameters: "Illegal\tCharacter?InPath")]
-	public void
-		Operations_WhenValueContainsIllegalPathCharacters_ShouldThrowArgumentException_OnNetFramework(
-			Expression<Action<IFileVersionInfoFactory>> callback, string paramName,
-			bool ignoreParamCheck)
-	{
-		Exception? exception = Record.Exception(() =>
-		{
-			callback.Compile().Invoke(FileSystem.FileVersionInfo);
-		});
-
-		if (Test.IsNetFramework)
-		{
-			exception.Should().BeException<ArgumentException>(
-				hResult: -2147024809,
-				because:
-				$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
-		}
-		else
-		{
-			exception.Should().BeException<IOException>(
-				hResult: -2147024894,
-				because: $"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
-		}
-	}
-
 	[SkippableTheory]
 	[MemberData(nameof(GetFileVersionInfoFactoryCallbacks), parameters: "")]
 	public void Operations_WhenValueIsEmpty_ShouldThrowArgumentException(

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/ExceptionTests.cs
@@ -30,10 +30,16 @@ public abstract partial class ExceptionTests<TFileSystem>
 				because:
 				$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
-		else
+		else if (Test.RunsOnWindows)
 		{
 			exception.Should().BeException<IOException>(
 				hResult: -2147024773,
+				because: $"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
+		}
+		else
+		{
+			exception.Should().BeException<FileNotFoundException>(
+				hResult: -2147024894,
 				because: $"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
 	}
@@ -120,7 +126,7 @@ public abstract partial class ExceptionTests<TFileSystem>
 			Expression<Action<IFileVersionInfoFactory>> Callback)>
 		GetFileVersionInfoFactoryCallbackTestParameters(string value)
 	{
-		yield return (ExceptionTestHelper.TestTypes.All, "fileName", fileVersionInfoFactory
+		yield return (ExceptionTestHelper.TestTypes.IgnoreParamNameCheck, "fileName", fileVersionInfoFactory
 			=> fileVersionInfoFactory.GetVersionInfo(value));
 	}
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/ExceptionTests.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Testably.Abstractions.Tests.FileSystem.FileVersionInfoFactory;
+
+// ReSharper disable once PartialTypeWithSinglePart
+public abstract partial class ExceptionTests<TFileSystem>
+	: FileSystemTestBase<TFileSystem>
+	where TFileSystem : IFileSystem
+{
+	[SkippableTheory]
+	[MemberData(nameof(GetFileInfoFactoryCallbacks),
+		parameters: "Illegal\tCharacter?InPath")]
+	public void
+		Operations_WhenValueContainsIllegalPathCharacters_ShouldThrowArgumentException_OnNetFramework(
+			Expression<Action<IFileVersionInfoFactory>> callback, string paramName,
+			bool ignoreParamCheck)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			callback.Compile().Invoke(FileSystem.FileVersionInfo);
+		});
+
+		if (Test.IsNetFramework)
+		{
+			exception.Should().BeException<ArgumentException>(
+				hResult: -2147024809,
+				because:
+				$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
+		}
+		else
+		{
+			exception.Should()
+				.BeNull(
+					$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
+		}
+	}
+
+	[SkippableTheory]
+	[MemberData(nameof(GetFileInfoFactoryCallbacks), parameters: "")]
+	public void Operations_WhenValueIsEmpty_ShouldThrowArgumentException(
+		Expression<Action<IFileVersionInfoFactory>> callback, string paramName,
+		bool ignoreParamCheck)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			callback.Compile().Invoke(FileSystem.FileVersionInfo);
+		});
+
+		exception.Should().BeException<ArgumentException>(
+			hResult: -2147024809,
+			paramName: ignoreParamCheck || Test.IsNetFramework ? null : paramName,
+			because:
+			$"\n{callback}\n has empty parameter for '{paramName}' (ignored: {ignoreParamCheck})");
+	}
+
+	[SkippableTheory]
+	[MemberData(nameof(GetFileInfoFactoryCallbacks), parameters: (string?)null)]
+	public void Operations_WhenValueIsNull_ShouldThrowArgumentNullException(
+		Expression<Action<IFileVersionInfoFactory>> callback, string paramName,
+		bool ignoreParamCheck)
+	{
+		Exception? exception = Record.Exception(() =>
+		{
+			callback.Compile().Invoke(FileSystem.FileVersionInfo);
+		});
+
+		exception.Should().BeException<ArgumentNullException>(
+			paramName: ignoreParamCheck ? null : paramName,
+			because:
+			$"\n{callback}\n has `null` parameter for '{paramName}' (ignored: {ignoreParamCheck})");
+	}
+
+	[SkippableTheory]
+	[MemberData(nameof(GetFileInfoFactoryCallbacks), parameters: "  ")]
+	public void Operations_WhenValueIsWhitespace_ShouldThrowArgumentException(
+		Expression<Action<IFileVersionInfoFactory>> callback, string paramName,
+		bool ignoreParamCheck)
+	{
+		Skip.IfNot(Test.RunsOnWindows);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			callback.Compile().Invoke(FileSystem.FileVersionInfo);
+		});
+
+		exception.Should().BeException<ArgumentException>(
+			hResult: -2147024809,
+			paramName: ignoreParamCheck || Test.IsNetFramework ? null : paramName,
+			because:
+			$"\n{callback}\n has whitespace parameter for '{paramName}' (ignored: {ignoreParamCheck})");
+	}
+
+	#region Helpers
+
+	#pragma warning disable MA0018
+	public static TheoryData<Expression<Action<IFileVersionInfoFactory>>, string, bool>
+		GetFileInfoFactoryCallbacks(string? path)
+	{
+		TheoryData<Expression<Action<IFileVersionInfoFactory>>, string, bool> theoryData = new();
+		foreach ((ExceptionTestHelper.TestTypes TestType,
+			string ParamName,
+			Expression<Action<IFileVersionInfoFactory>> Callback) item in
+			GetFileInfoFactoryCallbackTestParameters(path!)
+				.Where(item => item.TestType.HasFlag(path.ToTestType())))
+		{
+			theoryData.Add(
+				item.Callback,
+				item.ParamName,
+				item.TestType.HasFlag(ExceptionTestHelper.TestTypes.IgnoreParamNameCheck));
+		}
+
+		return theoryData;
+	}
+	#pragma warning restore MA0018
+
+	private static IEnumerable<(ExceptionTestHelper.TestTypes TestType, string ParamName,
+			Expression<Action<IFileVersionInfoFactory>> Callback)>
+		GetFileInfoFactoryCallbackTestParameters(string value)
+	{
+		yield return (ExceptionTestHelper.TestTypes.All, "fileName", fileInfoFactory
+			=> fileInfoFactory.GetVersionInfo(value));
+	}
+
+	#endregion
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/ExceptionTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/ExceptionTests.cs
@@ -30,15 +30,9 @@ public abstract partial class ExceptionTests<TFileSystem>
 				because:
 				$"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 		}
-		else if (Test.RunsOnWindows)
-		{
-			exception.Should().BeException<IOException>(
-				hResult: -2147024773,
-				because: $"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
-		}
 		else
 		{
-			exception.Should().BeException<FileNotFoundException>(
+			exception.Should().BeException<IOException>(
 				hResult: -2147024894,
 				because: $"\n{callback}\n contains invalid path characters for '{paramName}' (ignored: {ignoreParamCheck})");
 		}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/Tests.cs
@@ -1,0 +1,34 @@
+using System.IO;
+
+namespace Testably.Abstractions.Tests.FileSystem.FileVersionInfoFactory;
+
+// ReSharper disable once PartialTypeWithSinglePart
+public abstract partial class Tests<TFileSystem>
+	: FileSystemTestBase<TFileSystem>
+	where TFileSystem : IFileSystem
+{
+	[SkippableTheory]
+	[AutoData]
+	public void GetVersionInfo_ArbitraryFile_ShouldHaveFileNameSet(string fileName)
+	{
+		string filePath = FileSystem.Path.GetFullPath(fileName);
+		FileSystem.File.WriteAllText(fileName, "foo");
+
+		IFileVersionInfo result = FileSystem.FileVersionInfo.GetVersionInfo(fileName);
+
+		result.FileName.Should().Be(filePath);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void GetVersionInfo_MissingFile_ShouldThrowFileNotFoundException(
+		string path)
+	{
+		Exception? exception = Record.Exception(() =>
+			FileSystem.FileVersionInfo.GetVersionInfo(path));
+
+		exception.Should().BeException<FileNotFoundException>(
+			$"'{FileSystem.Path.GetFullPath(path)}'",
+			hResult: -2147024894);
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/Tests.cs
@@ -13,6 +13,11 @@ public abstract partial class Tests<TFileSystem>
 	{
 		string filePath = FileSystem.Path.GetFullPath(fileName);
 		FileSystem.File.WriteAllText(fileName, "foo");
+		if (Test.IsNetFramework)
+		{
+			// On .NET Framework an absolute path is required
+			fileName = filePath;
+		}
 
 		IFileVersionInfo result = FileSystem.FileVersionInfo.GetVersionInfo(fileName);
 
@@ -24,6 +29,11 @@ public abstract partial class Tests<TFileSystem>
 	public void GetVersionInfo_MissingFile_ShouldThrowFileNotFoundException(
 		string path)
 	{
+		if (Test.IsNetFramework)
+		{
+			path = FileSystem.Path.GetFullPath(path);
+		}
+		
 		Exception? exception = Record.Exception(() =>
 			FileSystem.FileVersionInfo.GetVersionInfo(path));
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileVersionInfoFactory/Tests.cs
@@ -28,7 +28,7 @@ public abstract partial class Tests<TFileSystem>
 			FileSystem.FileVersionInfo.GetVersionInfo(path));
 
 		exception.Should().BeException<FileNotFoundException>(
-			$"'{FileSystem.Path.GetFullPath(path)}'",
+			FileSystem.Path.GetFullPath(path),
 			hResult: -2147024894);
 	}
 }


### PR DESCRIPTION
Add a method to the `MockFileSystem` that allows setting the `IFileVersionInfo`:

```csharp
MockFileSystem fileSystem = new();
fileSystem.WithFileVersionInfo("foo.dll", b => b.SetFileVersion("2.3.4"));
fileSystem.Initialize().WithFile("foo.dll");

IFileVersionInfo fileVersionInfo = fileSystem.FileVersionInfo.GetVersionInfo("foo.dll");
fileVersionInfo.FileVersion.Should().Be("2.3.4");
```