### PR TITLE
docs: Update GitHub funding options

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [vbreuss]


### PR DESCRIPTION
This PR updates the GitHub funding configuration by adding a GitHub sponsor option for the user @vbreuss.