### PR TITLE
feat: consider pre-releases in build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,14 @@ jobs:
                     do
                       dotnet nuget push $entry --source https://api.nuget.org/v3/index.json --api-key "${{secrets.NUGET_API_KEY}}" --skip-duplicate
                     done
+            -   name: Check pre-release
+                id: check-pre-release
+                run: |
+                    if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                        echo "release=true" >> $GITHUB_OUTPUT
+                    fi
             -   name: Create GitHub release
+                if: steps.check-pre-release.outputs.release == 'true'
                 continue-on-error: true
                 uses: softprops/action-gh-release@v2
                 with:
@@ -209,7 +216,14 @@ jobs:
             issues: write
             pull-requests: write
         steps:
+            -   name: Check pre-release
+                id: check-pre-release
+                run: |
+                    if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                        echo "release=true" >> $GITHUB_OUTPUT
+                    fi
             -   name: Comment relevant issues and pull requests
+                if: steps.check-pre-release.outputs.release == 'true'
                 continue-on-error: true
                 uses: apexskier/github-release-commenter@v1.3.6
                 with:


### PR DESCRIPTION
This PR adds logic to the build pipeline to differentiate between stable releases and pre-releases, ensuring that GitHub release creation and issue commenting only occur for stable releases (matching the pattern `v[0-9]+.[0-9]+.[0-9]+$` without additional suffixes).

### Key Changes:
- Added pre-release detection steps that check if tags match the stable release pattern
- Conditionally execute GitHub release creation only for stable releases
- Conditionally execute issue/PR commenting only for stable releases