### PR TITLE
fix: mutation comment during update

### DIFF
--- a/Pipeline/Build.CodeAnalysis.cs
+++ b/Pipeline/Build.CodeAnalysis.cs
@@ -7,7 +7,7 @@ namespace Build;
 
 partial class Build
 {
-	[Parameter("The key to push to sonarcloud")] [Secret] readonly string SonarToken;
+	[Parameter("The key to push to sonarcloud")] [Secret] readonly string? SonarToken;
 
 	Target CodeAnalysisBegin => _ => _
 		.Unlisted()
@@ -21,7 +21,7 @@ partial class Build
 				.AddVSTestReports(TestResultsDirectory / "*.trx")
 				.AddOpenCoverPaths(TestResultsDirectory / "reports" / "OpenCover.xml")
 				.SetPullRequestOrBranchName(GitHubActions, GitVersion)
-				.SetVersion(GitVersion.SemVer)
+				.SetVersion(GitVersion?.SemVer)
 				.SetToken(SonarToken));
 		});
 
@@ -36,6 +36,7 @@ partial class Build
 				.SetToken(SonarToken));
 		});
 
+	// ReSharper disable once UnusedMember.Local
 	Target CodeAnalysis => _ => _
 		.DependsOn(CodeAnalysisBegin)
 		.DependsOn(CodeAnalysisEnd);

--- a/Pipeline/Build.Compile.cs
+++ b/Pipeline/Build.Compile.cs
@@ -2,7 +2,6 @@ using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Utilities.Collections;
-using Nuke.Components;
 using Serilog;
 using System;
 using System.Linq;
@@ -15,15 +14,15 @@ namespace Build;
 
 partial class Build
 {
-	string SemVer;
+	string? SemVer;
 
 	Target CalculateNugetVersion => _ => _
 		.Unlisted()
 		.Executes(() =>
 		{
-			SemVer = GitVersion.SemVer;
+			SemVer = GitVersion?.SemVer;
 
-			if (GitHubActions?.IsPullRequest == true)
+			if (GitHubActions?.IsPullRequest == true && GitVersion != null)
 			{
 				string buildNumber = GitHubActions.RunNumber.ToString();
 				Console.WriteLine(
@@ -73,8 +72,8 @@ partial class Build
 				.EnableNoLogo()
 				.EnableNoRestore()
 				.SetVersion(SemVer)
-				.SetAssemblyVersion(GitVersion.AssemblySemVer)
-				.SetFileVersion(GitVersion.AssemblySemFileVer)
-				.SetInformationalVersion(GitVersion.InformationalVersion));
+				.SetAssemblyVersion(GitVersion?.AssemblySemVer)
+				.SetFileVersion(GitVersion?.AssemblySemFileVer)
+				.SetInformationalVersion(GitVersion?.InformationalVersion));
 		});
 }

