### PR TITLE
fix: parallel access to `IFileStream`

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -324,6 +324,8 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 			throw ExceptionFactory.StreamDoesNotSupportWriting();
 		}
 
+		_minWrite = Position;
+		_maxWrite = Position + count;
 		return base.BeginWrite(buffer, offset, count, callback, state);
 	}
 
@@ -711,7 +713,7 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 		_ = _stream.Read(data, 0, (int)Length);
 		_stream.Seek(position, SeekOrigin.Begin);
 		_container.WriteBytes(data);
-		_minWrite = int.MaxValue;
+		_minWrite = long.MaxValue;
 		_maxWrite = 0;
 	}
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamMock.cs
@@ -701,7 +701,7 @@ internal sealed class FileStreamMock : FileSystemStream, IFileSystemExtensibilit
 
 	private void InternalFlush()
 	{
-		if (!_isContentChanged || Length == 0)
+		if (!_isContentChanged)
 		{
 			return;
 		}

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
@@ -69,8 +69,7 @@ public class TimerMockTests(ITestOutputHelper testOutputHelper)
 		await That(Act).Throws<ObjectDisposedException>()
 			.Whose(x => x.Message,
 				it => it.Satisfies(m
-					=> m != null &&
-					   m.Contains("Cannot access a disposed object.", StringComparison.Ordinal) &&
+					=> m!.Contains("Cannot access a disposed object.", StringComparison.Ordinal) &&
 					   m.Contains(nameof(ITimer.Change), StringComparison.Ordinal)));
 #endif
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
@@ -69,7 +69,8 @@ public class TimerMockTests(ITestOutputHelper testOutputHelper)
 		await That(Act).Throws<ObjectDisposedException>()
 			.Whose(x => x.Message,
 				it => it.Satisfies(m
-					=> m!.Contains("Cannot access a disposed object.", StringComparison.Ordinal) &&
+					=> m != null &&
+					   m.Contains("Cannot access a disposed object.", StringComparison.Ordinal) &&
 					   m.Contains(nameof(ITimer.Change), StringComparison.Ordinal)));
 #endif
 	}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ParallelTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ParallelTests.cs
@@ -1,0 +1,126 @@
+using System.IO;
+using System.Text;
+
+namespace Testably.Abstractions.Tests.FileSystem.FileStream;
+
+[FileSystemTests]
+public partial class ParallelTests
+{
+	[Theory]
+	[AutoData]
+	public async Task MultipleFlush_ShouldKeepLatestChanges(string path)
+	{
+		using (FileSystemStream stream1 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
+			FileAccess.Write, FileShare.ReadWrite))
+		{
+			using FileSystemStream stream2 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
+				FileAccess.Write, FileShare.ReadWrite);
+
+			stream2.Write(Encoding.UTF8.GetBytes("foo"), 0, 3);
+			stream1.Write(Encoding.UTF8.GetBytes("bar"), 0, 3);
+
+			stream1.Flush();
+			stream2.Flush();
+		}
+		
+		await That(FileSystem.File.ReadAllText(path)).IsEqualTo("foo");
+	}
+	
+	[Theory]
+	[AutoData]
+	public async Task MultipleFlush_DifferentLength_ShouldKeepAdditionalBytes(string path)
+	{
+		using (FileSystemStream stream1 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
+			FileAccess.Write, FileShare.ReadWrite))
+		{
+			using FileSystemStream stream2 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
+				FileAccess.Write, FileShare.ReadWrite);
+
+			stream2.Write(Encoding.UTF8.GetBytes("foo"), 0, 3);
+			stream1.Write(Encoding.UTF8.GetBytes("barfoo"), 0, 6);
+
+			await That(stream1).HasLength().EqualTo(6);
+			await That(stream2).HasLength().EqualTo(3);
+			
+			stream1.Flush();
+			
+			await That(stream1).HasLength().EqualTo(6);
+			await That(stream2).HasLength().EqualTo(6);
+			
+			stream2.Flush();
+			
+			await That(stream1).HasLength().EqualTo(6);
+			await That(stream2).HasLength().EqualTo(6);
+		}
+		
+		await That(FileSystem.File.ReadAllText(path)).IsEqualTo("foofoo");
+	}
+	
+	[Theory]
+	[AutoData]
+	public async Task MultipleFlush_DifferentPosition_ShouldKeepAdditionalBytes(string path)
+	{
+		FileSystem.File.WriteAllText(path, "AAAAAAAAAAAA");
+		using (FileSystemStream stream1 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
+			FileAccess.Write, FileShare.ReadWrite))
+		{
+			using FileSystemStream stream2 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
+				FileAccess.Write, FileShare.ReadWrite);
+			stream2.Position = 3;
+			stream1.Position = 2;
+
+			stream2.Write(Encoding.UTF8.GetBytes("CCC"), 0, 3);
+			stream1.Write(Encoding.UTF8.GetBytes("bbbbbb"), 0, 6);
+
+			stream1.Flush();
+			stream2.Flush();
+		}
+		
+		await That(FileSystem.File.ReadAllText(path)).IsEqualTo("AAbCCCbbAAAA");
+	}
+	
+	[Theory]
+	[AutoData]
+	public async Task MultipleFlush_DifferentPositionWithGaps_ShouldKeepAdditionalBytes(string path)
+	{
+		FileSystem.File.WriteAllText(path, "AAAAAAAAAAAA");
+		using (FileSystemStream stream1 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
+			FileAccess.Write, FileShare.ReadWrite))
+		{
+			using FileSystemStream stream2 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
+				FileAccess.Write, FileShare.ReadWrite);
+			stream1.Position = 2;
+
+			stream2.Position = 3;
+			stream2.Write(Encoding.UTF8.GetBytes("C"), 0, 1);
+			stream2.Position = 5;
+			stream2.Write(Encoding.UTF8.GetBytes("C"), 0, 1);
+			stream1.Write(Encoding.UTF8.GetBytes("bbbbbb"), 0, 6);
+
+			stream1.Flush();
+			stream2.Flush();
+		}
+		
+		await That(FileSystem.File.ReadAllText(path)).IsEqualTo("AAbbbCbbAAAA");
+	}
+	
+	[Theory]
+	[AutoData]
+	public async Task WriteEmpty_ShouldNotOverwrite(string path)
+	{
+		using (FileSystemStream stream1 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
+			FileAccess.Write, FileShare.ReadWrite))
+		{
+			using FileSystemStream stream2 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
+				FileAccess.Write, FileShare.ReadWrite);
+
+			stream2.Write(Encoding.UTF8.GetBytes(""), 0, 0);
+			stream1.Write(Encoding.UTF8.GetBytes("barfoo"), 0, 6);
+
+			stream1.Flush();
+			stream2.Flush();
+		}
+		
+		await That(FileSystem.File.ReadAllText(path)).IsEqualTo("barfoo");
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ParallelTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileStream/ParallelTests.cs
@@ -8,26 +8,6 @@ public partial class ParallelTests
 {
 	[Theory]
 	[AutoData]
-	public async Task MultipleFlush_ShouldKeepLatestChanges(string path)
-	{
-		using (FileSystemStream stream1 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
-			FileAccess.Write, FileShare.ReadWrite))
-		{
-			using FileSystemStream stream2 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
-				FileAccess.Write, FileShare.ReadWrite);
-
-			stream2.Write(Encoding.UTF8.GetBytes("foo"), 0, 3);
-			stream1.Write(Encoding.UTF8.GetBytes("bar"), 0, 3);
-
-			stream1.Flush();
-			stream2.Flush();
-		}
-		
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo("foo");
-	}
-	
-	[Theory]
-	[AutoData]
 	public async Task MultipleFlush_DifferentLength_ShouldKeepAdditionalBytes(string path)
 	{
 		using (FileSystemStream stream1 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
@@ -41,21 +21,21 @@ public partial class ParallelTests
 
 			await That(stream1).HasLength().EqualTo(6);
 			await That(stream2).HasLength().EqualTo(3);
-			
+
 			stream1.Flush();
-			
+
 			await That(stream1).HasLength().EqualTo(6);
 			await That(stream2).HasLength().EqualTo(6);
-			
+
 			stream2.Flush();
-			
+
 			await That(stream1).HasLength().EqualTo(6);
 			await That(stream2).HasLength().EqualTo(6);
 		}
-		
+
 		await That(FileSystem.File.ReadAllText(path)).IsEqualTo("foofoo");
 	}
