### PR TITLE
fix: use UTF8 encoding without preamble as default

### DIFF
--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 
@@ -45,14 +44,30 @@ public partial class AppendAllLinesAsyncTests
 
 	[Theory]
 	[AutoData]
+	public async Task AppendAllLinesAsync_Enumerable_WithoutEncoding_ShouldUseUtf8(
+		string path)
+	{
+		string[] contents = ["breuß"];
+
+		await FileSystem.File.AppendAllLinesAsync(path, contents.AsEnumerable(),
+			CancellationToken.None);
+
+		byte[] bytes = FileSystem.File.ReadAllBytes(path);
+		await That(bytes.Length).IsEqualTo(6 + Environment.NewLine.Length);
+	}
+
+	[Theory]
+	[AutoData]
 	public async Task AppendAllLinesAsync_ExistingFile_ShouldAppendLinesToFile(
 		string path, List<string> previousContents, List<string> contents)
 	{
 		string expectedContent = string.Join(Environment.NewLine, previousContents.Concat(contents))
 		                         + Environment.NewLine;
-		await FileSystem.File.AppendAllLinesAsync(path, previousContents, TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllLinesAsync(path, previousContents,
+			TestContext.Current.CancellationToken);
 
-		await FileSystem.File.AppendAllLinesAsync(path, contents, TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllLinesAsync(path, contents,
+			TestContext.Current.CancellationToken);
 
 		await That(FileSystem.File.Exists(path)).IsTrue();
 		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(expectedContent);
@@ -67,7 +82,8 @@ public partial class AppendAllLinesAsyncTests
 
 		async Task Act()
 		{
-			await FileSystem.File.AppendAllLinesAsync(filePath, contents, TestContext.Current.CancellationToken);
+			await FileSystem.File.AppendAllLinesAsync(filePath, contents,
+				TestContext.Current.CancellationToken);
 		}
 
 		await That(Act).Throws<DirectoryNotFoundException>().WithHResult(-2147024893);
@@ -81,7 +97,8 @@ public partial class AppendAllLinesAsyncTests
 		string expectedContent = string.Join(Environment.NewLine, contents)
 		                         + Environment.NewLine;
 
-		await FileSystem.File.AppendAllLinesAsync(path, contents, TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllLinesAsync(path, contents,
+			TestContext.Current.CancellationToken);
 
 		await That(FileSystem.File.Exists(path)).IsTrue();
 		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(expectedContent);
@@ -94,7 +111,8 @@ public partial class AppendAllLinesAsyncTests
 	{
 		async Task Act()
 		{
-			await FileSystem.File.AppendAllLinesAsync(path, null!, TestContext.Current.CancellationToken);
+			await FileSystem.File.AppendAllLinesAsync(path, null!,
+				TestContext.Current.CancellationToken);
 		}
 
 		await That(Act).Throws<ArgumentNullException>()
@@ -109,7 +127,8 @@ public partial class AppendAllLinesAsyncTests
 	{
 		async Task Act()
 		{
-			await FileSystem.File.AppendAllLinesAsync(path, [], null!, TestContext.Current.CancellationToken);
+			await FileSystem.File.AppendAllLinesAsync(path, [], null!,
+				TestContext.Current.CancellationToken);
 		}
 
 		await That(Act).Throws<ArgumentNullException>()
@@ -124,7 +143,8 @@ public partial class AppendAllLinesAsyncTests
 		string[] contents = ["foo", "bar"];
 		string expectedResult = "foo" + Environment.NewLine + "bar" + Environment.NewLine;
 
-		await FileSystem.File.AppendAllLinesAsync(path, contents, TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllLinesAsync(path, contents,
+			TestContext.Current.CancellationToken);
 
 		await That(FileSystem.File.Exists(path)).IsTrue();
 		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(expectedResult);
@@ -140,7 +160,8 @@ public partial class AppendAllLinesAsyncTests
 
 		async Task Act()
 		{
-			await FileSystem.File.AppendAllLinesAsync(path, contents, TestContext.Current.CancellationToken);
+			await FileSystem.File.AppendAllLinesAsync(path, contents,
+				TestContext.Current.CancellationToken);
 		}
 
 		await That(Act).Throws<UnauthorizedAccessException>().WithHResult(-2147024891);
@@ -157,7 +178,8 @@ public partial class AppendAllLinesAsyncTests
 		string path = new Fixture().Create<string>();
 		string[] lines = new Fixture().Create<string[]>();
 		lines[1] = specialLine;
-		await FileSystem.File.AppendAllLinesAsync(path, lines, writeEncoding, TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllLinesAsync(path, lines, writeEncoding,
+			TestContext.Current.CancellationToken);
 
 		string[] result = FileSystem.File.ReadAllLines(path, readEncoding);
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
@@ -10,6 +10,19 @@ public partial class AppendAllLinesTests
 {
 	[Theory]
 	[AutoData]
+	public async Task AppendAllLines_Enumerable_WithoutEncoding_ShouldUseUtf8(
+		string path)
+	{
+		string[] contents = ["breuß"];
+
+		FileSystem.File.AppendAllLines(path, contents.AsEnumerable());
+
+		byte[] bytes = FileSystem.File.ReadAllBytes(path);
+		await That(bytes.Length).IsEqualTo(6 + Environment.NewLine.Length);
+	}
+
+	[Theory]
+	[AutoData]
 	public async Task AppendAllLines_ExistingFile_ShouldAppendLinesToFile(
 		string path, List<string> previousContents, List<string> contents)
 	{
@@ -111,5 +124,18 @@ public partial class AppendAllLinesTests
 
 		await That(result).IsNotEqualTo(lines).InAnyOrder();
 		await That(result[0]).IsEqualTo(lines[0]);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task AppendAllLines_WithoutEncoding_ShouldUseUtf8(
+		string path)
+	{
+		string[] contents = ["breuß"];
+
+		FileSystem.File.AppendAllLines(path, contents);
+
+		byte[] bytes = FileSystem.File.ReadAllBytes(path);
+		await That(bytes.Length).IsEqualTo(6 + Environment.NewLine.Length);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
@@ -44,9 +44,11 @@ public partial class AppendAllTextAsyncTests
 	public async Task AppendAllTextAsync_ExistingFile_ShouldAppendLinesToFile(
 		string path, string previousContents, string contents)
 	{
-		await FileSystem.File.AppendAllTextAsync(path, previousContents, TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllTextAsync(path, previousContents,
+			TestContext.Current.CancellationToken);
 
-		await FileSystem.File.AppendAllTextAsync(path, contents, TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllTextAsync(path, contents,
+			TestContext.Current.CancellationToken);
 
 		await That(FileSystem.File.Exists(path)).IsTrue();
 		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(previousContents + contents);
@@ -61,7 +63,8 @@ public partial class AppendAllTextAsyncTests
 
 		async Task Act()
 		{
-			await FileSystem.File.AppendAllTextAsync(filePath, contents, TestContext.Current.CancellationToken);
+			await FileSystem.File.AppendAllTextAsync(filePath, contents,
+				TestContext.Current.CancellationToken);
 		}
 
 		await That(Act).Throws<DirectoryNotFoundException>().WithHResult(-2147024893);
@@ -72,7 +75,8 @@ public partial class AppendAllTextAsyncTests
 	public async Task AppendAllTextAsync_MissingFile_ShouldCreateFile(
 		string path, string contents)
 	{
-		await FileSystem.File.AppendAllTextAsync(path, contents, TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllTextAsync(path, contents,
+			TestContext.Current.CancellationToken);
 
 		await That(FileSystem.File.Exists(path)).IsTrue();
 		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(contents);
@@ -84,7 +88,8 @@ public partial class AppendAllTextAsyncTests
 	{
 		string contents = "foo";
 
-		await FileSystem.File.AppendAllTextAsync(path, contents, TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllTextAsync(path, contents,
+			TestContext.Current.CancellationToken);
 
 		await That(FileSystem.File.Exists(path)).IsTrue();
 		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(contents);
@@ -100,7 +105,8 @@ public partial class AppendAllTextAsyncTests
 
 		async Task Act()
 		{
-			await FileSystem.File.AppendAllTextAsync(path, contents, TestContext.Current.CancellationToken);
+			await FileSystem.File.AppendAllTextAsync(path, contents,
+				TestContext.Current.CancellationToken);
 		}
 
 		await That(Act).Throws<UnauthorizedAccessException>().WithHResult(-2147024891);
@@ -114,11 +120,25 @@ public partial class AppendAllTextAsyncTests
 		string contents, Encoding writeEncoding, Encoding readEncoding)
 	{
 		string path = new Fixture().Create<string>();
-		await FileSystem.File.AppendAllTextAsync(path, contents, writeEncoding, TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllTextAsync(path, contents, writeEncoding,
+			TestContext.Current.CancellationToken);
 
 		string[] result = FileSystem.File.ReadAllLines(path, readEncoding);
 
 		await That(result).IsNotEqualTo([contents]);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task AppendAllTextAsync_WithoutEncoding_ShouldUseUtf8(
+		string path)
+	{
+		string contents = "breuß";
+
+		await FileSystem.File.AppendAllTextAsync(path, contents, CancellationToken.None);
+
+		byte[] bytes = FileSystem.File.ReadAllBytes(path);
+		await That(bytes.Length).IsEqualTo(6);
 	}
 
 #if FEATURE_FILE_SPAN
@@ -146,7 +166,8 @@ public partial class AppendAllTextAsyncTests
 		cts.Cancel();
 
 		async Task Act() =>
-			await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(), Encoding.UTF8, cts.Token);
+			await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(), Encoding.UTF8,
+				cts.Token);
 
 		await That(Act).Throws<TaskCanceledException>().WithHResult(-2146233029);
 	}
@@ -156,9 +177,11 @@ public partial class AppendAllTextAsyncTests
 	public async Task AppendAllTextAsync_ReadOnlyMemory_ExistingFile_ShouldAppendLinesToFile(
 		string path, string previousContents, string contents)
 	{
-		await FileSystem.File.AppendAllTextAsync(path, previousContents, TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllTextAsync(path, previousContents,
+			TestContext.Current.CancellationToken);
 
-		await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(), TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(),
+			TestContext.Current.CancellationToken);
 
 		await That(FileSystem.File.Exists(path)).IsTrue();
 		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(previousContents + contents);
@@ -166,14 +189,16 @@ public partial class AppendAllTextAsyncTests
 
 	[Theory]
 	[AutoData]
-	public async Task AppendAllTextAsync_ReadOnlyMemory_MissingDirectory_ShouldThrowDirectoryNotFoundException(
-		string missingPath, string fileName, string contents)
+	public async Task
+		AppendAllTextAsync_ReadOnlyMemory_MissingDirectory_ShouldThrowDirectoryNotFoundException(
+			string missingPath, string fileName, string contents)
 	{
 		string filePath = FileSystem.Path.Combine(missingPath, fileName);
 
 		async Task Act()
 		{
-			await FileSystem.File.AppendAllTextAsync(filePath, contents.AsMemory(), TestContext.Current.CancellationToken);
+			await FileSystem.File.AppendAllTextAsync(filePath, contents.AsMemory(),
+				TestContext.Current.CancellationToken);
 		}
 
 		await That(Act).Throws<DirectoryNotFoundException>().WithHResult(-2147024893);
@@ -184,7 +209,8 @@ public partial class AppendAllTextAsyncTests
 	public async Task AppendAllTextAsync_ReadOnlyMemory_MissingFile_ShouldCreateFile(
 		string path, string contents)
 	{
-		await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(), TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(),
+			TestContext.Current.CancellationToken);
 
 		await That(FileSystem.File.Exists(path)).IsTrue();
 		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(contents);
@@ -196,7 +222,8 @@ public partial class AppendAllTextAsyncTests
 	{
 		string contents = "foo";
 
-		await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(), TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(),
+			TestContext.Current.CancellationToken);
 
 		await That(FileSystem.File.Exists(path)).IsTrue();
 		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(contents);
@@ -212,7 +239,8 @@ public partial class AppendAllTextAsyncTests
 
 		async Task Act()
 		{
-			await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(), TestContext.Current.CancellationToken);
+			await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(),
+				TestContext.Current.CancellationToken);
 		}
 
 		await That(Act).Throws<UnauthorizedAccessException>().WithHResult(-2147024891);
@@ -222,15 +250,30 @@ public partial class AppendAllTextAsyncTests
 
 	[Theory]
 	[ClassData(typeof(TestDataGetEncodingDifference))]
-	public async Task AppendAllTextAsync_ReadOnlyMemory_WithDifferentEncoding_ShouldNotReturnWrittenText(
-		string contents, Encoding writeEncoding, Encoding readEncoding)
+	public async Task
+		AppendAllTextAsync_ReadOnlyMemory_WithDifferentEncoding_ShouldNotReturnWrittenText(
+			string contents, Encoding writeEncoding, Encoding readEncoding)
 	{
 		string path = new Fixture().Create<string>();
-		await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(), writeEncoding, TestContext.Current.CancellationToken);
+		await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(), writeEncoding,
+			TestContext.Current.CancellationToken);
 
 		string[] result = FileSystem.File.ReadAllLines(path, readEncoding);
 
 		await That(result).IsNotEqualTo([contents]);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task AppendAllTextAsync_ReadOnlyMemory_WithoutEncoding_ShouldUseUtf8(
+		string path)
+	{
+		string contents = "breuß";
+
+		await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(), CancellationToken.None);
+
+		byte[] bytes = FileSystem.File.ReadAllBytes(path);
+		await That(bytes.Length).IsEqualTo(6);
 	}
 #endif
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
@@ -152,6 +152,19 @@ public partial class AppendAllTextTests
 		await That(result).IsNotEqualTo([contents]);
 	}
 
+	[Theory]
+	[AutoData]
+	public async Task AppendAllText_WithoutEncoding_ShouldUseUtf8(
+		string path)
+	{
+		string contents = "breuß";
+
+		FileSystem.File.AppendAllText(path, contents);
+
+		byte[] bytes = FileSystem.File.ReadAllBytes(path);
+		await That(bytes.Length).IsEqualTo(6);
+	}
+
 #if FEATURE_FILE_SPAN
 	[Theory]
 	[AutoData]
@@ -172,6 +185,7 @@ public partial class AppendAllTextTests
 		string missingPath, string fileName, string contents)
 	{
 		string filePath = FileSystem.Path.Combine(missingPath, fileName);
+
 		void Act()
 		{
 			FileSystem.File.AppendAllText(filePath, contents.AsSpan());
@@ -224,12 +238,14 @@ public partial class AppendAllTextTests
 
 		if (Test.RunsOnWindows)
 		{
-			await That(creationTime).IsBetween(creationTimeStart).And(creationTimeEnd).Within(TimeComparison.Tolerance);
+			await That(creationTime).IsBetween(creationTimeStart).And(creationTimeEnd)
+				.Within(TimeComparison.Tolerance);
 			await That(lastAccessTime).IsOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
-			await That(lastAccessTime).IsBetween(creationTimeStart).And(creationTimeEnd).Within(TimeComparison.Tolerance);
+			await That(lastAccessTime).IsBetween(creationTimeStart).And(creationTimeEnd)
+				.Within(TimeComparison.Tolerance);
 		}
 
 		await That(lastWriteTime).IsOnOrAfter(updateTime.ApplySystemClockTolerance());
@@ -292,6 +308,19 @@ public partial class AppendAllTextTests
 		string[] result = FileSystem.File.ReadAllLines(path, readEncoding);
 
 		await That(result).IsNotEqualTo([contents]);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task AppendAllText_Span_WithoutEncoding_ShouldUseUtf8(
+		string path)
+	{
+		string contents = "breuß";
+
+		FileSystem.File.AppendAllText(path, contents.AsSpan());
+
+		byte[] bytes = FileSystem.File.ReadAllBytes(path);
+		await That(bytes.Length).IsEqualTo(6);
 	}
 #endif
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesAsyncTests.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
 
@@ -78,10 +77,11 @@ public partial class WriteAllLinesAsyncTests
 	{
 		await FileSystem.File.WriteAllTextAsync(path, "foo", TestContext.Current.CancellationToken);
 
-		await FileSystem.File.WriteAllLinesAsync(path, contents.AsEnumerable(), TestContext.Current.CancellationToken);
+		await FileSystem.File.WriteAllLinesAsync(path, contents.AsEnumerable(),
+			TestContext.Current.CancellationToken);
 
 		string[] result =
- await FileSystem.File.ReadAllLinesAsync(path, TestContext.Current.CancellationToken);
+			await FileSystem.File.ReadAllLinesAsync(path, TestContext.Current.CancellationToken);
 		await That(result).IsEqualTo(contents);
 	}
 
@@ -90,11 +90,26 @@ public partial class WriteAllLinesAsyncTests
 	public async Task WriteAllLinesAsync_Enumerable_ShouldCreateFileWithText(
 		string path, string[] contents)
 	{
-		await FileSystem.File.WriteAllLinesAsync(path, contents.AsEnumerable(), TestContext.Current.CancellationToken);
+		await FileSystem.File.WriteAllLinesAsync(path, contents.AsEnumerable(),
+			TestContext.Current.CancellationToken);
 
 		string[] result =
- await FileSystem.File.ReadAllLinesAsync(path, TestContext.Current.CancellationToken);
+			await FileSystem.File.ReadAllLinesAsync(path, TestContext.Current.CancellationToken);
 		await That(result).IsEqualTo(contents);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task WriteAllLinesAsync_Enumerable_WithoutEncoding_ShouldUseUtf8(
+		string path)
+	{
+		string[] contents = ["breuß"];
+
+		await FileSystem.File.WriteAllLinesAsync(path, contents.AsEnumerable(),
+			CancellationToken.None);
+
+		byte[] bytes = FileSystem.File.ReadAllBytes(path);
+		await That(bytes.Length).IsEqualTo(6 + Environment.NewLine.Length);
 	}
 
 	[Theory]
@@ -104,10 +119,11 @@ public partial class WriteAllLinesAsyncTests
 	{
 		await FileSystem.File.WriteAllTextAsync(path, "foo", TestContext.Current.CancellationToken);
 
-		await FileSystem.File.WriteAllLinesAsync(path, contents, TestContext.Current.CancellationToken);
+		await FileSystem.File.WriteAllLinesAsync(path, contents,
+			TestContext.Current.CancellationToken);
 
 		string[] result =
- await FileSystem.File.ReadAllLinesAsync(path, TestContext.Current.CancellationToken);
+			await FileSystem.File.ReadAllLinesAsync(path, TestContext.Current.CancellationToken);
 		await That(result).IsEqualTo(contents);
 	}
 
@@ -116,10 +132,11 @@ public partial class WriteAllLinesAsyncTests
 	public async Task WriteAllLinesAsync_ShouldCreateFileWithText(
 		string path, string[] contents)
 	{
-		await FileSystem.File.WriteAllLinesAsync(path, contents, TestContext.Current.CancellationToken);
+		await FileSystem.File.WriteAllLinesAsync(path, contents,
+			TestContext.Current.CancellationToken);
 
 		string[] result =
- await FileSystem.File.ReadAllLinesAsync(path, TestContext.Current.CancellationToken);
+			await FileSystem.File.ReadAllLinesAsync(path, TestContext.Current.CancellationToken);
 		await That(result).IsEqualTo(contents);
 	}
 
@@ -133,7 +150,8 @@ public partial class WriteAllLinesAsyncTests
 
 		async Task Act()
 		{
-			await FileSystem.File.WriteAllLinesAsync(path, contents, TestContext.Current.CancellationToken);
+			await FileSystem.File.WriteAllLinesAsync(path, contents,
+				TestContext.Current.CancellationToken);
 		}
 
 		await That(Act).Throws<UnauthorizedAccessException>().WithHResult(-2147024891);
@@ -154,7 +172,8 @@ public partial class WriteAllLinesAsyncTests
 
 		async Task Act()
 		{
-			await FileSystem.File.WriteAllLinesAsync(path, contents, TestContext.Current.CancellationToken);
+			await FileSystem.File.WriteAllLinesAsync(path, contents,
+				TestContext.Current.CancellationToken);
 		}
 
 		await That(Act).Throws<UnauthorizedAccessException>().WithHResult(-2147024891);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllLinesTests.cs
@@ -44,6 +44,19 @@ public partial class WriteAllLinesTests
 
 	[Theory]
 	[AutoData]
+	public async Task WriteAllLines_Enumerable_WithoutEncoding_ShouldUseUtf8(
+		string path)
+	{
+		string[] contents = ["breuß"];
+
+		FileSystem.File.WriteAllLines(path, contents.AsEnumerable());
+
+		byte[] bytes = FileSystem.File.ReadAllBytes(path);
+		await That(bytes.Length).IsEqualTo(6 + Environment.NewLine.Length);
+	}
+
+	[Theory]
+	[AutoData]
 	public async Task WriteAllLines_PreviousFile_ShouldOverwriteFileWithText(
 		string path, string[] contents)
 	{
@@ -111,5 +124,18 @@ public partial class WriteAllLinesTests
 
 		string[] result = FileSystem.File.ReadAllLines(path, encoding);
 		await That(result).IsEqualTo(contents);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task WriteAllLines_WithoutEncoding_ShouldUseUtf8(
+		string path)
+	{
+		string[] contents = ["breuß"];
+
+		FileSystem.File.WriteAllLines(path, contents);
+
+		byte[] bytes = FileSystem.File.ReadAllBytes(path);
+		await That(bytes.Length).IsEqualTo(6 + Environment.NewLine.Length);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextAsyncTests.cs
@@ -90,7 +90,8 @@ public partial class WriteAllTextAsyncTests
 			string result =
 				await FileSystem.File.ReadAllTextAsync(path, TestContext.Current.CancellationToken);
 
-			await That(result).IsEqualTo(contents).Because($"{contents} should be encoded and decoded identical.");
+			await That(result).IsEqualTo(contents)
+				.Because($"{contents} should be encoded and decoded identical.");
 		}
 	}
 
@@ -146,6 +147,19 @@ public partial class WriteAllTextAsyncTests
 		await That(Act).Throws<UnauthorizedAccessException>().WithHResult(-2147024891);
 	}
 
+	[Theory]
+	[AutoData]
+	public async Task WriteAllTextAsync_WithoutEncoding_ShouldUseUtf8(
+		string path)
+	{
+		string contents = "breuß";
+
+		await FileSystem.File.WriteAllTextAsync(path, contents, CancellationToken.None);
+
+		byte[] bytes = FileSystem.File.ReadAllBytes(path);
+		await That(bytes.Length).IsEqualTo(6);
+	}
+
 #if FEATURE_FILE_SPAN
 	[Theory]
 	[AutoData]
@@ -171,7 +185,8 @@ public partial class WriteAllTextAsyncTests
 		await cts.CancelAsync();
 
 		async Task Act() =>
-			await FileSystem.File.WriteAllTextAsync(path, contents.AsMemory(), Encoding.UTF8, cts.Token);
+			await FileSystem.File.WriteAllTextAsync(path, contents.AsMemory(), Encoding.UTF8,
+				cts.Token);
 
 		await That(Act).Throws<TaskCanceledException>().WithHResult(-2146233029);
 	}
@@ -229,7 +244,8 @@ public partial class WriteAllTextAsyncTests
 			string result =
 				await FileSystem.File.ReadAllTextAsync(path, TestContext.Current.CancellationToken);
 
-			await That(result).IsEqualTo(contents).Because($"{contents} should be encoded and decoded identical.");
+			await That(result).IsEqualTo(contents)
+				.Because($"{contents} should be encoded and decoded identical.");
 		}
 	}
 
@@ -270,6 +286,19 @@ public partial class WriteAllTextAsyncTests
 		}
 
 		await That(Act).Throws<UnauthorizedAccessException>().WithHResult(-2147024891);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task WriteAllTextAsync_ReadOnlyMemory_WithoutEncoding_ShouldUseUtf8(
+		string path)
+	{
+		string contents = "breuß";
+
+		await FileSystem.File.WriteAllTextAsync(path, contents.AsMemory(), CancellationToken.None);
+
+		byte[] bytes = FileSystem.File.ReadAllBytes(path);
+		await That(bytes.Length).IsEqualTo(6);
 	}
 #endif
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -196,6 +196,19 @@ public partial class WriteAllTextTests
 			.WithMessage($"Access to the path '{path}' is denied.");
 	}
 
+	[Theory]
+	[AutoData]
+	public async Task WriteAllText_WithoutEncoding_ShouldUseUtf8(
+		string path)
+	{
+		string contents = "breuß";
+
+		FileSystem.File.WriteAllText(path, contents);
+
+		byte[] bytes = FileSystem.File.ReadAllBytes(path);
+		await That(bytes.Length).IsEqualTo(6);
+	}
+
 #if FEATURE_FILE_SPAN
 	[Theory]
 	[AutoData]
@@ -203,6 +216,7 @@ public partial class WriteAllTextTests
 		string directory, string path)
 	{
 		string fullPath = FileSystem.Path.Combine(directory, path);
+
 		void Act()
 		{
 			FileSystem.File.WriteAllText(fullPath, "foo".AsSpan());
@@ -246,12 +260,14 @@ public partial class WriteAllTextTests
 
 		if (Test.RunsOnWindows)
 		{
-			await That(creationTime).IsBetween(creationTimeStart).And(creationTimeEnd).Within(TimeComparison.Tolerance);
+			await That(creationTime).IsBetween(creationTimeStart).And(creationTimeEnd)
+				.Within(TimeComparison.Tolerance);
 			await That(lastAccessTime).IsOnOrAfter(updateTime.ApplySystemClockTolerance());
 		}
 		else
 		{
-			await That(lastAccessTime).IsBetween(creationTimeStart).And(creationTimeEnd).Within(TimeComparison.Tolerance);
+			await That(lastAccessTime).IsBetween(creationTimeStart).And(creationTimeEnd)
+				.Within(TimeComparison.Tolerance);
 		}
 
 		await That(lastWriteTime).IsOnOrAfter(updateTime.ApplySystemClockTolerance());
@@ -301,14 +317,16 @@ public partial class WriteAllTextTests
 
 			string result = FileSystem.File.ReadAllText(path);
 
-			await That(result).IsEqualTo(contents).Because($"{contents} should be encoded and decoded identical.");
+			await That(result).IsEqualTo(contents)
+				.Because($"{contents} should be encoded and decoded identical.");
 		}
 	}
 
 	[Theory]
 	[AutoData]
-	public async Task WriteAllText_Span_WhenDirectoryWithSameNameExists_ShouldThrowUnauthorizedAccessException(
-		string path)
+	public async Task
+		WriteAllText_Span_WhenDirectoryWithSameNameExists_ShouldThrowUnauthorizedAccessException(
+			string path)
 	{
 		FileSystem.Directory.CreateDirectory(path);
 
@@ -324,8 +342,9 @@ public partial class WriteAllTextTests
 
 	[Theory]
 	[AutoData]
-	public async Task WriteAllText_Span_WhenFileIsHidden_ShouldThrowUnauthorizedAccessException_OnWindows(
-		string path, string contents)
+	public async Task
+		WriteAllText_Span_WhenFileIsHidden_ShouldThrowUnauthorizedAccessException_OnWindows(
+			string path, string contents)
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
@@ -338,6 +357,19 @@ public partial class WriteAllTextTests
 		}
 
 		await That(Act).Throws<UnauthorizedAccessException>().WithHResult(-2147024891);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task WriteAllText_Span_WithoutEncoding_ShouldUseUtf8(
+		string path)
+	{
+		string contents = "breuß";
+
+		FileSystem.File.WriteAllText(path, contents.AsSpan());
+
+		byte[] bytes = FileSystem.File.ReadAllBytes(path);
+		await That(bytes.Length).IsEqualTo(6);
 	}
 #endif
 }


### PR DESCRIPTION
This PR fixes the default encoding behavior in file write and append methods to use UTF-8 without BOM (byte order mark) instead of the system default encoding when no encoding is explicitly specified. This improves cross-platform compatibility.

### Key Changes:
- Modified file write/append methods to use UTF-8 encoding without preamble as default
- Consolidated encoding logic into a single `WriteText` helper method
- Added comprehensive tests to verify UTF-8 encoding behavior across all affected methods

---

- *Fixes #843*