### PR TITLE
feat: replay prior change notifications via OnEventOrReplay

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/ChangeHandler.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/ChangeHandler.cs
@@ -67,17 +67,29 @@ internal sealed class ChangeHandler
 				$"Use {nameof(OnEvent)} instead, or remove the opt-out.");
 		}
 
+		IAwaitableCallback<ChangeDescription> waiter;
+		ChangeDescription[] snapshot;
 		lock (_historyLock)
 		{
-			IAwaitableCallback<ChangeDescription> waiter =
+			waiter =
 				_changeOccurredCallbacks.RegisterCallback(notificationCallback, predicate);
-			foreach (ChangeDescription past in _history)
+			snapshot = _history.ToArray();
+		}
+
+		try
+		{
+			foreach (ChangeDescription past in snapshot)
 			{
 				_changeOccurredCallbacks.Replay(waiter, past);
 			}
-
-			return waiter;
 		}
+		catch
+		{
+			waiter.Dispose();
+			throw;
+		}
+
+		return waiter;
 	}
 
 	#endregion
@@ -105,11 +117,14 @@ internal sealed class ChangeHandler
 			return;
 		}
 
+		Action<ChangeDescription> invoke;
 		lock (_historyLock)
 		{
 			_history.Add(fileSystemChange);
-			_changeOccurredCallbacks.InvokeCallbacks(fileSystemChange);
+			invoke = _changeOccurredCallbacks.SnapshotInvocations();
 		}
+
+		invoke(fileSystemChange);
 	}
 
 	internal ChangeDescription NotifyPendingChange(WatcherChangeTypes changeType,

--- a/Source/Testably.Abstractions.Testing/FileSystem/ChangeHandler.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/ChangeHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Testably.Abstractions.Testing.Storage;
 
@@ -13,14 +14,22 @@ internal sealed class ChangeHandler
 	private readonly Notification.INotificationFactory<ChangeDescription>
 		_changeOccurringCallbacks = Notification.CreateFactory<ChangeDescription>();
 
+	private readonly List<ChangeDescription>? _history;
+#if NET9_0_OR_GREATER
+	private readonly System.Threading.Lock _historyLock = new();
+#else
+	private readonly object _historyLock = new();
+#endif
+
 	private readonly MockFileSystem _mockFileSystem;
 
 	private readonly Notification.INotificationFactory<ChangeDescription>
 		_watcherNotificationTriggeredCallbacks = Notification.CreateFactory<ChangeDescription>();
 
-	public ChangeHandler(MockFileSystem mockFileSystem)
+	public ChangeHandler(MockFileSystem mockFileSystem, bool recordNotificationHistory)
 	{
 		_mockFileSystem = mockFileSystem;
+		_history = recordNotificationHistory ? new List<ChangeDescription>() : null;
 	}
 
 	#region IInterceptionHandler Members
@@ -44,6 +53,33 @@ internal sealed class ChangeHandler
 		Func<ChangeDescription, bool>? predicate = null)
 		=> _changeOccurredCallbacks.RegisterCallback(notificationCallback, predicate);
 
+	/// <inheritdoc cref="INotificationHandler.OnEventOrReplay" />
+	public IAwaitableCallback<ChangeDescription> OnEventOrReplay(
+		Action<ChangeDescription>? notificationCallback = null,
+		Func<ChangeDescription, bool>? predicate = null)
+	{
+		if (_history is null)
+		{
+			throw new InvalidOperationException(
+				$"{nameof(OnEventOrReplay)} requires notification history, but it was disabled via " +
+				$"{nameof(MockFileSystem.MockFileSystemOptions)}." +
+				$"{nameof(MockFileSystem.MockFileSystemOptions.WithoutNotificationHistory)}. " +
+				$"Use {nameof(OnEvent)} instead, or remove the opt-out.");
+		}
+
+		lock (_historyLock)
+		{
+			IAwaitableCallback<ChangeDescription> waiter =
+				_changeOccurredCallbacks.RegisterCallback(notificationCallback, predicate);
+			foreach (ChangeDescription past in _history)
+			{
+				_changeOccurredCallbacks.Replay(waiter, past);
+			}
+
+			return waiter;
+		}
+	}
+
 	#endregion
 
 	#region IWatcherTriggeredHandler Members
