### PR TITLE
fix: cap real-fs temp-dir prefix to stay under MAX_PATH on net48

### DIFF
--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/FileSystemTestData.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/FileSystemTestData.cs
@@ -96,9 +96,18 @@ public abstract class FileSystemTestData
 
 		/// <inheritdoc />
 		public override IDirectoryCleaner GetDirectoryCleaner(IFileSystem fileSystem)
-			=> fileSystem.SetCurrentDirectoryToEmptyTemporaryDirectory(
-				$"{_dataGeneratorMetadata.TestInformation?.Class.Name}-{_dataGeneratorMetadata.TestInformation?.Name ?? _dataGeneratorMetadata.TestSessionId}-",
-				Console.WriteLine);
+		{
+			string testName =
+				$"{_dataGeneratorMetadata.TestInformation?.Class.Name}-{_dataGeneratorMetadata.TestInformation?.Name ?? _dataGeneratorMetadata.TestSessionId}";
+			// Cap below the MAX_PATH headroom on .NET Framework; uniqueness comes from the random suffix in DirectoryCleaner.
+			if (testName.Length > 60)
+			{
+				testName = testName.Substring(0, 60);
+			}
+
+			return fileSystem.SetCurrentDirectoryToEmptyTemporaryDirectory(
+				$"{testName}-", Console.WriteLine);
+		}
 
 		/// <inheritdoc />
 		public override Test GetTest()


### PR DESCRIPTION
The Real test data passed `{ClassName}-{MethodName}-` as the directory-cleaner prefix. For tests with long names — e.g. EnumerateFileSystemInfosTests's EnumerateFileSystemEntries_SearchOptionAllDirectories_FullPath_ShouldReturnAllFileSystemEntriesWithFullPath — this becomes a 130-char prefix. Combined with a longer CI user temp root (`runneradmin` vs typical short usernames) and AutoFixture-generated path components that include the literal `With whitespace` token from RandomSystemExtensions.FileNames, the working path tips over the 260-char MAX_PATH limit that .NET Framework still enforces (the Switch.System.IO opt-outs aren't enabled here on purpose — `New_PathTooLong_Should…OnNetFramework` documents that limit as a deliberate behavior).

Cap the prefix at 60 chars. Uniqueness still comes from the random suffix that `DirectoryCleaner.GetPathCandidate` appends.