### PR TITLE
refactor: use auto-property field declarations

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/DriveInfoMock.cs
@@ -37,7 +37,6 @@ internal sealed class DriveInfoMock : IStorageDrive
 	private long _totalSize;
 
 	private long _usedBytes;
-	private string _volumeLabel = nameof(MockFileSystem);
 
 	private DriveInfoMock(string driveName, MockFileSystem fileSystem)
 	{
@@ -178,7 +177,7 @@ internal sealed class DriveInfoMock : IStorageDrive
 			using IDisposable registration = _fileSystem.StatisticsRegistration
 				.DriveInfo.RegisterPathProperty(_name, nameof(VolumeLabel), PropertyAccess.Get);
 
-			return _volumeLabel;
+			return field;
 		}
 		[SupportedOSPlatform("windows")]
 		set
@@ -187,13 +186,13 @@ internal sealed class DriveInfoMock : IStorageDrive
 				.DriveInfo.RegisterPathProperty(_name, nameof(VolumeLabel), PropertyAccess.Set);
 
 			// ReSharper disable once ConstantNullCoalescingCondition
-			_volumeLabel = value ?? _volumeLabel;
+			field = value ?? field;
 			if (!_fileSystem.Execute.IsWindows)
 			{
 				throw ExceptionFactory.OperationNotSupportedOnThisPlatform();
 			}
 		}
-	}
+	} = nameof(MockFileSystem);
 
 	/// <inheritdoc cref="IStorageDrive.ChangeUsedBytes(long)" />
 	public IStorageDrive ChangeUsedBytes(long usedBytesDelta)

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
@@ -19,8 +19,8 @@ namespace Testably.Abstractions.Testing.FileSystem;
 ///     Mocked instance of a <see cref="IFileSystemWatcher" />
 /// </summary>
 /// <remarks>
-///  For more information about the implementation,
-///  see <see href="https://github.com/Testably/Testably.Abstractions/blob/main/Docs/FileSystemWatcherMock.md">_/Docs/FileSystemWatcherMock.md</see>
+///     For more information about the implementation, see
+///     <see href="https://github.com/Testably/Testably.Abstractions/blob/main/Docs/FileSystemWatcherMock.md">_/Docs/FileSystemWatcherMock.md</see>
 /// </remarks>
 internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 {
@@ -32,21 +32,11 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 
 	private CancellationTokenSource? _cancellationTokenSource;
 	private IDisposable? _changeHandler;
-	private bool _enableRaisingEvents;
 	private readonly MockFileSystem _fileSystem;
 	private readonly Collection<string> _filters = [];
-	private bool _includeSubdirectories;
-	private int _internalBufferSize = 8192;
 	private bool _isInitializing;
 
-	private NotifyFilters _notifyFilter = NotifyFilters.FileName |
-	                                      NotifyFilters.DirectoryName |
-	                                      NotifyFilters.LastWrite;
-
 	private string _path = string.Empty;
-	private string _fullPath = string.Empty;
-
-	private ISynchronizeInvoke? _synchronizingObject;
 
 	private FileSystemWatcherMock(MockFileSystem fileSystem)
 	{
@@ -66,7 +56,7 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 				.FileSystemWatcher.RegisterPathProperty(_path,
 					nameof(EnableRaisingEvents), PropertyAccess.Get);
 
-			return _enableRaisingEvents;
+			return field;
 		}
 		set
 		{
@@ -74,8 +64,8 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 				.FileSystemWatcher.RegisterPathProperty(_path,
 					nameof(EnableRaisingEvents), PropertyAccess.Set);
 
-			_enableRaisingEvents = value;
-			if (_enableRaisingEvents)
+			field = value;
+			if (field)
 			{
 				Start();
 			}
@@ -141,7 +131,7 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 				.FileSystemWatcher.RegisterPathProperty(_path,
 					nameof(IncludeSubdirectories), PropertyAccess.Get);
 
-			return _includeSubdirectories;
+			return field;
 		}
 		set
 		{
@@ -149,7 +139,7 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 				.FileSystemWatcher.RegisterPathProperty(_path,
 					nameof(IncludeSubdirectories), PropertyAccess.Set);
 
-			_includeSubdirectories = value;
+			field = value;
 		}
 	}
 
@@ -162,7 +152,7 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 				.FileSystemWatcher.RegisterPathProperty(_path,
 					nameof(InternalBufferSize), PropertyAccess.Get);
 
-			return _internalBufferSize;
+			return field;
 		}
 		set
 		{
@@ -170,10 +160,10 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 				.FileSystemWatcher.RegisterPathProperty(_path,
 					nameof(InternalBufferSize), PropertyAccess.Set);
 
-			_internalBufferSize = Math.Max(value, 4096);
+			field = Math.Max(value, 4096);
 			Restart();
 		}
