### PR TITLE
feat: add callback for `PeriodicTimer`

### DIFF
--- a/Source/Testably.Abstractions.Testing/MockTimeSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockTimeSystem.cs
@@ -96,7 +96,7 @@ public sealed class MockTimeSystem : ITimeSystem
 		_threadMock = new ThreadMock(this, _callbackHandler, initialization.AutoAdvance);
 		_taskMock = new TaskMock(this, _callbackHandler, initialization.AutoAdvance);
 #if FEATURE_PERIODIC_TIMER
-		_periodicTimerFactoryMock = new PeriodicTimerFactoryMock(this, initialization.AutoAdvance);
+		_periodicTimerFactoryMock = new PeriodicTimerFactoryMock(this, _callbackHandler, initialization.AutoAdvance);
 #endif
 		_timerFactoryMock = new TimerFactoryMock(this);
 	}

--- a/Source/Testably.Abstractions.Testing/TimeSystem/INotificationHandler.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/INotificationHandler.cs
@@ -5,10 +5,17 @@ using Testably.Abstractions.TimeSystem;
 namespace Testably.Abstractions.Testing.TimeSystem;
 
 /// <summary>
-///     The callback handler for the <see cref="MockTimeSystem" />
+///     The callback handler for the <see cref="MockTimeSystem" />.
 /// </summary>
 public interface INotificationHandler
 {
+#if FEATURE_PERIODIC_TIMER
+	/// <summary>
+	///     Notifications for the <see cref="IPeriodicTimer" />.
+	/// </summary>
+	IPeriodicTimerNotificationHandler PeriodicTimer { get; }
+#endif
+
 	/// <summary>
 	///     Callback executed when any of the following <c>DateTime</c> read methods is called:<br />
 	///     - <see cref="IDateTime.Now" /><br />

--- a/Source/Testably.Abstractions.Testing/TimeSystem/IPeriodicTimerNotificationHandler.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/IPeriodicTimerNotificationHandler.cs
@@ -19,7 +19,7 @@ public interface IPeriodicTimerNotificationHandler
 	///     (optional) A predicate used to filter which callbacks should be notified.<br />
 	///     If set to <see langword="null" /> (default value) all callbacks are notified.
 	/// </param>
-	/// <returns>A <see cref="IAwaitableCallback{DateTime}" /> to un-register the callback on dispose.</returns>
+	/// <returns>A <see cref="IAwaitableCallback{IPeriodicTimer}" /> to un-register the callback on dispose.</returns>
 	IAwaitableCallback<IPeriodicTimer> WaitingForNextTick(
 		Action<IPeriodicTimer>? callback = null,
 		Func<IPeriodicTimer, bool>? predicate = null);

--- a/Source/Testably.Abstractions.Testing/TimeSystem/IPeriodicTimerNotificationHandler.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/IPeriodicTimerNotificationHandler.cs
@@ -1,0 +1,27 @@
+﻿#if FEATURE_PERIODIC_TIMER
+using System;
+using Testably.Abstractions.TimeSystem;
+
+namespace Testably.Abstractions.Testing.TimeSystem;
+
+/// <summary>
+///     The callback handler for the <see cref="IPeriodicTimer" /> of the <see cref="MockTimeSystem" />.
+/// </summary>
+public interface IPeriodicTimerNotificationHandler
+{
+	/// <summary>
+	///     Callback executed when any periodic timer is waiting for the next tick.
+	/// </summary>
+	/// <param name="callback">
+	///     (optional) The callback to execute when the periodic timer is waiting for the next tick. The parameter is the periodic timer which is waiting for the next tick.
+	/// </param>
+	/// <param name="predicate">
+	///     (optional) A predicate used to filter which callbacks should be notified.<br />
+	///     If set to <see langword="null" /> (default value) all callbacks are notified.
+	/// </param>
+	/// <returns>A <see cref="IAwaitableCallback{DateTime}" /> to un-register the callback on dispose.</returns>
+	IAwaitableCallback<IPeriodicTimer> WaitingForNextTick(
+		Action<IPeriodicTimer>? callback = null,
+		Func<IPeriodicTimer, bool>? predicate = null);
+}
+#endif

--- a/Source/Testably.Abstractions.Testing/TimeSystem/NotificationHandler.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/NotificationHandler.cs
@@ -1,11 +1,24 @@
 ﻿using System;
+#if FEATURE_PERIODIC_TIMER
+using Testably.Abstractions.TimeSystem;
+#endif
 
 namespace Testably.Abstractions.Testing.TimeSystem;
 
-internal sealed class NotificationHandler(MockTimeSystem mockTimeSystem) : INotificationHandler
+internal sealed class NotificationHandler(MockTimeSystem mockTimeSystem)
+#if FEATURE_PERIODIC_TIMER
+	: INotificationHandler, IPeriodicTimerNotificationHandler
+#else
+	: INotificationHandler
+#endif
 {
 	private readonly Notification.INotificationFactory<DateTime>
 		_dateTimeReadCallbacks = Notification.CreateFactory<DateTime>();
+
+#if FEATURE_PERIODIC_TIMER
+	private readonly Notification.INotificationFactory<IPeriodicTimer>
+		_periodicTimerWaitingForNextTickCallbacks = Notification.CreateFactory<IPeriodicTimer>();
+#endif
 
 	private readonly Notification.INotificationFactory<TimeSpan>
 		_taskDelayCallbacks = Notification.CreateFactory<TimeSpan>();
@@ -17,6 +30,11 @@ internal sealed class NotificationHandler(MockTimeSystem mockTimeSystem) : INoti
 		_timeChangedCallbacks = Notification.CreateFactory<DateTime>();
 
 	#region INotificationHandler Members
+
+#if FEATURE_PERIODIC_TIMER
+	/// <inheritdoc cref="INotificationHandler.PeriodicTimer" />
+	public IPeriodicTimerNotificationHandler PeriodicTimer => this;
+#endif
 
 	/// <inheritdoc cref="INotificationHandler.DateTimeRead(Action{DateTime}?, Func{DateTime, bool}?)" />
 	public IAwaitableCallback<DateTime> DateTimeRead(
@@ -45,8 +63,30 @@ internal sealed class NotificationHandler(MockTimeSystem mockTimeSystem) : INoti
 
 	#endregion
 
+	#region IPeriodicTimerNotificationHandler Members
+
+#if FEATURE_PERIODIC_TIMER
+
+	#region IPeriodicTimerNotificationHandler Members
+
+	/// <inheritdoc cref="IPeriodicTimerNotificationHandler.WaitingForNextTick(Action{IPeriodicTimer}?, Func{IPeriodicTimer, bool}?)" />
+	public IAwaitableCallback<IPeriodicTimer> WaitingForNextTick(
+		Action<IPeriodicTimer>? callback = null, Func<IPeriodicTimer, bool>? predicate = null)
+		=> _periodicTimerWaitingForNextTickCallbacks.RegisterCallback(callback, predicate);
+
+	#endregion
+
+#endif
+
+	#endregion
+
 	public void InvokeDateTimeReadCallbacks(DateTime now)
 		=> _dateTimeReadCallbacks.InvokeCallbacks(now);
+
+#if FEATURE_PERIODIC_TIMER
+	public void InvokePeriodicTimerWaitingForNextTick(IPeriodicTimer timer)
+		=> _periodicTimerWaitingForNextTickCallbacks.InvokeCallbacks(timer);
+#endif
 
 	public void InvokeTaskDelayCallbacks(TimeSpan delay)
 		=> _taskDelayCallbacks.InvokeCallbacks(delay);

--- a/Source/Testably.Abstractions.Testing/TimeSystem/NotificationHandler.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/NotificationHandler.cs
@@ -63,8 +63,6 @@ internal sealed class NotificationHandler(MockTimeSystem mockTimeSystem)
 
 	#endregion
 
-	#region IPeriodicTimerNotificationHandler Members
-
 #if FEATURE_PERIODIC_TIMER
 
 	#region IPeriodicTimerNotificationHandler Members
@@ -77,8 +75,6 @@ internal sealed class NotificationHandler(MockTimeSystem mockTimeSystem)
 	#endregion
 
 #endif
-
-	#endregion
 
 	public void InvokeDateTimeReadCallbacks(DateTime now)
 		=> _dateTimeReadCallbacks.InvokeCallbacks(now);

--- a/Source/Testably.Abstractions.Testing/TimeSystem/PeriodicTimerFactoryMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/PeriodicTimerFactoryMock.cs
@@ -9,11 +9,14 @@ namespace Testably.Abstractions.Testing.TimeSystem;
 internal sealed class PeriodicTimerFactoryMock : IPeriodicTimerFactory
 {
 	private readonly MockTimeSystem _mockTimeSystem;
+	private readonly NotificationHandler _callbackHandler;
 	private readonly bool _autoAdvance;
 
-	internal PeriodicTimerFactoryMock(MockTimeSystem timeSystem, bool autoAdvance)
+	internal PeriodicTimerFactoryMock(MockTimeSystem timeSystem,
+		NotificationHandler callbackHandler, bool autoAdvance)
 	{
 		_mockTimeSystem = timeSystem;
+		_callbackHandler = callbackHandler;
 		_autoAdvance = autoAdvance;
 	}
 
@@ -24,7 +27,7 @@ internal sealed class PeriodicTimerFactoryMock : IPeriodicTimerFactory
 
 	/// <inheritdoc cref="IPeriodicTimerFactory.New(TimeSpan)" />
 	public IPeriodicTimer New(TimeSpan period)
-		=> new PeriodicTimerMock(_mockTimeSystem, period, _autoAdvance);
+		=> new PeriodicTimerMock(_mockTimeSystem, _callbackHandler, period, _autoAdvance);
 
 	/// <inheritdoc cref="IPeriodicTimerFactory.Wrap(PeriodicTimer)" />
 	public IPeriodicTimer Wrap(PeriodicTimer timer)

--- a/Source/Testably.Abstractions.Testing/TimeSystem/PeriodicTimerMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/PeriodicTimerMock.cs
@@ -13,13 +13,18 @@ internal sealed class PeriodicTimerMock : IPeriodicTimer
 	private bool _isDisposed;
 	private long _lastTime;
 	private readonly MockTimeSystem _timeSystem;
+	private readonly NotificationHandler _callbackHandler;
 
-	internal PeriodicTimerMock(MockTimeSystem timeSystem,
-		TimeSpan period, bool autoAdvance)
+	internal PeriodicTimerMock(
+		MockTimeSystem timeSystem,
+		NotificationHandler callbackHandler,
+		TimeSpan period,
+		bool autoAdvance)
 	{
 		ThrowIfPeriodIsInvalid(period, nameof(period));
 
 		_timeSystem = timeSystem;
+		_callbackHandler = callbackHandler;
 		_autoAdvance = autoAdvance;
 		_lastTime = _timeSystem.TimeProvider.ElapsedTicks;
 		Period = period;
@@ -58,6 +63,7 @@ internal sealed class PeriodicTimerMock : IPeriodicTimer
 			return false;
 		}
 
+		_callbackHandler.InvokePeriodicTimerWaitingForNextTick(this);
 		long now = _timeSystem.TimeProvider.ElapsedTicks;
 		long nextTime = _lastTime + Period.Ticks;
 		if (nextTime > now)

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
@@ -437,10 +437,15 @@ namespace Testably.Abstractions.Testing.TimeSystem
 {
     public interface INotificationHandler
     {
+        Testably.Abstractions.Testing.TimeSystem.IPeriodicTimerNotificationHandler PeriodicTimer { get; }
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> DateTimeRead(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> TaskDelay(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> ThreadSleep(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> TimeChanged(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, System.DateTime, bool>? predicate = null);
+    }
+    public interface IPeriodicTimerNotificationHandler
+    {
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.TimeSystem.IPeriodicTimer> WaitingForNextTick(System.Action<Testably.Abstractions.TimeSystem.IPeriodicTimer>? callback = null, System.Func<Testably.Abstractions.TimeSystem.IPeriodicTimer, bool>? predicate = null);
     }
     public interface ITimeProvider
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -437,10 +437,15 @@ namespace Testably.Abstractions.Testing.TimeSystem
 {
     public interface INotificationHandler
     {
+        Testably.Abstractions.Testing.TimeSystem.IPeriodicTimerNotificationHandler PeriodicTimer { get; }
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> DateTimeRead(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> TaskDelay(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> ThreadSleep(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> TimeChanged(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, System.DateTime, bool>? predicate = null);
+    }
+    public interface IPeriodicTimerNotificationHandler
+    {
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.TimeSystem.IPeriodicTimer> WaitingForNextTick(System.Action<Testably.Abstractions.TimeSystem.IPeriodicTimer>? callback = null, System.Func<Testably.Abstractions.TimeSystem.IPeriodicTimer, bool>? predicate = null);
     }
     public interface ITimeProvider
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
@@ -437,10 +437,15 @@ namespace Testably.Abstractions.Testing.TimeSystem
 {
     public interface INotificationHandler
     {
+        Testably.Abstractions.Testing.TimeSystem.IPeriodicTimerNotificationHandler PeriodicTimer { get; }
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> DateTimeRead(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> TaskDelay(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> ThreadSleep(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> TimeChanged(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, System.DateTime, bool>? predicate = null);
+    }
+    public interface IPeriodicTimerNotificationHandler
+    {
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.TimeSystem.IPeriodicTimer> WaitingForNextTick(System.Action<Testably.Abstractions.TimeSystem.IPeriodicTimer>? callback = null, System.Func<Testably.Abstractions.TimeSystem.IPeriodicTimer, bool>? predicate = null);
     }
     public interface ITimeProvider
     {

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/NotificationHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/NotificationHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
+using Testably.Abstractions.TimeSystem;
 
 namespace Testably.Abstractions.Testing.Tests.TimeSystem;
 
@@ -86,6 +87,129 @@ public class NotificationHandlerTests
 
 		await That(receivedTime).IsEqualTo(expectedTime);
 	}
+
+#if FEATURE_PERIODIC_TIMER
+	[Test]
+	public async Task OnPeriodicTimerWaitingForNextTick_DisposedCallback_ShouldNotBeCalled()
+	{
+		MockTimeSystem timeSystem = new();
+		IPeriodicTimer? receivedTimer = null;
+		using IPeriodicTimer periodicTimer =
+			timeSystem.PeriodicTimer.New(TimeSpan.FromSeconds(1));
+		IDisposable disposable =
+			timeSystem.On.PeriodicTimer.WaitingForNextTick(t => receivedTimer = t);
+
+		disposable.Dispose();
+		await periodicTimer.WaitForNextTickAsync();
+
+		await That(receivedTimer).IsNull();
+	}
+#endif
+
+#if FEATURE_PERIODIC_TIMER
+	[Test]
+	public async Task
+		OnPeriodicTimerWaitingForNextTick_MultipleCallbacks_DisposeOne_ShouldCallOtherCallbacks()
+	{
+		MockTimeSystem timeSystem = new();
+		IPeriodicTimer? receivedTimer1 = null;
+		IPeriodicTimer? receivedTimer2 = null;
+		using IPeriodicTimer periodicTimer =
+			timeSystem.PeriodicTimer.New(TimeSpan.FromSeconds(1));
+
+		using (timeSystem.On.PeriodicTimer.WaitingForNextTick(t => receivedTimer1 = t))
+		{
+			timeSystem.On.PeriodicTimer.WaitingForNextTick(t => receivedTimer2 = t).Dispose();
+			await periodicTimer.WaitForNextTickAsync();
+		}
+
+		await That(receivedTimer1).IsEqualTo(periodicTimer);
+		await That(receivedTimer2).IsNull();
+	}
+#endif
+
+#if FEATURE_PERIODIC_TIMER
+	[Test]
+	public async Task OnPeriodicTimerWaitingForNextTick_MultipleCallbacks_ShouldAllBeCalled()
+	{
+		MockTimeSystem timeSystem = new();
+		IPeriodicTimer? receivedTimer1 = null;
+		IPeriodicTimer? receivedTimer2 = null;
+		using IPeriodicTimer periodicTimer =
+			timeSystem.PeriodicTimer.New(TimeSpan.FromSeconds(1));
+
+		using (timeSystem.On.PeriodicTimer.WaitingForNextTick(t => receivedTimer1 = t))
+		{
+			using (timeSystem.On.PeriodicTimer.WaitingForNextTick(t => receivedTimer2 = t))
+			{
+				await periodicTimer.WaitForNextTickAsync();
+			}
+		}
+
+		await That(receivedTimer1).IsEqualTo(periodicTimer);
+		await That(receivedTimer2).IsEqualTo(periodicTimer);
+	}
+#endif
+
+#if FEATURE_PERIODIC_TIMER
+	[Test]
+	public async Task
+		OnPeriodicTimerWaitingForNextTick_ShouldBeCalledOnEachWaitForNextTickAsync()
+	{
+		MockTimeSystem timeSystem = new();
+		int callbackCount = 0;
+		using IPeriodicTimer periodicTimer =
+			timeSystem.PeriodicTimer.New(TimeSpan.FromSeconds(1));
+
+		using (timeSystem.On.PeriodicTimer.WaitingForNextTick(_ => callbackCount++))
+		{
+			await periodicTimer.WaitForNextTickAsync();
+			await periodicTimer.WaitForNextTickAsync();
+			await periodicTimer.WaitForNextTickAsync();
+		}
+
+		await That(callbackCount).IsEqualTo(3);
+	}
+#endif
+
+#if FEATURE_PERIODIC_TIMER
+	[Test]
+	public async Task OnPeriodicTimerWaitingForNextTick_ShouldExecuteCallbackWithCorrectParameter()
+	{
+		MockTimeSystem timeSystem = new();
+		IPeriodicTimer? receivedTimer = null;
+		using IPeriodicTimer periodicTimer =
+			timeSystem.PeriodicTimer.New(TimeSpan.FromSeconds(1));
+
+		using (timeSystem.On.PeriodicTimer.WaitingForNextTick(t => receivedTimer = t))
+		{
+			await periodicTimer.WaitForNextTickAsync();
+		}
+
+		await That(receivedTimer).IsEqualTo(periodicTimer);
+	}
+#endif
+
+#if FEATURE_PERIODIC_TIMER
+	[Test]
+	public async Task OnPeriodicTimerWaitingForNextTick_WithPredicate_ShouldFilterCallbacks()
+	{
+		MockTimeSystem timeSystem = new();
+		int callbackCount = 0;
+		using IPeriodicTimer periodicTimer1 =
+			timeSystem.PeriodicTimer.New(TimeSpan.FromSeconds(1));
+		using IPeriodicTimer periodicTimer2 =
+			timeSystem.PeriodicTimer.New(TimeSpan.FromSeconds(2));
+
+		using IAwaitableCallback<IPeriodicTimer> _ = timeSystem.On.PeriodicTimer.WaitingForNextTick(
+			callback: _ => callbackCount++,
+			predicate: p => p == periodicTimer1);
+		await periodicTimer1.WaitForNextTickAsync();
+		await That(callbackCount).IsEqualTo(1);
+		await periodicTimer2.WaitForNextTickAsync();
+		await That(callbackCount).IsEqualTo(1);
+	}
+#endif
 
 	[Test]
 	public async Task OnTaskDelay_DisposedCallback_ShouldNotBeCalled()

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/PeriodicTimerMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/PeriodicTimerMockTests.cs
@@ -72,5 +72,111 @@ public class PeriodicTimerMockTests
 		cts.Cancel();
 		await timerTask;
 	}
+
+	[Test]
+	public async Task WaitingForNextTick_AutoAdvance_ShouldFireCallback()
+	{
+		MockTimeSystem timeSystem = new();
+		IPeriodicTimer? receivedTimer = null;
+		using IPeriodicTimer periodicTimer = timeSystem.PeriodicTimer.New(1.Seconds());
+
+		using (timeSystem.On.PeriodicTimer.WaitingForNextTick(t => receivedTimer = t))
+		{
+			await periodicTimer.WaitForNextTickAsync();
+		}
+
+		await That(receivedTimer).IsEqualTo(periodicTimer);
+	}
+
+	[Test]
+	public async Task WaitingForNextTick_DisableAutoAdvance_ShouldFireCallbackBeforeWaiting()
+	{
+		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
+		using CancellationTokenSource cts = CancellationTokenSource
+			.CreateLinkedTokenSource(TestContext.Current!.Execution.CancellationToken);
+		cts.CancelAfter(30.Seconds());
+		CancellationToken token = cts.Token;
+
+		int callbackCount = 0;
+		using IPeriodicTimer periodicTimer = timeSystem.PeriodicTimer.New(1.Seconds());
+		using SemaphoreSlim callbackFired = new(0);
+
+		using (timeSystem.On.PeriodicTimer.WaitingForNextTick(_ =>
+			{
+				callbackCount++;
+				// ReSharper disable once AccessToDisposedClosure
+				callbackFired.Release();
+			}))
+		{
+			Task tickTask = Task.Run(async () =>
+			{
+				try
+				{
+					// ReSharper disable once AccessToDisposedClosure
+					await periodicTimer.WaitForNextTickAsync(token);
+				}
+				catch (OperationCanceledException)
+				{
+					// Ignore cancellation
+				}
+			}, token);
+
+			await callbackFired.WaitAsync(token);
+			await That(callbackCount).IsEqualTo(1);
+
+			timeSystem.TimeProvider.AdvanceBy(1.Seconds());
+			await tickTask;
+		}
+	}
+
+	[Test]
+	public async Task WaitingForNextTick_ShouldFireCallbackForEachTick()
+	{
+		MockTimeSystem timeSystem = new();
+		int callbackCount = 0;
+		using IPeriodicTimer periodicTimer = timeSystem.PeriodicTimer.New(1.Seconds());
+
+		using (timeSystem.On.PeriodicTimer.WaitingForNextTick(_ => callbackCount++))
+		{
+			await periodicTimer.WaitForNextTickAsync();
+			await periodicTimer.WaitForNextTickAsync();
+			await periodicTimer.WaitForNextTickAsync();
+		}
+
+		await That(callbackCount).IsEqualTo(3);
+	}
+
+	[Test]
+	public async Task WaitingForNextTick_ShouldNotFireCallbackAfterDispose()
+	{
+		MockTimeSystem timeSystem = new();
+		IPeriodicTimer? receivedTimer = null;
+		using IPeriodicTimer periodicTimer = timeSystem.PeriodicTimer.New(1.Seconds());
+		IDisposable disposable =
+			timeSystem.On.PeriodicTimer.WaitingForNextTick(t => receivedTimer = t);
+
+		disposable.Dispose();
+		await periodicTimer.WaitForNextTickAsync();
+
+		await That(receivedTimer).IsNull();
+	}
+
+	[Test]
+	public async Task WaitingForNextTick_WhenTimerIsDisposed_ShouldNotFireCallback()
+	{
+		MockTimeSystem timeSystem = new();
+		IPeriodicTimer? receivedTimer = null;
+		IPeriodicTimer periodicTimer = timeSystem.PeriodicTimer.New(1.Seconds());
+		periodicTimer.Dispose();
+
+		using (timeSystem.On.PeriodicTimer.WaitingForNextTick(t => receivedTimer = t))
+		{
+			#pragma warning disable MA0040 // Use an overload with a CancellationToken
+			await periodicTimer.WaitForNextTickAsync();
+			#pragma warning restore MA0040
+		}
+
+		await That(receivedTimer).IsNull();
+	}
 }
 #endif


### PR DESCRIPTION
This PR adds an extensibility/notification callback that fires when a mocked `IPeriodicTimer` is waiting for its next tick, aligning `PeriodicTimer` with the existing `MockTimeSystem.On.*` notification pattern.

**Changes:**
- Introduces `IPeriodicTimerNotificationHandler` and exposes it via `INotificationHandler.PeriodicTimer` (feature-gated).
- Wires `PeriodicTimerMock.WaitForNextTickAsync` to invoke the new notification via `NotificationHandler`.
- Adds test coverage for callback invocation, disposal behavior, multiple callbacks, and predicate filtering.