### PR TITLE
chore: update Meziantou.Analyzer to 2.0.185

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,6 +47,6 @@
 		<PackageVersion Include="Testably.Abstractions.FluentAssertions" Version="1.1.0" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageVersion Include="Meziantou.Analyzer" Version="2.0.163" />
+		<PackageVersion Include="Meziantou.Analyzer" Version="2.0.185" />
 	</ItemGroup>
 </Project>

--- a/Pipeline/Build.Pack.cs
+++ b/Pipeline/Build.Pack.cs
@@ -32,7 +32,7 @@ partial class Build
 
 			StringBuilder sb = new();
 			string[] lines = File.ReadAllLines(Solution.Directory / "README.md");
-			sb.AppendLine(lines.First());
+			sb.AppendLine(lines[0]);
 			sb.AppendLine(
 				$"[![Changelog](https://img.shields.io/badge/Changelog-v{version}-blue)](https://github.com/Testably/Testably.Abstractions/releases/tag/v{version})");
 			foreach (string line in lines.Skip(1))

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -20,7 +20,7 @@
 	<PropertyGroup>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<NoWarn>1701;1702</NoWarn>
+		<NoWarn>$(NoWarn);1701;1702;MA0003;MA0004</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -20,7 +20,7 @@
 	<PropertyGroup>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<NoWarn>$(NoWarn);1701;1702;MA0003;MA0004</NoWarn>
+		<NoWarn>$(NoWarn);1701;1702;MA0003;MA0004;MA0042;MA0076</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 

--- a/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
+++ b/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
@@ -90,7 +90,7 @@ internal static class ZipUtilities
 					#pragma warning disable MA0074
 					string entryName = file.FullName
 						.Substring(basePath.Length + 1)
-						.Replace("\\", "/");
+						.Replace('\\', '/');
 					#pragma warning restore MA0074
 					ZipArchiveEntry entry = compressionLevel.HasValue
 						? archive.CreateEntry(entryName, compressionLevel.Value)
@@ -166,7 +166,7 @@ internal static class ZipUtilities
 					#pragma warning disable MA0074
 					string entryName = file.FullName
 						.Substring(basePath.Length + 1)
-						.Replace("\\", "/");
+						.Replace('\\', '/');
 					#pragma warning restore MA0074
 					ZipArchiveEntry entry = compressionLevel.HasValue
 						? archive.CreateEntry(entryName, compressionLevel.Value)
@@ -268,7 +268,8 @@ internal static class ZipUtilities
 			throw new ArgumentException("The stream is unreadable.", nameof(source));
 		}
 
-		using (ZipArchive archive = new(source, ZipArchiveMode.Read, true, entryNameEncoding))
+		using (ZipArchive archive = new(source, ZipArchiveMode.Read,
+			leaveOpen: true, entryNameEncoding))
 		{
 			ZipArchiveWrapper wrappedArchive = new(fileSystem, archive);
 			foreach (ZipArchiveEntry entry in archive.Entries)

--- a/Source/Testably.Abstractions.Compression/Polyfills/StringExtensionMethods.cs
+++ b/Source/Testably.Abstractions.Compression/Polyfills/StringExtensionMethods.cs
@@ -21,5 +21,18 @@ internal static class StringExtensionMethods
 		return @this.EndsWith($"{value}");
 		#pragma warning restore MA0074
 	}
+
+	/// <summary>
+	///     Returns a new string in which all occurrences of a specified string in the current instance are replaced with another specified string, using the provided comparison type.
+	/// </summary>
+	internal static string Replace(
+		this string @this,
+		// ReSharper disable once UnusedParameter.Global
+		string oldValue, string? newValue, StringComparison comparisonType)
+	{
+		#pragma warning disable MA0074
+		return @this.Replace(oldValue, newValue);
+		#pragma warning restore MA0074
+	}
 }
 #endif

--- a/Source/Testably.Abstractions.Compression/Polyfills/StringExtensionMethods.cs
+++ b/Source/Testably.Abstractions.Compression/Polyfills/StringExtensionMethods.cs
@@ -21,18 +21,5 @@ internal static class StringExtensionMethods
 		return @this.EndsWith($"{value}");
 		#pragma warning restore MA0074
 	}
