### PR TITLE
fix: trigger build on tags with pre-release information

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     workflow_dispatch: 
     push:
         branches: [ main ]
-        tags: [ 'v[0-9]+.[0-9]+.[0-9]+', 'core/v[0-9]+.[0-9]+.[0-9]+' ]
+        tags: [ 'v[0-9]+.[0-9]+.[0-9]+*', 'core/v[0-9]+.[0-9]+.[0-9]+*' ]
 
 jobs:
     unit-tests:


### PR DESCRIPTION
Allow creating pre-release nuget packages by appending e.g. "-pre.1" to the tag