### PR TITLE
fix: MockTimeProvider constructor treats "now" having DateTimeKind.Unspecified as if it had DateTimeKind.Local

### DIFF
--- a/Source/Testably.Abstractions.Testing/TimeProvider.cs
+++ b/Source/Testably.Abstractions.Testing/TimeProvider.cs
@@ -34,6 +34,9 @@ public static class TimeProvider
 	/// <summary>
 	///     Initializes the <see cref="MockTimeSystem.TimeProvider" /> with the specified <paramref name="time" />.
 	/// </summary>
+	/// <remarks>
+	///     If the <paramref name="time" /> has Kind DateTimeKind.Unspecified it will be treated as if it had Kind DateTimeKind.Local.
+	/// </remarks>
 	public static ITimeProvider Use(DateTime time)
 	{
 		return new TimeProviderMock(time, "Fixed");

--- a/Source/Testably.Abstractions.Testing/TimeProvider.cs
+++ b/Source/Testably.Abstractions.Testing/TimeProvider.cs
@@ -35,7 +35,7 @@ public static class TimeProvider
 	///     Initializes the <see cref="MockTimeSystem.TimeProvider" /> with the specified <paramref name="time" />.
 	/// </summary>
 	/// <remarks>
-	///     If the <paramref name="time" /> has Kind DateTimeKind.Unspecified it will be treated as if it had Kind DateTimeKind.Local.
+	///     If the <paramref name="time" /> has Kind DateTimeKind.Unspecified it will be treated as if it had Kind DateTimeKind.Utc.
 	/// </remarks>
 	public static ITimeProvider Use(DateTime time)
 	{

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimeProviderMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimeProviderMock.cs
@@ -17,7 +17,10 @@ internal sealed class TimeProviderMock : ITimeProvider
 
 	public TimeProviderMock(DateTime now, string description)
 	{
-		_now = now;
+		_now = now.Kind == DateTimeKind.Unspecified
+			? DateTime.SpecifyKind(now, DateTimeKind.Local)
+			: now;
+
 		_description = description;
 	}
 

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimeProviderMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimeProviderMock.cs
@@ -18,7 +18,7 @@ internal sealed class TimeProviderMock : ITimeProvider
 	public TimeProviderMock(DateTime now, string description)
 	{
 		_now = now.Kind == DateTimeKind.Unspecified
-			? DateTime.SpecifyKind(now, DateTimeKind.Local)
+			? DateTime.SpecifyKind(now, DateTimeKind.Utc)
 			: now;
 
 		_description = description;

--- a/Tests/Testably.Abstractions.Testing.Tests/MockTimeSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockTimeSystemTests.cs
@@ -118,7 +118,7 @@ public class MockTimeSystemTests
 		string result = timeSystem.ToString();
 
 		await That(result).Contains("Fixed");
-		await That(result).Contains($"{now.ToUniversalTime()}Z");
+		await That(result).Contains($"{now}Z");
 	}
 
 	[Fact]

--- a/Tests/Testably.Abstractions.Testing.Tests/MockTimeSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockTimeSystemTests.cs
@@ -52,6 +52,22 @@ public class MockTimeSystemTests
 		await That(Act).ThrowsExactly<ArgumentOutOfRangeException>().WithParamName("delay");
 	}
 
+	[Theory]
+	[InlineData(DateTimeKind.Local)]
+	[InlineData(DateTimeKind.Unspecified)]
+	[InlineData(DateTimeKind.Utc)]
+	public async Task DifferenceBetweenDateTimeNowAndDateTimeUtcNow_ShouldBeLocalTimeZoneOffsetFromUtc(DateTimeKind dateTimeKind)
+	{
+		DateTime now = TimeTestHelper.GetRandomTime(DateTimeKind.Local);
+
+		var expectedDifference = TimeZoneInfo.Local.GetUtcOffset(now);
+
+		MockTimeSystem timeSystem = new(DateTime.SpecifyKind(now, dateTimeKind));
+		var actualDifference = timeSystem.DateTime.Now - timeSystem.DateTime.UtcNow;
+
+		await That(actualDifference).IsEqualTo(expectedDifference);
+	}
+
 	[Fact]
 	public async Task Sleep_Infinite_ShouldNotThrowException()
 	{

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeProviderTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeProviderTests.cs
@@ -59,4 +59,13 @@ public class TimeProviderTests
 		await That(result1).IsEqualTo(now);
 		await That(result2).IsEqualTo(now);
 	}
+
+	[Fact]
+	public async Task Use_UnspecifiedKind_ShouldConvertToLocalDateTime()
+	{
+		DateTime unspecifiedTime = TimeTestHelper.GetRandomTime(DateTimeKind.Unspecified);
+		ITimeProvider timeProvider = TimeProvider.Use(unspecifiedTime);
+		DateTime result1 = timeProvider.Read();
+		await That(result1).IsEqualTo(DateTime.SpecifyKind(unspecifiedTime, DateTimeKind.Local));
+	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeProviderTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeProviderTests.cs
@@ -61,11 +61,11 @@ public class TimeProviderTests
 	}
 
 	[Fact]
-	public async Task Use_UnspecifiedKind_ShouldConvertToLocalDateTime()
+	public async Task Use_UnspecifiedKind_ShouldConvertToUtcDateTime()
 	{
 		DateTime unspecifiedTime = TimeTestHelper.GetRandomTime(DateTimeKind.Unspecified);
 		ITimeProvider timeProvider = TimeProvider.Use(unspecifiedTime);
-		DateTime result1 = timeProvider.Read();
-		await That(result1).IsEqualTo(DateTime.SpecifyKind(unspecifiedTime, DateTimeKind.Local));
+		DateTime result = timeProvider.Read();
+		await That(result).IsEqualTo(DateTime.SpecifyKind(unspecifiedTime, DateTimeKind.Utc));
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/NotificationHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/NotificationHandlerTests.cs
@@ -60,7 +60,7 @@ public class NotificationHandlerTests
 	[Fact]
 	public async Task OnDateTimeRead_Today_ShouldExecuteCallbackWithCorrectParameter()
 	{
-		DateTime expectedTime = TimeTestHelper.GetRandomTime().Date;
+		DateTime expectedTime = TimeTestHelper.GetRandomTime(DateTimeKind.Local).Date;
 		MockTimeSystem timeSystem = new(expectedTime);
 		DateTime? receivedTime = null;
 


### PR DESCRIPTION
The difference between `DateTime.Now` And `DateTime.UtcNow` should be the offset from the local time zone to UTC. Before this change, `MockTimeSystem` would produce a difference double that size when initialized with a `DateTime` having `Kind` `DateTimeKind.Unspecified`.

The `MockTimeSystem` delegates to a `MockDateTime` wrapped around a `TimeProviderMock`. The `TimeProviderMock` would yield a `DateTime` with `Kind` `DateTimeKind.Unspecified` to the `MockDateTime`, which would then apply `ToLocalTime()` for `Now` or `ToUniversalTime` for `UtcNow`. When applied to a `DateTime` with `Kind` `DateTimeKind.Unspecified`, `ToLocalTime` assumes that the value is in UTC, but `ToUniversalTime` assumes that it is Local. This discrepancy results in the doubling of the expected difference.

Additionally, the test `OnDateTimeRead_Today_ShouldExecuteCallbackWithCorrectParameter` was failing, but only when run on systems outside of UTC. On systems running inside UTC, there was no difference between `Now` and `UtcNow`, so the error was hidden.

So, when the `MockTimeSystem` is initialized with a `DateTime` which has `Kind` `DateTimeKind.Unspecified`, it should pick a specific kind to use internally. Either `Utc` or `Local` would work.
`Utc` was selected because local times often lead to tests that only work in a specific time zone and should be selected intentionally.