### PR TITLE
fix: run static code analysis in CI build only from this repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
     
     static-code-analysis:
         name: "Static code analysis"
-        if: ${{ github.actor == 'vbreuss' }}
+        if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
         runs-on: ubuntu-latest
         env:
             REPORTGENERATOR_LICENSE: ${{ secrets.REPORTGENERATOR_LICENSE }}


### PR DESCRIPTION
This PR modifies the static code analysis workflow to run on all pull requests from the same repository while excluding dependabot PRs, rather than only running for a specific user.

- Updates the workflow condition to exclude dependabot and external repository PRs
- Removes user-specific restriction on static code analysis execution