### PR TITLE
fix: throw correct exception when ACL denies access

### DIFF
--- a/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
@@ -16,9 +16,6 @@ internal static class ExceptionFactory
 #endif
 		};
 
-	internal static IOException AclAccessToPathDenied(string path)
-		=> new($"Access to the path '{path}' is denied.");
-
 	internal static ArgumentException AppendAccessOnlyInWriteOnlyMode(
 		string paramName = "access")
 		=> new($"{nameof(FileMode.Append)} access can be requested only in write-only mode.",

--- a/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
@@ -91,7 +91,7 @@ internal interface IStorageContainer : IFileSystemEntity, ITimeSystemEntity
 		bool ignoreFileShare = false,
 		bool ignoreMetadataErrors = true,
 		int? hResult = null,
-		IStorageLocation? location = null);
+		IStorageLocation? onBehalfOfLocation = null);
 
 	/// <summary>
 	///     Writes the <paramref name="bytes" /> to the <see cref="IFileInfo" />.

--- a/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
@@ -90,7 +90,8 @@ internal interface IStorageContainer : IFileSystemEntity, ITimeSystemEntity
 		bool deleteAccess = false,
 		bool ignoreFileShare = false,
 		bool ignoreMetadataErrors = true,
-		int? hResult = null);
+		int? hResult = null,
+		IStorageLocation? location = null);
 
 	/// <summary>
 	///     Writes the <paramref name="bytes" /> to the <see cref="IFileInfo" />.

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -169,7 +169,7 @@ internal sealed class InMemoryContainer : IStorageContainer
 		bool ignoreFileShare = false,
 		bool ignoreMetadataErrors = true,
 		int? hResult = null,
