### PR TITLE
fix: zipped file remains locked after `ZipFile().CreateFromDirectory`

### DIFF
--- a/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
+++ b/Source/Testably.Abstractions.Compression/Internal/ZipUtilities.cs
@@ -96,7 +96,8 @@ internal static class ZipUtilities
 						? archive.CreateEntry(entryName, compressionLevel.Value)
 						: archive.CreateEntry(entryName);
 					using Stream stream = entry.Open();
-					fileInfo.OpenRead().CopyTo(stream);
+					using FileSystemStream fileStream = fileInfo.OpenRead();
+					fileStream.CopyTo(stream);
 				}
 				else if (file is IDirectoryInfo directoryInfo &&
 				         directoryInfo.GetFileSystemInfos().Length == 0)
@@ -172,7 +173,8 @@ internal static class ZipUtilities
 						? archive.CreateEntry(entryName, compressionLevel.Value)
 						: archive.CreateEntry(entryName);
 					using Stream stream = entry.Open();
-					fileInfo.OpenRead().CopyTo(stream);
+					using FileSystemStream fileStream = fileInfo.OpenRead();
+					fileStream.CopyTo(stream);
 				}
 				else if (file is IDirectoryInfo directoryInfo &&
 				         directoryInfo.GetFileSystemInfos().Length == 0)

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
@@ -374,6 +374,21 @@ public partial class CreateFromDirectoryTests
 	}
 #endif
 
+	[Fact]
+	public async Task ShouldNotLock()
+	{
+		string directory = "ToBeZipped";
+		string archive = "zippedDirectory.zip";
+		FileSystem.Directory.CreateDirectory(directory);
+		FileSystem.File.WriteAllText(FileSystem.Path.Combine(directory, "file.txt"),
+			"Some content");
+		void Act() => FileSystem.Directory.Delete(directory, true);
+
+		FileSystem.ZipFile().CreateFromDirectory(directory, archive);
+
+		await That(Act).DoesNotThrow();
+	}
+
 	#region Helpers
 
 	#pragma warning disable MA0018


### PR DESCRIPTION
Fixes #763 

The file stream used to create the zip file was not disposed correctly.