@@ -58,8 +94,20 @@ internal sealed class ChangeHandler
 
 	internal void NotifyCompletedChange(ChangeDescription? fileSystemChange)
 	{
-		if (fileSystemChange != null)
+		if (fileSystemChange is null)
 		{
+			return;
+		}
+
+		if (_history is null)
+		{
+			_changeOccurredCallbacks.InvokeCallbacks(fileSystemChange);
+			return;
+		}
+
+		lock (_historyLock)
+		{
+			_history.Add(fileSystemChange);
 			_changeOccurredCallbacks.InvokeCallbacks(fileSystemChange);
 		}
 	}

--- a/Source/Testably.Abstractions.Testing/FileSystem/INotificationHandler.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/INotificationHandler.cs
@@ -20,4 +20,27 @@ public interface INotificationHandler : IFileSystemEntity
 	IAwaitableCallback<ChangeDescription> OnEvent(
 		Action<ChangeDescription>? notificationCallback = null,
 		Func<ChangeDescription, bool>? predicate = null);
+
+	/// <summary>
+	///     Like <see cref="OnEvent" />, but the returned callback also replays any matching changes
+	///     that occurred before this call, in their original order.
+	///     <para />
+	///     Notification history is enabled by default. If it has been disabled via
+	///     <see cref="MockFileSystem.MockFileSystemOptions.WithoutNotificationHistory" />, calling
+	///     this method throws <see cref="InvalidOperationException" />; use <see cref="OnEvent" />
+	///     instead in that case.
+	/// </summary>
+	/// <param name="notificationCallback">(optional) The callback to execute for each replayed and future change.</param>
+	/// <param name="predicate">
+	///     (optional) A predicate used to filter which changes are replayed and which future changes notify the callback.<br />
+	///     If set to <see langword="null" /> (default value) all changes are considered.
+	/// </param>
+	/// <returns>An <see cref="IAwaitableCallback{ChangeDescription}" /> to un-register the callback on dispose.</returns>
+	/// <exception cref="InvalidOperationException">
+	///     Notification history was disabled via
+	///     <see cref="MockFileSystem.MockFileSystemOptions.WithoutNotificationHistory" />.
+	/// </exception>
+	IAwaitableCallback<ChangeDescription> OnEventOrReplay(
+		Action<ChangeDescription>? notificationCallback = null,
+		Func<ChangeDescription, bool>? predicate = null);
 }

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -27,11 +27,6 @@ public sealed class MockFileSystem : IFileSystem
 	public INotificationHandler Notify => ChangeHandler;
 
 	/// <summary>
-	///     Get notified of events after they were triggered by a <see cref="IFileSystemWatcher" />.
-	/// </summary>
-	public IWatcherTriggeredHandler Watcher => ChangeHandler;
-
-	/// <summary>
 	///     The used random system.
 	/// </summary>
 	public IRandomSystem RandomSystem { get; }
@@ -63,6 +58,11 @@ public sealed class MockFileSystem : IFileSystem
 	///     The used time system.
 	/// </summary>
 	public ITimeSystem TimeSystem { get; }