-		IStorageLocation? location = null)
+		IStorageLocation? onBehalfOfLocation = null)
 	{
 		if (FileSystemRegistration.IsInitializing())
 		{
@@ -203,7 +203,7 @@ internal sealed class InMemoryContainer : IStorageContainer
 		if (!_fileSystem.AccessControlStrategy
 			.IsAccessGranted(_location.FullPath, Extensibility))
 		{
-			throw ExceptionFactory.AccessToPathDenied((location ?? _location).FullPath);
+			throw ExceptionFactory.AccessToPathDenied((onBehalfOfLocation ?? _location).FullPath);
 		}
 
 		if (_fileSystem.Storage.TryGetFileAccess(

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -163,12 +163,13 @@ internal sealed class InMemoryContainer : IStorageContainer
 	/// <inheritdoc cref="IStorageContainer.GetBytes()" />
 	public byte[] GetBytes() => _bytes;
 
-	/// <inheritdoc cref="IStorageContainer.RequestAccess(FileAccess, FileShare, bool, bool, bool, int?)" />
+	/// <inheritdoc cref="IStorageContainer.RequestAccess(FileAccess, FileShare, bool, bool, bool, int?, IStorageLocation?)" />
 	public IStorageAccessHandle RequestAccess(FileAccess access, FileShare share,
 		bool deleteAccess = false,
 		bool ignoreFileShare = false,
 		bool ignoreMetadataErrors = true,
-		int? hResult = null)
+		int? hResult = null,
+		IStorageLocation? location = null)
 	{
 		if (FileSystemRegistration.IsInitializing())
 		{
@@ -202,7 +203,7 @@ internal sealed class InMemoryContainer : IStorageContainer
 		if (!_fileSystem.AccessControlStrategy
 			.IsAccessGranted(_location.FullPath, Extensibility))
 		{
-			throw ExceptionFactory.AclAccessToPathDenied(_location.FullPath);
+			throw ExceptionFactory.AccessToPathDenied((location ?? _location).FullPath);
 		}
 
 		if (_fileSystem.Storage.TryGetFileAccess(

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -758,7 +758,7 @@ internal sealed class InMemoryStorage : IStorage
 				throw ExceptionFactory.UnixFileModeAccessDenied(location.FullPath);
 			}
 #else
-			using (parentContainer.RequestAccess(FileAccess.Write, FileShare.ReadWrite))
+			using (parentContainer.RequestAccess(FileAccess.Write, FileShare.ReadWrite, location: location))
 			{
 				TimeAdjustments timeAdjustment = TimeAdjustments.LastWriteTime;
 				if (_fileSystem.Execute.IsWindows)

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -758,7 +758,7 @@ internal sealed class InMemoryStorage : IStorage
 				throw ExceptionFactory.UnixFileModeAccessDenied(location.FullPath);
 			}
 #else
-			using (parentContainer.RequestAccess(FileAccess.Write, FileShare.ReadWrite, location: location))
+			using (parentContainer.RequestAccess(FileAccess.Write, FileShare.ReadWrite, onBehalfOfLocation: location))
 			{
 				TimeAdjustments timeAdjustment = TimeAdjustments.LastWriteTime;
 				if (_fileSystem.Execute.IsWindows)

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -102,7 +102,7 @@ internal sealed class NullContainer : IStorageContainer
 		bool ignoreFileShare = false,
 		bool ignoreMetadataErrors = true,
 		int? hResult = null,
-		IStorageLocation? location = null)
+		IStorageLocation? onBehalfOfLocation = null)
 		=> new NullStorageAccessHandle(access, share, deleteAccess);
 
 	/// <inheritdoc cref="IStorageContainer.WriteBytes(byte[])" />

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -96,12 +96,13 @@ internal sealed class NullContainer : IStorageContainer
 	public byte[] GetBytes()
 		=> Array.Empty<byte>();
 
-	/// <inheritdoc cref="IStorageContainer.RequestAccess(FileAccess, FileShare, bool, bool, bool, int?)" />
+	/// <inheritdoc cref="IStorageContainer.RequestAccess(FileAccess, FileShare, bool, bool, bool, int?, IStorageLocation?)" />
 	public IStorageAccessHandle RequestAccess(FileAccess access, FileShare share,
 		bool deleteAccess = false,
 		bool ignoreFileShare = false,
 		bool ignoreMetadataErrors = true,
-		int? hResult = null)
+		int? hResult = null,
+		IStorageLocation? location = null)
 		=> new NullStorageAccessHandle(access, share, deleteAccess);
 
 	/// <inheritdoc cref="IStorageContainer.WriteBytes(byte[])" />

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -120,7 +120,7 @@ public class MockFileSystemTests
 
 	[Theory]
 	[AutoData]
-	public async Task WithAccessControl_Denied_CreateDirectoryShouldThrowIOException(
+	public async Task WithAccessControl_Denied_CreateDirectoryShouldThrowUnauthorizedAccessException(
 		string path)
 	{
 		Skip.If(!Test.RunsOnWindows);
@@ -134,7 +134,7 @@ public class MockFileSystemTests
 			sut.Directory.CreateDirectory(path);
 		});
 
-		await That(exception).IsExactly<IOException>();
+		await That(exception).IsExactly<UnauthorizedAccessException>();
 	}
 
 	[Theory]
@@ -155,7 +155,7 @@ public class MockFileSystemTests
 			sut.Directory.CreateDirectory(deniedPath);
 		});
 
-		await That(exception).IsExactly<IOException>();
+		await That(exception).IsExactly<UnauthorizedAccessException>();
 	}
 
 	[Fact]

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
@@ -12,7 +12,7 @@ namespace Testably.Abstractions.Testing.Tests.TestHelpers;
 ///     A <see cref="IStorageContainer" /> for testing purposes.
 ///     <para />
 ///     Set <see cref="IsLocked" /> to <see langword="true" /> to simulate a locked file
