### PR TITLE
refactor: remove .NET6 from test projects

### DIFF
--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -5,8 +5,8 @@
 	<Import Project="$([MSBuild]::GetPathOfFileAbove('Feature.Flags.props', '$(MSBuildThisFileDirectory)/../'))" />
 
 	<PropertyGroup Condition="'$(NCrunch)' != '1'">
-		<TargetFrameworks Condition="'$(NetCoreOnly)' != 'True'">net6.0;net8.0;net9.0;net48</TargetFrameworks>
-		<TargetFrameworks Condition="'$(NetCoreOnly)' == 'True'">net6.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$(NetCoreOnly)' != 'True'">net8.0;net9.0;net48</TargetFrameworks>
+		<TargetFrameworks Condition="'$(NetCoreOnly)' == 'True'">net8.0;net9.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(NetFrameworkOnly)' == 'True'">net48</TargetFrameworks>
 	</PropertyGroup>
 


### PR DESCRIPTION
As .NET6 is no longer officially supported, remove it from the test projects (but leave it as build target for the time being).