### PR TITLE
fix: Trigger correct notifications when moving directories (#865)

### DIFF
--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/FileSystemWatcherMockTests.cs
@@ -299,7 +299,7 @@ public sealed class FileSystemWatcherMockTests : IDisposable
 			fileSystem.File.WriteAllText(expectedOldFullPath, "foo");
 
 			using IFileSystemWatcher fileSystemWatcher =
-				fileSystem.FileSystemWatcher.New(fileSystem.Path.GetFullPath(parentDirectory));
+				fileSystem.FileSystemWatcher.New(parentDirectory);
 			using ManualResetEventSlim ms = new();
 			fileSystemWatcher.Renamed += (_, eventArgs) =>
 			{


### PR DESCRIPTION
This PR attempts to fix missing notifications from `FileSystemWatcherMock` on Windows, when moving directories into or out of the watched path, as described in #865.

On Windows, moving a directory from a location outside the watched path to a location inside the watched path should trigger a Created event. Similarly, moving a directory from a location inside the watched path to a location outside the watched path should trigger a Deleted event. On other platforms, these moves should trigger a Rename event instead.