### PR TITLE
feat: expose persistent execution counters on timer mocks

### DIFF
--- a/Source/Testably.Abstractions.Testing/TimeSystem/IPeriodicTimerMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/IPeriodicTimerMock.cs
@@ -1,0 +1,20 @@
+#if FEATURE_PERIODIC_TIMER
+using Testably.Abstractions.TimeSystem;
+
+namespace Testably.Abstractions.Testing.TimeSystem;
+
+/// <summary>
+///     Additional abstractions for a mocked periodic timer to simplify testing.<br />
+///     Implements <see cref="IPeriodicTimer" />.
+/// </summary>
+public interface IPeriodicTimerMock : IPeriodicTimer
+{
+	/// <summary>
+	///     Gets the total number of times <see cref="IPeriodicTimer.WaitForNextTickAsync" /> has been entered
+	///     since the periodic timer was created.<br />
+	///     The counter is not affected by changes to <see cref="IPeriodicTimer.Period" /> and stops increasing
+	///     once the periodic timer is disposed.
+	/// </summary>
+	long WaitForNextTickCount { get; }
+}
+#endif

--- a/Source/Testably.Abstractions.Testing/TimeSystem/ITimerMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/ITimerMock.cs
@@ -10,6 +10,13 @@ namespace Testably.Abstractions.Testing.TimeSystem;
 public interface ITimerMock : ITimer
 {
 	/// <summary>
+	///     Gets the total number of times the timer callback has been invoked since the timer was created.<br />
+	///     The counter is not reset by <see cref="ITimer.Change(System.TimeSpan, System.TimeSpan)" /> and stops
+	///     increasing once the timer is disposed.
+	/// </summary>
+	long ExecutionCount { get; }
+
+	/// <summary>
 	///     Blocks the current thread, until the timer is executed <paramref name="executionCount" /> times.<br />
 	///     Throws a <see cref="TimeoutException" />
 	/// </summary>

--- a/Source/Testably.Abstractions.Testing/TimeSystem/PeriodicTimerMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/PeriodicTimerMock.cs
@@ -7,11 +7,12 @@ using Testably.Abstractions.TimeSystem;
 
 namespace Testably.Abstractions.Testing.TimeSystem;
 
-internal sealed class PeriodicTimerMock : IPeriodicTimer
+internal sealed class PeriodicTimerMock : IPeriodicTimerMock
 {
 	private readonly bool _autoAdvance;
 	private bool _isDisposed;
 	private long _lastTime;
+	private long _waitForNextTickCount;
 	private readonly MockTimeSystem _timeSystem;
 	private readonly NotificationHandler _callbackHandler;
 
@@ -46,6 +47,9 @@ internal sealed class PeriodicTimerMock : IPeriodicTimer
 	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
 	public ITimeSystem TimeSystem => _timeSystem;
 
+	/// <inheritdoc cref="IPeriodicTimerMock.WaitForNextTickCount" />
+	public long WaitForNextTickCount => Volatile.Read(ref _waitForNextTickCount);
+
 	/// <inheritdoc cref="IDisposable.Dispose()" />
 	public void Dispose()
 		=> _isDisposed = true;
@@ -64,6 +68,7 @@ internal sealed class PeriodicTimerMock : IPeriodicTimer
 		}
 
 		_callbackHandler.InvokePeriodicTimerWaitingForNextTick(this);
+		Interlocked.Increment(ref _waitForNextTickCount);
 		long now = _timeSystem.TimeProvider.ElapsedTicks;
 		long nextTime = _lastTime + Period.Ticks;
 		if (nextTime > now)

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimerMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimerMock.cs
@@ -15,6 +15,7 @@ internal sealed class TimerMock : ITimerMock
 	private CountdownEvent? _countdownEvent;
 	private TimeSpan _dueTime;
 	private Exception? _exception;
+	private long _executionCount;
 	private bool _isDisposed;
 #if NET9_0_OR_GREATER
 	private readonly Lock _lock = new();
@@ -64,6 +65,10 @@ internal sealed class TimerMock : ITimerMock
 	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
 	public ITimeSystem TimeSystem
 		=> _mockTimeSystem;
+
+	/// <inheritdoc cref="ITimerMock.ExecutionCount" />
+	public long ExecutionCount
+		=> Volatile.Read(ref _executionCount);
 
 	/// <inheritdoc cref="ITimer.Change(int, int)" />
 	public bool Change(int dueTime, int period)
@@ -249,6 +254,8 @@ internal sealed class TimerMock : ITimerMock
 			{
 				_exception = swallowedException;
 			}
+
+			Interlocked.Increment(ref _executionCount);
 
 			if (_countdownEvent?.Signal() == true)
 			{

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
@@ -443,6 +443,10 @@ namespace Testably.Abstractions.Testing.TimeSystem
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> ThreadSleep(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> TimeChanged(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, System.DateTime, bool>? predicate = null);
     }
+    public interface IPeriodicTimerMock : System.IDisposable, Testably.Abstractions.TimeSystem.IPeriodicTimer, Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        long WaitForNextTickCount { get; }
+    }
     public interface IPeriodicTimerNotificationHandler
     {
         Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.TimeSystem.IPeriodicTimer> WaitingForNextTick(System.Action<Testably.Abstractions.TimeSystem.IPeriodicTimer>? callback = null, System.Func<Testably.Abstractions.TimeSystem.IPeriodicTimer, bool>? predicate = null);
@@ -468,6 +472,7 @@ namespace Testably.Abstractions.Testing.TimeSystem
     }
     public interface ITimerMock : System.IAsyncDisposable, System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity, Testably.Abstractions.TimeSystem.ITimer
     {
+        long ExecutionCount { get; }
         Testably.Abstractions.Testing.TimeSystem.ITimerMock Wait(int executionCount = 1, int timeout = 10000, System.Action<Testably.Abstractions.Testing.TimeSystem.ITimerMock>? callback = null);
     }
     public interface ITimerStrategy

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -452,6 +452,7 @@ namespace Testably.Abstractions.Testing.TimeSystem
     }
     public interface ITimerMock : System.IAsyncDisposable, System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity, Testably.Abstractions.TimeSystem.ITimer
     {
+        long ExecutionCount { get; }
         Testably.Abstractions.Testing.TimeSystem.ITimerMock Wait(int executionCount = 1, int timeout = 10000, System.Action<Testably.Abstractions.Testing.TimeSystem.ITimerMock>? callback = null);
     }
     public interface ITimerStrategy

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -443,6 +443,10 @@ namespace Testably.Abstractions.Testing.TimeSystem
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> ThreadSleep(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> TimeChanged(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, System.DateTime, bool>? predicate = null);
     }
