### PR TITLE
chore: bump core version to 10.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,8 +47,8 @@
 		<PackageVersion Include="NUnit3TestAdapter" Version="6.1.0"/>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageVersion Include="Testably.Abstractions.Interface" Version="10.1.0-rc1"/>
-		<PackageVersion Include="Testably.Abstractions" Version="10.1.0-rc1"/>
+		<PackageVersion Include="Testably.Abstractions.Interface" Version="10.1.0"/>
+		<PackageVersion Include="Testably.Abstractions" Version="10.1.0"/>
 		<PackageVersion Include="Testably.Abstractions.Testing" Version="5.0.3"/>
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
Updates centrally managed package versions to consume the stable `10.1.0` releases of the core Testably packages (moving off the prior RC), aligning dependency resolution across the repo (e.g., examples and helper projects that reference the NuGet packages).