### PR TITLE
feat: add OnTriggeredOrReplay method to replay watcher-triggered notifications

### DIFF
--- a/Source/Testably.Abstractions.Testing/FileSystem/ChangeDescription.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/ChangeDescription.cs
@@ -58,6 +58,17 @@ public class ChangeDescription
 		NotifyFilters = notifyFilters;
 	}
 
+	internal ChangeDescription(ChangeDescription source)
+	{
+		Path = source.Path;
+		Name = source.Name;
+		OldPath = source.OldPath;
+		OldName = source.OldName;
+		ChangeType = source.ChangeType;
+		FileSystemType = source.FileSystemType;
+		NotifyFilters = source.NotifyFilters;
+	}
+
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()
 		=> $"{ChangeType} ({FileSystemType}) {Path} [{NotifyFilters}]";

--- a/Source/Testably.Abstractions.Testing/FileSystem/ChangeHandler.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/ChangeHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Testably.Abstractions.Testing.Storage;
@@ -23,13 +23,24 @@ internal sealed class ChangeHandler
 
 	private readonly MockFileSystem _mockFileSystem;
 
-	private readonly Notification.INotificationFactory<ChangeDescription>
-		_watcherNotificationTriggeredCallbacks = Notification.CreateFactory<ChangeDescription>();
+	private readonly List<WatcherChangeDescription>? _watcherHistory;
+#if NET9_0_OR_GREATER
+	private readonly System.Threading.Lock _watcherHistoryLock = new();
+#else
+	private readonly object _watcherHistoryLock = new();
+#endif
+
+	private readonly Notification.INotificationFactory<WatcherChangeDescription>
+		_watcherNotificationTriggeredCallbacks =
+			Notification.CreateFactory<WatcherChangeDescription>();
 
 	public ChangeHandler(MockFileSystem mockFileSystem, bool recordNotificationHistory)
 	{
 		_mockFileSystem = mockFileSystem;
 		_history = recordNotificationHistory ? new List<ChangeDescription>() : null;
+		_watcherHistory = recordNotificationHistory
+			? new List<WatcherChangeDescription>()
+			: null;
 	}
 
 	#region IInterceptionHandler Members
@@ -97,10 +108,49 @@ internal sealed class ChangeHandler
 	#region IWatcherTriggeredHandler Members
 
 	/// <inheritdoc cref="IWatcherTriggeredHandler.OnTriggered" />
-	public IAwaitableCallback<ChangeDescription> OnTriggered(
-		Action<ChangeDescription>? triggerCallback = null,
-		Func<ChangeDescription, bool>? predicate = null)
+	public IAwaitableCallback<WatcherChangeDescription> OnTriggered(
+		Action<WatcherChangeDescription>? triggerCallback = null,
+		Func<WatcherChangeDescription, bool>? predicate = null)
 		=> _watcherNotificationTriggeredCallbacks.RegisterCallback(triggerCallback, predicate);
+
+	/// <inheritdoc cref="IWatcherTriggeredHandler.OnTriggeredOrReplay" />
+	public IAwaitableCallback<WatcherChangeDescription> OnTriggeredOrReplay(
+		Action<WatcherChangeDescription>? triggerCallback = null,
+		Func<WatcherChangeDescription, bool>? predicate = null)
+	{
+		if (_watcherHistory is null)
+		{
+			throw new InvalidOperationException(
+				$"{nameof(OnTriggeredOrReplay)} requires notification history, but it was disabled via " +
+				$"{nameof(MockFileSystem.MockFileSystemOptions)}." +
+				$"{nameof(MockFileSystem.MockFileSystemOptions.WithoutNotificationHistory)}. " +
+				$"Use {nameof(OnTriggered)} instead, or remove the opt-out.");
+		}
+
+		IAwaitableCallback<WatcherChangeDescription> waiter;
+		WatcherChangeDescription[] snapshot;
+		lock (_watcherHistoryLock)
+		{
+			waiter =
+				_watcherNotificationTriggeredCallbacks.RegisterCallback(triggerCallback, predicate);
+			snapshot = _watcherHistory.ToArray();
+		}
+
+		try
+		{
+			foreach (WatcherChangeDescription past in snapshot)
+			{
+				_watcherNotificationTriggeredCallbacks.Replay(waiter, past);
+			}
+		}
+		catch
+		{
+			waiter.Dispose();
+			throw;
+		}
+
+		return waiter;
+	}
 
 	#endregion
 
@@ -140,6 +190,24 @@ internal sealed class ChangeHandler
 		return fileSystemChange;
 	}
 
