### PR TITLE
refactor: simplify file existence and content checks in test cases

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,7 +46,7 @@
 		<PackageVersion Include="System.Net.Http" Version="4.3.4"/>
 		<PackageVersion Include="aweXpect" Version="2.33.0"/>
 		<PackageVersion Include="aweXpect.Chronology" Version="1.1.0"/>
-		<PackageVersion Include="aweXpect.Testably" Version="0.13.0"/>
+		<PackageVersion Include="aweXpect.Testably" Version="0.14.0"/>
 		<PackageVersion Include="aweXpect.Mockolate" Version="3.1.0"/>
 		<PackageVersion Include="Mockolate" Version="3.2.0"/>
 		<PackageVersion Include="TUnit.Engine" Version="1.24.0"/>

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
@@ -1,5 +1,4 @@
-﻿using aweXpect.Testably;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using Testably.Abstractions.Testing.Initializer;
 

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileSystemInitializerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using aweXpect.Testably;
+using System.IO;
 using System.Linq;
 using Testably.Abstractions.Testing.Initializer;
 
@@ -54,8 +55,7 @@ public class FileSystemInitializerTests
 		sut.With(description);
 
 		await That(fileSystem.Statistics.TotalCount).IsEqualTo(0);
-		await That(fileSystem.File.Exists(name)).IsTrue();
-		await That(fileSystem.File.ReadAllBytes(name)).IsEqualTo(bytes);
+		await That(fileSystem).HasFile(name).WithContent(bytes);
 	}
 
 	[Test]
@@ -70,8 +70,7 @@ public class FileSystemInitializerTests
 		sut.With(description);
 
 		await That(fileSystem.Statistics.TotalCount).IsEqualTo(0);
-		await That(fileSystem.File.Exists(name)).IsTrue();
-		await That(fileSystem.File.ReadAllText(name)).IsEqualTo(content);
+		await That(fileSystem).HasFile(name).WithContent(content);
 	}
 
 	[Test]
@@ -105,8 +104,14 @@ public class FileSystemInitializerTests
 		sut.With(description);
 
 		await That(fileSystem.Statistics.TotalCount).IsEqualTo(0);
-		await That(fileSystem.File.Exists(name)).IsTrue();
-		await That(fileSystem.FileInfo.New(name).IsReadOnly).IsEqualTo(isReadOnly);
+		if (isReadOnly)
+		{
+			await That(fileSystem).HasFile(name).Which.IsReadOnly();
+		}
+		else
+		{
+			await That(fileSystem).HasFile(name).Which.IsNotReadOnly();
+		}
 	}
 
 	[Test]
@@ -204,8 +209,7 @@ public class FileSystemInitializerTests
 		sut.WithFile(path).Which(f => f.HasStringContent("foo"));
 
 		await That(fileSystem.Statistics.TotalCount).IsEqualTo(0);
-		await That(fileSystem.File.Exists(path)).IsTrue();
-		await That(fileSystem.File.ReadAllText(path)).IsEqualTo("foo");
+		await That(fileSystem).HasFile(path).WithContent("foo");
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializerExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using aweXpect.Testably;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Testably.Abstractions.Testing.Initializer;

--- a/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Usings.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TestHelpers/Usings.cs
@@ -5,5 +5,6 @@ global using Testably.Abstractions.TestHelpers;
 global using Test = Testably.Abstractions.Testing.Tests.TestHelpers.Test;
 global using TUnit;
 global using aweXpect;
+global using aweXpect.Testably;
 global using static aweXpect.Expect;
 global using Skip = Testably.Abstractions.TestHelpers.Skip;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllBytesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllBytesAsyncTests.cs
@@ -1,5 +1,4 @@
 #if FEATURE_FILE_SPAN
-using aweXpect.Testably;
 using System.IO;
 using System.Threading;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllBytesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllBytesAsyncTests.cs
@@ -1,4 +1,5 @@
 #if FEATURE_FILE_SPAN
+using aweXpect.Testably;
 using System.IO;
 using System.Threading;
 
@@ -33,8 +34,7 @@ public class AppendAllBytesAsyncTests(FileSystemTestData testData) : FileSystemT
 		await FileSystem.File.AppendAllBytesAsync(path, bytes,
 			CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo([..previousBytes, ..bytes]);
+		await That(FileSystem).HasFile(path).WithContent([..previousBytes, ..bytes]);
 	}
 
 	[Test]
@@ -61,8 +61,7 @@ public class AppendAllBytesAsyncTests(FileSystemTestData testData) : FileSystemT
 		await FileSystem.File.AppendAllBytesAsync(path, bytes,
 			CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(bytes);
+		await That(FileSystem).HasFile(path).WithContent(bytes);
 	}
 
 	[Test]
@@ -90,8 +89,7 @@ public class AppendAllBytesAsyncTests(FileSystemTestData testData) : FileSystemT
 		await FileSystem.File.AppendAllBytesAsync(path, bytes.AsMemory(),
 			CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo([..previousBytes, ..bytes]);
+		await That(FileSystem).HasFile(path).WithContent([..previousBytes, ..bytes]);
 	}
 
 	[Test]