+    public interface IPeriodicTimerMock : System.IDisposable, Testably.Abstractions.TimeSystem.IPeriodicTimer, Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        long WaitForNextTickCount { get; }
+    }
     public interface IPeriodicTimerNotificationHandler
     {
         Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.TimeSystem.IPeriodicTimer> WaitingForNextTick(System.Action<Testably.Abstractions.TimeSystem.IPeriodicTimer>? callback = null, System.Func<Testably.Abstractions.TimeSystem.IPeriodicTimer, bool>? predicate = null);
@@ -468,6 +472,7 @@ namespace Testably.Abstractions.Testing.TimeSystem
     }
     public interface ITimerMock : System.IAsyncDisposable, System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity, Testably.Abstractions.TimeSystem.ITimer
     {
+        long ExecutionCount { get; }
         Testably.Abstractions.Testing.TimeSystem.ITimerMock Wait(int executionCount = 1, int timeout = 10000, System.Action<Testably.Abstractions.Testing.TimeSystem.ITimerMock>? callback = null);
     }
     public interface ITimerStrategy

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
@@ -443,6 +443,10 @@ namespace Testably.Abstractions.Testing.TimeSystem
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> ThreadSleep(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> TimeChanged(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, System.DateTime, bool>? predicate = null);
     }
+    public interface IPeriodicTimerMock : System.IDisposable, Testably.Abstractions.TimeSystem.IPeriodicTimer, Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        long WaitForNextTickCount { get; }
+    }
     public interface IPeriodicTimerNotificationHandler
     {
         Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.TimeSystem.IPeriodicTimer> WaitingForNextTick(System.Action<Testably.Abstractions.TimeSystem.IPeriodicTimer>? callback = null, System.Func<Testably.Abstractions.TimeSystem.IPeriodicTimer, bool>? predicate = null);
@@ -468,6 +472,7 @@ namespace Testably.Abstractions.Testing.TimeSystem
     }
     public interface ITimerMock : System.IAsyncDisposable, System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity, Testably.Abstractions.TimeSystem.ITimer
     {
+        long ExecutionCount { get; }
         Testably.Abstractions.Testing.TimeSystem.ITimerMock Wait(int executionCount = 1, int timeout = 10000, System.Action<Testably.Abstractions.Testing.TimeSystem.ITimerMock>? callback = null);
     }
     public interface ITimerStrategy

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -432,6 +432,7 @@ namespace Testably.Abstractions.Testing.TimeSystem
     }
     public interface ITimerMock : System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity, Testably.Abstractions.TimeSystem.ITimer
     {
+        long ExecutionCount { get; }
         Testably.Abstractions.Testing.TimeSystem.ITimerMock Wait(int executionCount = 1, int timeout = 10000, System.Action<Testably.Abstractions.Testing.TimeSystem.ITimerMock>? callback = null);
     }
     public interface ITimerStrategy

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -445,6 +445,7 @@ namespace Testably.Abstractions.Testing.TimeSystem
     }
     public interface ITimerMock : System.IAsyncDisposable, System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity, Testably.Abstractions.TimeSystem.ITimer
     {
+        long ExecutionCount { get; }
         Testably.Abstractions.Testing.TimeSystem.ITimerMock Wait(int executionCount = 1, int timeout = 10000, System.Action<Testably.Abstractions.Testing.TimeSystem.ITimerMock>? callback = null);
     }
     public interface ITimerStrategy

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/PeriodicTimerMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/PeriodicTimerMockTests.cs
@@ -1,6 +1,7 @@
 ﻿#if FEATURE_PERIODIC_TIMER
 using aweXpect.Chronology;
 using System.Threading;
