### PR TITLE
coverage: add tolerance to `Stopwatch` test

### DIFF
--- a/Tests/Testably.Abstractions.Tests/TimeSystem/StopwatchTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/StopwatchTests.cs
@@ -136,7 +136,8 @@ public partial class StopwatchTests
 		stopwatch.Stop();
 		TimeSpan elapsed = stopwatch.Elapsed;
 
-		await That(elapsed.TotalMilliseconds).IsGreaterThanOrEqualTo(100);
+		// Allow one millisecond tolerance due to potential rounding issues.
+		await That(elapsed.TotalMilliseconds).IsGreaterThanOrEqualTo(99);
 		await That(stopwatch.IsRunning).IsFalse();
 	}
 


### PR DESCRIPTION
This PR attempts to make the `Stop_ShouldSetIsRunningToFalse` test less brittle by adding tolerance for potential rounding issues on the real file system. The change reduces the expected minimum elapsed time from 100ms to 99ms (a 1ms tolerance) and adds an explanatory comment.