-	internal void NotifyWatcherTriggeredChange(ChangeDescription fileSystemChange)
-		=> _watcherNotificationTriggeredCallbacks.InvokeCallbacks(fileSystemChange);
+	internal void NotifyWatcherTriggeredChange(ChangeDescription fileSystemChange,
+		IFileSystemWatcher watcher)
+	{
+		WatcherChangeDescription watcherChange = new(fileSystemChange, watcher);
+
+		if (_watcherHistory is null)
+		{
+			_watcherNotificationTriggeredCallbacks.InvokeCallbacks(watcherChange);
+			return;
+		}
+
+		Action<WatcherChangeDescription> invoke;
+		lock (_watcherHistoryLock)
+		{
+			_watcherHistory.Add(watcherChange);
+			invoke = _watcherNotificationTriggeredCallbacks.SnapshotInvocations();
+		}
+
+		invoke(watcherChange);
+	}
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/FileSystemWatcherMock.cs
@@ -528,7 +528,7 @@ internal sealed class FileSystemWatcherMock : Component, IFileSystemWatcher
 				TriggerRenameNotification(item);
 			}
 
-			_fileSystem.ChangeHandler.NotifyWatcherTriggeredChange(item);
+			_fileSystem.ChangeHandler.NotifyWatcherTriggeredChange(item, this);
 		}
 	}
 

--- a/Source/Testably.Abstractions.Testing/FileSystem/IWatcherTriggeredHandler.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/IWatcherTriggeredHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Testably.Abstractions.Testing.FileSystem;
 
@@ -16,8 +16,31 @@ public interface IWatcherTriggeredHandler : IFileSystemEntity
 	///     (optional) A predicate used to filter which callbacks should be notified.<br />
 	///     If set to <see langword="null" /> (default value) all callbacks are notified.
 	/// </param>
-	/// <returns>An <see cref="IAwaitableCallback{ChangeDescription}" /> to un-register the callback on dispose.</returns>
-	IAwaitableCallback<ChangeDescription> OnTriggered(
-		Action<ChangeDescription>? triggerCallback = null,
-		Func<ChangeDescription, bool>? predicate = null);
+	/// <returns>An <see cref="IAwaitableCallback{WatcherChangeDescription}" /> to un-register the callback on dispose.</returns>
+	IAwaitableCallback<WatcherChangeDescription> OnTriggered(
+		Action<WatcherChangeDescription>? triggerCallback = null,
+		Func<WatcherChangeDescription, bool>? predicate = null);
+
+	/// <summary>
+	///     Like <see cref="OnTriggered" />, but the returned callback also replays any matching
+	///     watcher-triggered notifications that occurred before this call, in their original order.
+	///     <para />
+	///     Notification history is enabled by default. If it has been disabled via
+	///     <see cref="MockFileSystem.MockFileSystemOptions.WithoutNotificationHistory" />, calling
+	///     this method throws <see cref="InvalidOperationException" />; use <see cref="OnTriggered" />
+	///     instead in that case.
+	/// </summary>
+	/// <param name="triggerCallback">(optional) The callback to execute for each replayed and future notification.</param>
+	/// <param name="predicate">
+	///     (optional) A predicate used to filter which notifications are replayed and which future notifications notify the callback.<br />
+	///     If set to <see langword="null" /> (default value) all notifications are considered.
+	/// </param>
+	/// <returns>An <see cref="IAwaitableCallback{WatcherChangeDescription}" /> to un-register the callback on dispose.</returns>
+	/// <exception cref="InvalidOperationException">
+	///     Notification history was disabled via
+	///     <see cref="MockFileSystem.MockFileSystemOptions.WithoutNotificationHistory" />.
+	/// </exception>
+	IAwaitableCallback<WatcherChangeDescription> OnTriggeredOrReplay(
+		Action<WatcherChangeDescription>? triggerCallback = null,
+		Func<WatcherChangeDescription, bool>? predicate = null);
 }

