### PR TITLE
fix(FileSystem): When creating chained sym links of different types MockFileSystem in windows doesn't throw

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
 	<ItemGroup>
 		<PackageVersion Include="AutoFixture.AutoNSubstitute" Version="5.0.0-preview0012"/>
 		<PackageVersion Include="AutoFixture.Xunit3" Version="5.0.0-preview0012"/>
-		<PackageVersion Include="aweXpect" Version="2.21.0"/>
+		<PackageVersion Include="aweXpect" Version="2.21.1"/>
 		<PackageVersion Include="aweXpect.Testably" Version="0.11.0"/>
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
 		<PackageVersion Include="xunit.v3" Version="2.0.3"/>

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemInfoMock.cs
@@ -336,27 +336,14 @@ internal class FileSystemInfoMock : IFileSystemInfo, IFileSystemExtensibility
 	/// <inheritdoc cref="IFileSystemInfo.ResolveLinkTarget(bool)" />
 	public IFileSystemInfo? ResolveLinkTarget(bool returnFinalTarget)
 	{
-		using IDisposable registration = RegisterPathMethod(nameof(ResolveLinkTarget),
-			returnFinalTarget);
+		using IDisposable registration = RegisterPathMethod(
+			nameof(ResolveLinkTarget), returnFinalTarget
+		);
 
-		try
-		{
-			IStorageLocation? targetLocation =
-				_fileSystem.Storage.ResolveLinkTarget(
-					Location,
-					returnFinalTarget);
-			if (targetLocation != null)
-			{
-				return New(targetLocation, _fileSystem);
-			}
+		IStorageLocation? targetLocation
+			= _fileSystem.Storage.ResolveLinkTarget(Location, returnFinalTarget);
 
-			return null;
-		}
-		catch (IOException ex) when (ex.HResult != -2147024773)
-		{
-			throw ExceptionFactory.FileNameCannotBeResolved(Location.FullPath,
-				_fileSystem.Execute.IsWindows ? -2147022975 : -2146232800);
-		}
+		return targetLocation != null ? New(targetLocation, _fileSystem) : null;
 	}
 #endif
 

--- a/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
@@ -292,15 +292,13 @@ internal static class ExceptionFactory
 	internal static TimeoutException TimerWaitTimeoutException(int executionCount, int timeout)
 		=> new($"The execution count {executionCount} was not reached in {timeout}ms.");
 
-#if FEATURE_FILESYSTEM_UNIXFILEMODE
-	internal static UnauthorizedAccessException UnixFileModeAccessDenied(string path)
+	internal static UnauthorizedAccessException AccessDenied(string path)
 		=> new($"Access to the path '{path}' is denied.")
 		{
 #if FEATURE_EXCEPTION_HRESULT
 			HResult = -2147024891,
 #endif
 		};
-#endif
 
 	internal static PlatformNotSupportedException UnixFileModeNotSupportedOnThisPlatform()
 		=> new("Unix file modes are not supported on this platform.")

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -195,7 +195,7 @@ internal sealed class InMemoryContainer : IStorageContainer
 		if (!deleteAccess && !_fileSystem.UnixFileModeStrategy
 			.IsAccessGranted(_location.FullPath, _extensibility, UnixFileMode, access))
 		{
-			throw ExceptionFactory.UnixFileModeAccessDenied(_location.FullPath);
+			throw ExceptionFactory.AccessDenied(_location.FullPath);
 		}
 #endif
 

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -1092,7 +1092,7 @@ internal sealed class InMemoryStorage : IStorage
 				// This message looks wonky but is correct
 				// See System.IO.Win32Marshal.GetExceptionForWin32Error in the default section
 				throw new IOException(
-					$"The directory name is invalid. : '{previousLocation.FullPath}'"
+					$"The directory name is invalid. : '{previousLocation.FullPath}'", -2147024773
 				);
 		}
 	}

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -5,9 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-#if NET8_0_OR_GREATER
-using System.Runtime.InteropServices;
-#endif
 using Testably.Abstractions.Helpers;
 using Testably.Abstractions.Testing.FileSystem;
 using Testably.Abstractions.Testing.Helpers;