+using Testably.Abstractions.Testing.TimeSystem;
 using Testably.Abstractions.TimeSystem;
 
 namespace Testably.Abstractions.Testing.Tests.TimeSystem;
@@ -71,6 +72,73 @@ public class PeriodicTimerMockTests
 		await That(Volatile.Read(ref timerCount)).IsEqualTo(14);
 		cts.Cancel();
 		await timerTask;
+	}
+
+	[Test]
+	public async Task WaitForNextTickCount_AfterDispose_ShouldStopIncreasing()
+	{
+		MockTimeSystem timeSystem = new();
+		IPeriodicTimer periodicTimer = timeSystem.PeriodicTimer.New(1.Seconds());
+
+		await periodicTimer.WaitForNextTickAsync();
+		await periodicTimer.WaitForNextTickAsync();
+		long countBeforeDispose = ((IPeriodicTimerMock)periodicTimer).WaitForNextTickCount;
+		periodicTimer.Dispose();
+		#pragma warning disable MA0040
+		await periodicTimer.WaitForNextTickAsync();
+		#pragma warning restore MA0040
+
+		await That(((IPeriodicTimerMock)periodicTimer).WaitForNextTickCount)
+			.IsEqualTo(countBeforeDispose);
+	}
+
+	[Test]
+	public async Task WaitForNextTickCount_ShouldExposeMockAsIPeriodicTimerMock()
+	{
+		MockTimeSystem timeSystem = new();
+		using IPeriodicTimer periodicTimer = timeSystem.PeriodicTimer.New(1.Seconds());
+
+		await That(periodicTimer is IPeriodicTimerMock).IsTrue();
+	}
+
+	[Test]
+	public async Task WaitForNextTickCount_ShouldIncrementOnEachCall()
+	{
+		MockTimeSystem timeSystem = new();
+		using IPeriodicTimer periodicTimer = timeSystem.PeriodicTimer.New(1.Seconds());
+		IPeriodicTimerMock mock = (IPeriodicTimerMock)periodicTimer;
+
+		await That(mock.WaitForNextTickCount).IsEqualTo(0L);
+
+		await periodicTimer.WaitForNextTickAsync();
+		await That(mock.WaitForNextTickCount).IsEqualTo(1L);
+
+		await periodicTimer.WaitForNextTickAsync();
+		await periodicTimer.WaitForNextTickAsync();
+		await That(mock.WaitForNextTickCount).IsEqualTo(3L);
+	}
+
+	[Test]
+	public async Task WaitForNextTickCount_WhenCancelledBeforeNotification_ShouldNotIncrement()
+	{
+		MockTimeSystem timeSystem = new();
+		using IPeriodicTimer periodicTimer = timeSystem.PeriodicTimer.New(1.Seconds());
+		IPeriodicTimerMock mock = (IPeriodicTimerMock)periodicTimer;
+		using CancellationTokenSource cts = new();
+		cts.Cancel();
+
+		Exception? exception = null;
+		try
+		{
+			await periodicTimer.WaitForNextTickAsync(cts.Token);
+		}
+		catch (OperationCanceledException ex)
+		{
+			exception = ex;
+		}
+
+		await That(exception).IsNotNull();
+		await That(mock.WaitForNextTickCount).IsEqualTo(0L);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
@@ -290,6 +290,54 @@ public class TimerMockTests
 	}
 
 	[Test]