+
+	/// <summary>
+	///     Get notified of events after they were triggered by a <see cref="IFileSystemWatcher" />.
+	/// </summary>
+	public IWatcherTriggeredHandler Watcher => ChangeHandler;
 
 	internal IAccessControlStrategy AccessControlStrategy
 	{
@@ -144,7 +144,7 @@ public sealed class MockFileSystem : IFileSystem
 		TimeSystem = initialization.TimeSystem ?? new MockTimeSystem(TimeProvider.Now());
 		_pathMock = new PathMock(this);
 		_storage = new InMemoryStorage(this);
-		ChangeHandler = new ChangeHandler(this);
+		ChangeHandler = new ChangeHandler(this, initialization.RecordNotificationHistory);
 		_directoryMock = new DirectoryMock(this);
 		_fileMock = new FileMock(this);
 		DirectoryInfo = new DirectoryInfoFactoryMock(this);
@@ -315,6 +315,12 @@ public sealed class MockFileSystem : IFileSystem
 		internal IRandomProvider? RandomProvider { get; private set; }
 
 		/// <summary>
+		///     Whether to record a history of completed change notifications so that
+		///     <see cref="INotificationHandler.OnEventOrReplay" /> can replay past events.
+		/// </summary>
+		internal bool RecordNotificationHistory { get; private set; } = true;
+
+		/// <summary>
 		///     The simulated operating system.
 		/// </summary>
 		internal SimulationMode SimulationMode { get; private set; } = SimulationMode.Native;
@@ -368,6 +374,18 @@ public sealed class MockFileSystem : IFileSystem
 		public MockFileSystemOptions UseTimeSystem(ITimeSystem timeSystem)
 		{
 			TimeSystem = timeSystem;
+			return this;
+		}
+
+		/// <summary>
+		///     Disables recording the change notification history. With history disabled,
+		///     <see cref="INotificationHandler.OnEventOrReplay" /> throws
+		///     <see cref="InvalidOperationException" />; use <see cref="INotificationHandler.OnEvent" />
+		///     instead.
+		/// </summary>
+		public MockFileSystemOptions WithoutNotificationHistory()
+		{
+			RecordNotificationHistory = false;
 			return this;
 		}
 	}

--- a/Source/Testably.Abstractions.Testing/Notification.cs
+++ b/Source/Testably.Abstractions.Testing/Notification.cs
@@ -69,6 +69,14 @@ public static class Notification
 			return callbackWaiter;
 		}
 
+		public void Replay(IAwaitableCallback<TValue> callback, TValue value)
+		{
+			if (callback is CallbackWaiter waiter)
+			{
+				waiter.Invoke(value);
+			}
+		}
+
 		#endregion
 
 		private void UnRegisterCallback(Guid key)
@@ -120,7 +128,8 @@ public static class Notification
 			{
 				if (_isDisposed)
 				{
-					throw new ObjectDisposedException(null, "The awaitable callback is already disposed.");
+					throw new ObjectDisposedException(null,
+						"The awaitable callback is already disposed.");
 				}
 
 				_filter = filter;
@@ -159,7 +168,8 @@ public static class Notification
 			{
 				if (_isDisposed)
 				{
-					throw new ObjectDisposedException(null, "The awaitable callback is already disposed.");
+					throw new ObjectDisposedException(null,
+						"The awaitable callback is already disposed.");
 				}
 
 				_reset.Reset();
@@ -196,7 +206,8 @@ public static class Notification
 			{
 				if (_isDisposed)
 				{
-					throw new ObjectDisposedException(null, "The awaitable callback is already disposed.");
+					throw new ObjectDisposedException(null,
+						"The awaitable callback is already disposed.");
 				}
 
 				List<TValue> values = [];
@@ -265,6 +276,8 @@ public static class Notification
 		IAwaitableCallback<TValue> RegisterCallback(
 			Action<TValue>? callback,
 			Func<TValue, bool>? predicate = null);
+
+		void Replay(IAwaitableCallback<TValue> callback, TValue value);
 	}
 
 	/// <summary>
@@ -326,7 +339,8 @@ public static class Notification
 			=> _awaitableCallback.Dispose();
 
 		/// <inheritdoc cref="IAwaitableCallback{TValue, TFunc}.Wait(Func{TValue, bool}?,int,int, Action?)" />
-		[Obsolete("Use another `Wait` or `WaitAsync` overload and move the filter to the creation of the awaitable callback.")]
+		[Obsolete(
+			"Use another `Wait` or `WaitAsync` overload and move the filter to the creation of the awaitable callback.")]
 		public TFunc Wait(Func<TValue, bool>? filter,
 			int timeout = 30000,
 			int count = 1,

--- a/Source/Testably.Abstractions.Testing/Notification.cs
+++ b/Source/Testably.Abstractions.Testing/Notification.cs
@@ -77,6 +77,19 @@ public static class Notification
 			}
 		}
 
+		public Action<TValue> SnapshotInvocations()
+		{
+			System.Collections.Generic.ICollection<CallbackWaiter> snapshot =
+				_callbackWaiters.Values;
+			return value =>
+			{
+				foreach (CallbackWaiter callback in snapshot)
+				{
+					callback.Invoke(value);
+				}
+			};
+		}
+
 		#endregion
 
 		private void UnRegisterCallback(Guid key)
@@ -278,6 +291,14 @@ public static class Notification
 			Func<TValue, bool>? predicate = null);
 
 		void Replay(IAwaitableCallback<TValue> callback, TValue value);