@@ -119,8 +117,7 @@ public class AppendAllBytesAsyncTests(FileSystemTestData testData) : FileSystemT
 		await FileSystem.File.AppendAllBytesAsync(path, bytes.AsMemory(),
 			CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(bytes);
+		await That(FileSystem).HasFile(path).WithContent(bytes);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllBytesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllBytesTests.cs
@@ -1,5 +1,4 @@
 #if FEATURE_FILE_SPAN
-using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllBytesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllBytesTests.cs
@@ -1,4 +1,5 @@
 #if FEATURE_FILE_SPAN
+using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
@@ -15,8 +16,7 @@ public class AppendAllBytesTests(FileSystemTestData testData) : FileSystemTestBa
 
 		FileSystem.File.AppendAllBytes(path, bytes);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo([..previousBytes, ..bytes]);
+		await That(FileSystem).HasFile(path).WithContent([..previousBytes, ..bytes]);
 	}
 
 	[Test]
@@ -40,8 +40,7 @@ public class AppendAllBytesTests(FileSystemTestData testData) : FileSystemTestBa
 	{
 		FileSystem.File.AppendAllBytes(path, bytes);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(bytes);
+		await That(FileSystem).HasFile(path).WithContent(bytes);
 	}
 
 	[Test]
@@ -84,8 +83,7 @@ public class AppendAllBytesTests(FileSystemTestData testData) : FileSystemTestBa
 
 		FileSystem.File.AppendAllBytes(path, bytes.AsSpan());
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo([..previousBytes, ..bytes]);
+		await That(FileSystem).HasFile(path).WithContent([..previousBytes, ..bytes]);
 	}
 
 	[Test]
@@ -109,8 +107,7 @@ public class AppendAllBytesTests(FileSystemTestData testData) : FileSystemTestBa
 	{
 		FileSystem.File.AppendAllBytes(path, bytes.AsSpan());
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(bytes);
+		await That(FileSystem).HasFile(path).WithContent(bytes);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
@@ -1,4 +1,5 @@
 #if FEATURE_FILESYSTEM_ASYNC
+using aweXpect.Testably;
 using AutoFixture;
 using System.Collections.Generic;
 using System.IO;
@@ -69,8 +70,7 @@ public class AppendAllLinesAsyncTests(FileSystemTestData testData) : FileSystemT
 		await FileSystem.File.AppendAllLinesAsync(path, contents,
 			CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(expectedContent);
+		await That(FileSystem).HasFile(path).WithContent(expectedContent);
 	}
 
 	[Test]
@@ -100,8 +100,7 @@ public class AppendAllLinesAsyncTests(FileSystemTestData testData) : FileSystemT
 		await FileSystem.File.AppendAllLinesAsync(path, contents,
 			CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(expectedContent);
+		await That(FileSystem).HasFile(path).WithContent(expectedContent);
 	}
 
 	[Test]
@@ -146,8 +145,7 @@ public class AppendAllLinesAsyncTests(FileSystemTestData testData) : FileSystemT
 		await FileSystem.File.AppendAllLinesAsync(path, contents,
 			CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(expectedResult);
+		await That(FileSystem).HasFile(path).WithContent(expectedResult);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesAsyncTests.cs
@@ -1,5 +1,4 @@
 #if FEATURE_FILESYSTEM_ASYNC
-using aweXpect.Testably;
 using AutoFixture;
 using System.Collections.Generic;
 using System.IO;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using AutoFixture;
 using System.Collections.Generic;
 using System.Linq;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllLinesTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using AutoFixture;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,8 +33,7 @@ public class AppendAllLinesTests(FileSystemTestData testData) : FileSystemTestBa
 
 		FileSystem.File.AppendAllLines(path, contents);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(expectedContent);
+		await That(FileSystem).HasFile(path).WithContent(expectedContent);
 	}
 
 	[Test]
@@ -45,8 +45,7 @@ public class AppendAllLinesTests(FileSystemTestData testData) : FileSystemTestBa
 		                         + Environment.NewLine;
 		FileSystem.File.AppendAllLines(path, contents);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(expectedContent);
+		await That(FileSystem).HasFile(path).WithContent(expectedContent);
 	}
 
 	[Test]
@@ -88,8 +87,7 @@ public class AppendAllLinesTests(FileSystemTestData testData) : FileSystemTestBa
 
 		FileSystem.File.AppendAllLines(path, contents);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(expectedResult);
+		await That(FileSystem).HasFile(path).WithContent(expectedResult);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
@@ -1,4 +1,5 @@
 #if FEATURE_FILESYSTEM_ASYNC
+using aweXpect.Testably;
 using AutoFixture;
 using System.IO;
 using System.Text;
@@ -50,8 +51,7 @@ public class AppendAllTextAsyncTests(FileSystemTestData testData) : FileSystemTe
 		await FileSystem.File.AppendAllTextAsync(path, contents,
 			CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(previousContents + contents);
+		await That(FileSystem).HasFile(path).WithContent(previousContents + contents);
 	}
 
 	[Test]
@@ -78,8 +78,7 @@ public class AppendAllTextAsyncTests(FileSystemTestData testData) : FileSystemTe
 		await FileSystem.File.AppendAllTextAsync(path, contents,
 			CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(path).WithContent(contents);
 	}
 
 	[Test]
@@ -91,8 +90,7 @@ public class AppendAllTextAsyncTests(FileSystemTestData testData) : FileSystemTe
 		await FileSystem.File.AppendAllTextAsync(path, contents,
 			CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(path).WithContent(contents);
 	}
 
 	[Test]
@@ -183,8 +181,7 @@ public class AppendAllTextAsyncTests(FileSystemTestData testData) : FileSystemTe
 		await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(),
 			CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(previousContents + contents);
+		await That(FileSystem).HasFile(path).WithContent(previousContents + contents);
 	}
 
 	[Test]