-
-	/// <summary>
-	///     Returns a new string in which all occurrences of a specified string in the current instance are replaced with another specified string, using the provided comparison type.
-	/// </summary>
-	internal static string Replace(
-		this string @this,
-		// ReSharper disable once UnusedParameter.Global
-		string oldValue, string? newValue, StringComparison comparisonType)
-	{
-		#pragma warning disable MA0074
-		return @this.Replace(oldValue, newValue);
-		#pragma warning restore MA0074
-	}
 }
 #endif

--- a/Source/Testably.Abstractions.Compression/ZipArchiveEntryWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipArchiveEntryWrapper.cs
@@ -88,7 +88,7 @@ internal sealed class ZipArchiveEntryWrapper : IZipArchiveEntry
 	public void ExtractToFile(string destinationFileName)
 		=> Execute.WhenRealFileSystem(FileSystem,
 			() => _instance.ExtractToFile(destinationFileName),
-			() => ExtractToFile(destinationFileName, false));
+			() => ExtractToFile(destinationFileName, overwrite: false));
 
 	/// <inheritdoc cref="IZipArchiveEntry.ExtractToFile(string, bool)" />
 	public void ExtractToFile(string destinationFileName, bool overwrite)

--- a/Source/Testably.Abstractions.Compression/ZipArchiveWrapper.cs
+++ b/Source/Testably.Abstractions.Compression/ZipArchiveWrapper.cs
@@ -91,7 +91,7 @@ internal sealed class ZipArchiveWrapper : IZipArchive
 			{
 				foreach (IZipArchiveEntry entry in Entries)
 				{
-					entry.ExtractRelativeToDirectory(destinationDirectoryName, false);
+					entry.ExtractRelativeToDirectory(destinationDirectoryName, overwrite: false);
 				}
 			});
 	}

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileMock.cs
@@ -62,14 +62,14 @@ internal sealed class FileMock : IFile
 
 #if FEATURE_FILESYSTEM_ASYNC
 	/// <inheritdoc cref="IFile.AppendAllLinesAsync(string, IEnumerable{string}, CancellationToken)" />