+	public async Task ExecutionCount_AfterDispose_ShouldStopIncreasing()
+	{
+		MockTimeSystem timeSystem = new MockTimeSystem()
+			.WithTimerStrategy(new TimerStrategy(TimerMode.StartOnMockWait));
+		ITimerHandler timerHandler = timeSystem.TimerHandler;
+
+		using ITimer timer = timeSystem.Timer.New(_ => { }, null, 0, 100);
+		ITimerMock mock = timerHandler[0];
+
+		mock.Wait(5, callback: t => t.Dispose(), timeout: 10000);
+		long countAfterDispose = mock.ExecutionCount;
+		await Task.Delay(200, TestContext.Current!.Execution.CancellationToken);
+
+		await That(mock.ExecutionCount).IsEqualTo(countAfterDispose);
+	}
+
+	[Test]
+	public async Task ExecutionCount_PersistsAcrossWaitCalls()
+	{
+		MockTimeSystem timeSystem = new MockTimeSystem()
+			.WithTimerStrategy(new TimerStrategy(TimerMode.StartOnMockWait));
+		ITimerHandler timerHandler = timeSystem.TimerHandler;
+
+		using ITimer timer = timeSystem.Timer.New(_ => { }, null, 0, 100);
+
+		await That(timerHandler[0].ExecutionCount).IsEqualTo(0L);
+
+		timerHandler[0].Wait(3, timeout: 10000);
+		await That(timerHandler[0].ExecutionCount).IsGreaterThanOrEqualTo(3L);
+
+		long afterFirstWait = timerHandler[0].ExecutionCount;
+		timerHandler[0].Wait(3, timeout: 10000);
+		await That(timerHandler[0].ExecutionCount).IsGreaterThanOrEqualTo(afterFirstWait + 3L);
+	}
+
+	[Test]
+	public async Task ExecutionCount_ShouldStartAtZero()
+	{
+		MockTimeSystem timeSystem = new MockTimeSystem()
+			.WithTimerStrategy(new TimerStrategy(TimerMode.StartOnMockWait));
+		ITimerHandler timerHandler = timeSystem.TimerHandler;
+
+		using ITimer timer = timeSystem.Timer.New(_ => { }, null, 0, 100);
+
+		await That(timerHandler[0].ExecutionCount).IsEqualTo(0L);
+	}
+
+	[Test]
 	public async Task New_WithStartOnMockWaitMode_ShouldOnlyStartWhenCallingWait()
 	{
 		MockTimeSystem timeSystem = new MockTimeSystem()


### PR DESCRIPTION
Add `ITimerMock.ExecutionCount` and a new `IPeriodicTimerMock` interface with `WaitForNextTickCount` so tests can observe how often a timer callback fired or `WaitForNextTickAsync` was entered, including activity that happened before the assertion subscribed. Counters use `Interlocked.Increment` and `Volatile.Read`, persist across `Change(...)` / `Period` mutations, and freeze on dispose. `IPeriodicTimer` itself is left untouched; the new `IPeriodicTimerMock` lives in the testing project.