--- a/Source/Testably.Abstractions.Testing/FileSystem/WatcherChangeDescription.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystem/WatcherChangeDescription.cs
@@ -1,0 +1,20 @@
+namespace Testably.Abstractions.Testing.FileSystem;
+
+/// <summary>
+///     Describes a change in the <see cref="MockFileSystem" /> that was emitted by a specific
+///     <see cref="IFileSystemWatcher" />. The <see cref="FileSystemWatcher" /> property allows
+///     consumers to filter watcher-triggered notifications by the emitting watcher instance.
+/// </summary>
+public sealed class WatcherChangeDescription : ChangeDescription
+{
+	/// <summary>
+	///     The <see cref="IFileSystemWatcher" /> that emitted this change notification.
+	/// </summary>
+	public IFileSystemWatcher FileSystemWatcher { get; }
+
+	internal WatcherChangeDescription(ChangeDescription source, IFileSystemWatcher fileSystemWatcher)
+		: base(source)
+	{
+		FileSystemWatcher = fileSystemWatcher;
+	}
+}

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -316,7 +316,8 @@ public sealed class MockFileSystem : IFileSystem
 
 		/// <summary>
 		///     Whether to record a history of completed change notifications so that
-		///     <see cref="INotificationHandler.OnEventOrReplay" /> can replay past events.
+		///     <see cref="INotificationHandler.OnEventOrReplay" /> and
+		///     <see cref="IWatcherTriggeredHandler.OnTriggeredOrReplay" /> can replay past events.
 		/// </summary>
 		internal bool RecordNotificationHistory { get; private set; } = true;
 
@@ -378,10 +379,12 @@ public sealed class MockFileSystem : IFileSystem
 		}
 
 		/// <summary>
-		///     Disables recording the change notification history. With history disabled,
-		///     <see cref="INotificationHandler.OnEventOrReplay" /> throws
+		///     Disables recording the change notification history for both the notify and
+		///     watcher-triggered streams. With history disabled,
+		///     <see cref="INotificationHandler.OnEventOrReplay" /> and
+		///     <see cref="IWatcherTriggeredHandler.OnTriggeredOrReplay" /> throw
 		///     <see cref="InvalidOperationException" />; use <see cref="INotificationHandler.OnEvent" />
