### PR TITLE
chore: update aweXpect.Testably to v0.8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,7 +36,7 @@
 		<PackageVersion Include="AutoFixture.AutoNSubstitute" Version="5.0.0-preview0012"/>
 		<PackageVersion Include="AutoFixture.Xunit3" Version="5.0.0-preview0012"/>
 		<PackageVersion Include="aweXpect" Version="1.6.0"/>
-		<PackageVersion Include="aweXpect.Testably" Version="0.7.0"/>
+		<PackageVersion Include="aweXpect.Testably" Version="0.8.0"/>
 		<PackageVersion Include="FluentAssertions" Version="7.2.0"/>
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
 		<PackageVersion Include="xunit.v3" Version="1.1.0"/>

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
@@ -82,7 +82,7 @@ public partial class CreateFromDirectoryTests
 		using IZipArchive archive =
 			FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
 
-		var singleEntry = await That(archive.Entries).HasSingle();
+		IZipArchiveEntry singleEntry = await That(archive.Entries).HasSingle();
 		if (encodedCorrectly)
 		{
 			await That(singleEntry.Name).IsEqualTo(entryName);
@@ -150,9 +150,8 @@ public partial class CreateFromDirectoryTests
 
 		FileSystem.ZipFile().ExtractToDirectory("destination.zip", "destination");
 
-		await That(FileSystem).HasFile("destination/bar/test.txt");
-		await That(FileSystem.File.ReadAllBytes("destination/bar/test.txt"))
-			.IsEqualTo(FileSystem.File.ReadAllBytes("foo/bar/test.txt"));
+		await That(FileSystem).HasFile("destination/bar/test.txt")
+			.WithContent().SameAs("foo/bar/test.txt");
 	}
 
 #if FEATURE_COMPRESSION_STREAM
@@ -204,8 +203,9 @@ public partial class CreateFromDirectoryTests
 #if FEATURE_COMPRESSION_STREAM
 	[Theory]
 	[AutoData]
-	public async Task CreateFromDirectory_WithStream_EmptySource_DoNotIncludeBaseDirectory_ShouldBeEmpty(
-		CompressionLevel compressionLevel)
+	public async Task
+		CreateFromDirectory_WithStream_EmptySource_DoNotIncludeBaseDirectory_ShouldBeEmpty(
+			CompressionLevel compressionLevel)
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
@@ -258,7 +258,7 @@ public partial class CreateFromDirectoryTests
 
 		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
 
-		var singleEntry = await That(archive.Entries).HasSingle();
+		IZipArchiveEntry singleEntry = await That(archive.Entries).HasSingle();
 		if (encodedCorrectly)
 		{
 			await That(singleEntry.Name).IsEqualTo(entryName);
@@ -273,8 +273,9 @@ public partial class CreateFromDirectoryTests
 #if FEATURE_COMPRESSION_STREAM
 	[Theory]
 	[AutoData]
-	public async Task CreateFromDirectory_WithStream_IncludeBaseDirectory_ShouldPrependDirectoryName(
-		CompressionLevel compressionLevel)
+	public async Task
+		CreateFromDirectory_WithStream_IncludeBaseDirectory_ShouldPrependDirectoryName(
+			CompressionLevel compressionLevel)
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("foo").Initialized(s => s
@@ -368,9 +369,8 @@ public partial class CreateFromDirectoryTests
 
 		FileSystem.ZipFile().ExtractToDirectory(stream, "destination");
 
-		await That(FileSystem).HasFile("destination/bar/test.txt");
-		await That(FileSystem.File.ReadAllBytes("destination/bar/test.txt"))
-			.IsEqualTo(FileSystem.File.ReadAllBytes("foo/bar/test.txt"));
+		await That(FileSystem).HasFile("destination/bar/test.txt")
+			.WithContent().SameAs("foo/bar/test.txt");
 	}
 #endif
 

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
@@ -21,9 +21,8 @@ public partial class ExtractToDirectoryTests
 
 		FileSystem.ZipFile().ExtractToDirectory("destination.zip", "bar");
 
-		await That(FileSystem).HasFile("bar/test.txt");
-		await That(FileSystem.File.ReadAllBytes("bar/test.txt"))
-			.IsEqualTo(FileSystem.File.ReadAllBytes("foo/test.txt"));
+		await That(FileSystem).HasFile("bar/test.txt")
+			.WithContent().SameAs("foo/test.txt");
 	}
 
 	[Fact]
@@ -120,9 +119,8 @@ public partial class ExtractToDirectoryTests
 
 		FileSystem.ZipFile().ExtractToDirectory("destination.zip", "bar", encoding);
 
-		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"));
-		await That(FileSystem.File.ReadAllBytes(FileSystem.Path.Combine("bar", "test.txt")))
-			.IsEqualTo(FileSystem.File.ReadAllBytes(FileSystem.Path.Combine("foo", "test.txt")));
+		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"))
+			.WithContent().SameAs(FileSystem.Path.Combine("foo", "test.txt"));
 	}
 
 	[Theory]
@@ -155,7 +153,8 @@ public partial class ExtractToDirectoryTests
 
 #if FEATURE_COMPRESSION_STREAM
 	[Fact]
-	public async Task ExtractToDirectory_WithStream_MissingDestinationDirectory_ShouldCreateDirectory()
+	public async Task
+		ExtractToDirectory_WithStream_MissingDestinationDirectory_ShouldCreateDirectory()
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("foo").Initialized(s => s
@@ -166,9 +165,8 @@ public partial class ExtractToDirectoryTests
 
 		FileSystem.ZipFile().ExtractToDirectory(stream, "bar");
 
-		await That(FileSystem).HasFile("bar/test.txt");
-		await That(FileSystem.File.ReadAllBytes("bar/test.txt"))
-			.IsEqualTo(FileSystem.File.ReadAllBytes("foo/test.txt"));
+		await That(FileSystem).HasFile("bar/test.txt")
+			.WithContent().SameAs("foo/test.txt");
 	}
 #endif
 
@@ -276,17 +274,17 @@ public partial class ExtractToDirectoryTests
 
 		FileSystem.ZipFile().ExtractToDirectory(stream, "bar", encoding);
 
-		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"));
-		await That(FileSystem.File.ReadAllBytes(FileSystem.Path.Combine("bar", "test.txt")))
-			.IsEqualTo(FileSystem.File.ReadAllBytes(FileSystem.Path.Combine("foo", "test.txt")));
+		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"))
+			.WithContent().SameAs(FileSystem.Path.Combine("foo", "test.txt"));
 	}
 #endif
 
 #if FEATURE_COMPRESSION_STREAM
 	[Theory]
 	[AutoData]
-	public async Task ExtractToDirectory_WithStream_WithoutOverwriteAndExistingFile_ShouldOverwriteFile(
-		string contents)
+	public async Task
+		ExtractToDirectory_WithStream_WithoutOverwriteAndExistingFile_ShouldOverwriteFile(
+			string contents)
 	{
 		FileSystem.Initialize()
 			.WithSubdirectory("bar").Initialized(s => s


### PR DESCRIPTION
Use new functionality with file content `SameAs` in tests