### PR TITLE
refactor: simplify `InternalsVisibleTo`

### DIFF
--- a/Source/Testably.Abstractions.AccessControl/Testably.Abstractions.AccessControl.csproj
+++ b/Source/Testably.Abstractions.AccessControl/Testably.Abstractions.AccessControl.csproj
@@ -25,9 +25,7 @@
 			<_Parameter1>true</_Parameter1>
 			<_Parameter1_TypeName>System.Boolean</_Parameter1_TypeName>
 		</AssemblyAttribute>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-			<_Parameter1>Testably.Abstractions.AccessControl.Tests</_Parameter1>
-		</AssemblyAttribute>
+		<InternalsVisibleTo Include="Testably.Abstractions.AccessControl.Tests" />
 	</ItemGroup>
 
 </Project>

--- a/Source/Testably.Abstractions.Compression/Testably.Abstractions.Compression.csproj
+++ b/Source/Testably.Abstractions.Compression/Testably.Abstractions.Compression.csproj
@@ -21,9 +21,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-			<_Parameter1>Testably.Abstractions.Compression.Tests</_Parameter1>
-		</AssemblyAttribute>
+		<InternalsVisibleTo Include="Testably.Abstractions.Compression.Tests" />
 	</ItemGroup>
 
 </Project>

--- a/Source/Testably.Abstractions.Testing/Testably.Abstractions.Testing.csproj
+++ b/Source/Testably.Abstractions.Testing/Testably.Abstractions.Testing.csproj
@@ -18,9 +18,7 @@
 			<_Parameter1>true</_Parameter1>
 			<_Parameter1_TypeName>System.Boolean</_Parameter1_TypeName>
 		</AssemblyAttribute>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-			<_Parameter1>Testably.Abstractions.Testing.Tests</_Parameter1>
-		</AssemblyAttribute>
+		<InternalsVisibleTo Include="Testably.Abstractions.Testing.Tests" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Testably.Abstractions/Testably.Abstractions.csproj
+++ b/Source/Testably.Abstractions/Testably.Abstractions.csproj
@@ -19,9 +19,7 @@
 			<_Parameter1>true</_Parameter1>
 			<_Parameter1_TypeName>System.Boolean</_Parameter1_TypeName>
 		</AssemblyAttribute>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-			<_Parameter1>Testably.Abstractions.Tests</_Parameter1>
-		</AssemblyAttribute>
+		<InternalsVisibleTo Include="Testably.Abstractions.Tests" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Use the `InternalsVisibleTo` property instead of the generic "AssemblyAttribute"