### PR TITLE
feat: support Windows NT device alias path prefixes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,8 +35,8 @@
 	<ItemGroup>
 		<PackageVersion Include="AutoFixture.AutoNSubstitute" Version="5.0.0-preview0012"/>
 		<PackageVersion Include="AutoFixture.Xunit3" Version="5.0.0-preview0012"/>
-		<PackageVersion Include="aweXpect" Version="1.6.0"/>
-		<PackageVersion Include="aweXpect.Testably" Version="0.8.0"/>
+		<PackageVersion Include="aweXpect" Version="2.18.0"/>
+		<PackageVersion Include="aweXpect.Testably" Version="0.10.0"/>
 		<PackageVersion Include="FluentAssertions" Version="7.2.0"/>
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
 		<PackageVersion Include="xunit.v3" Version="2.0.3"/>

--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
@@ -696,7 +696,7 @@ internal sealed class DirectoryMock : IDirectory
 	{
 		StorageExtensions.AdjustedLocation adjustedLocation = _fileSystem.Storage
 			.AdjustLocationFromSearchPattern(_fileSystem,
-				path.EnsureValidFormat(_fileSystem),
+				path,
 				searchPattern);
 		return _fileSystem.Storage.EnumerateLocations(
 				adjustedLocation.Location,

--- a/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/FileSystemExtensions.cs
@@ -63,6 +63,11 @@ internal static class FileSystemExtensions
 				return friendlyName;
 			}
 
+			if (givenPath.IsNtDeviceAlias(fileSystem.Execute))
+			{
+				return givenPath.Substring(0, 4) + fullFilePath;
+			}
+
 			return fullFilePath;
 		}
 

--- a/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Testably.Abstractions.Testing.Helpers;
 
@@ -21,6 +22,7 @@ internal static class PathHelper
 		string? paramName = null,
 		bool? includeIsEmptyCheck = null)
 	{
+		path = RemoveNtDeviceAliasPrefix(path, fileSystem.Execute);
 		CheckPathArgument(fileSystem.Execute, path, paramName ?? nameof(path),
 			includeIsEmptyCheck ?? fileSystem.Execute.IsWindows);
 		CheckPathCharacters(path, fileSystem, paramName ?? nameof(path), null);
@@ -96,6 +98,21 @@ internal static class PathHelper
 		return false;
 	}
 
+	/// <summary>
+	///     Checks if the path is a Windows NT device alias, meaning it starts with <c>\\?\</c>, <c>\??\</c> or <c>\\.\</c>.
+	/// </summary>
+	internal static bool IsNtDeviceAlias(this string path, Execute execute)
+	{
+		if (execute.IsWindows && path.StartsWith(@"\", StringComparison.Ordinal))
+		{
+			string[] specialPaths = [@"\\?\", @"\??\", @"\\.\",];
+			return specialPaths.Any(specialPath
+				=> path.StartsWith(specialPath, StringComparison.Ordinal));
+		}
+
+		return false;
+	}
+
 	internal static bool IsUncPath([NotNullWhen(true)] this string? path, MockFileSystem fileSystem)
 	{
 		if (path == null)
@@ -113,15 +130,37 @@ internal static class PathHelper
 				       StringComparison.OrdinalIgnoreCase);
 		}
 
-
 		return path.StartsWith(
 			new string(fileSystem.Execute.Path.DirectorySeparatorChar, 2),
 			StringComparison.OrdinalIgnoreCase);
 	}
 
+	/// <summary>
+	///     Removes the Windows NT device alias prefix from <paramref name="path" />, if it has any.
+	/// </summary>
+	/// <remarks>
+	///     A Windows NT device alias starts with <c>\\?\</c>, <c>\??\</c> or <c>\\.\</c>.
+	/// </remarks>
+	[return: NotNullIfNotNull(nameof(path))]
+	internal static string? RemoveNtDeviceAliasPrefix(this string? path, Execute execute)
+	{
+		if (path is null)
+		{
+			return null;
+		}
+
+		if (path.IsNtDeviceAlias(execute))
+		{
+			return path.Substring(4);
+		}
+
+		return path;
+	}
+
 	internal static void ThrowCommonExceptionsIfPathToTargetIsInvalid(
 		[NotNull] this string? pathToTarget, MockFileSystem fileSystem)
 	{
+		pathToTarget = RemoveNtDeviceAliasPrefix(pathToTarget, fileSystem.Execute);
 		CheckPathArgument(fileSystem.Execute, pathToTarget, nameof(pathToTarget), false);
 		CheckPathCharacters(pathToTarget, fileSystem, nameof(pathToTarget), -2147024713);
 	}

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
@@ -148,6 +148,7 @@ internal sealed class InMemoryLocation : IStorageLocation
 
 	private static string NormalizeKey(MockFileSystem fileSystem, string fullPath)
 	{
+		fullPath = fullPath.RemoveNtDeviceAliasPrefix(fileSystem.Execute);
 #if FEATURE_PATH_ADVANCED
 		return fileSystem.Execute.Path.TrimEndingDirectorySeparator(fullPath);
 #else

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -304,6 +304,8 @@ internal sealed class InMemoryStorage : IStorage
 			}
 		}
 
