### PR TITLE
docs: add example for working with `UnixFileMode`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,7 @@
 	<ItemGroup>
 		<PackageVersion Include="Testably.Abstractions.Interface" Version="9.0.0"/>
 		<PackageVersion Include="Testably.Abstractions" Version="9.0.0"/>
-		<PackageVersion Include="Testably.Abstractions.Testing" Version="4.2.1"/>
+		<PackageVersion Include="Testably.Abstractions.Testing" Version="4.3.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Meziantou.Analyzer" Version="2.0.210"/>

--- a/Examples/.idea/.idea.Examples/.idea/vcs.xml
+++ b/Examples/.idea/.idea.Examples/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/Examples/Examples.sln
+++ b/Examples/Examples.sln
@@ -73,6 +73,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FileSystemWatcher", "FileSy
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FileSystemWatcher.Tests", "FileSystemWatcher\FileSystemWatcher.Tests\FileSystemWatcher.Tests.csproj", "{BD564722-10AE-481F-B13C-A1C319731E7D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UnixFileMode", "UnixFileMode", "{49827AFF-DC5B-4676-A4F5-399F25CB3E43}"
+	ProjectSection(SolutionItems) = preProject
+		UnixFileMode\README.md = UnixFileMode\README.md
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnixFileMode", "UnixFileMode\UnixFileMode\UnixFileMode.csproj", "{D0B6D4D2-C42F-46A4-8429-C9F3085BD9A3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnixFileMode.Tests", "UnixFileMode\UnixFileMode.Tests\UnixFileMode.Tests.csproj", "{5E08ED65-7869-43FD-8430-20AEC2458A83}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -127,6 +136,14 @@ Global
 		{BD564722-10AE-481F-B13C-A1C319731E7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BD564722-10AE-481F-B13C-A1C319731E7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BD564722-10AE-481F-B13C-A1C319731E7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0B6D4D2-C42F-46A4-8429-C9F3085BD9A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0B6D4D2-C42F-46A4-8429-C9F3085BD9A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0B6D4D2-C42F-46A4-8429-C9F3085BD9A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0B6D4D2-C42F-46A4-8429-C9F3085BD9A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E08ED65-7869-43FD-8430-20AEC2458A83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E08ED65-7869-43FD-8430-20AEC2458A83}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E08ED65-7869-43FD-8430-20AEC2458A83}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E08ED65-7869-43FD-8430-20AEC2458A83}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -145,6 +162,8 @@ Global
 		{C58E47F9-84D6-4D1C-8348-D72159597996} = {B19433E1-9187-4A98-A2F9-4A84366CD2DC}
 		{BD564722-10AE-481F-B13C-A1C319731E7D} = {F05DF273-2CC0-4E23-81BF-AA48E8142144}
 		{3D1F1BF2-0605-4EAA-AE14-7D06B02B9830} = {641A4EEA-484D-4332-B410-45DE0E95A4C6}
+		{D0B6D4D2-C42F-46A4-8429-C9F3085BD9A3} = {49827AFF-DC5B-4676-A4F5-399F25CB3E43}
+		{5E08ED65-7869-43FD-8430-20AEC2458A83} = {49827AFF-DC5B-4676-A4F5-399F25CB3E43}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D439CFB9-E2DD-4DF9-AA90-F321B50EAD16}

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -21,5 +21,8 @@ This is an overview of the provided examples for "Testably.Abstractions".
   In a scenario with multiple threads running in parallel, these would each influence each other differently in the mocked instance than "in the real world".  
   This example illustrates how to implement a thread-aware time provider for such a scenario.
 