-///     (<see cref="RequestAccess(FileAccess, FileShare, bool, bool, bool, int?)" /> throws an <see cref="IOException" />).
+///     (<see cref="RequestAccess(FileAccess, FileShare, bool, bool, bool, int?, IStorageLocation?)" /> throws an <see cref="IOException" />).
 /// </summary>
 internal sealed class LockableContainer(
 	MockFileSystem fileSystem,
@@ -24,7 +24,7 @@ internal sealed class LockableContainer(
 
 	/// <summary>
 	///     Simulate a locked file, if set to <see langword="true" />.<br />
-	///     In this case <see cref="RequestAccess(FileAccess, FileShare, bool, bool, bool, int?)" /> throws
+	///     In this case <see cref="RequestAccess(FileAccess, FileShare, bool, bool, bool, int?, IStorageLocation?)" /> throws
 	///     an <see cref="IOException" />, otherwise it will succeed.
 	/// </summary>
 	public bool IsLocked { get; set; }
@@ -95,12 +95,13 @@ internal sealed class LockableContainer(
 	public byte[] GetBytes()
 		=> _bytes;
 
-	/// <inheritdoc cref="IStorageContainer.RequestAccess(FileAccess, FileShare, bool, bool, bool, int?)" />
+	/// <inheritdoc cref="IStorageContainer.RequestAccess(FileAccess, FileShare, bool, bool, bool, int?, IStorageLocation?)" />
 	public IStorageAccessHandle RequestAccess(FileAccess access, FileShare share,
 		bool deleteAccess = false,
 		bool ignoreFileShare = false,
 		bool ignoreMetadataErrors = true,
-		int? hResult = null)
+		int? hResult = null,
+		IStorageLocation? location = null)
 	{
 		if (IsLocked)
 		{

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
@@ -101,7 +101,7 @@ internal sealed class LockableContainer(
 		bool ignoreFileShare = false,
 		bool ignoreMetadataErrors = true,
 		int? hResult = null,
-		IStorageLocation? location = null)
+		IStorageLocation? onBehalfOfLocation = null)
 	{
 		if (IsLocked)
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -277,7 +277,7 @@ public partial class CreateDirectoryTests
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string restrictedDirectory = @"C:\Windows\System32\config";
+		string restrictedDirectory = @"C:\Windows\WaaS";
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
 			restrictedDirectory = @"C:\Restricted directory";

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -272,16 +272,18 @@ public partial class CreateDirectoryTests
 #endif
 
 	[Fact]
-	public async Task CreateDirectory_WithoutAccessRightsToParent_ShouldThrowUnauthorizedAccessException()
+	public async Task
+		CreateDirectory_WithoutAccessRightsToParent_ShouldThrowUnauthorizedAccessException()
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string folderPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+		string folderPath = @"C:\Program Files";
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
 			mockFileSystem.Directory.CreateDirectory(folderPath);
 			mockFileSystem.WithAccessControlStrategy(
-				new DefaultAccessControlStrategy((p, _) => !folderPath.Equals(p)));
+				new DefaultAccessControlStrategy((p, _)
+					=> !folderPath.Equals(p, StringComparison.Ordinal)));
 		}
 
 		string path = FileSystem.Path.Combine(folderPath, "my-subdirectory");

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -277,7 +277,7 @@ public partial class CreateDirectoryTests
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string restrictedDirectory = @"C:\Windows\System32";
+		string restrictedDirectory = @"C:\Windows\System32\config";
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
 			restrictedDirectory = @"C:\Restricted directory";

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -277,7 +277,7 @@ public partial class CreateDirectoryTests
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string restrictedDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+		string restrictedDirectory = @"C:\Windows\System32";
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
 			restrictedDirectory = @"C:\Restricted directory";

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -277,16 +277,17 @@ public partial class CreateDirectoryTests
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string folderPath = @"C:\Program Files";
+		string restrictedDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
-			mockFileSystem.Directory.CreateDirectory(folderPath);
+			restrictedDirectory = @"C:\Restricted directory";
+			mockFileSystem.Directory.CreateDirectory(restrictedDirectory);
 			mockFileSystem.WithAccessControlStrategy(
 				new DefaultAccessControlStrategy((p, _)
-					=> !folderPath.Equals(p, StringComparison.Ordinal)));
+					=> !restrictedDirectory.Equals(p, StringComparison.Ordinal)));
 		}
 
-		string path = FileSystem.Path.Combine(folderPath, "my-subdirectory");
+		string path = FileSystem.Path.Combine(restrictedDirectory, "my-subdirectory");
 
 		void Act()
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
@@ -137,16 +137,18 @@ public partial class CreateTests
 	}
 
 	[Fact]
