### PR TITLE
docs: Update GitHub funding username to Testably organization

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [vbreuss]
+github: [Testably]


### PR DESCRIPTION
This PR updates the GitHub Sponsors funding configuration to redirect sponsorship from an individual user account to the [Testably organization account](https://github.com/sponsors/Testably).