### PR TITLE
fix: update the location of moved or replaced containers

### DIFF
--- a/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/IStorageContainer.cs
@@ -94,6 +94,11 @@ internal interface IStorageContainer : IFileSystemEntity, ITimeSystemEntity
 		IStorageLocation? onBehalfOfLocation = null);
 
 	/// <summary>
+	///     Updates the location of the container.
+	/// </summary>
+	IStorageContainer UpdateLocation(IStorageLocation newLocation);
+
+	/// <summary>
 	///     Writes the <paramref name="bytes" /> to the <see cref="IFileInfo" />.
 	/// </summary>
 	void WriteBytes(byte[] bytes);

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -17,7 +17,7 @@ internal sealed class InMemoryContainer : IStorageContainer
 	private readonly FileSystemExtensibility _extensibility = new();
 	private readonly MockFileSystem _fileSystem;
 	private bool _isEncrypted;
-	private readonly IStorageLocation _location;
+	private IStorageLocation _location;
 
 #if FEATURE_FILESYSTEM_UNIXFILEMODE
 	private UnixFileMode _unixFileMode = UnixFileMode.OtherRead |
@@ -221,6 +221,13 @@ internal sealed class InMemoryContainer : IStorageContainer
 
 		throw ExceptionFactory.ProcessCannotAccessTheFile(_location.FullPath,
 			hResult ?? -2147024864);
+	}
+
+	/// <inheritdoc cref="IStorageContainer.UpdateLocation(IStorageLocation)" />
+	public IStorageContainer UpdateLocation(IStorageLocation newLocation)
+	{
+		_location = newLocation;
+		return this;
 	}
 
 	/// <inheritdoc cref="IStorageContainer.WriteBytes(byte[])" />

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryStorage.cs
@@ -550,7 +550,7 @@ internal sealed class InMemoryStorage : IStorage
 						existingDestinationContainer.GetBytes().Length;
 					destination.Drive?.ChangeUsedBytes(-1 * destinationBytesLength);
 					if (backup != null &&
-					    _containers.TryAdd(backup, existingDestinationContainer))
+					    _containers.TryAdd(backup, existingDestinationContainer.UpdateLocation(backup)))
 					{
 						if (_fileSystem.Execute.IsWindows &&
 						    sourceContainer.Type == FileSystemTypes.File)
@@ -587,7 +587,7 @@ internal sealed class InMemoryStorage : IStorage
 								DateTimeKind.Utc);
 						}
 
-						_containers.TryAdd(destination, existingSourceContainer);
+						_containers.TryAdd(destination, existingSourceContainer.UpdateLocation(destination));
 						return destination;
 					}
 				}
@@ -1041,7 +1041,7 @@ internal sealed class InMemoryStorage : IStorage
 					existingContainer.ClearBytes();
 				}
 
-				if (_containers.TryAdd(destination, sourceContainer))
+				if (_containers.TryAdd(destination, sourceContainer.UpdateLocation(destination)))
 				{
 					int bytesLength = sourceContainer.GetBytes().Length;
 					source.Drive?.ChangeUsedBytes(-1 * bytesLength);

--- a/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/NullContainer.cs
@@ -105,6 +105,13 @@ internal sealed class NullContainer : IStorageContainer
 		IStorageLocation? onBehalfOfLocation = null)
 		=> new NullStorageAccessHandle(access, share, deleteAccess);
 
+	/// <inheritdoc cref="IStorageContainer.UpdateLocation(IStorageLocation)" />
+	public IStorageContainer UpdateLocation(IStorageLocation newLocation)
+	{
+		// Do nothing in NullContainer
+		return this;
+	}
+
 	/// <inheritdoc cref="IStorageContainer.WriteBytes(byte[])" />
 	public void WriteBytes(byte[] bytes)
 	{

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/LockableContainer.cs
@@ -111,6 +111,10 @@ internal sealed class LockableContainer(
 		return new AccessHandle(access, share, deleteAccess);
 	}
 
+	/// <inheritdoc cref="IStorageContainer.UpdateLocation(IStorageLocation)" />
+	public IStorageContainer UpdateLocation(IStorageLocation newLocation)
+		=> this;
+
 	/// <inheritdoc cref="IStorageContainer.WriteBytes(byte[])" />
 	public void WriteBytes(byte[] bytes)
 	{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
@@ -186,6 +187,26 @@ public partial class ReplaceTests
 		await That(FileSystem.File.ReadAllText(destinationName)).IsEquivalentTo(sourceContents);
 		await That(FileSystem.File.Exists(backupName)).IsTrue();
 		await That(FileSystem.File.ReadAllText(backupName)).IsEquivalentTo(destinationContents);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Replace_Twice_ShouldReplaceFile(
+		string sourceName,
+		string destinationName)
+	{
+		FileSystem.Initialize()
+			.WithFile(sourceName).Which(f => f.HasStringContent("abc"))
+			.WithFile(destinationName).Which(f => f.HasStringContent("xyz"));
+		var file1 = FileSystem.FileInfo.New(sourceName);
+		var file2 = FileSystem.FileInfo.New(destinationName);
+		FileSystem.File.Replace(file2.FullName, file1.FullName, null);
+
+		var file3 = FileSystem.FileInfo.New(destinationName);
+		FileSystem.File.WriteAllText(destinationName, "def");
+		FileSystem.File.Replace(file3.FullName, file1.FullName, null);
+
+		await That(file1).HasContent("def");
 	}
 
 	[Theory]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
@@ -396,6 +397,26 @@ public partial class ReplaceTests
 			// Behaviour on Linux/MacOS is uncertain
 			await That(FileSystem.File.Exists(backupName)).IsFalse();
 		}
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Replace_Twice_ShouldReplaceFile(
+		string sourceName,
+		string destinationName)
+	{
+		FileSystem.Initialize()
+			.WithFile(sourceName).Which(f => f.HasStringContent("abc"))
+			.WithFile(destinationName).Which(f => f.HasStringContent("xyz"));
+		IFileInfo file1 = FileSystem.FileInfo.New(sourceName);
+		IFileInfo file2 = FileSystem.FileInfo.New(destinationName);
+		file2.Replace(file1.FullName, null);
+
+		IFileInfo file3 = FileSystem.FileInfo.New(destinationName);
+		FileSystem.File.WriteAllText(destinationName, "def");
+		file3.Replace(file1.FullName, null);
+
+		await That(file1).HasContent("def");
 	}
 
 	[Theory]


### PR DESCRIPTION
This PR implements the `UpdateLocation` method for storage containers to properly update their location references when files are moved or replaced. This fixes an issue where containers retained stale location information after file system operations.

### Key changes:
- Adds `UpdateLocation` method to the `IStorageContainer` interface and all implementing classes
- Updates file move and replace operations to call `UpdateLocation` when containers change location
- Adds test coverage for multiple replace operations to verify the fix works correctly

---

- *Fixes #859*