-	public async Task CreateDirectory_WithoutAccessRightsToParent_ShouldThrowUnauthorizedAccessException()
+	public async Task
+		CreateDirectory_WithoutAccessRightsToParent_ShouldThrowUnauthorizedAccessException()
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string folderPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+		string folderPath = @"C:\Program Files";
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
 			mockFileSystem.Directory.CreateDirectory(folderPath);
 			mockFileSystem.WithAccessControlStrategy(
-				new DefaultAccessControlStrategy((p, _) => !folderPath.Equals(p)));
+				new DefaultAccessControlStrategy((p, _)
+					=> !folderPath.Equals(p, StringComparison.Ordinal)));
 		}
 
 		string path = FileSystem.Path.Combine(folderPath, "my-subdirectory");

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
@@ -142,7 +142,7 @@ public partial class CreateTests
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string restrictedDirectory = @"C:\Windows\System32\config";
+		string restrictedDirectory = @"C:\Windows\WaaS";
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
 			restrictedDirectory = @"C:\Restricted directory";

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
@@ -142,7 +142,7 @@ public partial class CreateTests
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string restrictedDirectory = @"C:\Windows\System32";
+		string restrictedDirectory = @"C:\Windows\System32\config";
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
 			restrictedDirectory = @"C:\Restricted directory";

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
@@ -142,8 +142,7 @@ public partial class CreateTests
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string restrictedDirectory =
-			Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+		string restrictedDirectory = @"C:\Windows\System32";
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
 			restrictedDirectory = @"C:\Restricted directory";

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/CreateTests.cs
@@ -142,16 +142,18 @@ public partial class CreateTests
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string folderPath = @"C:\Program Files";
+		string restrictedDirectory =
+			Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
-			mockFileSystem.Directory.CreateDirectory(folderPath);
+			restrictedDirectory = @"C:\Restricted directory";
+			mockFileSystem.Directory.CreateDirectory(restrictedDirectory);
 			mockFileSystem.WithAccessControlStrategy(
 				new DefaultAccessControlStrategy((p, _)
-					=> !folderPath.Equals(p, StringComparison.Ordinal)));
+					=> !restrictedDirectory.Equals(p, StringComparison.Ordinal)));
 		}
 
-		string path = FileSystem.Path.Combine(folderPath, "my-subdirectory");
+		string path = FileSystem.Path.Combine(restrictedDirectory, "my-subdirectory");
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
 
 		void Act()

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -169,16 +169,18 @@ public partial class WriteAllTextTests
 	}
 
 	[Fact]
-	public async Task WriteAllText_WithoutAccessRightsToParentDirectory_ShouldThrowUnauthorizedAccessException()
+	public async Task
+		WriteAllText_WithoutAccessRightsToParentDirectory_ShouldThrowUnauthorizedAccessException()
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string folderPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+		string folderPath = @"C:\Program Files";
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
 			mockFileSystem.Directory.CreateDirectory(folderPath);
 			mockFileSystem.WithAccessControlStrategy(
-				new DefaultAccessControlStrategy((p, _) => !folderPath.Equals(p)));
+				new DefaultAccessControlStrategy((p, _)
+					=> !folderPath.Equals(p, StringComparison.Ordinal)));
 		}
 
 		string path = FileSystem.Path.Combine(folderPath, "my-file.txt");

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -174,7 +174,7 @@ public partial class WriteAllTextTests
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string restrictedDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+		string restrictedDirectory = @"C:\Windows\System32";
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
 			restrictedDirectory = @"C:\Restricted directory";

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -174,16 +174,17 @@ public partial class WriteAllTextTests
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string folderPath = @"C:\Program Files";
+		string restrictedDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
-			mockFileSystem.Directory.CreateDirectory(folderPath);
+			restrictedDirectory = @"C:\Restricted directory";
+			mockFileSystem.Directory.CreateDirectory(restrictedDirectory);
 			mockFileSystem.WithAccessControlStrategy(
 				new DefaultAccessControlStrategy((p, _)
-					=> !folderPath.Equals(p, StringComparison.Ordinal)));
+					=> !restrictedDirectory.Equals(p, StringComparison.Ordinal)));
 		}
 
-		string path = FileSystem.Path.Combine(folderPath, "my-file.txt");
+		string path = FileSystem.Path.Combine(restrictedDirectory, "my-file.txt");
 
 		void Act()
 		{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -174,7 +174,7 @@ public partial class WriteAllTextTests
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string restrictedDirectory = @"C:\Windows\System32";
+		string restrictedDirectory = @"C:\Windows\System32\config";
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
 			restrictedDirectory = @"C:\Restricted directory";

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -174,7 +174,7 @@ public partial class WriteAllTextTests
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
-		string restrictedDirectory = @"C:\Windows\System32\config";
+		string restrictedDirectory = @"C:\Windows\WaaS";
 		if (FileSystem is MockFileSystem mockFileSystem)
 		{
 			restrictedDirectory = @"C:\Restricted directory";


### PR DESCRIPTION
This PR fixes an issue where ACL-denied access operations were throwing `IOException` instead of the correct `UnauthorizedAccessException` on Windows. The change ensures proper exception handling when trying to create directories or write files in directories that are denied access by Windows ACL.

- Fixes the exception type thrown when ACL denies access from `IOException` to `UnauthorizedAccessException`
- Updates the storage container interface to pass location context for better error reporting

---

- *Fixes #829*