### PR TITLE
fix: return correct `Parent` of `DirectoryInfo` with trailing directory separator

### DIFF
--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
@@ -90,9 +90,10 @@ internal sealed class InMemoryLocation : IStorageLocation
 	/// <inheritdoc cref="IStorageLocation.GetParent()" />
 	public IStorageLocation? GetParent()
 	{
-		string? parentPath = _fileSystem.Execute.Path.GetDirectoryName(FullPath);
+		string path = FullPath.TrimEnd(_fileSystem.Path.DirectorySeparatorChar);
+		string? parentPath = _fileSystem.Execute.Path.GetDirectoryName(path);
 		if (string.Equals(
-			    _fileSystem.Execute.Path.GetPathRoot(FullPath),
+			    _fileSystem.Execute.Path.GetPathRoot(path),
 			    FullPath,
 			    _fileSystem.Execute.StringComparisonMode)
 		    || parentPath == null)

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryLocation.cs
@@ -90,10 +90,12 @@ internal sealed class InMemoryLocation : IStorageLocation
 	/// <inheritdoc cref="IStorageLocation.GetParent()" />
 	public IStorageLocation? GetParent()
 	{
-		string path = FullPath.TrimEnd(_fileSystem.Path.DirectorySeparatorChar);
-		string? parentPath = _fileSystem.Execute.Path.GetDirectoryName(path);
+		string fullPathWithoutTrailingSeparator = FullPath
+			.TrimEnd(_fileSystem.Path.DirectorySeparatorChar);
+		string? parentPath =
+			_fileSystem.Execute.Path.GetDirectoryName(fullPathWithoutTrailingSeparator);
 		if (string.Equals(
-			    _fileSystem.Execute.Path.GetPathRoot(path),
+			    _fileSystem.Execute.Path.GetPathRoot(fullPathWithoutTrailingSeparator),
 			    FullPath,
 			    _fileSystem.Execute.StringComparisonMode)
 		    || parentPath == null)

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/Tests.cs
@@ -279,9 +279,8 @@ public partial class Tests
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New(path);
 
 		await That(sut.Parent).IsNotNull();
-		await That(sut?.Exists).IsFalse();
-		await That(sut?.Parent).IsNotNull();
-		await That(sut?.Parent?.Exists).IsFalse();
+		await That(sut.Exists).IsFalse();
+		await That(sut.Parent!.Exists).IsFalse();
 	}
 
 	[Fact]
@@ -341,6 +340,21 @@ public partial class Tests
 		{
 			await That(parent!.ToString()).IsEqualTo(FileSystem.Path.GetFullPath(expectedParent));
 		}
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Parent_WithTrailingDirectorySeparator_ShouldReturnCorrectParent(string path1,
+		string path2)
+	{
+		string path = FileSystem.Path.Combine(path1, path2);
+		string expectedParent = FileSystem.Path.GetFullPath(path1);
+
+		IDirectoryInfo sut =
+			FileSystem.DirectoryInfo.New(path + FileSystem.Path.DirectorySeparatorChar);
+
+		await That(sut.Parent).IsNotNull();
+		await That(sut.Parent!.FullName).IsEqualTo(expectedParent);
 	}
 
 	[Fact]


### PR DESCRIPTION
This PR fixes a bug in the `DirectoryInfo.Parent` property when the directory path contains a trailing directory separator. The issue was that the parent directory calculation incorrectly included the trailing separator, leading to wrong parent resolution.

### Key Changes
- Fixed the `GetParent()` method in `InMemoryLocation` to trim trailing directory separators before calculating the parent path
- Added a test case to verify the correct parent is returned when a directory path has a trailing separator

---

- *Fixes #842*