--- a/Pipeline/Build.Compile.cs
+++ b/Pipeline/Build.Compile.cs
@@ -22,7 +22,7 @@ partial class Build
 		{
 			SemVer = GitVersion?.SemVer;
 
-			if (GitHubActions?.IsPullRequest == true && GitVersion != null)
+			if (GitHubActions.IsPullRequest && GitVersion != null)
 			{
 				string buildNumber = GitHubActions.RunNumber.ToString();
 				Console.WriteLine(

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -26,10 +26,10 @@ partial class Build
 	Target MutationComment => _ => _
 		.After(MutationTestsLinux)
 		.After(MutationTestsWindows)
-		.OnlyWhenDynamic(() => GitHubActions?.IsPullRequest == true)
+		.OnlyWhenDynamic(() => GitHubActions.IsPullRequest)
 		.Executes(async () =>
 		{
-			int? prId = GitHubActions?.PullRequestNumber;
+			int? prId = GitHubActions.PullRequestNumber;
 			Log.Debug("Pull request number: {PullRequestId}", prId);
 			if (MutationCommentBodies.Count == 0)
 			{

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -26,10 +26,10 @@ partial class Build
 	Target MutationComment => _ => _
 		.After(MutationTestsLinux)
 		.After(MutationTestsWindows)
-		.OnlyWhenDynamic(() => GitHubActions.IsPullRequest)
+		.OnlyWhenDynamic(() => GitHubActions?.IsPullRequest == true)
 		.Executes(async () =>
 		{
-			int? prId = GitHubActions.PullRequestNumber;
+			int? prId = GitHubActions?.PullRequestNumber;
 			Log.Debug("Pull request number: {PullRequestId}", prId);
 			if (MutationCommentBodies.Count == 0)
 			{
@@ -117,7 +117,7 @@ partial class Build
 
 			foreach (KeyValuePair<Project, Project[]> project in projects)
 			{
-				string branchName = GitVersion.BranchName;
+				string? branchName = GitVersion?.BranchName;
 				if (GitHubActions?.Ref.StartsWith("refs/tags/",
 					StringComparison.OrdinalIgnoreCase) == true)
 				{
@@ -141,7 +141,7 @@ partial class Build
 				                      		"target-framework": "net8.0",
 				                      		"since": {
 				                      			"target": "main",
-				                      			"enabled": {{(GitVersion.BranchName != "main").ToString().ToLowerInvariant()}},
+				                      			"enabled": {{(GitVersion?.BranchName != "main").ToString().ToLowerInvariant()}},
 				                      			"ignore-changes-in": [
 				                      				"**/.github/**/*.*"
 				                      			]
@@ -233,7 +233,7 @@ partial class Build
 
 			foreach (KeyValuePair<Project, Project[]> project in projects)
 			{
-				string branchName = GitVersion.BranchName;
+				string? branchName = GitVersion?.BranchName;
 				if (GitHubActions?.Ref.StartsWith("refs/tags/",
 					StringComparison.OrdinalIgnoreCase) == true)
 				{
@@ -257,7 +257,7 @@ partial class Build
 				                      		"target-framework": "net8.0",
 				                      		"since": {
 				                      			"target": "main",
-				                      			"enabled": {{(GitVersion.BranchName != "main").ToString().ToLowerInvariant()}},
+				                      			"enabled": {{(GitVersion?.BranchName != "main").ToString().ToLowerInvariant()}},
 				                      			"ignore-changes-in": [
 				                      				"**/.github/**/*.*"
 				                      			]

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -355,7 +355,7 @@ partial class Build
 		if (startIndex >= 0 && endIndex > startIndex)
 		{
 			string prefix = body.Substring(0, startIndex);
-			string suffix = body.Substring(endIndex + 1);
+			string suffix = body.Substring(endIndex + $"<!-- END {project} -->".Length);
 			return prefix + value + suffix;
 		}
 

--- a/Pipeline/Build.Pack.cs
+++ b/Pipeline/Build.Pack.cs
@@ -2,7 +2,6 @@ using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Utilities.Collections;
-using Nuke.Components;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -20,6 +19,11 @@ partial class Build
 		.Before(Compile)
 		.Executes(() =>
 		{
+			if (GitVersion == null)
+			{
+				return;
+			}
+			
 			string version = string.Join('.', GitVersion.SemVer.Split('.').Take(3));
 			if (version.IndexOf('-') != -1)
 			{
@@ -60,6 +64,7 @@ partial class Build
 			File.WriteAllText(ArtifactsDirectory / "README.md", sb.ToString());
 		});
 
+	// ReSharper disable once UnusedMember.Local
 	Target Pack => _ => _
 		.DependsOn(UpdateReadme)
 		.DependsOn(Compile)

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -17,18 +17,19 @@ partial class Build : NukeBuild
 	[Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
 	readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
 
-	[Parameter("Github Token")] readonly string GithubToken;
+	[Parameter("Github Token")] readonly string? GithubToken;
 
-	[Required] [GitVersion(Framework = "net8.0", NoCache = true, NoFetch = true)] readonly GitVersion GitVersion;
+	[Required] [GitVersion(Framework = "net8.0", NoCache = true, NoFetch = true)] readonly GitVersion? GitVersion;
 
-	[Solution(GenerateProjects = true)] readonly Solution Solution;
+	[Solution(GenerateProjects = true)] readonly Solution Solution = null!;
 
 	AbsolutePath ArtifactsDirectory => RootDirectory / "Artifacts";
 	AbsolutePath TestResultsDirectory => RootDirectory / "TestResults";
-	GitHubActions GitHubActions => GitHubActions.Instance;
+	GitHubActions? GitHubActions => GitHubActions.Instance;
 
 	public static int Main() => Execute<Build>([
 		x => x.ApiChecks,
 		x => x.UnitTests,
+		x => x.MutationTests,
 	]);
 }

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -25,7 +25,7 @@ partial class Build : NukeBuild
 
 	AbsolutePath ArtifactsDirectory => RootDirectory / "Artifacts";
 	AbsolutePath TestResultsDirectory => RootDirectory / "TestResults";
-	GitHubActions? GitHubActions => GitHubActions.Instance;
+	GitHubActions GitHubActions => GitHubActions.Instance;
 
 	public static int Main() => Execute<Build>([
 		x => x.ApiChecks,

--- a/Pipeline/Build.csproj
+++ b/Pipeline/Build.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
+		<Nullable>enable</Nullable>
 		<TargetFramework>net8.0</TargetFramework>
 		<NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE1006</NoWarn>
 		<NukeRootDirectory>..</NukeRootDirectory>

--- a/Pipeline/BuildExtensions.cs
+++ b/Pipeline/BuildExtensions.cs
@@ -10,8 +10,8 @@ public static class BuildExtensions
 {
 	public static SonarScannerBeginSettings SetPullRequestOrBranchName(
 		this SonarScannerBeginSettings settings,
-		GitHubActions gitHubActions,
-		GitVersion gitVersion)
+		GitHubActions? gitHubActions,
+		GitVersion? gitVersion)
 	{
 		if (gitHubActions?.IsPullRequest == true)
 		{
@@ -30,7 +30,7 @@ public static class BuildExtensions
 			return settings.SetBranchName(branchName);
 		}
 
-		Log.Information("Use branch analysis for '{BranchName}'", gitVersion.BranchName);
-		return settings.SetBranchName(gitVersion.BranchName);
+		Log.Information("Use branch analysis for '{BranchName}'", gitVersion?.BranchName);
+		return settings.SetBranchName(gitVersion?.BranchName);
 	}
 }


### PR DESCRIPTION
When the mutation comment is updated, it adds an incorrect string:
![image](https://github.com/user-attachments/assets/6f18b1cf-e189-44a4-ab14-b9b0201dcc2b)