@@ -1094,24 +1091,7 @@ internal sealed class InMemoryStorage : IStorage
 					$"Access to the path '{previousLocation.FullPath}' is denied."
 				);
 			case FileSystemTypes.Directory:
-				// We should be clear here with Marshal, as the symbolic link types only differ on windows
-				string errorMessage =
-#if NET8_0_OR_GREATER
-					Marshal.GetPInvokeErrorMessage(267) // Magic number, error code was discovered via debugger
-#else
-						"The directory name is invalid." // Marshal.GetPInvokeErrorMessage is only available for .NET 7 and above
-#endif
-					;
-
-				// This message looks wonky but is correct
-				// See System.IO.Win32Marshal.GetExceptionForWin32Error in the default section
-				throw new IOException(
-					$"{errorMessage} : '{previousLocation.FullPath}'"
-#if NET9_0_OR_GREATER
-					+ '.'
-#endif
-					, -2147024629
-				);
+				throw ExceptionFactory.InvalidDirectoryName(previousLocation.FullPath);
 		}
 	}
 #endif

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -1092,7 +1092,11 @@ internal sealed class InMemoryStorage : IStorage
 				// This message looks wonky but is correct
 				// See System.IO.Win32Marshal.GetExceptionForWin32Error in the default section
 				throw new IOException(
-					$"The directory name is invalid. : '{previousLocation.FullPath}'", -2147024773
+					$"The directory name is invalid. : '{previousLocation.FullPath}'"
+					#if NET9_0_OR_GREATER
+					+ '.'
+					#endif
+					, -2147024629
 				);
 		}
 	}

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -764,7 +764,7 @@ internal sealed class InMemoryStorage : IStorage
 			catch (UnauthorizedAccessException)
 			{
 				// On Unix, if the parent directory is not writable, we include the child path in the exception.
-				throw ExceptionFactory.UnixFileModeAccessDenied(location.FullPath);
+				throw ExceptionFactory.AccessDenied(location.FullPath);
 			}
 #else
 			using (parentContainer.RequestAccess(FileAccess.Write, FileShare.ReadWrite))
@@ -1087,9 +1087,7 @@ internal sealed class InMemoryStorage : IStorage
 		switch (previous.Type)
 		{
 			case FileSystemTypes.File:
-				throw new UnauthorizedAccessException(
-					$"Access to the path '{previousLocation.FullPath}' is denied."
-				);
+				throw ExceptionFactory.AccessDenied(previousLocation.FullPath);
 			case FileSystemTypes.Directory:
 				throw ExceptionFactory.InvalidDirectoryName(previousLocation.FullPath);
 		}

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -1060,7 +1060,9 @@ internal sealed class InMemoryStorage : IStorage
 
 		if (container.LinkTarget != null)
 		{
-			throw ExceptionFactory.FileNameCannotBeResolved(originalLocation.FullPath);
+			throw ExceptionFactory.FileNameCannotBeResolved(
+				originalLocation.FullPath, _fileSystem.Execute.IsWindows ? -2147022975 : -2146232800
+			);
 		}
 
 		return nextLocation;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ResolveLinkTargetTests.cs
@@ -125,5 +125,28 @@ public partial class ResolveLinkTargetTests
 
 		await That(resolvedTarget?.FullName).IsEqualTo(targetDir.FullName);
 	}