-	}
+	} = 8192;
 
 	/// <inheritdoc cref="IFileSystemWatcher.NotifyFilter" />
 	public NotifyFilters NotifyFilter
@@ -184,7 +174,7 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 				.FileSystemWatcher.RegisterPathProperty(_path,
 					nameof(NotifyFilter), PropertyAccess.Get);
 
-			return _notifyFilter;
+			return field;
 		}
 		set
 		{
@@ -192,9 +182,11 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 				.FileSystemWatcher.RegisterPathProperty(_path,
 					nameof(NotifyFilter), PropertyAccess.Set);
 
-			_notifyFilter = value;
+			field = value;
 		}
-	}
+	} = NotifyFilters.FileName |
+	    NotifyFilters.DirectoryName |
+	    NotifyFilters.LastWrite;
 
 	/// <inheritdoc cref="IFileSystemWatcher.Path" />
 	public string Path
@@ -254,7 +246,7 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 				.FileSystemWatcher.RegisterPathProperty(_path,
 					nameof(SynchronizingObject), PropertyAccess.Get);
 
-			return _synchronizingObject;
+			return field;
 		}
 		set
 		{
@@ -262,30 +254,30 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 				.FileSystemWatcher.RegisterPathProperty(_path,
 					nameof(SynchronizingObject), PropertyAccess.Set);
 
-			_synchronizingObject = value;
+			field = value;
 		}
 	}
 
 	/// <summary>
-	/// Caches the full path of <see cref="Path"/>
+	///     Caches the full path of <see cref="Path" />
 	/// </summary>
 	private string FullPath
 	{
-		get => _fullPath;
+		get;
 		set
 		{
 			if (string.IsNullOrEmpty(value))
 			{
-				_fullPath = value;
-				
+				field = value;
+
 				return;
 			}
-			
+
 			string fullPath = GetNormalizedFullPath(value);
-			
-			_fullPath = fullPath;
+
+			field = fullPath;
 		}
-	}
+	} = string.Empty;
 
 	/// <inheritdoc cref="IFileSystemWatcher.BeginInit()" />
 	public void BeginInit()
@@ -763,11 +755,11 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	}
 
 	/// <summary>
-	/// Counts the number of directory separators inside the relative path to <see cref="FullPath"/>
+	///     Counts the number of directory separators inside the relative path to <see cref="FullPath" />
 	/// </summary>
 	/// <param name="path"></param>
-	/// <returns>The number of directory separators inside the relative path to <see cref="FullPath"/></returns>
-	/// <remarks>Returns -1 if the path is outside the <see cref="FullPath"/></remarks>
+	/// <returns>The number of directory separators inside the relative path to <see cref="FullPath" /></returns>
+	/// <remarks>Returns -1 if the path is outside the <see cref="FullPath" /></remarks>
 	private int GetSubDirectoryCount(string path)
 	{
 		string normalizedPath = GetNormalizedFullPath(path);
@@ -786,7 +778,7 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 	{
 		string normalizedPath = GetNormalizedFullPath(changeDescription.Path);
 		string normalizedOldPath = GetNormalizedFullPath(changeDescription.OldPath!);
-		
+
 		string name = _fileSystem.Execute.Path.GetFileName(normalizedPath);
 		string oldName = _fileSystem.Execute.Path.GetFileName(normalizedOldPath);
 
@@ -799,10 +791,10 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 		{
 			return false;
 		}
-		
+
 		string? parent = _fileSystem.Execute.Path.GetDirectoryName(normalizedPath);
 		string? oldParent = _fileSystem.Execute.Path.GetDirectoryName(normalizedOldPath);
-		
+
 		return string.Equals(parent, oldParent, _fileSystem.Execute.StringComparisonMode);
 	}
 
@@ -837,7 +829,7 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 		string name = TransformPathAndName(changePath);
 
 		FileSystemEventArgs eventArgs = new(changeType, Path, name);
-		
+
 		SetFileSystemEventArgsFullPath(eventArgs, name);
 
 		return eventArgs;
@@ -845,7 +837,8 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 
 	private string TransformPathAndName(string changeDescriptionPath)
 	{
-		return changeDescriptionPath.Substring(FullPath.Length).TrimStart(_fileSystem.Execute.Path.DirectorySeparatorChar);
+		return changeDescriptionPath.Substring(FullPath.Length)
+			.TrimStart(_fileSystem.Execute.Path.DirectorySeparatorChar);
 	}
 
 	private void SetFileSystemEventArgsFullPath(FileSystemEventArgs args, string name)
@@ -854,9 +847,9 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 		{
 			return;
 		}
-		
+
 		string fullPath = _fileSystem.Execute.Path.Combine(Path, name);
-		
+
 		// FileSystemEventArgs implicitly combines the path in https://github.com/dotnet/runtime/blob/v8.0.4/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
 		// HACK: The combination uses the system separator, so to simulate the behavior, we must override it using reflection!
 #if NETFRAMEWORK
@@ -876,9 +869,9 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 		{
 			return;
 		}
-		
+
 		string fullPath = _fileSystem.Execute.Path.Combine(Path, oldName);
-		
+
 		// FileSystemEventArgs implicitly combines the path in https://github.com/dotnet/runtime/blob/v8.0.4/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
 		// HACK: The combination uses the system separator, so to simulate the behavior, we must override it using reflection!
 #if NETFRAMEWORK
@@ -993,12 +986,12 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 		public bool GoesToOutside { get; } = goesToOutside;
 
 		/// <remarks>
-		/// If this is <see langword="true"/> then <see cref="ComesFromDeepNested"/> is <see langword="false"/>
+		///     If this is <see langword="true" /> then <see cref="ComesFromDeepNested" /> is <see langword="false" />
 		/// </remarks>
 		public bool ComesFromNested { get; } = oldSubDirectoryCount == NestedLevelCount;
 
 		/// <remarks>
-		/// If this is <see langword="true"/> then <see cref="ComesFromNested"/> is <see langword="false"/>
+		///     If this is <see langword="true" /> then <see cref="ComesFromNested" /> is <see langword="false" />
 		/// </remarks>
 		public bool ComesFromDeepNested { get; } = oldSubDirectoryCount > NestedLevelCount;
 	}

