### PR TITLE
chore: bump Mockolate and aweXpect.Mockolate to v3.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,8 +43,8 @@
 		<PackageVersion Include="aweXpect" Version="2.31.0"/>
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0"/>
 		<PackageVersion Include="aweXpect.Testably" Version="0.13.0"/>
-		<PackageVersion Include="aweXpect.Mockolate" Version="2.0.0"/>
-		<PackageVersion Include="Mockolate" Version="2.1.1"/>
+		<PackageVersion Include="aweXpect.Mockolate" Version="3.0.0"/>
+		<PackageVersion Include="Mockolate" Version="3.0.0"/>
 		<PackageVersion Include="TUnit.Engine" Version="1.24.0"/>
 		<PackageVersion Include="Polyfill" Version="9.22.0"/>
 		<PackageVersion Include="PublicApiGenerator" Version="11.5.4"/>


### PR DESCRIPTION
This pull request updates package dependencies to ensure the project uses the latest versions. The most significant change is upgrading both `aweXpect.Mockolate` and `Mockolate` to version 3.0.0.

Dependency upgrades:

* Upgraded `aweXpect.Mockolate` from version 2.0.0 to 3.0.0 in `Directory.Packages.props`
* Upgraded `Mockolate` from version 2.1.1 to 3.0.0 in `Directory.Packages.props`