@@ -212,8 +209,7 @@ public class AppendAllTextAsyncTests(FileSystemTestData testData) : FileSystemTe
 		await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(),
 			CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(path).WithContent(contents);
 	}
 
 	[Test]
@@ -225,8 +221,7 @@ public class AppendAllTextAsyncTests(FileSystemTestData testData) : FileSystemTe
 		await FileSystem.File.AppendAllTextAsync(path, contents.AsMemory(),
 			CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(path).WithContent(contents);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextAsyncTests.cs
@@ -1,5 +1,4 @@
 #if FEATURE_FILESYSTEM_ASYNC
-using aweXpect.Testably;
 using AutoFixture;
 using System.IO;
 using System.Text;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using AutoFixture;
 using System.IO;
 using System.Text;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendAllTextTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using AutoFixture;
 using System.IO;
 using System.Text;
@@ -16,8 +17,7 @@ public class AppendAllTextTests(FileSystemTestData testData) : FileSystemTestBas
 
 		FileSystem.File.AppendAllText(path, contents);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(previousContents + contents);
+		await That(FileSystem).HasFile(path).WithContent(previousContents + contents);
 	}
 
 	[Test]
@@ -42,8 +42,7 @@ public class AppendAllTextTests(FileSystemTestData testData) : FileSystemTestBas
 	{
 		FileSystem.File.AppendAllText(path, contents);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(path).WithContent(contents);
 	}
 
 	[Test]
@@ -55,8 +54,7 @@ public class AppendAllTextTests(FileSystemTestData testData) : FileSystemTestBas
 
 		FileSystem.File.AppendAllText(path, "AA", Encoding.UTF32);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(expectedBytes);
+		await That(FileSystem).HasFile(path).WithContent(expectedBytes);
 	}
 
 	[Test]
@@ -100,8 +98,7 @@ public class AppendAllTextTests(FileSystemTestData testData) : FileSystemTestBas
 
 		FileSystem.File.AppendAllText(path, contents);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(path).WithContent(contents);
 	}
 
 	[Test]
@@ -175,8 +172,7 @@ public class AppendAllTextTests(FileSystemTestData testData) : FileSystemTestBas
 
 		FileSystem.File.AppendAllText(path, contents.AsSpan());
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(previousContents + contents);
+		await That(FileSystem).HasFile(path).WithContent(previousContents + contents);
 	}
 
 	[Test]
@@ -201,8 +197,7 @@ public class AppendAllTextTests(FileSystemTestData testData) : FileSystemTestBas
 	{
 		FileSystem.File.AppendAllText(path, contents.AsSpan());
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(path).WithContent(contents);
 	}
 
 	[Test]
@@ -214,8 +209,7 @@ public class AppendAllTextTests(FileSystemTestData testData) : FileSystemTestBas
 
 		FileSystem.File.AppendAllText(path, "AA".AsSpan(), Encoding.UTF32);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(expectedBytes);
+		await That(FileSystem).HasFile(path).WithContent(expectedBytes);
 	}
 
 	[Test]
@@ -259,8 +253,7 @@ public class AppendAllTextTests(FileSystemTestData testData) : FileSystemTestBas
 
 		FileSystem.File.AppendAllText(path, contents.AsSpan());
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(path).WithContent(contents);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendTextTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/AppendTextTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
@@ -15,8 +16,7 @@ public class AppendTextTests(FileSystemTestData testData) : FileSystemTestBase(t
 			stream.Write(appendText);
 		}
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(appendText);
+		await That(FileSystem).HasFile(path).WithContent(appendText);
 	}
 
 	[Test]
@@ -31,7 +31,6 @@ public class AppendTextTests(FileSystemTestData testData) : FileSystemTestBase(t
 			stream.Write(appendText);
 		}
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(contents + appendText);
+		await That(FileSystem).HasFile(path).WithContent(contents + appendText);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
@@ -68,10 +69,8 @@ public class CopyTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 
 		await That(Act).Throws<IOException>().WithHResult(Test.RunsOnWindows ? -2147024816 : 17);
 
-		await That(FileSystem.File.Exists(sourceName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(sourceName)).IsEqualTo(sourceContents);
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(destinationContents);
+		await That(FileSystem).HasFile(sourceName).WithContent(sourceContents);
+		await That(FileSystem).HasFile(destinationName).WithContent(destinationContents);
 	}
 
 #if FEATURE_FILE_MOVETO_OVERWRITE
@@ -88,10 +87,8 @@ public class CopyTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 
 		FileSystem.File.Copy(sourceName, destinationName, true);
 
-		await That(FileSystem.File.Exists(sourceName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(sourceName)).IsEqualTo(sourceContents);
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(sourceContents);
+		await That(FileSystem).HasFile(sourceName).WithContent(sourceContents);
+		await That(FileSystem).HasFile(destinationName).WithContent(sourceContents);
 	}
 #endif
 
@@ -149,10 +146,8 @@ public class CopyTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 
 		FileSystem.File.Copy(sourceName, destinationName);
 
-		await That(FileSystem.File.Exists(sourceName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(sourceName)).IsEqualTo(contents);
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(sourceName).WithContent(contents);
+		await That(FileSystem).HasFile(destinationName).WithContent(contents);
 		await That(FileSystem.File.GetAttributes(destinationName)).HasFlag(FileAttributes.ReadOnly);
 	}
 
@@ -241,8 +236,7 @@ public class CopyTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 			binaryWriter.Write("Some text");
 		}
 
