### PR TITLE
fix: fix directory tests that fail on windows under certain conditions

### DIFF
--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ExistsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/ExistsTests.cs
@@ -29,7 +29,7 @@ public partial class ExistsTests
 	[Fact]
 	public async Task Exists_ForwardSlash_ShouldReturnTrue()
 	{
-		FileSystem.InitializeIn("D:");
+		FileSystem.InitializeIn("/");
 
 		bool result = FileSystem.Directory.Exists("/");
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExistsTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/ExistsTests.cs
@@ -39,7 +39,7 @@ public partial class ExistsTests
 	[Fact]
 	public async Task Exists_ForwardSlash_ShouldReturnTrue()
 	{
-		FileSystem.InitializeIn("D:");
+		FileSystem.InitializeIn("/");
 
 		IDirectoryInfo sut = FileSystem.DirectoryInfo.New("/");
 


### PR DESCRIPTION
This fixes two tests that fail on Windows when the executing code is not located on the `D:` drive.

The fix is to change test setup code to initialize the `FileSystem` with the "drive unspecific" root path `/` instead of the drive specific root path `D:`, so that the `FileSystem` is always initialized on the current drive.

Fixes issue #888