### PR TITLE
fix: set UnixFileMode when creating new mock file stream

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileStreamFactoryMock.cs
@@ -119,6 +119,30 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 			options);
 	}
 
+#if FEATURE_FILESYSTEM_UNIXFILEMODE
+	private FileStreamMock New(string path,
+		FileMode mode,
+		FileAccess access,
+		FileShare share,
+		int bufferSize,
+		FileOptions options,
+		UnixFileMode? unixFileMode)
+	{
+		using IDisposable registration = _fileSystem.StatisticsRegistration
+			.FileStream.RegisterMethod(nameof(New),
+				path, mode, access, share, bufferSize, options, unixFileMode);
+
+		return new FileStreamMock(_fileSystem,
+			path,
+			mode,
+			access,
+			share,
+			bufferSize,
+			options,
+			unixFileMode);
+	}
+#endif
+
 	/// <inheritdoc cref="IFileStreamFactory.New(SafeFileHandle, FileAccess)" />
 #if NET6_0_OR_GREATER
 	[ExcludeFromCodeCoverage(Justification = "SafeFileHandle cannot be unit tested.")]
@@ -193,7 +217,11 @@ internal sealed class FileStreamFactoryMock : IFileStreamFactory
 			options.Access,
 			options.Share,
 			options.BufferSize,
-			options.Options);
+			options.Options
+#if FEATURE_FILESYSTEM_UNIXFILEMODE
+			,options.UnixCreateMode
+#endif
+			);
 	}
 #endif
 

--- a/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
@@ -304,4 +304,7 @@ internal static class ExceptionFactory
 			HResult = -2146233031,
 #endif
 		};
+	
+	internal static ArgumentException InvalidUnixCreateMode(string paramName)
+		=> new("UnixCreateMode can only be used with file modes that can create a new file.", paramName);
 }

--- a/Source/Testably.Abstractions.Testing/Statistics/CallStatistics.cs
+++ b/Source/Testably.Abstractions.Testing/Statistics/CallStatistics.cs
@@ -180,6 +180,31 @@ internal class CallStatistics<TType> : IStatistics<TType>
 
 		return release;
 	}
+	
+	/// <summary>
+	///     Registers the method <paramref name="name" /> with <paramref name="parameter1" />, <paramref name="parameter2" />,
+	///     <paramref name="parameter3" />, <paramref name="parameter4" />, <paramref name="parameter5" /> and
+	///     <paramref name="parameter6" />, <paramref name="parameter7" />.
+	/// </summary>
+	/// <returns>A disposable which ignores all registrations, until it is disposed.</returns>
+	internal IDisposable RegisterMethod<T1, T2, T3, T4, T5, T6, T7>(string name, T1 parameter1,
+		T2 parameter2, T3 parameter3, T4 parameter4, T5 parameter5, T6 parameter6, T7 parameter7)
+	{
+		if (_statisticsGate.TryGetLock(out IDisposable release))
+		{
+			int counter = _statisticsGate.GetCounter();
+			_methods.Enqueue(new MethodStatistic(counter, name,
+				ParameterDescription.FromParameter(parameter1),
+				ParameterDescription.FromParameter(parameter2),
+				ParameterDescription.FromParameter(parameter3),
+				ParameterDescription.FromParameter(parameter4),
+				ParameterDescription.FromParameter(parameter5),
+				ParameterDescription.FromParameter(parameter6),
+				ParameterDescription.FromParameter(parameter7)));
+		}
+
+		return release;
+	}
 
 #if FEATURE_SPAN
 	/// <summary>


### PR DESCRIPTION
This PR sets `UnixFileMode` when creating a new mock file stream via `MockFileSystem.FileStream.New(string, FileStreamOptions)`.

* Adds `UnixFileMode` argument to `FileStreamMock` constructors
* Sets `UnixFileMode` if valid `FileMode` is used
* Throws `ArgumentException` if invalid `FileMode` is used
* Passes `FileStreamOptions.UnixCreateMode` in `FileStreamFactoryMock` to `FileStreamMock`
* Adds new CallStatistics overload to handle an additional parameter
* Adds tests

Not sure if the unit tests are in the correct location.

Fixes: #914 