### PR TITLE
refactor: remove NCrunch from test projects

### DIFF
--- a/Tests/Api/Testably.Abstractions.Api.Tests/Testably.Abstractions.Api.Tests.csproj
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Testably.Abstractions.Api.Tests.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup Condition="'$(NCrunch)' == '1'">
-		<TargetFrameworks>net8.0</TargetFrameworks>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="PublicApiGenerator"/>
 	</ItemGroup>

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Testably.Abstractions.Core.Api.Tests.csproj
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Testably.Abstractions.Core.Api.Tests.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup Condition="'$(NCrunch)' == '1'">
-		<TargetFrameworks>net8.0</TargetFrameworks>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="PublicApiGenerator" />
 	</ItemGroup>

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -4,10 +4,14 @@
 	        Condition="Exists('$(MSBuildThisFileDirectory)/../Directory.Build.props')" />
 	<Import Project="$([MSBuild]::GetPathOfFileAbove('Feature.Flags.props', '$(MSBuildThisFileDirectory)/../'))" />
 
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(NCrunch)' != '1'">
 		<TargetFrameworks Condition="'$(NetCoreOnly)' != 'True'">net6.0;net8.0;net9.0;net48</TargetFrameworks>
 		<TargetFrameworks Condition="'$(NetCoreOnly)' == 'True'">net6.0;net8.0;net9.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(NetFrameworkOnly)' == 'True'">net48</TargetFrameworks>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(NCrunch)' == '1'">
+		<TargetFrameworks>net9.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/Testably.Abstractions.TestHelpers.csproj
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/Testably.Abstractions.TestHelpers.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup Condition="'$(NCrunch)' == '1'">
-		<TargetFrameworks>net6.0</TargetFrameworks>
-	</PropertyGroup>
-
 	<PropertyGroup>
 		<TargetFrameworks>$(TargetFrameworks);netstandard2.0</TargetFrameworks>
 		<IsTestProject>false</IsTestProject>

--- a/Tests/Settings/Testably.Abstractions.TestSettings/Testably.Abstractions.TestSettings.csproj
+++ b/Tests/Settings/Testably.Abstractions.TestSettings/Testably.Abstractions.TestSettings.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup Condition="'$(NCrunch)' == '1'">
-		<TargetFrameworks>net8.0</TargetFrameworks>
-	</PropertyGroup>
-
 	<ItemGroup>
 	  <ProjectReference Include="..\..\Helpers\Testably.Abstractions.TestHelpers\Testably.Abstractions.TestHelpers.csproj" />
 	</ItemGroup>

--- a/Tests/Testably.Abstractions.AccessControl.Tests/Testably.Abstractions.AccessControl.Tests.csproj
+++ b/Tests/Testably.Abstractions.AccessControl.Tests/Testably.Abstractions.AccessControl.Tests.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup Condition="'$(NCrunch)' == '1'">
-		<TargetFrameworks>net6.0</TargetFrameworks>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<ProjectReference Include="..\..\Source\Testably.Abstractions.AccessControl\Testably.Abstractions.AccessControl.csproj" />
 		<ProjectReference Include="..\..\Source\Testably.Abstractions.Testing\Testably.Abstractions.Testing.csproj" />

--- a/Tests/Testably.Abstractions.Compression.Tests/Testably.Abstractions.Compression.Tests.csproj
+++ b/Tests/Testably.Abstractions.Compression.Tests/Testably.Abstractions.Compression.Tests.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup Condition="'$(NCrunch)' == '1'">
-		<TargetFrameworks>net6.0</TargetFrameworks>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<ProjectReference Include="..\..\Source\Testably.Abstractions.Compression\Testably.Abstractions.Compression.csproj" />
 		<ProjectReference Include="..\..\Source\Testably.Abstractions.Testing\Testably.Abstractions.Testing.csproj" />

--- a/Tests/Testably.Abstractions.Parity.Tests/Testably.Abstractions.Parity.Tests.csproj
+++ b/Tests/Testably.Abstractions.Parity.Tests/Testably.Abstractions.Parity.Tests.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup Condition="'$(NCrunch)' == '1'">
-		<TargetFrameworks>net6.0</TargetFrameworks>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="Testably.Abstractions.Interface" />
 		<ProjectReference Include="..\..\Source\Testably.Abstractions.Compression\Testably.Abstractions.Compression.csproj" />

--- a/Tests/Testably.Abstractions.Testing.Tests/Testably.Abstractions.Testing.Tests.csproj
+++ b/Tests/Testably.Abstractions.Testing.Tests/Testably.Abstractions.Testing.Tests.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup Condition="'$(NCrunch)' == '1'">
-		<TargetFrameworks>net6.0</TargetFrameworks>
-	</PropertyGroup>
-
 	<ItemGroup>
 	  <None Remove="TestResources\SubResource\SubResourceFile1.txt" />
 	  <None Remove="TestResources\TestFile1.txt" />

--- a/Tests/Testably.Abstractions.Tests/Testably.Abstractions.Tests.csproj
+++ b/Tests/Testably.Abstractions.Tests/Testably.Abstractions.Tests.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup Condition="'$(NCrunch)' == '1'">
-		<TargetFrameworks>net6.0</TargetFrameworks>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="Testably.Abstractions.Interface" />
 		<ProjectReference Include="..\..\Source\Testably.Abstractions\Testably.Abstractions.csproj" />


### PR DESCRIPTION
Consolidate NCrunch target framework in the `Directory.Build.props` file for tests.