### PR TITLE
fix: trim trailing slash in `Directory.GetDirectories`

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DirectoryMock.cs
@@ -712,7 +712,8 @@ internal sealed class DirectoryMock : IDirectory
 				adjustedLocation.SearchPattern,
 				enumerationOptions)
 			.Select(x => _fileSystem
-				.GetSubdirectoryPath(x.FullPath, x.FriendlyName, adjustedLocation.GivenPath));
+				.GetSubdirectoryPath(x.FullPath, x.FriendlyName, adjustedLocation.GivenPath)
+				.TrimTrailingDirectorySeparator(_fileSystem));
 	}
 
 	private IDirectoryInfo LoadDirectoryInfoOrThrowNotFoundException(

--- a/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
@@ -175,6 +175,18 @@ internal static class PathHelper
 		return path;
 	}
 
+	internal static string TrimTrailingDirectorySeparator(this string path,
+		MockFileSystem fileSystem)
+	{
+		path = path.TrimEnd(fileSystem.Path.DirectorySeparatorChar);
+		if (string.IsNullOrEmpty(path))
+		{
+			return $"{fileSystem.Path.DirectorySeparatorChar}";
+		}
+
+		return path;
+	}
+
 	private static void CheckPathArgument(Execute execute, [NotNull] string? path, string paramName,
 		bool includeIsEmptyCheck)
 	{

--- a/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/PathHelper.cs
@@ -178,13 +178,12 @@ internal static class PathHelper
 	internal static string TrimTrailingDirectorySeparator(this string path,
 		MockFileSystem fileSystem)
 	{
-		path = path.TrimEnd(fileSystem.Path.DirectorySeparatorChar);
-		if (string.IsNullOrEmpty(path))
+		if (path.Length == 1 && path[0] == fileSystem.Path.DirectorySeparatorChar)
 		{
-			return $"{fileSystem.Path.DirectorySeparatorChar}";
+			return path;
 		}
 
-		return path;
+		return path.TrimEnd(fileSystem.Path.DirectorySeparatorChar);
 	}
 
 	private static void CheckPathArgument(Execute execute, [NotNull] string? path, string paramName,

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -348,7 +348,8 @@ public partial class CreateDirectoryTests
 		await That(result.Name).IsEqualTo(expectedName.TrimEnd(
 			FileSystem.Path.DirectorySeparatorChar,
 			FileSystem.Path.AltDirectorySeparatorChar));
-		await That(result.FullName).IsEqualTo($"{BasePath}{FileSystem.Path.DirectorySeparatorChar}{expectedName}"
+		await That(result.FullName).IsEqualTo(
+			$"{BasePath}{FileSystem.Path.DirectorySeparatorChar}{expectedName}"
 				.Replace(FileSystem.Path.AltDirectorySeparatorChar,
 					FileSystem.Path.DirectorySeparatorChar));
 		await That(FileSystem.Directory.Exists(nameWithSuffix)).IsTrue();

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
@@ -185,7 +185,8 @@ public partial class EnumerateDirectoriesTests
 	public async Task EnumerateDirectories_ShouldIncludeEmptyDirectoriesWithTrailingSlash()
 	{
 		string rootDirectory = "RootDir";
-		string emptyDirectory = FileSystem.Path.Combine(rootDirectory, "EmptyDir") + FileSystem.Path.DirectorySeparatorChar;
+		string emptyDirectory = FileSystem.Path.Combine(rootDirectory, "EmptyDir") +
+		                        FileSystem.Path.DirectorySeparatorChar;
 
 		FileSystem.Directory.CreateDirectory(emptyDirectory);
 
@@ -225,11 +226,29 @@ public partial class EnumerateDirectoriesTests
 			.InAnyOrder();
 	}
 
+	[Theory]
+	[InlineData('/')]
+	[InlineData('\\')]
+	public async Task EnumerateDirectories_TrailingDirectorySeparator_ShouldBeTrimmed(char suffix)
+	{
+		Skip.IfNot(Test.RunsOnWindows ||
+		           suffix == FileSystem.Path.DirectorySeparatorChar ||
+		           suffix == FileSystem.Path.AltDirectorySeparatorChar);
+
+		string path = $"foo{suffix}";
+
+		FileSystem.Directory.CreateDirectory(path);
+		IEnumerable<string> result = FileSystem.Directory.EnumerateDirectories(".");
+
+		await That(result).HasSingle()
+			.Which.DoesNotEndWith(suffix);
+	}
+
 #if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS
 	[Theory]
 	[AutoData]
 	public async Task EnumerateDirectories_WithEnumerationOptions_ShouldConsiderAttributesToSkip(
-			string path)
+		string path)
 	{
 		EnumerationOptions enumerationOptions = new()
 		{
@@ -254,7 +273,7 @@ public partial class EnumerateDirectoriesTests
 	[InlineData(true)]
 	[InlineData(false)]
 	public async Task EnumerateDirectories_WithEnumerationOptions_ShouldConsiderIgnoreInaccessible(
-			bool ignoreInaccessible)
+		bool ignoreInaccessible)
 	{
 		Skip.IfNot(Test.RunsOnWindows);
 
@@ -299,8 +318,8 @@ public partial class EnumerateDirectoriesTests
 	[InlineAutoData(MatchCasing.CaseInsensitive)]
 	[InlineAutoData(MatchCasing.CaseSensitive)]
 	public async Task EnumerateDirectories_WithEnumerationOptions_ShouldConsiderMatchCasing(
-			MatchCasing matchCasing,
-			string path)
+		MatchCasing matchCasing,
+		string path)
 	{
 		EnumerationOptions enumerationOptions = new()
 		{
@@ -329,8 +348,8 @@ public partial class EnumerateDirectoriesTests
 	[InlineAutoData(MatchType.Simple)]
 	[InlineAutoData(MatchType.Win32)]
 	public async Task EnumerateDirectories_WithEnumerationOptions_ShouldConsiderMatchType(
-			MatchType matchType,
-			string path)
+		MatchType matchType,
+		string path)
 	{
 		EnumerationOptions enumerationOptions = new()
 		{
@@ -360,7 +379,8 @@ public partial class EnumerateDirectoriesTests
 	[InlineAutoData(true, 2)]
 	[InlineAutoData(true, 3)]
 	[InlineAutoData(false, 2)]
-	public async Task EnumerateDirectories_WithEnumerationOptions_ShouldConsiderMaxRecursionDepthWhenRecurseSubdirectoriesIsSet(
+	public async Task
+		EnumerateDirectories_WithEnumerationOptions_ShouldConsiderMaxRecursionDepthWhenRecurseSubdirectoriesIsSet(
 			bool recurseSubdirectories,
 			int maxRecursionDepth,
 			string path)
@@ -409,7 +429,8 @@ public partial class EnumerateDirectoriesTests
 	[Theory]
 	[InlineAutoData(true)]
 	[InlineAutoData(false)]
-	public async Task EnumerateDirectories_WithEnumerationOptions_ShouldConsiderRecurseSubdirectories(
+	public async Task
+		EnumerateDirectories_WithEnumerationOptions_ShouldConsiderRecurseSubdirectories(
 			bool recurseSubdirectories,
 			string path)
 	{
@@ -440,7 +461,8 @@ public partial class EnumerateDirectoriesTests
 	[Theory]
 	[InlineAutoData(true)]
 	[InlineAutoData(false)]
-	public async Task EnumerateDirectories_WithEnumerationOptions_ShouldConsiderReturnSpecialDirectories(
+	public async Task
+		EnumerateDirectories_WithEnumerationOptions_ShouldConsiderReturnSpecialDirectories(
 			bool returnSpecialDirectories,
 			string path)
 	{
@@ -469,7 +491,8 @@ public partial class EnumerateDirectoriesTests
 
 #if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS
 	[Fact]
-	public async Task EnumerateDirectories_WithEnumerationOptions_ShouldConsiderReturnSpecialDirectoriesCorrectlyForPathRoots()
+	public async Task
+		EnumerateDirectories_WithEnumerationOptions_ShouldConsiderReturnSpecialDirectoriesCorrectlyForPathRoots()
 	{
 		string root = FileSystem.Path.GetPathRoot(FileSystem.Directory.GetCurrentDirectory())!;
 		EnumerationOptions enumerationOptions = new()

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/GetDirectoriesTests.cs
@@ -101,11 +101,29 @@ public partial class GetDirectoriesTests
 		}
 	}
 
+	[Theory]
+	[InlineData('/')]
+	[InlineData('\\')]
+	public async Task GetDirectories_TrailingDirectorySeparator_ShouldBeTrimmed(char suffix)
+	{
+		Skip.IfNot(Test.RunsOnWindows ||
+		           suffix == FileSystem.Path.DirectorySeparatorChar ||
+		           suffix == FileSystem.Path.AltDirectorySeparatorChar);
+
+		string path = $"foo{suffix}";
+
+		FileSystem.Directory.CreateDirectory(path);
+		string[] result = FileSystem.Directory.GetDirectories(".");
+
+		await That(result).HasSingle()
+			.Which.DoesNotEndWith(suffix);
+	}
+
 #if FEATURE_FILESYSTEM_ENUMERATION_OPTIONS
 	[Theory]
 	[AutoData]
 	public async Task GetDirectories_WithEnumerationOptions_ShouldConsiderSetOptions(
-			string path)
+		string path)
 	{
 		IDirectoryInfo baseDirectory =
 			FileSystem.Directory.CreateDirectory(path);


### PR DESCRIPTION
This PR fixes the `Directory.GetDirectories` method to trim trailing slashes from directory paths in the returned results. This ensures consistent behavior where directory paths returned by enumeration methods don't include trailing directory separators.

### Key changes:
- Adds helper method `TrimTrailingDirectorySeparator` for consistent path normalization
- Updates directory enumeration logic to remove trailing slashes from results
- Includes comprehensive test coverage for both `GetDirectories` and `EnumerateDirectories` methods

---

- *Fixes #850*