+
+		/// <summary>
+		///     Captures the set of currently-registered callbacks and returns a delegate that, when
+		///     invoked with a value, delivers it to that snapshot. Call this under whatever lock guards
+		///     the surrounding state, then invoke the returned delegate outside the lock so user
+		///     callbacks do not run while the lock is held.
+		/// </summary>
+		Action<TValue> SnapshotInvocations();
 	}
 
 	/// <summary>

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
@@ -83,6 +83,7 @@ namespace Testably.Abstractions.Testing
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseTimeSystem(Testably.Abstractions.ITimeSystem timeSystem) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions WithoutNotificationHistory() { }
         }
     }
     public static class MockFileSystemExtensions
@@ -217,6 +218,7 @@ namespace Testably.Abstractions.Testing.FileSystem
     public interface INotificationHandler : System.IO.Abstractions.IFileSystemEntity
     {
         Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnEvent(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? notificationCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnEventOrReplay(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? notificationCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
     }
     public interface ISafeFileHandleStrategy
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -82,6 +82,7 @@ namespace Testably.Abstractions.Testing
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseTimeSystem(Testably.Abstractions.ITimeSystem timeSystem) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions WithoutNotificationHistory() { }
         }
     }
     public static class MockFileSystemExtensions
@@ -215,6 +216,7 @@ namespace Testably.Abstractions.Testing.FileSystem
     public interface INotificationHandler : System.IO.Abstractions.IFileSystemEntity
     {
         Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnEvent(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? notificationCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnEventOrReplay(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? notificationCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
     }
     public interface ISafeFileHandleStrategy
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -83,6 +83,7 @@ namespace Testably.Abstractions.Testing
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseTimeSystem(Testably.Abstractions.ITimeSystem timeSystem) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions WithoutNotificationHistory() { }
         }
     }
     public static class MockFileSystemExtensions
@@ -217,6 +218,7 @@ namespace Testably.Abstractions.Testing.FileSystem
     public interface INotificationHandler : System.IO.Abstractions.IFileSystemEntity
     {
         Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnEvent(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? notificationCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnEventOrReplay(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? notificationCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
     }
     public interface ISafeFileHandleStrategy
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
@@ -83,6 +83,7 @@ namespace Testably.Abstractions.Testing
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseTimeSystem(Testably.Abstractions.ITimeSystem timeSystem) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions WithoutNotificationHistory() { }
         }
     }
     public static class MockFileSystemExtensions
@@ -217,6 +218,7 @@ namespace Testably.Abstractions.Testing.FileSystem
     public interface INotificationHandler : System.IO.Abstractions.IFileSystemEntity
     {
         Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnEvent(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? notificationCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnEventOrReplay(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? notificationCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
     }
     public interface ISafeFileHandleStrategy
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -77,6 +77,7 @@ namespace Testably.Abstractions.Testing
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseTimeSystem(Testably.Abstractions.ITimeSystem timeSystem) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions WithoutNotificationHistory() { }
         }
     }
     public static class MockFileSystemExtensions