-	
+
 	[Theory]
 	[AutoData]
 	public async Task MultipleFlush_DifferentPosition_ShouldKeepAdditionalBytes(string path)
@@ -75,10 +55,10 @@ public partial class ParallelTests
 			stream1.Flush();
 			stream2.Flush();
 		}
-		
+
 		await That(FileSystem.File.ReadAllText(path)).IsEqualTo("AAbCCCbbAAAA");
 	}
-	
+
 	[Theory]
 	[AutoData]
 	public async Task MultipleFlush_DifferentPositionWithGaps_ShouldKeepAdditionalBytes(string path)
@@ -100,10 +80,30 @@ public partial class ParallelTests
 			stream1.Flush();
 			stream2.Flush();
 		}
-		
+
 		await That(FileSystem.File.ReadAllText(path)).IsEqualTo("AAbbbCbbAAAA");
 	}
-	
+
+	[Theory]
+	[AutoData]
+	public async Task MultipleFlush_ShouldKeepLatestChanges(string path)
+	{
+		using (FileSystemStream stream1 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
+			FileAccess.Write, FileShare.ReadWrite))
+		{
+			using FileSystemStream stream2 = FileSystem.File.Open(path, FileMode.OpenOrCreate,
+				FileAccess.Write, FileShare.ReadWrite);
+
+			stream2.Write(Encoding.UTF8.GetBytes("foo"), 0, 3);
+			stream1.Write(Encoding.UTF8.GetBytes("bar"), 0, 3);
+
+			stream1.Flush();
+			stream2.Flush();
+		}
+
+		await That(FileSystem.File.ReadAllText(path)).IsEqualTo("foo");
+	}
+
 	[Theory]
 	[AutoData]
 	public async Task WriteEmpty_ShouldNotOverwrite(string path)
@@ -120,7 +120,7 @@ public partial class ParallelTests
 			stream1.Flush();
 			stream2.Flush();
 		}
-		
+
 		await That(FileSystem.File.ReadAllText(path)).IsEqualTo("barfoo");
 	}
 }


### PR DESCRIPTION
This PR enhances parallel write support for `IFileStream` by ensuring only the modified byte ranges are flushed per stream, and adds tests to validate this behavior.

- Added parallel write and flush behavior tests covering overlapping writes, differing lengths, and empty writes.
- Updated `FileStreamMock` to track minimum and maximum write positions and flush only the modified segments.