--- a/Source/Testably.Abstractions.Testing/Helpers/Execute.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/Execute.cs
@@ -15,14 +15,14 @@ internal sealed partial class Execute
 	{
 		get
 		{
-			_globOptions ??= new GlobOptions
+			field ??= new GlobOptions
 			{
 				Evaluation =
 				{
 					CaseInsensitive = !IsLinux,
 				},
 			};
-			return _globOptions;
+			return field;
 		}
 	}
 
@@ -58,8 +58,6 @@ internal sealed partial class Execute
 	///     The default <see cref="StringComparison" /> used for comparing paths.
 	/// </summary>
 	public StringComparison StringComparisonMode { get; }
-
-	private GlobOptions? _globOptions;
 
 #if !CAN_SIMULATE_OTHER_OS
 	[Obsolete("Simulating other operating systems is not supported on .NET Framework")]

--- a/Source/Testably.Abstractions.Testing/Helpers/RandomFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/RandomFactory.cs
@@ -6,12 +6,12 @@ namespace Testably.Abstractions.Testing.Helpers;
 
 internal static class RandomFactory
 {
-	[ThreadStatic] private static IRandom? _shared;
 	private static readonly Random Global = new();
 
 	/// <inheritdoc cref="IRandomFactory.Shared" />
+	[field: ThreadStatic]
 	public static IRandom Shared
-		=> _shared ??= CreateThreadSafeRandomWrapper();
+		=> field ??= CreateThreadSafeRandomWrapper();
 
 	/// <summary>
 	///     <see href="https://andrewlock.net/building-a-thread-safe-random-implementation-for-dotnet-framework/" />

--- a/Source/Testably.Abstractions.Testing/Polyfills/EnumerationOptions.cs
+++ b/Source/Testably.Abstractions.Testing/Polyfills/EnumerationOptions.cs
@@ -87,7 +87,7 @@ public class EnumerationOptions
 	/// </remarks>
 	public int MaxRecursionDepth
 	{
-		get => _maxRecursionDepth;
+		get;
 		set
 		{
 			if (value < 0)
@@ -95,7 +95,7 @@ public class EnumerationOptions
 				throw new ArgumentOutOfRangeException(nameof(value));
 			}
 
-			_maxRecursionDepth = value;
+			field = value;
 		}
 	}
 
@@ -116,8 +116,6 @@ public class EnumerationOptions
 	///     <see langword="false" />.
 	/// </value>
 	public bool ReturnSpecialDirectories { get; set; }
-
-	private int _maxRecursionDepth;
 
 	/// <summary>
 	///     Initializes a new instance of the <see cref="EnumerationOptions" /> class with the recommended default