@@ -209,6 +210,7 @@ namespace Testably.Abstractions.Testing.FileSystem
     public interface INotificationHandler : System.IO.Abstractions.IFileSystemEntity
     {
         Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnEvent(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? notificationCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnEventOrReplay(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? notificationCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
     }
     public interface ISafeFileHandleStrategy
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -77,6 +77,7 @@ namespace Testably.Abstractions.Testing
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseCurrentDirectory(string path) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseRandomProvider(Testably.Abstractions.Testing.RandomSystem.IRandomProvider randomProvider) { }
             public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions UseTimeSystem(Testably.Abstractions.ITimeSystem timeSystem) { }
+            public Testably.Abstractions.Testing.MockFileSystem.MockFileSystemOptions WithoutNotificationHistory() { }
         }
     }
     public static class MockFileSystemExtensions
@@ -209,6 +210,7 @@ namespace Testably.Abstractions.Testing.FileSystem
     public interface INotificationHandler : System.IO.Abstractions.IFileSystemEntity
     {
         Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnEvent(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? notificationCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnEventOrReplay(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? notificationCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
     }
     public interface ISafeFileHandleStrategy
     {

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
@@ -168,6 +168,21 @@ public class ChangeHandlerTests
 	}
 
 	[Test]
+	[AutoArguments]
+	public async Task OnEventOrReplay_CallbackThrowsDuringReplay_ShouldNotLeakWaiter(string path)
+	{
+		FileSystem.File.WriteAllText(path, null);
+
+		void Subscribe() => FileSystem.Notify.OnEventOrReplay(
+			_ => throw new InvalidOperationException("boom"));
+
+		await That(Subscribe).Throws<InvalidOperationException>().WithMessage("boom");
+
+		void TriggerAnotherChange() => FileSystem.File.WriteAllText(path, "more");
+		await That(TriggerAnotherChange).DoesNotThrow();
+	}
+
+	[Test]
 	public async Task Watcher_ShouldNotTriggerWhenFileSystemWatcherDoesNotMatch()
 	{
 		FileSystem.Directory.CreateDirectory("bar");

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
@@ -7,11 +7,7 @@ namespace Testably.Abstractions.Testing.Tests.FileSystem;
 
 public class ChangeHandlerTests
 {
-	#region Test Setup
-
 	public MockFileSystem FileSystem { get; } = new();
-
-	#endregion
 
 	[Test]
 	[AutoArguments]
@@ -97,6 +93,80 @@ public class ChangeHandlerTests
 		await That(receivedPath).IsEqualTo(FileSystem.Path.GetFullPath(path));
 	}
 
+	public static
+		IEnumerable<(Action<IFileSystem, string>?, Action<IFileSystem, string>, WatcherChangeTypes, FileSystemTypes, string)> NotificationTriggeringMethods()
+	{
+		yield return (null, (f, p) => f.Directory.CreateDirectory(p), WatcherChangeTypes.Created,
+			FileSystemTypes.Directory, $"path_{Guid.NewGuid()}");
+		yield return ((f, p) => f.Directory.CreateDirectory(p), (f, p) => f.Directory.Delete(p),
+			WatcherChangeTypes.Deleted, FileSystemTypes.Directory, $"path_{Guid.NewGuid()}");
+		yield return (null, (f, p) => f.File.WriteAllText(p, null), WatcherChangeTypes.Created,
+			FileSystemTypes.File, $"path_{Guid.NewGuid()}");
+		yield return ((f, p) => f.File.WriteAllText(p, null), (f, p) => f.File.Delete(p),
+			WatcherChangeTypes.Deleted, FileSystemTypes.File, $"path_{Guid.NewGuid()}");
+	}
+
+	[Test]
+	[AutoArguments]
+	public async Task OnEventOrReplay_ShouldAlsoReceiveFutureEvents(string path1, string path2)
+	{
+		FileSystem.File.WriteAllText(path1, null);
+
+		using IAwaitableCallback<ChangeDescription> onEvent = FileSystem.Notify
+			.OnEventOrReplay(predicate: c => c.ChangeType == WatcherChangeTypes.Created);
+
+		FileSystem.File.WriteAllText(path2, null);
+
+		ChangeDescription[] received = await onEvent.WaitAsync(
+			count: 2,
+			timeout: TimeSpan.FromSeconds(5));
+
+		await That(received.Length).IsEqualTo(2);
+	}
+
+	[Test]
+	[AutoArguments]
+	public async Task OnEventOrReplay_ShouldNotReplayEventsFilteredOutByPredicate(string path)
+	{
+		FileSystem.File.WriteAllText(path, null);
+
+		using IAwaitableCallback<ChangeDescription> onEvent = FileSystem.Notify
+			.OnEventOrReplay(predicate: c => c.ChangeType == WatcherChangeTypes.Deleted);
+
+		void Act() =>
+			// ReSharper disable once AccessToDisposedClosure
+			onEvent.Wait(timeout: 50);
+
+		await That(Act).Throws<TimeoutException>();
+	}
+
+	[Test]
+	[AutoArguments]
+	public async Task OnEventOrReplay_ShouldReplayPriorMatchingEvents(string path)
+	{
+		FileSystem.File.WriteAllText(path, null);
+
+		using IAwaitableCallback<ChangeDescription> onEvent = FileSystem.Notify
+			.OnEventOrReplay(predicate: c => c.ChangeType == WatcherChangeTypes.Created);
+
+		ChangeDescription[] replayed =
+			await onEvent.WaitAsync(timeout: TimeSpan.FromMilliseconds(100));
+
+		await That(replayed.Length).IsEqualTo(1);
+		await That(replayed[0].Path).IsEqualTo(FileSystem.Path.GetFullPath(path));
+	}
+
+	[Test]
+	public async Task OnEventOrReplay_WithoutNotificationHistory_ShouldThrow()
+	{
+		MockFileSystem fileSystem = new(o => o.WithoutNotificationHistory());
+
+		void Act() => fileSystem.Notify.OnEventOrReplay();
+
+		await That(Act).Throws<InvalidOperationException>()
+			.WithMessage("*WithoutNotificationHistory*").AsWildcard();
+	}
+
 	[Test]
 	public async Task Watcher_ShouldNotTriggerWhenFileSystemWatcherDoesNotMatch()
 	{
@@ -131,26 +201,4 @@ public class ChangeHandlerTests
 
 		await That(isTriggered).IsTrue();
 	}
-
-	#region Helpers
-
-	public static
-		IEnumerable<(
-			Action<IFileSystem, string>?,
-			Action<IFileSystem, string>,
-			WatcherChangeTypes,
-			FileSystemTypes,
-			string)> NotificationTriggeringMethods()
-	{
-		yield return (null, (f, p) => f.Directory.CreateDirectory(p), WatcherChangeTypes.Created,
-			FileSystemTypes.Directory, $"path_{Guid.NewGuid()}");
-		yield return ((f, p) => f.Directory.CreateDirectory(p), (f, p) => f.Directory.Delete(p),
-				WatcherChangeTypes.Deleted, FileSystemTypes.Directory, $"path_{Guid.NewGuid()}");
-		yield return (null, (f, p) => f.File.WriteAllText(p, null), WatcherChangeTypes.Created,
-				FileSystemTypes.File, $"path_{Guid.NewGuid()}");
-		yield return ((f, p) => f.File.WriteAllText(p, null), (f, p) => f.File.Delete(p),
-			WatcherChangeTypes.Deleted, FileSystemTypes.File, $"path_{Guid.NewGuid()}");
-	}
-
-	#endregion
 }


### PR DESCRIPTION
Adds INotificationHandler.OnEventOrReplay, which registers a subscriber and atomically replays any matching ChangeDescription events that fired before the subscription. Enables late-subscriber assertion patterns (e.g. asserting against a MockFileSystem that has already mutated) without bracketing the trigger inside the assertion call.

Notification history is recorded by default and can be disabled via MockFileSystemOptions.WithoutNotificationHistory(); when disabled, OnEventOrReplay throws InvalidOperationException so misconfiguration cannot manifest as flaky tests.