### PR TITLE
feat: loosen package versions for .NET6/.NET8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,17 +8,19 @@
 		<PackageVersion Include="System.IO.Compression" Version="4.3.0"/>
 		<PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0"/>
 	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<PackageVersion Include="System.Threading.Channels" Version="[6.0.0]"/>
-		<PackageVersion Include="System.Linq.Async" Version="[6.0.3]"/>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netstandard2.0' ">
+		<PackageVersion Include="System.Threading.Channels" Version="6.0.0"/>
+		<PackageVersion Include="System.Linq.Async" Version="6.0.3"/>
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<PackageVersion Include="System.Threading.Channels" Version="[8.0.0]"/>
+		<PackageVersion Include="System.Threading.Channels" Version="8.0.0"/>
 		<PackageVersion Include="System.Linq.Async" Version="7.0.0"/>
 	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' And '$(TargetFramework)' != 'net6.0' ">
-		<PackageVersion Include="System.Threading.Channels" Version="10.0.7"/>
-		<PackageVersion Include="System.Linq.Async" Version="7.0.0"/>
+	<ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' And '$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'netstandard2.1' And '$(TargetFramework)' != 'netstandard2.0' ">
+		<PackageVersion Include="System.Threading.Channels" Version="10.0.8"/>
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+		<PackageVersion Include="System.Linq.Async" Version="7.0.1"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1"/>
@@ -29,8 +31,10 @@
 		<PackageVersion Include="LibGit2Sharp" Version="0.31.0"/>
 		<PackageVersion Include="SharpCompress" Version="0.47.4"/>
 	</ItemGroup>
-	<ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netstandard2.0' ">
 		<PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.7"/>
+	</ItemGroup>
+	<ItemGroup>
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0"/>
 		<PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0"/>
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7"/>

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -16,7 +16,7 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<OutputType>Exe</OutputType>
-		<NoWarn>$(NoWarn);701;1702;CA1845;MA0003;MA0004;MA0018;MA0020;MA0038;MA0042;MA0076;xUnit1045;NU1603;NU1608</NoWarn>
+		<NoWarn>$(NoWarn);701;1702;CA1845;MA0003;MA0004;MA0018;MA0020;MA0038;MA0042;MA0076;xUnit1045;NU1603</NoWarn>
 		<EnableTUnitPolyfills>false</EnableTUnitPolyfills>
 	</PropertyGroup>
 

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,18 @@
 		{
 			"matchPackagePatterns": "^Testably.Abstractions",
 			"groupName": [ "Testably.Abstractions packages" ]
+		},
+		{
+			"description": "Freeze the legacy System.Threading.Channels entries (net6.0=6.x, net8.0=8.x) so they stay aligned with the runtime-bundled assembly. Only the entry for newer TFMs (currently 10.x) is auto-updated.",
+			"matchPackageNames": ["System.Threading.Channels"],
+			"matchCurrentVersion": "/^(6|8)\\./",
+			"enabled": false
+		},
+		{
+			"description": "Freeze the System.Linq.Async entries that aren't on the latest line: the net6.0 entry on 6.x, and the net8.0 entry on 7.0.0. The entry for newer TFMs (currently 7.0.1) continues to be updated.",
+			"matchPackageNames": ["System.Linq.Async"],
+			"matchCurrentVersion": "/^(6\\.|7\\.0\\.0$)/",
+			"enabled": false
 		}
 	],
 	"ignoreDeps": [ "actions/download-artifact", "actions/upload-artifact" ],


### PR DESCRIPTION
This pull request updates package management and configuration for multiple target frameworks, improves dependency alignment, and adjusts warning suppression for test projects. The most important changes are grouped below.

### Package versioning and target framework alignment

* Expanded the conditions for `System.Threading.Channels` and `System.Linq.Async` package references in `Directory.Packages.props` to better align versions with the appropriate target frameworks, including explicit handling for `netstandard2.0`, `netstandard2.1`, `net8.0`, and `net9.0`. This ensures that each framework uses the most compatible and runtime-aligned package version.
* Added conditional inclusion of `Microsoft.Bcl.Memory` for specific target frameworks (`net8.0`, `net9.0`, `netstandard2.1`, `netstandard2.0`), improving dependency management and avoiding unnecessary package references for other frameworks.

### Dependency update automation

* Updated `renovate.json` to freeze updates for legacy `System.Threading.Channels` and `System.Linq.Async` package versions for certain target frameworks, ensuring these stay aligned with runtime-bundled assemblies and only newer TFM entries are auto-updated.

### Build and test configuration

* Reduced the number of suppressed NuGet warnings in `Tests/Directory.Build.props` by removing `NU1608` from the `NoWarn` list, allowing these warnings to be surfaced and addressed.

---

- *Fixes #993*