--- a/Source/Testably.Abstractions.Testing/Storage/FileVersionInfoContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/FileVersionInfoContainer.cs
@@ -30,10 +30,10 @@ internal sealed class FileVersionInfoContainer
 	/// <inheritdoc cref="IFileVersionInfo.FileVersion" />
 	public string? FileVersion
 	{
-		get => _fileVersion;
+		get;
 		set
 		{
-			_fileVersion = value;
+			field = value;
 			if (value != null)
 			{
 				string cleanedFileVersion = CleanVersion(value);
@@ -116,10 +116,10 @@ internal sealed class FileVersionInfoContainer
 	/// <inheritdoc cref="IFileVersionInfo.ProductVersion" />
 	public string? ProductVersion
 	{
-		get => _productVersion;
+		get;
 		set
 		{
-			_productVersion = value;
+			field = value;
 			if (value != null)
 			{
 				string cleanedFileVersion = CleanVersion(value);
@@ -151,9 +151,6 @@ internal sealed class FileVersionInfoContainer
 
 	/// <inheritdoc cref="IFileVersionInfo.SpecialBuild" />
 	public string? SpecialBuild { get; set; }
-
-	private string? _fileVersion;
-	private string? _productVersion;
 
 	private static string CleanVersion(string version)
 	{

--- a/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
+++ b/Source/Testably.Abstractions.Testing/Storage/InMemoryContainer.cs
@@ -12,7 +12,6 @@ namespace Testably.Abstractions.Testing.Storage;
 
 internal sealed class InMemoryContainer : IStorageContainer
 {
-	private FileAttributes _attributes;
 	private byte[] _bytes = Array.Empty<byte>();
 	private readonly FileSystemExtensibility _extensibility = new();
 	private readonly MockFileSystem _fileSystem;
@@ -20,10 +19,6 @@ internal sealed class InMemoryContainer : IStorageContainer
 	private IStorageLocation _location;
 
 #if FEATURE_FILESYSTEM_UNIXFILEMODE
-	private UnixFileMode _unixFileMode = UnixFileMode.OtherRead |
-	                                     UnixFileMode.GroupRead |
-	                                     UnixFileMode.UserWrite |
-	                                     UnixFileMode.UserRead;
 #endif
 
 	public InMemoryContainer(FileSystemTypes type,
@@ -41,7 +36,7 @@ internal sealed class InMemoryContainer : IStorageContainer
 	/// <inheritdoc cref="IStorageContainer.Attributes" />
 	public FileAttributes Attributes
 	{
-		get => AdjustAttributes(_attributes);
+		get => AdjustAttributes(field);
 		set
 		{
 			if (_fileSystem.Execute.IsWindows)
@@ -68,7 +63,7 @@ internal sealed class InMemoryContainer : IStorageContainer
 				         FileAttributes.ReadOnly;
 			}
 
-			_attributes = value;
+			field = value;
 		}
 	}
 
@@ -101,16 +96,19 @@ internal sealed class InMemoryContainer : IStorageContainer
 	/// <inheritdoc cref="IStorageContainer.UnixFileMode" />
 	public UnixFileMode UnixFileMode
 	{
-		get => _unixFileMode;
+		get;
 		set
 		{
-			_unixFileMode = value;
+			field = value;
 			_fileSystem.UnixFileModeStrategy.OnSetUnixFileMode(
 				_location.FullPath,
 				_extensibility,
-				_unixFileMode);
+				field);
 		}
-	}
+	} = UnixFileMode.OtherRead |
+	    UnixFileMode.GroupRead |
+	    UnixFileMode.UserWrite |
+	    UnixFileMode.UserRead;
 #endif
 
 	/// <inheritdoc cref="IStorageContainer.AppendBytes(byte[])" />

--- a/Testably.Abstractions.sln.DotSettings
+++ b/Testably.Abstractions.sln.DotSettings
@@ -22,6 +22,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_STATEMENT_CONDITIONS/@EntryValue">False</s:Boolean>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_AFTER_USING_LIST/@EntryValue">0</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_PREPROCESSOR_OTHER/@EntryValue">USUAL_INDENT</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_STYLE/@EntryValue">Tab</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_DECLARATION_BLOCK_ARRANGEMENT/@EntryValue">True</s:Boolean>

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/AutoDomainDataAttribute.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/AutoDomainDataAttribute.cs
@@ -18,18 +18,14 @@ public class AutoDomainDataAttribute : AutoDataAttribute
 	/// </summary>
 	public Type? CustomizeWith
 	{
-		get
-		{
-			return _customizeWith;
-		}
+		get;
 		set
 		{
-			_customizeWith = value;
+			field = value;
 			_fixtureFactory.CustomizeWith(value);
 		}
 	}
 
-	private Type? _customizeWith;
 	private readonly DomainFixtureFactory _fixtureFactory;
 
 	/// <summary>


### PR DESCRIPTION
This PR modernizes field declarations using C# auto-property field features and improves code formatting. The changes reduce boilerplate code while maintaining identical functionality.

### Key Changes:
- Replaced private backing fields with auto-property field syntax (`field` keyword)
- Added property initializers for default values
- Updated code formatting configuration to use Tab indentation
- Improved line formatting for better readability in `FileSystemWatcherMock`