### PR TITLE
feat: allow setting the used `ITimeSystem`

### DIFF
--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -128,7 +128,7 @@ public sealed class MockFileSystem : IFileSystem
 		using IDisposable release = FileSystemRegistration.Ignore();
 		RandomSystem =
 			new MockRandomSystem(initialization.RandomProvider ?? RandomProvider.Default());
-		TimeSystem = new MockTimeSystem(TimeProvider.Now());
+		TimeSystem = initialization.TimeSystem ?? new MockTimeSystem(TimeProvider.Now());
 		_pathMock = new PathMock(this);
 		_storage = new InMemoryStorage(this);
 		ChangeHandler = new ChangeHandler(this);
@@ -276,6 +276,11 @@ public sealed class MockFileSystem : IFileSystem
 		internal IRandomProvider? RandomProvider { get; private set; }
 
 		/// <summary>
+		///     The <see cref="ITimeSystem" /> to use within the <see cref="MockFileSystem" />.
+		/// </summary>
+		internal ITimeSystem? TimeSystem { get; private set; }
+
+		/// <summary>
 		///     The simulated operating system.
 		/// </summary>
 		internal SimulationMode SimulationMode { get; private set; } = SimulationMode.Native;
@@ -315,6 +320,15 @@ public sealed class MockFileSystem : IFileSystem
 		public MockFileSystemOptions UseRandomProvider(IRandomProvider randomProvider)
 		{
 			RandomProvider = randomProvider;
+			return this;
+		}
+
+		/// <summary>
+		///     Use the given <paramref name="timeSystem" /> within the <see cref="MockFileSystem" />.
+		/// </summary>
+		public MockFileSystemOptions UseTimeSystem(ITimeSystem timeSystem)
+		{
+			TimeSystem = timeSystem;
 			return this;
 		}
 	}

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -125,6 +125,7 @@ namespace Testably.Abstractions.Testing
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory() { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseTimeSystem(Testably.Abstractions.ITimeSystem timeSystem) { }
         }
     }
     public static class MockFileSystemExtensions

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -125,6 +125,7 @@ namespace Testably.Abstractions.Testing
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory() { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseTimeSystem(Testably.Abstractions.ITimeSystem timeSystem) { }
         }
     }
     public static class MockFileSystemExtensions

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
@@ -125,6 +125,7 @@ namespace Testably.Abstractions.Testing
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory() { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseTimeSystem(Testably.Abstractions.ITimeSystem timeSystem) { }
         }
     }
     public static class MockFileSystemExtensions

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -122,6 +122,7 @@ namespace Testably.Abstractions.Testing
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory() { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseTimeSystem(Testably.Abstractions.ITimeSystem timeSystem) { }
         }
     }
     public static class MockFileSystemExtensions

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -122,6 +122,7 @@ namespace Testably.Abstractions.Testing
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory() { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseTimeSystem(Testably.Abstractions.ITimeSystem timeSystem) { }
         }
     }
     public static class MockFileSystemExtensions

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
@@ -127,7 +127,7 @@ public class MockFileSystemInitializationTests
 	[AutoData]
 	public async Task UseRandomProvider_ShouldUseFixedRandomValue(int fixedRandomValue)
 	{
-		MockFileSystem fileSystem = new(i => i
+		MockFileSystem fileSystem = new(options => options
 			.UseRandomProvider(RandomProvider.Generate(
 				intGenerator: new RandomProvider.Generator<int>(() => fixedRandomValue))));
 
@@ -137,6 +137,21 @@ public class MockFileSystemInitializationTests
 		results.Add(fileSystem.RandomSystem.Random.Shared.Next());
 
 		await That(results).All().AreEqualTo(fixedRandomValue);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task UseTimeSystem_ShouldUseProvidedTimeSystem(int offsetSeconds)
+	{
+		DateTime simulatedNow = DateTime.Now.AddSeconds(offsetSeconds);
+		MockTimeSystem timeSystem = new(TimeProvider.Use(simulatedNow));
+		MockFileSystem fileSystem = new(options => options
+			.UseTimeSystem(timeSystem));
+
+		fileSystem.File.WriteAllText("foo", "some text");
+		DateTime result = fileSystem.File.GetCreationTime("foo");
+
+		await That(result).IsEqualTo(simulatedNow);
 	}
 
 	#region Helpers


### PR DESCRIPTION
This PR adds the ability to configure a custom `ITimeSystem` when initializing a `MockFileSystem`, enhancing the testing capabilities by allowing developers to control time behavior in their tests.

- Adds a new `UseTimeSystem()` method to `MockFileSystemOptions` for configuring custom time systems
- Updates the `MockFileSystem` constructor to use the provided time system instead of always defaulting to current time