### PR TITLE
fix: avoid warnings about untested "System.Threading.Channels" version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,51 +3,62 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Threading.Channels" Version="9.0.0" />
-    <PackageVersion Include="TestableIO.System.IO.Abstractions" Version="21.2.1" />
-    <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
-    <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
+    <PackageVersion Include="DotNet.Glob" Version="3.1.3"/>
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1"/>
+    <PackageVersion Include="TestableIO.System.IO.Abstractions" Version="21.2.1"/>
+    <PackageVersion Include="System.IO.Compression" Version="4.3.0"/>
+    <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0"/>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageVersion Include="System.Threading.Channels" Version="6.0.0"/>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageVersion Include="System.Threading.Channels" Version="7.0.0"/>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageVersion Include="System.Threading.Channels" Version="8.0.0"/>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' And '$(TargetFramework)' != 'net7.0' And '$(TargetFramework)' != 'net6.0' ">
+    <PackageVersion Include="System.Threading.Channels" Version="9.0.0"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="MinVer" Version="6.0.0" />
-    <PackageVersion Include="Nullable" Version="1.3.1" />
+    <PackageVersion Include="MinVer" Version="6.0.0"/>
+    <PackageVersion Include="Nullable" Version="1.3.1"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Nuke.Common" Version="9.0.3" />
-    <PackageVersion Include="Nuke.Components" Version="9.0.3" />
-    <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
-    <PackageVersion Include="SharpCompress" Version="0.38.0" />
+    <PackageVersion Include="Nuke.Common" Version="9.0.3"/>
+    <PackageVersion Include="Nuke.Components" Version="9.0.3"/>
+    <PackageVersion Include="LibGit2Sharp" Version="0.31.0"/>
+    <PackageVersion Include="SharpCompress" Version="0.38.0"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
-    <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
-    <PackageVersion Include="aweXpect" Version="0.15.0" />
-    <PackageVersion Include="aweXpect.Testably" Version="0.2.0" />
-    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
-    <PackageVersion Include="PublicApiGenerator" Version="11.3.0" />
-    <PackageVersion Include="NUnit" Version="4.3.2" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.6.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1"/>
+    <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1"/>
+    <PackageVersion Include="aweXpect" Version="0.15.0"/>
+    <PackageVersion Include="aweXpect.Testably" Version="0.2.0"/>
+    <PackageVersion Include="FluentAssertions" Version="7.0.0"/>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23"/>
+    <PackageVersion Include="xunit" Version="2.9.3"/>
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
+    <PackageVersion Include="coverlet.collector" Version="6.0.3"/>
+    <PackageVersion Include="PublicApiGenerator" Version="11.3.0"/>
+    <PackageVersion Include="NUnit" Version="4.3.2"/>
+    <PackageVersion Include="NUnit.Analyzers" Version="4.6.0"/>
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Testably.Abstractions" Version="3.2.4" />
-    <PackageVersion Include="Testably.Abstractions.Testing" Version="3.2.4" />
-    <PackageVersion Include="Testably.Abstractions.FluentAssertions" Version="1.1.0" />
+    <PackageVersion Include="Testably.Abstractions" Version="3.2.4"/>
+    <PackageVersion Include="Testably.Abstractions.Testing" Version="3.2.4"/>
+    <PackageVersion Include="Testably.Abstractions.FluentAssertions" Version="1.1.0"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.185" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.185"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Use a framework-dependent version of ["System.Threading.Channels"](https://www.nuget.org/packages/System.Threading.Channels#versions-body-tab).