### PR TITLE
fix: use `dotnet nuget` to push packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,15 +142,13 @@ jobs:
         permissions:
             contents: write
         steps:
-            -   name: Install NuGet.exe
-                uses: nuget/setup-nuget@v2
-                with:
-                    nuget-version: 'latest'
             -   name: Download packages
                 uses: actions/download-artifact@v4
                 with:
                     name: Packages
                     path: Artifacts/Packages
+            -   name: Setup .NET SDKs
+                uses: actions/setup-dotnet@v4
             -   name: Publish
                 run: |
                     echo "Found the following packages to push:"
@@ -161,7 +159,7 @@ jobs:
                     done
                     for entry in Artifacts/Packages/Core/*.nupkg
                     do
-                      nuget push $entry -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}} -SkipDuplicate
+                      dotnet nuget push $entry --source https://api.nuget.org/v3/index.json --api-key "${{secrets.NUGET_API_KEY}}" --skip-duplicate
                     done
     
     push:
@@ -173,15 +171,13 @@ jobs:
         permissions:
             contents: write
         steps:
-            -   name: Install NuGet.exe
-                uses: nuget/setup-nuget@v2
-                with:
-                    nuget-version: 'latest'
             -   name: Download packages
                 uses: actions/download-artifact@v4
                 with:
                     name: Packages
                     path: Artifacts/Packages
+            -   name: Setup .NET SDKs
+                uses: actions/setup-dotnet@v4
             -   name: Publish
                 run: |
                     echo "Found the following packages to push:"
@@ -192,7 +188,7 @@ jobs:
                     done
                     for entry in Artifacts/Packages/Main/*.nupkg
                     do
-                      nuget push $entry -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}} -SkipDuplicate
+                      dotnet nuget push $entry --source https://api.nuget.org/v3/index.json --api-key "${{secrets.NUGET_API_KEY}}" --skip-duplicate
                     done
             -   name: Create GitHub release
                 continue-on-error: true


### PR DESCRIPTION
This PR modernizes the NuGet package publishing process by replacing the legacy `nuget.exe` tool with the built-in `dotnet nuget` command. This change follows best practices recommended in [Meziantou's blog]((https://www.meziantou.net/publishing-a-nuget-package-following-best-practices-using-github.htm)) for more reliable and streamlined package publishing.

Key changes:
- Replaces `nuget/setup-nuget@v2` action with `actions/setup-dotnet@v4`
- Updates push commands from `nuget push` to `dotnet nuget push` with updated parameter syntax