-		await That(FileSystem.File.Exists(destination)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(destination)).IsEqualTo(original);
+		await That(FileSystem).HasFile(destination).WithContent(original);
 		await That(FileSystem.File.ReadAllBytes(destination))
 			.IsNotEqualTo(FileSystem.File.ReadAllBytes(source));
 	}
@@ -281,10 +275,8 @@ public class CopyTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 		TimeSystem.Thread.Sleep(EnsureTimeout);
 
 		FileSystem.File.Copy(sourceName, destinationName);
-		await That(FileSystem.File.Exists(sourceName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(sourceName)).IsEqualTo(contents);
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(sourceName).WithContent(contents);
+		await That(FileSystem).HasFile(destinationName).WithContent(contents);
 	}
 
 	[Test]
@@ -309,8 +301,7 @@ public class CopyTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 			FileSystem.File.Copy(sourcePath, destinationPath);
 		}
 
-		await That(FileSystem.File.Exists(destinationPath)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationPath)).IsEqualTo(sourceContents);
+		await That(FileSystem).HasFile(destinationPath).WithContent(sourceContents);
 	}
 
 	[Test]
@@ -333,8 +324,7 @@ public class CopyTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 			FileSystem.File.Copy(sourcePath, destinationPath);
 		}
 
-		await That(FileSystem.File.Exists(destinationPath)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationPath)).IsEqualTo(sourceContents);
+		await That(FileSystem).HasFile(destinationPath).WithContent(sourceContents);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
@@ -18,8 +19,7 @@ public class CreateTests(FileSystemTestData testData) : FileSystemTestBase(testD
 			streamWriter.Write(newContent);
 		}
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(newContent);
+		await That(FileSystem).HasFile(path).WithContent(newContent);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTextTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
@@ -15,8 +16,7 @@ public class CreateTextTests(FileSystemTestData testData) : FileSystemTestBase(t
 			stream.Write(appendText);
 		}
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(appendText);
+		await That(FileSystem).HasFile(path).WithContent(appendText);
 	}
 
 	[Test]
@@ -31,7 +31,6 @@ public class CreateTextTests(FileSystemTestData testData) : FileSystemTestBase(t
 			stream.Write(appendText);
 		}
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(appendText);
+		await That(FileSystem).HasFile(path).WithContent(appendText);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CreateTextTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/MoveTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;
@@ -22,8 +23,7 @@ public class MoveTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 			await That(FileSystem.File.Exists(sourceName)).IsFalse();
 		}
 
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(destinationName).WithContent(contents);
 		await That(FileSystem.Directory.GetFiles(".")).HasSingle()
 			.Matching(d => d.Contains(destinationName, StringComparison.Ordinal));
 	}
@@ -64,10 +64,8 @@ public class MoveTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 
 		await That(Act).Throws<IOException>().WithHResult(Test.RunsOnWindows ? -2147024713 : 17);
 
-		await That(FileSystem.File.Exists(sourceName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(sourceName)).IsEqualTo(sourceContents);
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(destinationContents);
+		await That(FileSystem).HasFile(sourceName).WithContent(sourceContents);
+		await That(FileSystem).HasFile(destinationName).WithContent(destinationContents);
 	}
 
 #if FEATURE_FILE_MOVETO_OVERWRITE
@@ -85,8 +83,7 @@ public class MoveTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 		FileSystem.File.Move(sourceName, destinationName, true);
 
 		await That(FileSystem.File.Exists(sourceName)).IsFalse();
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(sourceContents);
+		await That(FileSystem).HasFile(destinationName).WithContent(sourceContents);
 	}
 #endif
 
@@ -101,8 +98,7 @@ public class MoveTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 		FileSystem.File.Move(sourceName, destinationName);
 
 		await That(FileSystem.File.Exists(sourceName)).IsFalse();
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(destinationName).WithContent(contents);
 		await That(FileSystem.File.GetAttributes(destinationName)).HasFlag(FileAttributes.ReadOnly);
 	}
 
@@ -116,8 +112,7 @@ public class MoveTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 		FileSystem.File.Move(sourceName, destinationName);
 
 		await That(FileSystem.File.Exists(sourceName)).IsFalse();
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(destinationName).WithContent(contents);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
@@ -119,11 +119,9 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 		FileSystem.File.Replace(sourceName, destinationName, backupName, true);
 
 		await That(FileSystem.File.Exists(sourceName)).IsFalse();
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEquivalentTo(sourceContents);
+		await That(FileSystem).HasFile(destinationName).WhoseContent(it => it.IsEquivalentTo(sourceContents));
 		await That(FileSystem.File.GetAttributes(destinationName)).HasFlag(FileAttributes.ReadOnly);
-		await That(FileSystem.File.Exists(backupName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(backupName)).IsEquivalentTo(destinationContents);
+		await That(FileSystem).HasFile(backupName).WhoseContent(it => it.IsEquivalentTo(destinationContents));
 	}
 
 	[Test]
