### PR TITLE
chore: bump dependencies to fix a .NET Denial of Service Vulnerability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
 		<PackageVersion Include="System.Linq.Async" Version="7.0.0"/>
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' And '$(TargetFramework)' != 'net6.0' ">
-		<PackageVersion Include="System.Threading.Channels" Version="10.0.3"/>
+		<PackageVersion Include="System.Threading.Channels" Version="10.0.5"/>
 		<PackageVersion Include="System.Linq.Async" Version="7.0.0"/>
 	</ItemGroup>
 	<ItemGroup>
@@ -27,23 +27,24 @@
 		<PackageVersion Include="Nuke.Common" Version="10.1.0"/>
 		<PackageVersion Include="Nuke.Components" Version="10.1.0"/>
 		<PackageVersion Include="LibGit2Sharp" Version="0.31.0"/>
-		<PackageVersion Include="SharpCompress" Version="0.43.0"/>
+		<PackageVersion Include="SharpCompress" Version="0.47.0"/>
 	</ItemGroup>
 	<ItemGroup>
+		<PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.5"/>
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0"/>
 		<PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0"/>
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3"/>
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5"/>
 		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.1.0" />
-		<PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.1" />
+		<PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="System.Net.Http" Version="4.3.4"/>
 		<PackageVersion Include="aweXpect" Version="2.30.0"/>
 		<PackageVersion Include="aweXpect.Testably" Version="0.13.0"/>
-		<PackageVersion Include="aweXpect.Mockolate" Version="1.1.1"/>
-		<PackageVersion Include="Mockolate" Version="1.5.0"/>
-		<PackageVersion Include="TUnit.Engine" Version="1.17.54"/>
-		<PackageVersion Include="Polyfill" Version="9.1.0"/>
+		<PackageVersion Include="aweXpect.Mockolate" Version="1.2.0"/>
+		<PackageVersion Include="Mockolate" Version="1.5.4"/>
+		<PackageVersion Include="TUnit.Engine" Version="1.19.22"/>
+		<PackageVersion Include="Polyfill" Version="9.18.0"/>
 		<PackageVersion Include="PublicApiGenerator" Version="11.5.4"/>
 		<PackageVersion Include="AutoFixture" Version="4.18.1" />
 	</ItemGroup>

--- a/Source/Testably.Abstractions.Testing/Testably.Abstractions.Testing.csproj
+++ b/Source/Testably.Abstractions.Testing/Testably.Abstractions.Testing.csproj
@@ -29,6 +29,8 @@
 	<!-- https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/asyncenumerable -->
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="System.Linq.Async" />
+		<!-- https://github.com/advisories/GHSA-73j8-2gch-69rq -->
+		<PackageReference Include="Microsoft.Bcl.Memory" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates several package dependencies to newer versions and introduces a new package reference for certain target frameworks. The main focus is on keeping dependencies up to date, addressing security advisories, and ensuring compatibility with newer .NET targets.

**General dependency updates:**
* Updated `System.Threading.Channels` to version 10.0.5 for non-net6.0/net8.0 targets.
* Updated `SharpCompress` to 0.47.0, `Microsoft.Extensions.DependencyInjection` to 10.0.5, and `Microsoft.Testing.Extensions.CodeCoverage` to 18.5.2.
* Updated several test and utility dependencies: `aweXpect.Mockolate` to 1.2.0, `Mockolate` to 1.5.4, `TUnit.Engine` to 1.19.22, and `Polyfill` to 9.18.0.

**New package references:**
* Added explicit reference to `Microsoft.Bcl.Memory` version 10.0.5 in `Testably.Abstractions.Testing.csproj`, in order to adress a [.NET Denial of Service Vulnerability](https://github.com/advisories/GHSA-73j8-2gch-69rq).