### PR TITLE
fix: install nuget.exe before pushing packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,12 +136,16 @@ jobs:
     push_core:
         name: "Push core"
         if: ${{ startsWith(github.ref, 'refs/tags/core/v') }}
-        runs-on: macos-latest
+        runs-on: ubuntu-latest
         environment: production
         needs: [ pack ]
         permissions:
             contents: write
         steps:
+            -   name: Install NuGet.exe
+                uses: nuget/setup-nuget@v2
+                with:
+                    nuget-version: 'latest'
             -   name: Download packages
                 uses: actions/download-artifact@v4
                 with:
@@ -163,12 +167,16 @@ jobs:
     push:
         name: "Push"
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        runs-on: macos-latest
+        runs-on: ubuntu-latest
         environment: production
         needs: [ pack ]
         permissions:
             contents: write
         steps:
+            -   name: Install NuGet.exe
+                uses: nuget/setup-nuget@v2
+                with:
+                    nuget-version: 'latest'
             -   name: Download packages
                 uses: actions/download-artifact@v4
                 with:


### PR DESCRIPTION
This PR fixes the CI/CD pipeline by ensuring NuGet.exe is properly installed before attempting to push packages. The changes address a missing dependency issue that was previously masked by using macOS runners which have NuGet pre-installed.

- Switches the package push jobs from `macos-latest` to `ubuntu-latest` runners
- Adds explicit NuGet.exe installation step using the official [setup-nuget](https://github.com/marketplace/actions/setup-nuget-exe-for-use-with-actions) action
- Ensures consistent tooling across both core and regular package push workflows