+
+	[Theory]
+	[AutoData]
+	public async Task ResolveLinkTarget_OfDifferentTypes_ShouldThrow(string directoryName, string fileLinkName, string directoryLinkName)
+	{
+		IDirectoryInfo targetDirectory = FileSystem.Directory.CreateDirectory(directoryName);
+
+		IFileSystemInfo fileSymLink = FileSystem.File.CreateSymbolicLink(fileLinkName, targetDirectory.FullName);
+
+		IFileSystemInfo dirSymLink = FileSystem.Directory.CreateSymbolicLink(directoryLinkName, fileSymLink.FullName);
+
+		if(Test.RunsOnWindows)
+		{
+			await That(() => dirSymLink.ResolveLinkTarget(true))
+				.Throws<IOException>().Which
+				.Satisfies(x => x.Message.Contains(dirSymLink.FullName, StringComparison.Ordinal));
+		}
+		else
+		{
+			await That(() => dirSymLink.ResolveLinkTarget(true))
+				.DoesNotThrow<IOException>();
+		}
+	}
 }
 #endif

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ResolveLinkTargetTests.cs
@@ -139,13 +139,12 @@ public partial class ResolveLinkTargetTests
 		if(Test.RunsOnWindows)
 		{
 			await That(() => dirSymLink.ResolveLinkTarget(true))
-				.Throws<IOException>().Which
-				.Satisfies(x => x.Message.Contains(dirSymLink.FullName, StringComparison.Ordinal));
+				.Throws<IOException>().WithMessage($"The directory name is invalid. : '{dirSymLink.FullName}'");
 		}
 		else
 		{
-			await That(() => dirSymLink.ResolveLinkTarget(true))
-				.DoesNotThrow<IOException>();
+			await That(dirSymLink.ResolveLinkTarget(true)?.FullName)
+				.IsEqualTo(targetDirectory.FullName);
 		}
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ResolveLinkTargetTests.cs
@@ -7,19 +7,45 @@ namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
 [FileSystemTests]
 public partial class ResolveLinkTargetTests
 {
+	#region Test Setup
+
+	/// <summary>
+	///     The maximum number of symbolic links that are followed.<br />
+	///     <see href="https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks" />
+	/// </summary>
+	private int MaxResolveLinks => Test.RunsOnWindows ? 63 : 40;
+
+	#endregion
+
 	[Theory]
 	[AutoData]
-	public async Task ResolveLinkTarget_ShouldThrow(string path)
+	public async Task ResolveLinkTarget_FinalTargetWithTooManyLevels_ShouldThrowIOException(
+		string path,
+		string pathToFinalTarget
+	)
 	{
-		IFileSystemInfo link = FileSystem.Directory.CreateSymbolicLink(path, path + "-start");
+		int maxLinks = MaxResolveLinks + 1;
+		FileSystem.Directory.CreateDirectory(pathToFinalTarget);
+		string previousPath = pathToFinalTarget;
 
-		// UNIX allows 43 and Windows 63 nesting, so 70 is plenty to force the exception
-		for (int i = 0; i < 70; i++)
+		for (int i = 0; i < maxLinks; i++)
 		{
-			link = FileSystem.Directory.CreateSymbolicLink($"{path}{i}", link.Name);
+			string newPath = $"{path}-{i}";
+			IDirectoryInfo linkDirectoryInfo = FileSystem.DirectoryInfo.New(newPath);
+			linkDirectoryInfo.CreateAsSymbolicLink(previousPath);
+			previousPath = newPath;
 		}
 
-		await That(() => link.ResolveLinkTarget(true)).Throws<IOException>();
+		IDirectoryInfo directoryInfo = FileSystem.DirectoryInfo.New(previousPath);
+
+		void Act()
+		{
+			_ = directoryInfo.ResolveLinkTarget(true);
+		}
+
+		await That(Act).Throws<IOException>()
+			.WithHResult(Test.RunsOnWindows ? -2147022975 : -2146232800).And
+			.WithMessageContaining($"'{directoryInfo.FullName}'");
 	}
 
 	[Theory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ResolveLinkTargetTests.cs
@@ -168,17 +168,21 @@ public partial class ResolveLinkTargetTests
 			directoryLinkName, fileSymLink.FullName
 		);
 
+		string? Act()
+		{
+			return dirSymLink.ResolveLinkTarget(true)?.FullName;
+		}
+
 		if (Test.RunsOnWindows)
 		{
-			await That(() => dirSymLink.ResolveLinkTarget(true)).Throws<IOException>()
+			await That(Act).Throws<IOException>()
 				.WithMessage(
 					$@"^.*directory.*invalid.*\'{Regex.Escape(dirSymLink.FullName)}\'"
 				).AsRegex().And.WithHResult(-2147024629);
 		}
 		else
 		{
-			await That(dirSymLink.ResolveLinkTarget(true)?.FullName)
-				.IsEqualTo(targetDirectory.FullName);
+			await That(Act()).IsEqualTo(targetDirectory.FullName);
 		}
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ResolveLinkTargetTests.cs
@@ -1,8 +1,5 @@
 ﻿#if FEATURE_FILESYSTEM_LINK
 using System.IO;
-#if NET8_0_OR_GREATER
-using System.Runtime.InteropServices;
-#endif
 using System.Text.RegularExpressions;
 
 namespace Testably.Abstractions.Tests.FileSystem.DirectoryInfo;
@@ -173,19 +170,9 @@ public partial class ResolveLinkTargetTests
 
 		if (Test.RunsOnWindows)
 		{
-			const int errorCode = 267; // Magic number, error code was discovered via debugger
-			Marshal.SetLastPInvokeError(errorCode);
-
-			string errorMessage =
-#if NET8_0_OR_GREATER
-					Marshal.GetPInvokeErrorMessage(errorCode)
-#else
-						"The directory name is invalid." // Marshal.GetPInvokeErrorMessage is only available for .NET 7 and above
-#endif
-				;
 			await That(() => dirSymLink.ResolveLinkTarget(true)).Throws<IOException>()
 				.WithMessage(
-					$@"^{Regex.Escape(errorMessage)} \: \'{Regex.Escape(dirSymLink.FullName)}\'\.?$"
+					$@"^.*directory.*invalid.*\'{Regex.Escape(dirSymLink.FullName)}\'"
 				).AsRegex().And.WithHResult(-2147024629);
 		}
 		else

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ResolveLinkTargetTests.cs
@@ -25,7 +25,11 @@ public partial class ResolveLinkTargetTests
 	)
 	{
 		int maxLinks = MaxResolveLinks + 1;
-		await FileSystem.File.WriteAllTextAsync(pathToFinalTarget, string.Empty, CancellationToken.None);
+
+		await FileSystem.File.WriteAllTextAsync(
+			pathToFinalTarget, string.Empty, CancellationToken.None
+		);
+
 		string previousPath = pathToFinalTarget;
 
 		for (int i = 0; i < maxLinks; i++)
@@ -160,15 +164,21 @@ public partial class ResolveLinkTargetTests
 		IFileSystemInfo fileSymLink
 			= FileSystem.File.CreateSymbolicLink(fileLinkName, dirSymLink.FullName);
 
+		string? Act()
+		{
+			return fileSymLink.ResolveLinkTarget(true)?.FullName;
+		}
+
 		if (Test.RunsOnWindows)
 		{
-			await That(() => fileSymLink.ResolveLinkTarget(true))
-				.Throws<UnauthorizedAccessException>().WithMessage($"Access to the path '{fileSymLink.FullName}' is denied.");
+			await That(Act)
+				.Throws<UnauthorizedAccessException>().WithMessage(
+					$"Access to the path '{fileSymLink.FullName}' is denied."
+				);
 		}
 		else
 		{
-			await That(() => fileSymLink.ResolveLinkTarget(true))
-				.DoesNotThrow<UnauthorizedAccessException>();
+			await That(Act()).IsEqualTo(targetFile.FullName);
 		}
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ResolveLinkTargetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ResolveLinkTargetTests.cs
@@ -136,8 +136,7 @@ public partial class ResolveLinkTargetTests
 		if (Test.RunsOnWindows)
 		{
 			await That(() => fileSymLink.ResolveLinkTarget(true))
-				.Throws<UnauthorizedAccessException>().Which
-				.Satisfies(x => x.Message.Contains(fileSymLink.FullName, StringComparison.Ordinal));
+				.Throws<UnauthorizedAccessException>().WithMessage($"Access to the path '{fileSymLink.FullName}' is denied.");
 		}
 		else
 		{


### PR DESCRIPTION
Closes #818