-		///     instead.
+		///     or <see cref="IWatcherTriggeredHandler.OnTriggered" /> instead.
 		/// </summary>
 		public MockFileSystemOptions WithoutNotificationHistory()
 		{

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
@@ -231,7 +231,8 @@ namespace Testably.Abstractions.Testing.FileSystem
     }
     public interface IWatcherTriggeredHandler : System.IO.Abstractions.IFileSystemEntity
     {
-        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnTriggered(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription> OnTriggered(System.Action<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription> OnTriggeredOrReplay(System.Action<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool>? predicate = null);
     }
     public class NullAccessControlStrategy : Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy
     {
@@ -256,6 +257,10 @@ namespace Testably.Abstractions.Testing.FileSystem
         public System.IO.FileMode Mode { get; }
         public string Path { get; }
         public System.IO.FileShare Share { get; }
+    }
+    public sealed class WatcherChangeDescription : Testably.Abstractions.Testing.FileSystem.ChangeDescription
+    {
+        public System.IO.Abstractions.IFileSystemWatcher FileSystemWatcher { get; }
     }
 }
 namespace Testably.Abstractions.Testing.Initializer

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -224,7 +224,8 @@ namespace Testably.Abstractions.Testing.FileSystem
     }
     public interface IWatcherTriggeredHandler : System.IO.Abstractions.IFileSystemEntity
     {
-        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnTriggered(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription> OnTriggered(System.Action<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription> OnTriggeredOrReplay(System.Action<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool>? predicate = null);
     }
     public class NullAccessControlStrategy : Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy
     {
@@ -243,6 +244,10 @@ namespace Testably.Abstractions.Testing.FileSystem
         public System.IO.FileMode Mode { get; }
         public string Path { get; }
         public System.IO.FileShare Share { get; }
+    }
+    public sealed class WatcherChangeDescription : Testably.Abstractions.Testing.FileSystem.ChangeDescription
+    {
+        public System.IO.Abstractions.IFileSystemWatcher FileSystemWatcher { get; }
     }
 }
 namespace Testably.Abstractions.Testing.Initializer

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -231,7 +231,8 @@ namespace Testably.Abstractions.Testing.FileSystem
     }
     public interface IWatcherTriggeredHandler : System.IO.Abstractions.IFileSystemEntity
     {
-        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnTriggered(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription> OnTriggered(System.Action<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription> OnTriggeredOrReplay(System.Action<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool>? predicate = null);
     }
     public class NullAccessControlStrategy : Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy
     {
@@ -256,6 +257,10 @@ namespace Testably.Abstractions.Testing.FileSystem
         public System.IO.FileMode Mode { get; }
         public string Path { get; }
         public System.IO.FileShare Share { get; }
+    }
+    public sealed class WatcherChangeDescription : Testably.Abstractions.Testing.FileSystem.ChangeDescription
+    {
+        public System.IO.Abstractions.IFileSystemWatcher FileSystemWatcher { get; }
     }
 }
 namespace Testably.Abstractions.Testing.Initializer

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
@@ -231,7 +231,8 @@ namespace Testably.Abstractions.Testing.FileSystem
     }
     public interface IWatcherTriggeredHandler : System.IO.Abstractions.IFileSystemEntity
     {
-        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnTriggered(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription> OnTriggered(System.Action<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription> OnTriggeredOrReplay(System.Action<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool>? predicate = null);
     }
     public class NullAccessControlStrategy : Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy
     {
@@ -256,6 +257,10 @@ namespace Testably.Abstractions.Testing.FileSystem
         public System.IO.FileMode Mode { get; }
         public string Path { get; }
         public System.IO.FileShare Share { get; }
+    }
+    public sealed class WatcherChangeDescription : Testably.Abstractions.Testing.FileSystem.ChangeDescription
+    {
+        public System.IO.Abstractions.IFileSystemWatcher FileSystemWatcher { get; }
     }
 }
 namespace Testably.Abstractions.Testing.Initializer

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -218,7 +218,8 @@ namespace Testably.Abstractions.Testing.FileSystem
     }
     public interface IWatcherTriggeredHandler : System.IO.Abstractions.IFileSystemEntity
     {
-        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnTriggered(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription> OnTriggered(System.Action<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription> OnTriggeredOrReplay(System.Action<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool>? predicate = null);
     }
     public class NullAccessControlStrategy : Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy
     {
@@ -236,6 +237,10 @@ namespace Testably.Abstractions.Testing.FileSystem
         public System.IO.FileMode Mode { get; }
         public string Path { get; }
         public System.IO.FileShare Share { get; }
+    }
+    public sealed class WatcherChangeDescription : Testably.Abstractions.Testing.FileSystem.ChangeDescription
+    {
+        public System.IO.Abstractions.IFileSystemWatcher FileSystemWatcher { get; }
     }
 }
 namespace Testably.Abstractions.Testing.Initializer

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -218,7 +218,8 @@ namespace Testably.Abstractions.Testing.FileSystem
     }
     public interface IWatcherTriggeredHandler : System.IO.Abstractions.IFileSystemEntity
     {
-        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.ChangeDescription> OnTriggered(System.Action<Testably.Abstractions.Testing.FileSystem.ChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.ChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription> OnTriggered(System.Action<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool>? predicate = null);
+        Testably.Abstractions.Testing.IAwaitableCallback<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription> OnTriggeredOrReplay(System.Action<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription>? triggerCallback = null, System.Func<Testably.Abstractions.Testing.FileSystem.WatcherChangeDescription, bool>? predicate = null);
     }
     public class NullAccessControlStrategy : Testably.Abstractions.Testing.FileSystem.IAccessControlStrategy
     {
@@ -236,6 +237,10 @@ namespace Testably.Abstractions.Testing.FileSystem
         public System.IO.FileMode Mode { get; }
         public string Path { get; }
         public System.IO.FileShare Share { get; }
+    }
+    public sealed class WatcherChangeDescription : Testably.Abstractions.Testing.FileSystem.ChangeDescription
+    {
+        public System.IO.Abstractions.IFileSystemWatcher FileSystemWatcher { get; }
     }
 }
 namespace Testably.Abstractions.Testing.Initializer

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/ChangeHandlerTests.cs
@@ -94,7 +94,8 @@ public class ChangeHandlerTests
 	}
 
 	public static
-		IEnumerable<(Action<IFileSystem, string>?, Action<IFileSystem, string>, WatcherChangeTypes, FileSystemTypes, string)> NotificationTriggeringMethods()
+		IEnumerable<(Action<IFileSystem, string>?, Action<IFileSystem, string>, WatcherChangeTypes,
+			FileSystemTypes, string)> NotificationTriggeringMethods()
 	{
 		yield return (null, (f, p) => f.Directory.CreateDirectory(p), WatcherChangeTypes.Created,
 			FileSystemTypes.Directory, $"path_{Guid.NewGuid()}");
@@ -104,6 +105,21 @@ public class ChangeHandlerTests
 			FileSystemTypes.File, $"path_{Guid.NewGuid()}");
 		yield return ((f, p) => f.File.WriteAllText(p, null), (f, p) => f.File.Delete(p),
 			WatcherChangeTypes.Deleted, FileSystemTypes.File, $"path_{Guid.NewGuid()}");