-	public Task AppendAllLinesAsync(string path, IEnumerable<string> contents,
+	public async Task AppendAllLinesAsync(string path, IEnumerable<string> contents,
 		CancellationToken cancellationToken = default)
 	{
 		using IDisposable registration = _fileSystem.StatisticsRegistration
 			.File.RegisterMethod(nameof(AppendAllLinesAsync),
 				path, contents, cancellationToken);
 
-		return AppendAllLinesAsync(path, contents, Encoding.Default, cancellationToken);
+		await AppendAllLinesAsync(path, contents, Encoding.Default, cancellationToken);
 	}
 #endif
 
@@ -135,14 +135,14 @@ internal sealed class FileMock : IFile
 
 #if FEATURE_FILESYSTEM_ASYNC
 	/// <inheritdoc cref="IFile.AppendAllTextAsync(string, string?, CancellationToken)" />
-	public Task AppendAllTextAsync(string path, string? contents,
+	public async Task AppendAllTextAsync(string path, string? contents,
 		CancellationToken cancellationToken = default)
 	{
 		using IDisposable registration = _fileSystem.StatisticsRegistration
 			.File.RegisterMethod(nameof(AppendAllTextAsync),
 				path, contents, cancellationToken);
 
-		return AppendAllTextAsync(path, contents, Encoding.Default, cancellationToken);
+		await AppendAllTextAsync(path, contents, Encoding.Default, cancellationToken);
 	}
 #endif
 
@@ -774,7 +774,7 @@ internal sealed class FileMock : IFile
 
 #if FEATURE_FILESYSTEM_ASYNC
 	/// <inheritdoc cref="IFile.ReadAllLinesAsync(string, CancellationToken)" />
-	public Task<string[]> ReadAllLinesAsync(
+	public async Task<string[]> ReadAllLinesAsync(
 		string path,
 		CancellationToken cancellationToken = default)
 	{
@@ -782,7 +782,7 @@ internal sealed class FileMock : IFile
 			.File.RegisterMethod(nameof(ReadAllLinesAsync),
 				path, cancellationToken);
 
-		return ReadAllLinesAsync(path, Encoding.Default, cancellationToken);
+		return await ReadAllLinesAsync(path, Encoding.Default, cancellationToken);
 	}
 #endif
 
@@ -839,7 +839,7 @@ internal sealed class FileMock : IFile
 
 #if FEATURE_FILESYSTEM_ASYNC
 	/// <inheritdoc cref="IFile.ReadAllTextAsync(string, CancellationToken)" />
-	public Task<string> ReadAllTextAsync(
+	public async Task<string> ReadAllTextAsync(
 		string path,
 		CancellationToken cancellationToken = default)
 	{
@@ -847,7 +847,7 @@ internal sealed class FileMock : IFile
 			.File.RegisterMethod(nameof(ReadAllTextAsync),
 				path, cancellationToken);
 
-		return ReadAllTextAsync(path, Encoding.Default, cancellationToken);
+		return await ReadAllTextAsync(path, Encoding.Default, cancellationToken);
 	}
 #endif
 
@@ -1307,7 +1307,7 @@ internal sealed class FileMock : IFile
 
 #if FEATURE_FILESYSTEM_ASYNC
 	/// <inheritdoc cref="IFile.WriteAllLinesAsync(string, IEnumerable{string}, CancellationToken)" />
-	public Task WriteAllLinesAsync(
+	public async Task WriteAllLinesAsync(
 		string path,
 		IEnumerable<string> contents,
 		CancellationToken cancellationToken = default)
@@ -1316,7 +1316,7 @@ internal sealed class FileMock : IFile
 			.File.RegisterMethod(nameof(WriteAllLinesAsync),
 				path, contents, cancellationToken);
 
-		return WriteAllLinesAsync(path, contents, Encoding.Default, cancellationToken);
+		await WriteAllLinesAsync(path, contents, Encoding.Default, cancellationToken);
 	}
 #endif
 
@@ -1390,14 +1390,14 @@ internal sealed class FileMock : IFile
 
 #if FEATURE_FILESYSTEM_ASYNC
 	/// <inheritdoc cref="IFile.WriteAllTextAsync(string, string?, CancellationToken)" />
-	public Task WriteAllTextAsync(string path, string? contents,
+	public async Task WriteAllTextAsync(string path, string? contents,
 		CancellationToken cancellationToken = default)
 	{
 		using IDisposable registration = _fileSystem.StatisticsRegistration
 			.File.RegisterMethod(nameof(WriteAllTextAsync),
 				path, contents, cancellationToken);
 
-		return WriteAllTextAsync(path, contents, Encoding.Default, cancellationToken);
+		await WriteAllTextAsync(path, contents, Encoding.Default, cancellationToken);
 	}
 #endif
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -350,7 +350,7 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 	}
 
 	/// <inheritdoc cref="FileSystemStream.CopyToAsync(Stream, int, CancellationToken)" />
-	public override Task CopyToAsync(Stream destination, int bufferSize,
+	public override async Task CopyToAsync(Stream destination, int bufferSize,
 		CancellationToken cancellationToken)
 	{
 		using IDisposable registration = _fileSystem.StatisticsRegistration
@@ -358,7 +358,7 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 				destination, bufferSize, cancellationToken);
 
 		_container.AdjustTimes(TimeAdjustments.LastAccessTime);
-		return base.CopyToAsync(destination, bufferSize, cancellationToken);
+		await base.CopyToAsync(destination, bufferSize, cancellationToken);
 	}
 
 	/// <inheritdoc cref="FileSystemStream.EndRead(IAsyncResult)" />
@@ -461,7 +461,7 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 #endif
 
 	/// <inheritdoc cref="FileSystemStream.ReadAsync(byte[], int, int, CancellationToken)" />
-	public override Task<int> ReadAsync(byte[] buffer, int offset, int count,
+	public override async Task<int> ReadAsync(byte[] buffer, int offset, int count,
 		CancellationToken cancellationToken)
 	{
 		using IDisposable registration = _fileSystem.StatisticsRegistration
@@ -478,12 +478,12 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 			_container.AdjustTimes(TimeAdjustments.LastAccessTime);
 		}
 
-		return base.ReadAsync(buffer, offset, count, cancellationToken);
+		return await base.ReadAsync(buffer, offset, count, cancellationToken);
 	}
 
 #if FEATURE_SPAN
 	/// <inheritdoc cref="FileSystemStream.ReadAsync(Memory{byte}, CancellationToken)" />
-	public override ValueTask<int> ReadAsync(Memory<byte> buffer,
+	public override async ValueTask<int> ReadAsync(Memory<byte> buffer,
 		CancellationToken cancellationToken = new())
 	{
 		using IDisposable registration = _fileSystem.StatisticsRegistration
@@ -500,7 +500,7 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 			_container.AdjustTimes(TimeAdjustments.LastAccessTime);
 		}
 
-		return base.ReadAsync(buffer, cancellationToken);
+		return await base.ReadAsync(buffer, cancellationToken);
 	}
 #endif
 
@@ -598,7 +598,7 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 #endif
 
 	/// <inheritdoc cref="FileSystemStream.WriteAsync(byte[], int, int, CancellationToken)" />
-	public override Task WriteAsync(byte[] buffer, int offset, int count,
+	public override async Task WriteAsync(byte[] buffer, int offset, int count,
 		CancellationToken cancellationToken)
 	{
 		using IDisposable registration = _fileSystem.StatisticsRegistration
@@ -611,12 +611,12 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 		}
 
 		_isContentChanged = true;
-		return base.WriteAsync(buffer, offset, count, cancellationToken);
+		await base.WriteAsync(buffer, offset, count, cancellationToken);
 	}
 
 #if FEATURE_SPAN
 	/// <inheritdoc cref="FileSystemStream.WriteAsync(ReadOnlyMemory{byte}, CancellationToken)" />
-	public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer,
+	public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer,
 		CancellationToken cancellationToken = new())
 	{
 		using IDisposable registration = _fileSystem.StatisticsRegistration
@@ -629,7 +629,7 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 		}
 
 		_isContentChanged = true;
-		return base.WriteAsync(buffer, cancellationToken);
+		await base.WriteAsync(buffer, cancellationToken);
 	}
 #endif
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
@@ -689,7 +689,7 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 		public bool TimedOut { get; }
 	}
 
-	internal class ChangeDescriptionEventArgs(ChangeDescription changeDescription) : EventArgs
+	internal sealed class ChangeDescriptionEventArgs(ChangeDescription changeDescription) : EventArgs
 	{
 		public ChangeDescription ChangeDescription { get; } = changeDescription;
 	}

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.LinuxPath.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.LinuxPath.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace Testably.Abstractions.Testing.Helpers;
 
-internal partial class Execute
+internal sealed partial class Execute
 {
 	private class LinuxPath(MockFileSystem fileSystem) : SimulatedPath(fileSystem)
 	{

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.MacPath.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.MacPath.cs
@@ -1,6 +1,6 @@
 ﻿namespace Testably.Abstractions.Testing.Helpers;
 
-internal partial class Execute
+internal sealed partial class Execute
 {
 	private sealed class MacPath(MockFileSystem fileSystem) : LinuxPath(fileSystem)
 	{

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.NativePath.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.NativePath.cs
@@ -9,7 +9,7 @@ using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.Helpers;
 
-internal partial class Execute
+internal sealed partial class Execute
 {
 	private sealed class NativePath(MockFileSystem fileSystem) : IPath
 	{

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.SimulatedPath.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.SimulatedPath.cs
@@ -8,7 +8,7 @@ using Testably.Abstractions.Testing.Storage;
 
 namespace Testably.Abstractions.Testing.Helpers;
 
-internal partial class Execute
+internal sealed partial class Execute
 {
 	private abstract class SimulatedPath(MockFileSystem fileSystem) : IPath
 	{

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.WindowsPath.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.WindowsPath.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Testably.Abstractions.Testing.Helpers;
 
-internal partial class Execute
+internal sealed partial class Execute
 {
 	private sealed class WindowsPath(MockFileSystem fileSystem) : SimulatedPath(fileSystem)
 	{

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 namespace Testably.Abstractions.Testing.Helpers;
 
-internal partial class Execute
+internal sealed partial class Execute
 {
 	/// <summary>
 	///     Flag indicating if the code runs on <see cref="OSPlatform.Linux" />.

--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensibility.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensibility.cs
@@ -6,7 +6,7 @@ using Testably.Abstractions.Helpers;
 
 namespace Testably.Abstractions.Testing.Helpers;
 
-internal class FileSystemExtensibility : IFileSystemExtensibility
+internal sealed class FileSystemExtensibility : IFileSystemExtensibility
 {
 	private readonly Dictionary<string, object?> _metadata = new(StringComparer.Ordinal);
 

--- a/Source/Testably.Abstractions.Testing/RandomSystem/RandomMock.cs
+++ b/Source/Testably.Abstractions.Testing/RandomSystem/RandomMock.cs
@@ -19,17 +19,17 @@ internal sealed class RandomMock : IRandom
 #if FEATURE_RANDOM_ADVANCED
 	/// <summary>
 	///     Initializes a new instance of <see cref="RandomMock" /> which allows specifying explicit generators:<br />
-	///     - <paramref name="intGenerator" />: The generator for <c>int</c> values.
-	///     - <paramref name="longGenerator" />: The generator for <c>long</c> values.
-	///     - <paramref name="singleGenerator" />: The generator for <c>float</c> values.
-	///     - <paramref name="doubleGenerator" />: The generator for <c>double</c> values.
+	///     - <paramref name="intGenerator" />: The generator for <see langword="int" /> values.
+	///     - <paramref name="longGenerator" />: The generator for <see langword="long" /> values.
+	///     - <paramref name="singleGenerator" />: The generator for <see langword="float" /> values.
+	///     - <paramref name="doubleGenerator" />: The generator for <see langword="double" /> values.
 	///     - <paramref name="byteGenerator" />: The generator for <c>byte[]</c> values.
 	/// </summary>
 #else
 	/// <summary>
 	///     Initializes a new instance of <see cref="RandomMock" /> which allows specifying explicit generators:<br />
-	///     - <paramref name="intGenerator" />: The generator for <c>int</c> values.
-	///     - <paramref name="doubleGenerator" />: The generator for <c>double</c> values.
+	///     - <paramref name="intGenerator" />: The generator for <see langword="int" /> values.
+	///     - <paramref name="doubleGenerator" />: The generator for <see langword="double" /> values.
 	///     - <paramref name="byteGenerator" />: The generator for <c>byte[]</c> values.
 	/// </summary>
 #endif

--- a/Source/Testably.Abstractions.Testing/Statistics/ParameterDescription.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/ParameterDescription.cs
@@ -9,7 +9,7 @@ namespace Testably.Abstractions.Testing.Statistics;
 public abstract class ParameterDescription
 {
 	/// <summary>
-	///     Specifies, if the parameter was used as an <c>out</c> parameter.
+	///     Specifies, if the parameter was used as an <see langword="out" /> parameter.
 	/// </summary>
 	public bool IsOutParameter { get; }
 
@@ -23,7 +23,7 @@ public abstract class ParameterDescription
 	}
 
 	/// <summary>
-	///     Creates a <see cref="ParameterDescription" /> from the <paramref name="value" /> used as an <c>out</c> parameter.
+	///     Creates a <see cref="ParameterDescription" /> from the <paramref name="value" /> used as an <see langword="out" /> parameter.
 	/// </summary>
 	public static ParameterDescription FromOutParameter<T>(T value)
 	{

--- a/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/PathStatistics.cs
@@ -5,7 +5,7 @@ using Testably.Abstractions.Testing.Helpers;
 
 namespace Testably.Abstractions.Testing.Statistics;
 
-internal class PathStatistics<TFactory, TType> : CallStatistics<TFactory>,
+internal sealed class PathStatistics<TFactory, TType> : CallStatistics<TFactory>,
 	IPathStatistics<TFactory, TType>
 {
 	private readonly MockFileSystem _fileSystem;

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -10,7 +10,7 @@ using static Testably.Abstractions.Testing.Storage.IStorageContainer;
 
 namespace Testably.Abstractions.Testing.Storage;
 
-internal class InMemoryContainer : IStorageContainer
+internal sealed class InMemoryContainer : IStorageContainer
 {
 	private FileAttributes _attributes;
 	private byte[] _bytes = Array.Empty<byte>();

--- a/Source/Testably.Abstractions.Testing/Storage/StorageExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/StorageExtensions.cs
@@ -64,7 +64,7 @@ internal static class StorageExtensions
 		return new AdjustedLocation(location, searchPattern, givenPath);
 	}
 
-	internal class AdjustedLocation
+	internal sealed class AdjustedLocation
 	{
 		public string GivenPath { get; }
 

--- a/Source/Testably.Abstractions.Testing/Testably.Abstractions.Testing.csproj
+++ b/Source/Testably.Abstractions.Testing/Testably.Abstractions.Testing.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<Description>Testing helpers for `Testably.Abstractions` to write testable code by abstracting away system dependencies.</Description>
 		<PackageReadmeFile>Docs/Testing.md</PackageReadmeFile>
-		<NoWarn>$(NoWarn);MA0042</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Source/Testably.Abstractions.Testing/Testably.Abstractions.Testing.csproj
+++ b/Source/Testably.Abstractions.Testing/Testably.Abstractions.Testing.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<Description>Testing helpers for `Testably.Abstractions` to write testable code by abstracting away system dependencies.</Description>
 		<PackageReadmeFile>Docs/Testing.md</PackageReadmeFile>
+		<NoWarn>$(NoWarn);MA0042</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Source/Testably.Abstractions/FileSystem/FileSystemExtensibility.cs
+++ b/Source/Testably.Abstractions/FileSystem/FileSystemExtensibility.cs
@@ -5,7 +5,7 @@ using Testably.Abstractions.Helpers;
 
 namespace Testably.Abstractions.FileSystem;
 
-internal class FileSystemExtensibility : IFileSystemExtensibility
+internal sealed class FileSystemExtensibility : IFileSystemExtensibility
 {
 	private readonly Dictionary<string, object?> _metadata = new(StringComparer.Ordinal);
 	private readonly object _wrappedInstance;

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -15,7 +15,7 @@
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<NoWarn>$(NoWarn);701;1702;CA1845;MA0003;MA0004;xUnit1044;xUnit1045;NU1603</NoWarn>
+		<NoWarn>$(NoWarn);701;1702;CA1845;MA0003;MA0004;MA0042;MA0076;xUnit1044;xUnit1045;NU1603</NoWarn>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -15,7 +15,7 @@
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<NoWarn>701;1702;CA1845;MA0004</NoWarn>
+		<NoWarn>$(NoWarn);701;1702;CA1845;MA0003;MA0004;xUnit1044;xUnit1045;NU1603</NoWarn>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/AutoDomainDataAttribute.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/AutoDomainDataAttribute.cs
@@ -88,8 +88,7 @@ public class AutoDomainDataAttribute : AutoDataAttribute
 			Type autoDataCustomizationInterface = typeof(IAutoDataCustomization);
 			foreach (Type type in AppDomain.CurrentDomain.GetAssemblies()
 				.SelectMany(a => a.GetTypes())
-				.Where(x => x.IsClass)
-				.Where(autoDataCustomizationInterface.IsAssignableFrom))
+				.Where(x => x.IsClass && autoDataCustomizationInterface.IsAssignableFrom(x)))
 			{
 				try
 				{

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/FileSystemClassGenerator.cs
@@ -5,7 +5,7 @@ using Testably.Abstractions.Tests.SourceGenerator.Model;
 namespace Testably.Abstractions.Tests.SourceGenerator.ClassGenerators;
 
 // ReSharper disable StringLiteralTypo
-internal class FileSystemClassGenerator : ClassGeneratorBase
+internal sealed class FileSystemClassGenerator : ClassGeneratorBase
 {
 	/// <inheritdoc cref="ClassGeneratorBase.Marker" />
 	public override string Marker

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/RandomSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/RandomSystemClassGenerator.cs
@@ -4,7 +4,7 @@ using Testably.Abstractions.Tests.SourceGenerator.Model;
 
 namespace Testably.Abstractions.Tests.SourceGenerator.ClassGenerators;
 
-internal class RandomSystemClassGenerator : ClassGeneratorBase
+internal sealed class RandomSystemClassGenerator : ClassGeneratorBase
 {
 	/// <inheritdoc cref="ClassGeneratorBase.Marker" />
 	public override string Marker

--- a/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/TimeSystemClassGenerator.cs
+++ b/Tests/Helpers/Testably.Abstractions.Tests.SourceGenerator/ClassGenerators/TimeSystemClassGenerator.cs
@@ -4,7 +4,7 @@ using Testably.Abstractions.Tests.SourceGenerator.Model;
 
 namespace Testably.Abstractions.Tests.SourceGenerator.ClassGenerators;
 
-internal class TimeSystemClassGenerator : ClassGeneratorBase
+internal sealed class TimeSystemClassGenerator : ClassGeneratorBase
 {
 	/// <inheritdoc cref="ClassGeneratorBase.Marker" />
 	public override string Marker

--- a/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/ParityCheck.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/ParityCheck.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 using Xunit.Abstractions;
 
 namespace Testably.Abstractions.Parity.Tests.TestHelpers;
-
+#pragma warning disable MA0029 // Combine 'Where' with 'Where'
 public class ParityCheck
 {
 	public List<Type> ExcludedBaseTypes { get; } =
@@ -154,8 +154,8 @@ public class ParityCheck
 			.GetMethods(
 				BindingFlags.Public |
 				BindingFlags.Instance)
-			.Where(p => p.DeclaringType == null ||
-			            !ExcludedBaseTypes.Contains(p.DeclaringType))
+			.Where(m => m.DeclaringType == null ||
+			            !ExcludedBaseTypes.Contains(m.DeclaringType))
 			.Where(m => !MissingMethods.Contains(m))
 			.Where(m => !m.IsSpecialName)
 			.OrderBy(m => m.Name)
@@ -237,3 +237,4 @@ public class ParityCheck
 		}
 	}
 }
+#pragma warning restore MA0029

--- a/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/ParityCheckHelper.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/ParityCheckHelper.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 
 namespace Testably.Abstractions.Parity.Tests.TestHelpers;
 
+#pragma warning disable MA0029 // Combine 'Where' with 'Where'
 internal static class ParityCheckHelper
 {
 	public static bool ContainsEquivalentExtensionMethod(this Type abstractionType,
@@ -341,3 +342,5 @@ internal static class ParityCheckHelper
 		return true;
 	}
 }
+
+#pragma warning restore MA0029

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemExtensibilityTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemExtensibilityTests.cs
@@ -52,7 +52,7 @@ public class FileSystemExtensibilityTests
 	[MemberData(nameof(GetFileSystems))]
 	public void DriveInfo_ShouldSetExtensionPoint(IFileSystem fileSystem)
 	{
-		IDriveInfo sut = fileSystem.DriveInfo.GetDrives().First();
+		IDriveInfo sut = fileSystem.DriveInfo.GetDrives()[0];
 
 		IFileSystem result = sut.FileSystem;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoFactoryStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/FileSystem/DriveInfoFactoryStatisticsTests.cs
@@ -35,7 +35,7 @@ public sealed class DriveInfoFactoryStatisticsTests
 	public void Method_Wrap_DriveInfo_ShouldRegisterCall()
 	{
 		MockFileSystem sut = new();
-		DriveInfo driveInfo = DriveInfo.GetDrives().First();
+		DriveInfo driveInfo = DriveInfo.GetDrives()[0];
 
 		sut.DriveInfo.Wrap(driveInfo);
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/MethodStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/MethodStatisticsTests.cs
@@ -10,7 +10,7 @@ public sealed class MethodStatisticsTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "bar");
-		MethodStatistic sut = fileSystem.Statistics.File.Methods.First();
+		MethodStatistic sut = fileSystem.Statistics.File.Methods[0];
 
 		sut.Counter.Should().Be(1);
 	}
@@ -20,7 +20,7 @@ public sealed class MethodStatisticsTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.Directory.CreateDirectory("foo");
-		MethodStatistic sut = fileSystem.Statistics.Directory.Methods.First();
+		MethodStatistic sut = fileSystem.Statistics.Directory.Methods[0];
 
 		string result = sut.ToString();
 
@@ -35,7 +35,7 @@ public sealed class MethodStatisticsTests
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.File.WriteAllText("foo", "bar");
-		MethodStatistic sut = fileSystem.Statistics.File.Methods.First();
+		MethodStatistic sut = fileSystem.Statistics.File.Methods[0];
 
 		string result = sut.ToString();
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/PropertyStatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/PropertyStatisticsTests.cs
@@ -10,7 +10,7 @@ public sealed class PropertyStatisticsTests
 	{
 		MockFileSystem fileSystem = new();
 		_ = fileSystem.Path.DirectorySeparatorChar;
-		PropertyStatistic sut = fileSystem.Statistics.Path.Properties.First();
+		PropertyStatistic sut = fileSystem.Statistics.Path.Properties[0];
 
 		sut.Counter.Should().Be(1);
 	}
@@ -22,7 +22,7 @@ public sealed class PropertyStatisticsTests
 		fileSystem.Initialize().WithFile("foo");
 		IFileInfo fileInfo = fileSystem.FileInfo.New("foo");
 		_ = fileInfo.IsReadOnly;
-		PropertyStatistic sut = fileSystem.Statistics.FileInfo["foo"].Properties.First();
+		PropertyStatistic sut = fileSystem.Statistics.FileInfo["foo"].Properties[0];
 
 		string result = sut.ToString();
 
@@ -38,7 +38,7 @@ public sealed class PropertyStatisticsTests
 		fileSystem.Initialize().WithFile("foo");
 		IFileInfo fileInfo = fileSystem.FileInfo.New("foo");
 		fileInfo.IsReadOnly = false;
-		PropertyStatistic sut = fileSystem.Statistics.FileInfo["foo"].Properties.First();
+		PropertyStatistic sut = fileSystem.Statistics.FileInfo["foo"].Properties[0];
 
 		string result = sut.ToString();
 

--- a/Tests/Testably.Abstractions.Testing.Tests/Statistics/StatisticsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Statistics/StatisticsTests.cs
@@ -152,19 +152,19 @@ public sealed partial class StatisticsTests
 		using FileSystemStream stream = fileInfo.Open(FileMode.Open, FileAccess.Read);
 		_ = new StreamReader(stream).ReadToEnd();
 
-		sut.Statistics.Directory.Methods.First()
+		sut.Statistics.Directory.Methods[0]
 			.Should().Match<MethodStatistic>(m =>
 				m.Name == nameof(IDirectory.CreateDirectory) &&
 				m.Counter == 1);
-		sut.Statistics.File.Methods.First()
+		sut.Statistics.File.Methods[0]
 			.Should().Match<MethodStatistic>(m =>
 				m.Name == nameof(IFile.WriteAllText) &&
 				m.Counter == 2);
-		sut.Statistics.FileInfo.Methods.First()
+		sut.Statistics.FileInfo.Methods[0]
 			.Should().Match<MethodStatistic>(m =>
 				m.Name == nameof(IFileInfoFactory.New) &&
 				m.Counter == 3);
-		sut.Statistics.FileInfo["bar.txt"].Methods.First()
+		sut.Statistics.FileInfo["bar.txt"].Methods[0]
 			.Should().Match<MethodStatistic>(m =>
 				m.Name == nameof(IFileInfo.Open) &&
 				// Note: Index 4 could be used internally for creating the full path of the file info.

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/Tests.cs
@@ -135,7 +135,7 @@ public abstract partial class Tests<TFileSystem>
 		Skip.If(FileSystem is MockFileSystem mockFileSystem &&
 		        mockFileSystem.SimulationMode != SimulationMode.Native);
 
-		System.IO.DriveInfo driveInfo = System.IO.DriveInfo.GetDrives().First();
+		System.IO.DriveInfo driveInfo = System.IO.DriveInfo.GetDrives()[0];
 
 		IDriveInfo result = FileSystem.DriveInfo.Wrap(driveInfo);
 
@@ -148,7 +148,7 @@ public abstract partial class Tests<TFileSystem>
 		Skip.IfNot(FileSystem is MockFileSystem mockFileSystem &&
 		           mockFileSystem.SimulationMode != SimulationMode.Native);
 
-		System.IO.DriveInfo driveInfo = System.IO.DriveInfo.GetDrives().First();
+		System.IO.DriveInfo driveInfo = System.IO.DriveInfo.GetDrives()[0];
 
 		Exception? exception = Record.Exception(() =>
 		{

--- a/Tests/Testably.Abstractions.Tests/RandomSystem/RandomFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/RandomSystem/RandomFactoryTests.cs
@@ -33,7 +33,7 @@ public abstract partial class RandomFactoryTests<TRandomSystem>
 			results.Add(RandomSystem.Random.New(seed).Next());
 		}
 
-		results.Should().AllBeEquivalentTo(results.First());
+		results.Should().AllBeEquivalentTo(results[0]);
 	}
 
 	[SkippableFact]


### PR DESCRIPTION
Fix the following rules:
- Fix [MA0053](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0053.md): Make class sealed
- Fix [MA0098](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0098.md): Use '[]' instead of 'First()'
- Fix [MA0029](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0029.md): Combine 'Where' with 'Where'
- Fix [MA0154](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0154.md): Use langword in XML comment

Disable the following rules:
- [MA0003](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0003.md)
- [MA0004](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0004.md)
- [MA0042](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md)
- [MA0076](https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0076.md)
- [xUnit1044](https://xunit.net/xunit.analyzers/rules/xUnit1044) (tests only)
- [xUnit1045](https://xunit.net/xunit.analyzers/rules/xUnit1045) (tests only)
- [NU1603](https://learn.microsoft.com/de-de/nuget/reference/errors-and-warnings/nu1603) (tests only)