+- **[Unix file mode](UnixFileMode/README.md)**  
+  This example highlights how to simulate working with the [`UnixFileMode`](https://learn.microsoft.com/en-us/dotnet/api/system.io.unixfilemode) in the `MockFileSystem`.
+
 - **[Zip-File](ZipFile/README.md)**  
   This example highlights how to use the `IFileSystem` to compress and uncompress directories using `System.IO.Compression`.

--- a/Examples/UnixFileMode/README.md
+++ b/Examples/UnixFileMode/README.md
@@ -1,9 +1,9 @@
-# UnixFileMode example
+# Unix file mode example
 This example highlights how to simulate working with the [`UnixFileMode`](https://learn.microsoft.com/en-us/dotnet/api/system.io.unixfilemode) in the `MockFileSystem`.
 
 The `DefaultUnixFileModeStrategy` simulates the user and group and stores this information alongside the file/directory in the `OnSetUnixFileMode` method.
 Later in the `IsAccessGranted` method you can access the stored data from the `IFileSystemExtensibility` and act accordingly to read or write requests in the `MockFileSystem`.
-Grant read access when
+Read access is granted when
 - When the unix file mode is set to `OtherRead` OR
 - When the unix file mode is set to `GroupRead` and the simulated group of the file is the same as the currently simulated group
 - When the unix file mode is set to `UserRead` and the simulated user of the file is the same as the currently simulated user

--- a/Examples/UnixFileMode/README.md
+++ b/Examples/UnixFileMode/README.md
@@ -1,0 +1,13 @@
+# UnixFileMode example
+This example highlights how to simulate working with the [`UnixFileMode`](https://learn.microsoft.com/en-us/dotnet/api/system.io.unixfilemode) in the `MockFileSystem`.
+
+The `DefaultUnixFileModeStrategy` simulates the user and group and stores this information alongside the file/directory in the `OnSetUnixFileMode` method.
+Later in the `IsAccessGranted` method you can access the stored data from the `IFileSystemExtensibility` and act accordingly to read or write requests in the `MockFileSystem`.
+Grant read access when
+- When the unix file mode is set to `OtherRead` OR
+- When the unix file mode is set to `GroupRead` and the simulated group of the file is the same as the currently simulated group
+- When the unix file mode is set to `UserRead` and the simulated user of the file is the same as the currently simulated user
+
+The same logic applies to write access.
+
+Simulating a user or group is done by calling `SimulateUser`/`SimulateGroup` on the `DefaultUnixFileModeStrategy`.

--- a/Examples/UnixFileMode/UnixFileMode.Tests/DefaultUnixFileModeStrategyTests.cs
+++ b/Examples/UnixFileMode/UnixFileMode.Tests/DefaultUnixFileModeStrategyTests.cs
@@ -1,0 +1,262 @@
+using aweXpect;
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Testably.Abstractions.Testing;
+using Xunit;
+
+namespace Testably.Abstractions.Examples.UnixFileMode.Tests;
+
+public class DefaultUnixFileModeStrategyTests
+{
+	[Fact]
+	public async Task GroupRead_WhenSameGroup_ShouldNotThrow()
+	{
+		Skip.When(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+			"Unix file mode is not supported on Windows.");
+
+		DefaultUnixFileModeStrategy sut = new();
+		MockFileSystem fileSystem = new MockFileSystem().WithUnixFileModeStrategy(sut);
+		sut.SimulateGroup("some group");
+
+		fileSystem.Directory.CreateDirectory("foo", System.IO.UnixFileMode.GroupRead);
+		sut.SimulateGroup("some other group");
+		fileSystem.Directory.CreateDirectory("another directory", System.IO.UnixFileMode.GroupRead);
+		sut.SimulateGroup("some group");
+
+		void Act()
+		{
+			fileSystem.Directory.GetFiles("foo");
+		}
+
+		await Expect.That(Act).DoesNotThrow();
+	}
+
+	[Fact]
+	public async Task GroupRead_WhenSimulatingOtherGroup_ShouldThrowUnauthorizedAccessException()
+	{
+		Skip.When(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+			"Unix file mode is not supported on Windows.");
+
+		DefaultUnixFileModeStrategy sut = new();
+		MockFileSystem fileSystem = new MockFileSystem().WithUnixFileModeStrategy(sut);
+		sut.SimulateGroup("some group");
+
+		fileSystem.Directory.CreateDirectory("foo", System.IO.UnixFileMode.GroupRead);
+		sut.SimulateGroup("some other group");
+
+		void Act()
+		{
+			fileSystem.Directory.GetFiles("foo");
+		}
+
+		await Expect.That(Act).Throws<UnauthorizedAccessException>();
+	}
+
+	[Fact]
+	public async Task GroupWrite_WhenSameGroup_ShouldNotThrow()
+	{
+		Skip.When(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+			"Unix file mode is not supported on Windows.");
+
+		DefaultUnixFileModeStrategy sut = new();
+		MockFileSystem fileSystem = new MockFileSystem().WithUnixFileModeStrategy(sut);
+		sut.SimulateGroup("some group");
+
+		fileSystem.Directory.CreateDirectory("foo", System.IO.UnixFileMode.GroupWrite);
+		sut.SimulateGroup("some other group");
+		fileSystem.Directory.CreateDirectory("another directory",
+			System.IO.UnixFileMode.GroupWrite);
+		sut.SimulateGroup("some group");
+
+		void Act()
+		{
+			fileSystem.Directory.CreateDirectory("foo/bar");
+		}
+
+		await Expect.That(Act).DoesNotThrow();
+	}
+
+	[Fact]
+	public async Task GroupWrite_WhenSimulatingOtherGroup_ShouldThrowUnauthorizedAccessException()
+	{
+		Skip.When(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+			"Unix file mode is not supported on Windows.");
+
+		DefaultUnixFileModeStrategy sut = new();
+		MockFileSystem fileSystem = new MockFileSystem().WithUnixFileModeStrategy(sut);
+		sut.SimulateGroup("some group");
+
+		fileSystem.Directory.CreateDirectory("foo", System.IO.UnixFileMode.GroupWrite);
+		sut.SimulateGroup("some other group");
+
+		void Act()
+		{
+			fileSystem.Directory.CreateDirectory("foo/bar");
+		}
+
+		await Expect.That(Act).Throws<UnauthorizedAccessException>();
+	}
+
+	[Fact]
+	public async Task OtherRead_WhenSimulatingOtherUser_ShouldNotThrow()
+	{
+		Skip.When(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+			"Unix file mode is not supported on Windows.");
+
+		DefaultUnixFileModeStrategy sut = new();
+		MockFileSystem fileSystem = new MockFileSystem().WithUnixFileModeStrategy(sut);
+		sut.SimulateUser("some user");
+
+		fileSystem.Directory.CreateDirectory("foo", System.IO.UnixFileMode.OtherRead);
+		sut.SimulateUser("some other user");
+
+		void Act()
+		{
+			fileSystem.Directory.GetFiles("foo");
+		}
+
+		await Expect.That(Act).DoesNotThrow();
+	}
+
+	[Fact]
+	public async Task OtherWrite_WhenSimulatingOtherUser_ShouldNotThrow()
+	{
+		Skip.When(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+			"Unix file mode is not supported on Windows.");
+
+		DefaultUnixFileModeStrategy sut = new();
+		MockFileSystem fileSystem = new MockFileSystem().WithUnixFileModeStrategy(sut);
+		sut.SimulateUser("some user");
+
+		fileSystem.Directory.CreateDirectory("foo", System.IO.UnixFileMode.OtherWrite);
+		sut.SimulateUser("some other user");
+
+		void Act()
+		{
+			fileSystem.Directory.CreateDirectory("foo/bar");
+		}
+
+		await Expect.That(Act).DoesNotThrow();
+	}
+
+	[Fact]
+	public async Task ShouldInitializeWithEmptyStringForUserAndGroup()
+	{
+		Skip.When(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+			"Unix file mode is not supported on Windows.");
+
+		DefaultUnixFileModeStrategy sut = new();
+		MockFileSystem fileSystem = new MockFileSystem().WithUnixFileModeStrategy(sut);
+		fileSystem.Directory.CreateDirectory("foo",
+			System.IO.UnixFileMode.GroupRead | System.IO.UnixFileMode.UserRead);
+
+		sut.SimulateUser("foo")
+			.SimulateGroup("bar");
+
+		void ActWithDifferentUserAndGroup()
+		{
+			fileSystem.Directory.GetFiles("foo");
+		}
+
+		await Expect.That(ActWithDifferentUserAndGroup).Throws<UnauthorizedAccessException>();
+
+		sut.SimulateGroup("")
+			.SimulateUser("");
+
+		void ActWithEmptyUserAndGroup()
+		{
+			fileSystem.Directory.GetFiles("foo");
+		}
+
+		await Expect.That(ActWithEmptyUserAndGroup).DoesNotThrow();
+	}
+
+	[Fact]
+	public async Task UserRead_WhenSameUser_ShouldNotThrow()
+	{
+		Skip.When(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+			"Unix file mode is not supported on Windows.");
+
+		DefaultUnixFileModeStrategy sut = new();
+		MockFileSystem fileSystem = new MockFileSystem().WithUnixFileModeStrategy(sut);
+		sut.SimulateUser("some user");
+
+		fileSystem.Directory.CreateDirectory("foo", System.IO.UnixFileMode.UserRead);
+		sut.SimulateUser("some other user");
+		fileSystem.Directory.CreateDirectory("another directory", System.IO.UnixFileMode.UserRead);
+		sut.SimulateUser("some user");
+
+		void Act()
+		{
+			fileSystem.Directory.GetFiles("foo");
+		}
+
+		await Expect.That(Act).DoesNotThrow();
+	}
+
+	[Fact]
+	public async Task UserRead_WhenSimulatingOtherUser_ShouldThrowUnauthorizedAccessException()
+	{
+		Skip.When(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+			"Unix file mode is not supported on Windows.");
+
+		DefaultUnixFileModeStrategy sut = new();
+		MockFileSystem fileSystem = new MockFileSystem().WithUnixFileModeStrategy(sut);
+		sut.SimulateUser("some user");
+
+		fileSystem.Directory.CreateDirectory("foo", System.IO.UnixFileMode.UserRead);
+		sut.SimulateUser("some other user");
+
+		void Act()
+		{
+			fileSystem.Directory.GetFiles("foo");
+		}
+
+		await Expect.That(Act).Throws<UnauthorizedAccessException>();
+	}
+
+	[Fact]
+	public async Task UserWrite_WhenSameUser_ShouldNotThrow()
+	{
+		Skip.When(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+			"Unix file mode is not supported on Windows.");
+
+		DefaultUnixFileModeStrategy sut = new();
+		MockFileSystem fileSystem = new MockFileSystem().WithUnixFileModeStrategy(sut);
+		sut.SimulateUser("some user");
+
+		fileSystem.Directory.CreateDirectory("foo", System.IO.UnixFileMode.UserWrite);
+		sut.SimulateUser("some other user");
+		fileSystem.Directory.CreateDirectory("another directory", System.IO.UnixFileMode.UserWrite);
+		sut.SimulateUser("some user");
+
+		void Act()
+		{
+			fileSystem.Directory.CreateDirectory("foo/bar");
+		}
+
+		await Expect.That(Act).DoesNotThrow();
+	}
+
+	[Fact]
+	public async Task UserWrite_WhenSimulatingOtherUser_ShouldThrowUnauthorizedAccessException()
+	{
+		Skip.When(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+			"Unix file mode is not supported on Windows.");
+
+		DefaultUnixFileModeStrategy sut = new();
+		MockFileSystem fileSystem = new MockFileSystem().WithUnixFileModeStrategy(sut);
+		sut.SimulateUser("some user");
+
+		fileSystem.Directory.CreateDirectory("foo", System.IO.UnixFileMode.UserWrite);
+		sut.SimulateUser("some other user");
+
+		void Act()
+		{
+			fileSystem.Directory.CreateDirectory("foo/bar");
+		}
+
+		await Expect.That(Act).Throws<UnauthorizedAccessException>();
+	}
+}

--- a/Examples/UnixFileMode/UnixFileMode.Tests/UnixFileMode.Tests.csproj
+++ b/Examples/UnixFileMode/UnixFileMode.Tests/UnixFileMode.Tests.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<RootNamespace>Testably.Abstractions.Examples.UnixFileMode.Tests</RootNamespace>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\UnixFileMode\UnixFileMode.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/Examples/UnixFileMode/UnixFileMode/DefaultUnixFileModeStrategy.cs
+++ b/Examples/UnixFileMode/UnixFileMode/DefaultUnixFileModeStrategy.cs
@@ -21,7 +21,8 @@ public class DefaultUnixFileModeStrategy : IUnixFileModeStrategy
 		System.IO.UnixFileMode mode, FileAccess requestedAccess)
 	{
 		UserGroup fileUserGroup = extensibility
-			.RetrieveMetadata<UserGroup>(nameof(DefaultUnixFileModeStrategy))
+			                          .RetrieveMetadata<UserGroup>(
+				                          nameof(DefaultUnixFileModeStrategy))
 		                          ?? new UserGroup(_user, _group);
 		switch (requestedAccess)
 		{
@@ -40,7 +41,7 @@ public class DefaultUnixFileModeStrategy : IUnixFileModeStrategy
 		}
 	}
 
-	/// <inheritdoc />
+	/// <inheritdoc cref="IUnixFileModeStrategy.OnSetUnixFileMode(string, IFileSystemExtensibility, UnixFileMode)" />
 	public void OnSetUnixFileMode(string fullPath, IFileSystemExtensibility extensibility,
 		System.IO.UnixFileMode mode)
 	{
@@ -51,7 +52,7 @@ public class DefaultUnixFileModeStrategy : IUnixFileModeStrategy
 	#endregion
 
 	/// <summary>
-	///     Simulates that the process runs under the given <paramref name="group" />.
+	///     Simulate running under the given <paramref name="group" />.
 	/// </summary>
 	public DefaultUnixFileModeStrategy SimulateGroup(string group)
 	{
@@ -60,7 +61,7 @@ public class DefaultUnixFileModeStrategy : IUnixFileModeStrategy
 	}
 
 	/// <summary>
-	///     Simulates that the process runs under the given <paramref name="user" />.
+	///     Simulate running under the given <paramref name="user" />.
 	/// </summary>
 	public DefaultUnixFileModeStrategy SimulateUser(string user)
 	{

--- a/Examples/UnixFileMode/UnixFileMode/DefaultUnixFileModeStrategy.cs
+++ b/Examples/UnixFileMode/UnixFileMode/DefaultUnixFileModeStrategy.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.IO;
+using Testably.Abstractions.Helpers;
+using Testably.Abstractions.Testing.FileSystem;
+
+namespace Testably.Abstractions.Examples.UnixFileMode;
+
+/// <summary>
+///     Default implementation of an <see cref="IUnixFileModeStrategy" /> which uses a callback to determine if access
+///     should be granted.
+/// </summary>
+public class DefaultUnixFileModeStrategy : IUnixFileModeStrategy
+{
+	private string _group = "";
+	private string _user = "";
+
+	#region IUnixFileModeStrategy Members
+
+	/// <inheritdoc cref="IUnixFileModeStrategy.IsAccessGranted(string, IFileSystemExtensibility, UnixFileMode, FileAccess)" />
+	public bool IsAccessGranted(string fullPath, IFileSystemExtensibility extensibility,
+		System.IO.UnixFileMode mode, FileAccess requestedAccess)
+	{
+		UserGroup fileUserGroup = extensibility
+			.RetrieveMetadata<UserGroup>(nameof(DefaultUnixFileModeStrategy))
+		                          ?? new UserGroup(_user, _group);
+		switch (requestedAccess)
+		{
+			case FileAccess.Read:
+				return mode.HasFlag(System.IO.UnixFileMode.OtherRead) ||
+				       (mode.HasFlag(System.IO.UnixFileMode.GroupRead) &&
+				        string.Equals(fileUserGroup.Group, _group, StringComparison.Ordinal)) ||
+				       (mode.HasFlag(System.IO.UnixFileMode.UserRead) &&
+				        string.Equals(fileUserGroup.User, _user, StringComparison.Ordinal));
+			default:
+				return mode.HasFlag(System.IO.UnixFileMode.OtherWrite) ||
+				       (mode.HasFlag(System.IO.UnixFileMode.GroupWrite) &&
+				        string.Equals(fileUserGroup.Group, _group, StringComparison.Ordinal)) ||
+				       (mode.HasFlag(System.IO.UnixFileMode.UserWrite) &&
+				        string.Equals(fileUserGroup.User, _user, StringComparison.Ordinal));
+		}
+	}
+
+	/// <inheritdoc />
+	public void OnSetUnixFileMode(string fullPath, IFileSystemExtensibility extensibility,
+		System.IO.UnixFileMode mode)
+	{
+		extensibility.StoreMetadata(nameof(DefaultUnixFileModeStrategy),
+			new UserGroup(_user, _group));
+	}
+
+	#endregion
+
+	/// <summary>
+	///     Simulates that the process runs under the given <paramref name="group" />.
+	/// </summary>
+	public DefaultUnixFileModeStrategy SimulateGroup(string group)
+	{
+		_group = group;
+		return this;
+	}
+
+	/// <summary>
+	///     Simulates that the process runs under the given <paramref name="user" />.
+	/// </summary>
+	public DefaultUnixFileModeStrategy SimulateUser(string user)
+	{
+		_user = user;
+		return this;
+	}
+
+	private record UserGroup(string User, string Group);
+}

--- a/Examples/UnixFileMode/UnixFileMode/DefaultUnixFileModeStrategy.cs
+++ b/Examples/UnixFileMode/UnixFileMode/DefaultUnixFileModeStrategy.cs
@@ -24,20 +24,27 @@ public class DefaultUnixFileModeStrategy : IUnixFileModeStrategy
 			                          .RetrieveMetadata<UserGroup>(
 				                          nameof(DefaultUnixFileModeStrategy))
 		                          ?? new UserGroup(_user, _group);
+
+		bool hasReadAccess = mode.HasFlag(System.IO.UnixFileMode.OtherRead) ||
+		                     (mode.HasFlag(System.IO.UnixFileMode.GroupRead) &&
+		                      string.Equals(fileUserGroup.Group, _group,
+			                      StringComparison.Ordinal)) ||
+		                     (mode.HasFlag(System.IO.UnixFileMode.UserRead) &&
+		                      string.Equals(fileUserGroup.User, _user, StringComparison.Ordinal));
+		bool hasWriteAccess = mode.HasFlag(System.IO.UnixFileMode.OtherWrite) ||
+		                      (mode.HasFlag(System.IO.UnixFileMode.GroupWrite) &&
+		                       string.Equals(fileUserGroup.Group, _group,
+			                       StringComparison.Ordinal)) ||
+		                      (mode.HasFlag(System.IO.UnixFileMode.UserWrite) &&
+		                       string.Equals(fileUserGroup.User, _user, StringComparison.Ordinal));
 		switch (requestedAccess)
 		{
 			case FileAccess.Read:
-				return mode.HasFlag(System.IO.UnixFileMode.OtherRead) ||
-				       (mode.HasFlag(System.IO.UnixFileMode.GroupRead) &&
-				        string.Equals(fileUserGroup.Group, _group, StringComparison.Ordinal)) ||
-				       (mode.HasFlag(System.IO.UnixFileMode.UserRead) &&
-				        string.Equals(fileUserGroup.User, _user, StringComparison.Ordinal));
+				return hasReadAccess;
+			case FileAccess.Write:
+				return hasWriteAccess;
 			default:
-				return mode.HasFlag(System.IO.UnixFileMode.OtherWrite) ||
-				       (mode.HasFlag(System.IO.UnixFileMode.GroupWrite) &&
-				        string.Equals(fileUserGroup.Group, _group, StringComparison.Ordinal)) ||
-				       (mode.HasFlag(System.IO.UnixFileMode.UserWrite) &&
-				        string.Equals(fileUserGroup.User, _user, StringComparison.Ordinal));
+				return hasReadAccess && hasWriteAccess;
 		}
 	}
 

--- a/Examples/UnixFileMode/UnixFileMode/UnixFileMode.csproj
+++ b/Examples/UnixFileMode/UnixFileMode/UnixFileMode.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<RootNamespace>Testably.Abstractions.Examples.UnixFileMode</RootNamespace>
+	</PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This PR adds a comprehensive example demonstrating how to work with `UnixFileMode` in the `MockFileSystem`. The example includes a complete implementation of a Unix file mode strategy that simulates user and group permissions for testing scenarios.

### Unix file mode example
This example highlights how to simulate working with the [`UnixFileMode`](https://learn.microsoft.com/en-us/dotnet/api/system.io.unixfilemode) in the `MockFileSystem`.

The `DefaultUnixFileModeStrategy` simulates the user and group and stores this information alongside the file/directory in the `OnSetUnixFileMode` method.
Later in the `IsAccessGranted` method you can access the stored data from the `IFileSystemExtensibility` and act accordingly to read or write requests in the `MockFileSystem`.
Read access is granted when
- When the unix file mode is set to `OtherRead` OR
- When the unix file mode is set to `GroupRead` and the simulated group of the file is the same as the currently simulated group
- When the unix file mode is set to `UserRead` and the simulated user of the file is the same as the currently simulated user

The same logic applies to write access.

Simulating a user or group is done by calling `SimulateUser`/`SimulateGroup` on the `DefaultUnixFileModeStrategy`.

---

- *Adds documentation for #823*