+	}
+
+	[Test]
+	[AutoArguments]
+	public async Task OnEventOrReplay_CallbackThrowsDuringReplay_ShouldNotLeakWaiter(string path)
+	{
+		FileSystem.File.WriteAllText(path, null);
+
+		void Subscribe()
+			=> FileSystem.Notify.OnEventOrReplay(_ => throw new InvalidOperationException("boom"));
+
+		await That(Subscribe).Throws<InvalidOperationException>().WithMessage("boom");
+
+		void TriggerAnotherChange() => FileSystem.File.WriteAllText(path, "more");
+		await That(TriggerAnotherChange).DoesNotThrow();
 	}
 
 	[Test]
@@ -168,18 +184,107 @@ public class ChangeHandlerTests
 	}
 
 	[Test]
-	[AutoArguments]
-	public async Task OnEventOrReplay_CallbackThrowsDuringReplay_ShouldNotLeakWaiter(string path)
+	public async Task OnTriggeredOrReplay_ShouldAlsoReceiveFutureEmissions()
 	{
-		FileSystem.File.WriteAllText(path, null);
+		FileSystem.InitializeIn(".");
+		IFileSystemWatcher watcher = FileSystem.FileSystemWatcher.New(".");
+		watcher.EnableRaisingEvents = true;
 
-		void Subscribe() => FileSystem.Notify.OnEventOrReplay(
-			_ => throw new InvalidOperationException("boom"));
+		using IAwaitableCallback<WatcherChangeDescription> warmup =
+			FileSystem.Watcher.OnTriggered();
+		FileSystem.File.WriteAllText("foo.txt", "some-text");
+		warmup.Wait(timeout: 30000);
 
-		await That(Subscribe).Throws<InvalidOperationException>().WithMessage("boom");
+		using IAwaitableCallback<WatcherChangeDescription> onEvent = FileSystem.Watcher
+			.OnTriggeredOrReplay(predicate: c => c.ChangeType == WatcherChangeTypes.Created);
 
-		void TriggerAnotherChange() => FileSystem.File.WriteAllText(path, "more");
-		await That(TriggerAnotherChange).DoesNotThrow();
+		FileSystem.File.WriteAllText("bar.txt", "more-text");
+
+		WatcherChangeDescription[] received = await onEvent.WaitAsync(
+			count: 2,
+			timeout: TimeSpan.FromSeconds(5));
+
+		await That(received.Length).IsEqualTo(2);
+	}
+
+	[Test]
+	public async Task OnTriggeredOrReplay_ShouldFilterByEmittingWatcher()
+	{
+		FileSystem.InitializeIn(".");
+		IFileSystemWatcher watcher1 = FileSystem.FileSystemWatcher.New(".");
+		IFileSystemWatcher watcher2 = FileSystem.FileSystemWatcher.New(".");
+		watcher1.EnableRaisingEvents = true;
+		watcher2.EnableRaisingEvents = true;
+
+		using IAwaitableCallback<WatcherChangeDescription> warmup =
+			FileSystem.Watcher.OnTriggered();
+		FileSystem.File.WriteAllText("foo.txt", "some-text");
+		warmup.Wait(count: 2, timeout: TimeSpan.FromSeconds(30));
+
+		using IAwaitableCallback<WatcherChangeDescription> onEvent = FileSystem.Watcher
+			.OnTriggeredOrReplay(predicate: c =>
+				ReferenceEquals(c.FileSystemWatcher, watcher1));
+
+		WatcherChangeDescription[] replayed =
+			await onEvent.WaitAsync(timeout: TimeSpan.FromSeconds(5));
+
+		await That(replayed.Length).IsEqualTo(1);
+		await That(replayed[0].FileSystemWatcher).IsSameAs(watcher1);
+	}
+
+	[Test]
+	public async Task OnTriggeredOrReplay_ShouldNotReplayEmissionsFilteredOutByPredicate()
+	{
+		FileSystem.InitializeIn(".");
+		IFileSystemWatcher watcher = FileSystem.FileSystemWatcher.New(".");
+		watcher.EnableRaisingEvents = true;
+
+		using IAwaitableCallback<WatcherChangeDescription> warmup =
+			FileSystem.Watcher.OnTriggered();
+		FileSystem.File.WriteAllText("foo.txt", "some-text");
+		warmup.Wait(timeout: 30000);
+
+		using IAwaitableCallback<WatcherChangeDescription> onEvent = FileSystem.Watcher
+			.OnTriggeredOrReplay(predicate: c => c.ChangeType == WatcherChangeTypes.Deleted);
+
+		void Act() =>
+			// ReSharper disable once AccessToDisposedClosure
+			onEvent.Wait(timeout: 50);
+
+		await That(Act).Throws<TimeoutException>();
+	}
+
+	[Test]
+	public async Task OnTriggeredOrReplay_ShouldReplayPriorMatchingEmissions()
+	{
+		FileSystem.InitializeIn(".");
+		IFileSystemWatcher watcher = FileSystem.FileSystemWatcher.New(".");
+		watcher.EnableRaisingEvents = true;
+
+		using IAwaitableCallback<WatcherChangeDescription> warmup =
+			FileSystem.Watcher.OnTriggered();
+		FileSystem.File.WriteAllText("foo.txt", "some-text");
+		warmup.Wait(timeout: 30000);
+
+		using IAwaitableCallback<WatcherChangeDescription> onEvent = FileSystem.Watcher
+			.OnTriggeredOrReplay(predicate: c => c.ChangeType == WatcherChangeTypes.Created);
+
+		WatcherChangeDescription[] replayed =
+			await onEvent.WaitAsync(timeout: TimeSpan.FromSeconds(5));
+
+		await That(replayed.Length).IsEqualTo(1);
+		await That(replayed[0].Path).IsEqualTo(FileSystem.Path.GetFullPath("foo.txt"));
+	}
+
+	[Test]
+	public async Task OnTriggeredOrReplay_WithoutNotificationHistory_ShouldThrow()
+	{
+		MockFileSystem fileSystem = new(o => o.WithoutNotificationHistory());
+
+		void Act() => fileSystem.Watcher.OnTriggeredOrReplay();
+
+		await That(Act).Throws<InvalidOperationException>()
+			.WithMessage("*WithoutNotificationHistory*").AsWildcard();
 	}
 
 	[Test]