+		driveName = driveName.RemoveNtDeviceAliasPrefix(_fileSystem.Execute);
+
 		DriveInfoMock drive = DriveInfoMock.New(driveName, _fileSystem);
 		return _drives.GetValueOrDefault(drive.GetName());
 	}

--- a/Source/Testably.Abstractions.Testing/Storage/StorageExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/StorageExtensions.cs
@@ -22,8 +22,8 @@ internal static class StorageExtensions
 			throw ExceptionFactory.SearchPatternCannotContainTwoDots();
 		}
 
-		IStorageLocation location = storage.GetLocation(path);
-		string givenPath = location.FriendlyName;
+		IStorageLocation location = storage.GetLocation(path.EnsureValidFormat(fileSystem));
+		string givenPath = path.StartsWith(@"\", StringComparison.Ordinal) ? path : location.FriendlyName;
 		if (searchPattern.StartsWith("..", StringComparison.Ordinal))
 		{
 			Stack<string> parentDirectories = new();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -48,6 +48,16 @@ public partial class CreateDirectoryTests
 		}
 	}
 
+	[Fact]
+	public async Task CreateDirectory_ShouldSupportExtendedLengthPaths()
+	{
+		Skip.If(!Test.RunsOnWindows);
+
+		FileSystem.DirectoryInfo.New(@"\\?\c:\bar").Create();
+
+		await That(FileSystem.Directory.Exists(@"\\?\c:\bar")).IsTrue();
+	}
+
 	[Theory]
 	[AutoData]
 	public void CreateDirectory_FileWithSameNameAlreadyExists_ShouldThrowIOException(string name)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+#if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS
 using Testably.Abstractions.Testing.FileSystem;
+#endif
 
 namespace Testably.Abstractions.Tests.FileSystem.Directory;
 
@@ -180,6 +182,38 @@ public partial class EnumerateDirectoriesTests
 			result.Should()
 				.BeEmpty($"{extension} should not match {searchPattern}");
 		}
+	}
+
+	[Fact]
+	public async Task EnumerateDirectories_ShouldSupportExtendedLengthPaths1()
+	{
+		Skip.If(!Test.RunsOnWindows);
+
+		FileSystem.Directory.CreateDirectory(@"\\?\c:\bar");
+		FileSystem.File.WriteAllText(@"\\?\c:\bar\foo1.txt", "foo1");
+		FileSystem.File.WriteAllText(@"\\?\c:\bar\foo2.txt", "foo2");
+
+		IEnumerable<string> result = FileSystem.Directory.EnumerateFiles(@"c:\bar");
+
+		await That(result)
+			.IsEqualTo([@"c:\bar\foo1.txt", @"c:\bar\foo2.txt"])
+			.InAnyOrder();
+	}
+
+	[Fact]
+	public async Task EnumerateDirectories_ShouldSupportExtendedLengthPaths2()
+	{
+		Skip.If(!Test.RunsOnWindows);
+
+		FileSystem.Directory.CreateDirectory(@"\\?\c:\bar");
+		FileSystem.File.WriteAllText(@"\\?\c:\bar\foo1.txt", "foo1");
+		FileSystem.File.WriteAllText(@"\\?\c:\bar\foo2.txt", "foo2");
+
+		IEnumerable<string> result = FileSystem.Directory.EnumerateFiles(@"\\?\c:\bar");
+
+		await That(result)
+			.IsEqualTo([@"\\?\c:\bar\foo1.txt", @"\\?\c:\bar\foo2.txt"])
+			.InAnyOrder();
 	}
 
 #if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS


### PR DESCRIPTION
Support paths with a Windows NT device alias (`\\?\`, `\??\` or `\\.\`)