@@ -148,11 +146,8 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 		if (Test.RunsOnWindows)
 		{
 			await That(Act).Throws<UnauthorizedAccessException>().WithHResult(-2147024891);
-			await That(FileSystem.File.Exists(sourceName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(sourceName)).IsEquivalentTo(sourceContents);
-			await That(FileSystem.File.Exists(destinationName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(destinationName))
-				.IsEquivalentTo(destinationContents);
+			await That(FileSystem).HasFile(sourceName).WhoseContent(it => it.IsEquivalentTo(sourceContents));
+			await That(FileSystem).HasFile(destinationName).WhoseContent(it => it.IsEquivalentTo(destinationContents));
 			await That(FileSystem.File.GetAttributes(destinationName))
 				.DoesNotHaveFlag(FileAttributes.ReadOnly);
 			await That(FileSystem.File.Exists(backupName)).IsFalse();
@@ -161,10 +156,8 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 		{
 			await That(Act).DoesNotThrow();
 			await That(FileSystem.File.Exists(sourceName)).IsFalse();
-			await That(FileSystem.File.Exists(destinationName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(destinationName)).IsEquivalentTo(sourceContents);
-			await That(FileSystem.File.Exists(backupName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(backupName)).IsEquivalentTo(destinationContents);
+			await That(FileSystem).HasFile(destinationName).WhoseContent(it => it.IsEquivalentTo(sourceContents));
+			await That(FileSystem).HasFile(backupName).WhoseContent(it => it.IsEquivalentTo(destinationContents));
 		}
 	}
 
@@ -183,10 +176,8 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 		FileSystem.File.Replace(sourceName, destinationName, backupName);
 
 		await That(FileSystem.File.Exists(sourceName)).IsFalse();
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEquivalentTo(sourceContents);
-		await That(FileSystem.File.Exists(backupName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(backupName)).IsEquivalentTo(destinationContents);
+		await That(FileSystem).HasFile(destinationName).WhoseContent(it => it.IsEquivalentTo(sourceContents));
+		await That(FileSystem).HasFile(backupName).WhoseContent(it => it.IsEquivalentTo(destinationContents));
 	}
 
 	[Test]
@@ -266,11 +257,8 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 		if (Test.RunsOnWindows)
 		{
 			await That(Act).Throws<IOException>().WithHResult(-2147024864);
-			await That(FileSystem.File.Exists(sourceName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(sourceName)).IsEquivalentTo(sourceContents);
-			await That(FileSystem.File.Exists(destinationName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(destinationName))
-				.IsEquivalentTo(destinationContents);
+			await That(FileSystem).HasFile(sourceName).WhoseContent(it => it.IsEquivalentTo(sourceContents));
+			await That(FileSystem).HasFile(destinationName).WhoseContent(it => it.IsEquivalentTo(destinationContents));
 			await That(FileSystem.File.GetAttributes(destinationName))
 				.DoesNotHaveFlag(FileAttributes.ReadOnly);
 			await That(FileSystem.File.Exists(backupName)).IsFalse();
@@ -280,10 +268,8 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 			// https://github.com/dotnet/runtime/issues/52700
 			await That(Act).DoesNotThrow();
 			await That(FileSystem.File.Exists(sourceName)).IsFalse();
-			await That(FileSystem.File.Exists(destinationName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(destinationName)).IsEquivalentTo(sourceContents);
-			await That(FileSystem.File.Exists(backupName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(backupName)).IsEquivalentTo(destinationContents);
+			await That(FileSystem).HasFile(destinationName).WhoseContent(it => it.IsEquivalentTo(sourceContents));
+			await That(FileSystem).HasFile(backupName).WhoseContent(it => it.IsEquivalentTo(destinationContents));
 		}
 	}
 
@@ -326,10 +312,8 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 		FileSystem.File.Replace(sourceName, destinationName, null);
 
 		await That(FileSystem.File.Exists(sourceName)).IsFalse();
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEquivalentTo(sourceContents);
-		await That(FileSystem.File.Exists(backupName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(backupName)).IsEquivalentTo(backupContents);
+		await That(FileSystem).HasFile(destinationName).WhoseContent(it => it.IsEquivalentTo(sourceContents));
+		await That(FileSystem).HasFile(backupName).WhoseContent(it => it.IsEquivalentTo(backupContents));
 	}
 
 	[Test]
@@ -346,7 +330,6 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 		FileSystem.File.Replace(sourceName, destinationName, null);
 
 		await That(FileSystem.File.Exists(sourceName)).IsFalse();
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEquivalentTo(sourceContents);
+		await That(FileSystem).HasFile(destinationName).WhoseContent(it => it.IsEquivalentTo(sourceContents));
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/ReplaceTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.File;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesAsyncTests.cs
@@ -1,5 +1,4 @@
 #if FEATURE_FILESYSTEM_ASYNC
-using aweXpect.Testably;
 using System.IO;
 using System.Text;
 using System.Threading;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesAsyncTests.cs
@@ -1,4 +1,5 @@
 #if FEATURE_FILESYSTEM_ASYNC
+using aweXpect.Testably;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -33,8 +34,7 @@ public class WriteAllBytesAsyncTests(FileSystemTestData testData) : FileSystemTe
 
 		await FileSystem.File.WriteAllBytesAsync(path, bytes, CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(bytes);
+		await That(FileSystem).HasFile(path).WithContent(bytes);
 	}
 
 	[Test]
@@ -44,8 +44,7 @@ public class WriteAllBytesAsyncTests(FileSystemTestData testData) : FileSystemTe
 	{
 		await FileSystem.File.WriteAllBytesAsync(path, bytes, CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(bytes);
+		await That(FileSystem).HasFile(path).WithContent(bytes);
 	}
 
 	[Test]
@@ -122,8 +121,7 @@ public class WriteAllBytesAsyncTests(FileSystemTestData testData) : FileSystemTe
 
 		await FileSystem.File.WriteAllBytesAsync(path, bytes.AsMemory(), CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(bytes);
+		await That(FileSystem).HasFile(path).WithContent(bytes);
 	}
 
 	[Test]
@@ -133,8 +131,7 @@ public class WriteAllBytesAsyncTests(FileSystemTestData testData) : FileSystemTe
 	{
 		await FileSystem.File.WriteAllBytesAsync(path, bytes.AsMemory(), CancellationToken);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(bytes);
+		await That(FileSystem).HasFile(path).WithContent(bytes);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using System.IO;
 using System.Text;
 
@@ -15,8 +16,7 @@ public class WriteAllBytesTests(FileSystemTestData testData) : FileSystemTestBas
 
 		FileSystem.File.WriteAllBytes(path, bytes);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(bytes);
+		await That(FileSystem).HasFile(path).WithContent(bytes);
 	}
 
 	[Test]
@@ -25,8 +25,7 @@ public class WriteAllBytesTests(FileSystemTestData testData) : FileSystemTestBas
 	{
 		FileSystem.File.WriteAllBytes(path, bytes);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(bytes);
+		await That(FileSystem).HasFile(path).WithContent(bytes);
 	}
 
 	[Test]
@@ -88,8 +87,7 @@ public class WriteAllBytesTests(FileSystemTestData testData) : FileSystemTestBas
 
 		FileSystem.File.WriteAllBytes(path, bytes.AsSpan());
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(bytes);
+		await That(FileSystem).HasFile(path).WithContent(bytes);
 	}
 
 	[Test]
@@ -98,8 +96,7 @@ public class WriteAllBytesTests(FileSystemTestData testData) : FileSystemTestBas
 	{
 		FileSystem.File.WriteAllBytes(path, bytes.AsSpan());
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(bytes);
+		await That(FileSystem).HasFile(path).WithContent(bytes);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllBytesTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using System.IO;
 using System.Text;
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using System.IO;
 using System.Text;
 using Testably.Abstractions.Testing.FileSystem;
@@ -79,8 +80,7 @@ public class WriteAllTextTests(FileSystemTestData testData) : FileSystemTestBase
 
 		FileSystem.File.WriteAllText(path, "AA", Encoding.UTF32);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(expectedBytes);
+		await That(FileSystem).HasFile(path).WithContent(expectedBytes);
 	}
 
 	[Test]
@@ -282,8 +282,7 @@ public class WriteAllTextTests(FileSystemTestData testData) : FileSystemTestBase
 
 		FileSystem.File.WriteAllText(path, "AA".AsSpan(), Encoding.UTF32);
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllBytes(path)).IsEqualTo(expectedBytes);
+		await That(FileSystem).HasFile(path).WithContent(expectedBytes);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/WriteAllTextTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using System.IO;
 using System.Text;
 using Testably.Abstractions.Testing.FileSystem;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AppendTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AppendTextTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
@@ -17,8 +18,7 @@ public class AppendTextTests(FileSystemTestData testData) : FileSystemTestBase(t
 			stream.Write(appendText);
 		}
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(appendText);
+		await That(FileSystem).HasFile(path).WithContent(appendText);
 	}
 
 	[Test]
@@ -34,7 +34,6 @@ public class AppendTextTests(FileSystemTestData testData) : FileSystemTestBase(t
 			stream.Write(appendText);
 		}
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(contents + appendText);
+		await That(FileSystem).HasFile(path).WithContent(contents + appendText);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AppendTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AppendTextTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CopyToTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
@@ -24,10 +25,8 @@ public class CopyToTests(FileSystemTestData testData) : FileSystemTestBase(testD
 
 		await That(Act).Throws<IOException>().WithHResult(Test.RunsOnWindows ? -2147024816 : 17);
 		await That(sut.Exists).IsTrue();
-		await That(FileSystem.File.Exists(sourceName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(sourceName)).IsEqualTo(sourceContents);
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(destinationContents);
+		await That(FileSystem).HasFile(sourceName).WithContent(sourceContents);
+		await That(FileSystem).HasFile(destinationName).WithContent(destinationContents);
 	}
 
 #if FEATURE_FILE_MOVETO_OVERWRITE
@@ -49,10 +48,8 @@ public class CopyToTests(FileSystemTestData testData) : FileSystemTestBase(testD
 		await That(sut.FullName).IsEqualTo(FileSystem.Path.GetFullPath(sourceName));
 		await That(result.Exists).IsTrue();
 		await That(result.FullName).IsEqualTo(FileSystem.Path.GetFullPath(destinationName));
-		await That(FileSystem.File.Exists(sourceName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(sourceName)).IsEqualTo(sourceContents);
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(sourceContents);
+		await That(FileSystem).HasFile(sourceName).WithContent(sourceContents);
+		await That(FileSystem).HasFile(destinationName).WithContent(sourceContents);
 	}
 #endif
 
@@ -116,10 +113,8 @@ public class CopyToTests(FileSystemTestData testData) : FileSystemTestBase(testD
 		await That(sut.Exists).IsTrue();
 		await That(result.Exists).IsTrue();
 		await That(result.FullName).IsEqualTo(FileSystem.Path.GetFullPath(destinationName));
-		await That(FileSystem.File.Exists(sourceName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(sourceName)).IsEqualTo(contents);
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(sourceName).WithContent(contents);
+		await That(FileSystem).HasFile(destinationName).WithContent(contents);
 	}
 
 	[Test]
@@ -192,8 +187,7 @@ public class CopyToTests(FileSystemTestData testData) : FileSystemTestBase(testD
 			sut.CopyTo(destinationPath);
 		}
 
-		await That(FileSystem.File.Exists(destinationPath)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationPath)).IsEqualTo(sourceContents);
+		await That(FileSystem).HasFile(destinationPath).WithContent(sourceContents);
 	}
 
 	[Test]
@@ -217,8 +211,7 @@ public class CopyToTests(FileSystemTestData testData) : FileSystemTestBase(testD
 			sut.CopyTo(destinationPath);
 		}
 
-		await That(FileSystem.File.Exists(destinationPath)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationPath)).IsEqualTo(sourceContents);
+		await That(FileSystem).HasFile(destinationPath).WithContent(sourceContents);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/CreateTextTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
@@ -17,8 +18,7 @@ public class CreateTextTests(FileSystemTestData testData) : FileSystemTestBase(t
 			stream.Write(appendText);
 		}
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(appendText);
+		await That(FileSystem).HasFile(path).WithContent(appendText);
 	}
 
 #if NET8_0_OR_GREATER
@@ -70,7 +70,6 @@ public class CreateTextTests(FileSystemTestData testData) : FileSystemTestBase(t
 			stream.Write(appendText);
 		}
 
-		await That(FileSystem.File.Exists(path)).IsTrue();
-		await That(FileSystem.File.ReadAllText(path)).IsEqualTo(appendText);
+		await That(FileSystem).HasFile(path).WithContent(appendText);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/MoveToTests.cs
@@ -1,3 +1,4 @@
+using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;
@@ -25,10 +26,8 @@ public class MoveToTests(FileSystemTestData testData) : FileSystemTestBase(testD
 		await That(Act).Throws<IOException>().WithHResult(Test.RunsOnWindows ? -2147024713 : 17);
 
 		await That(sut.Exists).IsTrue();
-		await That(FileSystem.File.Exists(sourceName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(sourceName)).IsEqualTo(sourceContents);
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(destinationContents);
+		await That(FileSystem).HasFile(sourceName).WithContent(sourceContents);
+		await That(FileSystem).HasFile(destinationName).WithContent(destinationContents);
 	}
 
 #if FEATURE_FILE_MOVETO_OVERWRITE
@@ -50,8 +49,7 @@ public class MoveToTests(FileSystemTestData testData) : FileSystemTestBase(testD
 		await That(sut.ToString()).IsEqualTo(destinationName);
 		await That(sut.FullName).IsEqualTo(FileSystem.Path.GetFullPath(destinationName));
 		await That(FileSystem.File.Exists(sourceName)).IsFalse();
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(sourceContents);
+		await That(FileSystem).HasFile(destinationName).WithContent(sourceContents);
 	}
 #endif
 
@@ -114,8 +112,7 @@ public class MoveToTests(FileSystemTestData testData) : FileSystemTestBase(testD
 		await That(Act).Throws<DirectoryNotFoundException>().WithHResult(-2147024893);
 
 		await That(sut.Exists).IsTrue();
-		await That(FileSystem.File.Exists(sourceName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(sourceName)).IsEqualTo(sourceContents);
+		await That(FileSystem).HasFile(sourceName).WithContent(sourceContents);
 		await That(FileSystem.File.Exists(destinationName)).IsFalse();
 	}
 
@@ -131,8 +128,7 @@ public class MoveToTests(FileSystemTestData testData) : FileSystemTestBase(testD
 		sut.MoveTo(destinationName);
 
 		await That(FileSystem.File.Exists(sourceName)).IsFalse();
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(destinationName).WithContent(contents);
 		await That(FileSystem.File.GetAttributes(destinationName)).HasFlag(FileAttributes.ReadOnly);
 	}
 
@@ -199,8 +195,7 @@ public class MoveToTests(FileSystemTestData testData) : FileSystemTestBase(testD
 		await That(sut.FullName).IsEqualTo(FileSystem.Path.GetFullPath(destinationName));
 		await That(sut.Exists).IsTrue();
 		await That(FileSystem.File.Exists(sourceName)).IsFalse();
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(contents);
+		await That(FileSystem).HasFile(destinationName).WithContent(contents);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
@@ -1,4 +1,3 @@
-using aweXpect.Testably;
 using System.IO;
 
 namespace Testably.Abstractions.Tests.FileSystem.FileInfo;

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/ReplaceTests.cs
@@ -104,8 +104,7 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 		await That(sut.Exists).IsFalse();
 		await That(FileSystem.File.Exists(sourceName)).IsFalse();
 		await That(result.FullName).IsEqualTo(FileSystem.Path.GetFullPath(destinationName));
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(sourceContents);
+		await That(FileSystem).HasFile(destinationName).WithContent(sourceContents);
 		await That(FileSystem.File.GetAttributes(destinationName)).HasFlag(FileAttributes.ReadOnly);
 		await That(FileSystem.File.Exists(backupName)).IsTrue();
 		await That(FileSystem.File.ReadAllText(backupName)).IsEqualTo(destinationContents);
@@ -134,10 +133,8 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 		if (Test.RunsOnWindows)
 		{
 			await That(Act).Throws<UnauthorizedAccessException>().WithHResult(-2147024891);
-			await That(FileSystem.File.Exists(sourceName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(sourceName)).IsEqualTo(sourceContents);
-			await That(FileSystem.File.Exists(destinationName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(destinationContents);
+			await That(FileSystem).HasFile(sourceName).WithContent(sourceContents);
+			await That(FileSystem).HasFile(destinationName).WithContent(destinationContents);
 			await That(FileSystem.File.GetAttributes(destinationName))
 				.DoesNotHaveFlag(FileAttributes.ReadOnly);
 			await That(FileSystem.File.Exists(backupName)).IsFalse();
@@ -147,10 +144,8 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 			await That(Act).DoesNotThrow();
 			await That(sut.Exists).IsFalse();
 			await That(FileSystem.File.Exists(sourceName)).IsFalse();
-			await That(FileSystem.File.Exists(destinationName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(sourceContents);
-			await That(FileSystem.File.Exists(backupName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(backupName)).IsEqualTo(destinationContents);
+			await That(FileSystem).HasFile(destinationName).WithContent(sourceContents);
+			await That(FileSystem).HasFile(backupName).WithContent(destinationContents);
 		}
 	}
 
@@ -272,10 +267,8 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 		await That(sut.Exists).IsFalse();
 		await That(FileSystem.File.Exists(sourceName)).IsFalse();
 		await That(result.FullName).IsEqualTo(FileSystem.Path.GetFullPath(destinationName));
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(sourceContents);
-		await That(FileSystem.File.Exists(backupName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(backupName)).IsEqualTo(destinationContents);
+		await That(FileSystem).HasFile(destinationName).WithContent(sourceContents);
+		await That(FileSystem).HasFile(backupName).WithContent(destinationContents);
 	}
 
 	[Test]
@@ -355,10 +348,8 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 		{
 			await That(Act).Throws<IOException>().WithHResult(-2147024864);
 			await That(sut.Exists).IsTrue();
-			await That(FileSystem.File.Exists(sourceName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(sourceName)).IsEqualTo(sourceContents);
-			await That(FileSystem.File.Exists(destinationName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(destinationContents);
+			await That(FileSystem).HasFile(sourceName).WithContent(sourceContents);
+			await That(FileSystem).HasFile(destinationName).WithContent(destinationContents);
 			await That(FileSystem.File.GetAttributes(destinationName))
 				.DoesNotHaveFlag(FileAttributes.ReadOnly);
 			await That(FileSystem.File.Exists(backupName)).IsFalse();
@@ -369,10 +360,8 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 			await That(Act).DoesNotThrow();
 			await That(sut.Exists).IsFalse();
 			await That(FileSystem.File.Exists(sourceName)).IsFalse();
-			await That(FileSystem.File.Exists(destinationName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(sourceContents);
-			await That(FileSystem.File.Exists(backupName)).IsTrue();
-			await That(FileSystem.File.ReadAllText(backupName)).IsEqualTo(destinationContents);
+			await That(FileSystem).HasFile(destinationName).WithContent(sourceContents);
+			await That(FileSystem).HasFile(backupName).WithContent(destinationContents);
 		}
 	}
 
@@ -465,10 +454,8 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 		await That(sut.Exists).IsFalse();
 		await That(FileSystem.File.Exists(sourceName)).IsFalse();
 		await That(result.FullName).IsEqualTo(FileSystem.Path.GetFullPath(destinationName));
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(sourceContents);
-		await That(FileSystem.File.Exists(backupName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(backupName)).IsEqualTo(backupContents);
+		await That(FileSystem).HasFile(destinationName).WithContent(sourceContents);
+		await That(FileSystem).HasFile(backupName).WithContent(backupContents);
 	}
 
 	[Test]
@@ -488,7 +475,6 @@ public class ReplaceTests(FileSystemTestData testData) : FileSystemTestBase(test
 		await That(sut.Exists).IsFalse();
 		await That(FileSystem.File.Exists(sourceName)).IsFalse();
 		await That(result.FullName).IsEqualTo(FileSystem.Path.GetFullPath(destinationName));
-		await That(FileSystem.File.Exists(destinationName)).IsTrue();
-		await That(FileSystem.File.ReadAllText(destinationName)).IsEqualTo(sourceContents);
+		await That(FileSystem).HasFile(destinationName).WithContent(sourceContents);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/TestHelpers/Usings.cs
+++ b/Tests/Testably.Abstractions.Tests/TestHelpers/Usings.cs
@@ -7,6 +7,7 @@ global using Testably.Abstractions.TestHelpers;
 global using Testably.Abstractions.Tests.TestHelpers;
 global using TUnit;
 global using aweXpect;
+global using aweXpect.Testably;
 global using static aweXpect.Expect;
 global using Skip = Testably.Abstractions.TestHelpers.Skip;
 #if NET48


### PR DESCRIPTION
This pull request updates the `aweXpect.Testably` package to version 0.14.0 and refactors the test code to use new assertion methods provided by this package. The main focus is on improving the readability and expressiveness of file system assertions in tests by replacing manual file existence and content checks with fluent assertion chains.

**Dependency update:**
- Upgraded the `aweXpect.Testably` NuGet package from version 0.13.0 to 0.14.0 in `Directory.Packages.props`.

**Test assertion refactoring:**

*General assertion improvements:*
- Replaced assertions like `await That(FileSystem.File.Exists(path)).IsTrue();` and `await That(FileSystem.File.ReadAllText(path)).IsEqualTo(content);` with the more fluent `await That(FileSystem).HasFile(path).WithContent(content);` in all relevant test cases for file content validation.

*Read-only file assertions:*
- Updated assertions for read-only file flags to use the new fluent syntax: `await That(fileSystem).HasFile(name).Which.IsReadOnly();` or `.IsNotReadOnly();` depending on the test case.

These changes modernize the test code, making it more expressive and easier to maintain by leveraging the latest features of `aweXpect.Testably`.