@@ -189,7 +294,8 @@ public class ChangeHandlerTests
 		IFileSystemWatcher watcher = FileSystem.FileSystemWatcher.New("bar");
 		watcher.EnableRaisingEvents = true;
 
-		using IAwaitableCallback<ChangeDescription> onEvent = FileSystem.Watcher.OnTriggered();
+		using IAwaitableCallback<WatcherChangeDescription> onEvent =
+			FileSystem.Watcher.OnTriggered();
 
 		FileSystem.File.WriteAllText(@"foo.txt", "some-text");
 
@@ -209,7 +315,8 @@ public class ChangeHandlerTests
 		watcher.Created += (_, _) => isTriggered = true;
 		watcher.EnableRaisingEvents = true;
 
-		using IAwaitableCallback<ChangeDescription> onEvent = FileSystem.Watcher.OnTriggered();
+		using IAwaitableCallback<WatcherChangeDescription> onEvent =
+			FileSystem.Watcher.OnTriggered();
 		FileSystem.File.WriteAllText(@"foo.txt", "some-text");
 
 		onEvent.Wait(timeout: 30000);


### PR DESCRIPTION
This pull request introduces a new `WatcherChangeDescription` class to provide richer context for watcher-triggered file system notifications, and updates the watcher notification APIs to use this new type. It also adds support for replaying watcher-triggered notifications to newly registered callbacks, similar to the existing notification replay mechanism. The changes ensure that consumers can filter or replay notifications by watcher instance and that notification history can be enabled or disabled for both standard and watcher-triggered events.

**Watcher notification enhancements:**

* Introduced the `WatcherChangeDescription` class, which extends `ChangeDescription` and includes a reference to the emitting `IFileSystemWatcher`, allowing consumers to filter notifications by watcher instance. 
* Updated the `IWatcherTriggeredHandler` interface and related APIs to use `WatcherChangeDescription` instead of `ChangeDescription`, and added a new `OnTriggeredOrReplay` method to allow callbacks to receive both past and future watcher-triggered notifications.
* Implemented notification history and replay support for watcher-triggered notifications in `ChangeHandler`, including thread-safety improvements and opt-out support.

**Notification history configuration:**

* Updated `MockFileSystemOptions` and related documentation to clarify that notification history now applies to both standard and watcher-triggered streams, and that disabling history affects both.

**Internal improvements:**

* Added a copy constructor to `ChangeDescription` to support the new `WatcherChangeDescription` type. 
* Updated `FileSystemWatcherMock` to use the new watcher-triggered notification API. 