### PR TITLE
refactor: modernize tests after updating aweXpect.Testably to v0.15.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,7 +46,7 @@
 		<PackageVersion Include="System.Net.Http" Version="4.3.4"/>
 		<PackageVersion Include="aweXpect" Version="2.33.0"/>
 		<PackageVersion Include="aweXpect.Chronology" Version="1.1.0"/>
-		<PackageVersion Include="aweXpect.Testably" Version="0.14.0"/>
+		<PackageVersion Include="aweXpect.Testably" Version="0.15.0"/>
 		<PackageVersion Include="aweXpect.Mockolate" Version="3.1.0"/>
 		<PackageVersion Include="Mockolate" Version="3.2.0"/>
 		<PackageVersion Include="TUnit.Engine" Version="1.24.0"/>

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DriveInfoMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystem/DriveInfoMockTests.cs
@@ -21,7 +21,7 @@ public class DriveInfoMockTests
 
 		FileSystem.WithDrive(d => d.ChangeUsedBytes(-1));
 
-		await That(drive.AvailableFreeSpace).IsEqualTo(size);
+		await That(drive).HasAvailableFreeSpace(size);
 	}
 
 	[Test]
@@ -38,7 +38,7 @@ public class DriveInfoMockTests
 
 		IDriveInfo drive = FileSystem.GetDefaultDrive();
 		await That(Act).ThrowsExactly<IOException>().WithMessage($"*'{drive.Name}'*").AsWildcard();
-		await That(drive.AvailableFreeSpace).IsEqualTo(fileSize - 1);
+		await That(drive).HasAvailableFreeSpace(fileSize - 1);
 	}
 
 	[Test]
@@ -54,10 +54,10 @@ public class DriveInfoMockTests
 		IDriveInfo drive = FileSystem.GetDefaultDrive();
 
 		FileSystem.File.WriteAllText(path, fileContent1, encoding);
-		await That(drive.AvailableFreeSpace).IsEqualTo(expectedRemainingBytes + fileSize2);
+		await That(drive).HasAvailableFreeSpace(expectedRemainingBytes + fileSize2);
 		FileSystem.File.AppendAllText(path, fileContent2, encoding);
 
-		await That(drive.AvailableFreeSpace).IsEqualTo(expectedRemainingBytes);
+		await That(drive).HasAvailableFreeSpace(expectedRemainingBytes);
 	}
 
 	[Test]
@@ -78,7 +78,7 @@ public class DriveInfoMockTests
 			stream.SetLength(stream.Length - reduceLength);
 		}
 
-		await That(drive.AvailableFreeSpace).IsEqualTo(previousFreeSpace + reduceLength);
+		await That(drive).HasAvailableFreeSpace(previousFreeSpace + reduceLength);
 	}
 
 	[Test]
@@ -94,7 +94,7 @@ public class DriveInfoMockTests
 
 		IDriveInfo drive = FileSystem.GetDefaultDrive();
 
-		await That(drive.AvailableFreeSpace).IsEqualTo(0);
+		await That(drive).HasAvailableFreeSpace(0);
 	}
 
 	[Test]
@@ -111,7 +111,7 @@ public class DriveInfoMockTests
 
 		IDriveInfo drive = FileSystem.GetDefaultDrive();
 
-		await That(drive.AvailableFreeSpace).IsEqualTo(fileSize);
+		await That(drive).HasAvailableFreeSpace(fileSize);
 	}
 
 	[Test]
@@ -122,7 +122,7 @@ public class DriveInfoMockTests
 
 		IDriveInfo drive = FileSystem.GetDefaultDrive();
 
-		await That(drive.AvailableFreeSpace).IsEqualTo(size);
+		await That(drive).HasAvailableFreeSpace(size);
 	}
 
 	[Test]
@@ -220,7 +220,7 @@ public class DriveInfoMockTests
 		FileSystem.WithDrive(d => d.SetDriveFormat());
 
 		IDriveInfo drive = FileSystem.GetDefaultDrive();
-		await That(drive.DriveFormat).IsEqualTo("NTFS");
+		await That(drive).HasDriveFormat("NTFS");
 	}
 
 	[Test]
@@ -230,7 +230,7 @@ public class DriveInfoMockTests
 		FileSystem.WithDrive(d => d.SetDriveFormat(driveFormat));
 
 		IDriveInfo drive = FileSystem.GetDefaultDrive();
-		await That(drive.DriveFormat).IsEqualTo(driveFormat);
+		await That(drive).HasDriveFormat(driveFormat);
 	}
 
 	[Test]
@@ -239,7 +239,7 @@ public class DriveInfoMockTests
 		FileSystem.WithDrive(d => d.SetDriveType());
 
 		IDriveInfo drive = FileSystem.GetDefaultDrive();
-		await That(drive.DriveType).IsEqualTo(DriveType.Fixed);
+		await That(drive).HasDriveType(DriveType.Fixed);
 	}
 
 	[Test]
@@ -249,7 +249,7 @@ public class DriveInfoMockTests
 		FileSystem.WithDrive(d => d.SetDriveType(driveType));
 
 		IDriveInfo drive = FileSystem.GetDefaultDrive();
-		await That(drive.DriveType).IsEqualTo(driveType);
+		await That(drive).HasDriveType(driveType);
 	}
 
 	[Test]
@@ -270,6 +270,6 @@ public class DriveInfoMockTests
 
 		IDriveInfo drive = FileSystem.GetDefaultDrive();
 
-		await That(drive.AvailableFreeSpace).IsEqualTo(1024 * 1024 * 1024);
+		await That(drive).HasAvailableFreeSpace(1024 * 1024 * 1024);
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileVersionInfoBuilderTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/FileVersionInfoBuilderTests.cs
@@ -50,21 +50,21 @@ public class FileVersionInfoBuilderTests
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
 		await That(result.Comments).IsEqualTo(comments);
-		await That(result.CompanyName).IsEqualTo(companyName);
-		await That(result.FileDescription).IsEqualTo(fileDescription);
-		await That(result.FileVersion).IsEqualTo(fileVersion);
+		await That(result).HasCompanyName(companyName);
+		await That(result).HasFileDescription(fileDescription);
+		await That(result).HasFileVersion(fileVersion);
 		await That(result.InternalName).IsEqualTo(internalName);
 		await That(result.IsDebug).IsEqualTo(isDebug);
 		await That(result.IsPatched).IsEqualTo(isPatched);
 		await That(result.IsPreRelease).IsEqualTo(isPreRelease);
 		await That(result.IsSpecialBuild).IsEqualTo(isSpecialBuild);
-		await That(result.Language).IsEqualTo(language);
+		await That(result).HasLanguage(language);
 		await That(result.LegalCopyright).IsEqualTo(legalCopyright);
 		await That(result.LegalTrademarks).IsEqualTo(legalTrademarks);
-		await That(result.OriginalFilename).IsEqualTo(originalFilename);
+		await That(result).HasOriginalFilename(originalFilename);
 		await That(result.PrivateBuild).IsEqualTo(privateBuild);
-		await That(result.ProductName).IsEqualTo(productName);
-		await That(result.ProductVersion).IsEqualTo(productVersion);
+		await That(result).HasProductName(productName);
+		await That(result).HasProductVersion(productVersion);
 		await That(result.SpecialBuild).IsEqualTo(specialBuild);
 	}
 
@@ -91,7 +91,7 @@ public class FileVersionInfoBuilderTests
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
-		await That(result.CompanyName).IsEqualTo(companyName);
+		await That(result).HasCompanyName(companyName);
 	}
 
 	[Test]
@@ -104,7 +104,7 @@ public class FileVersionInfoBuilderTests
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
-		await That(result.FileDescription).IsEqualTo(fileDescription);
+		await That(result).HasFileDescription(fileDescription);
 	}
 
 	[Test]
@@ -123,7 +123,7 @@ public class FileVersionInfoBuilderTests
 			b => b.SetFileVersion("9.8.7.6").SetFileVersion(fileVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
-		await That(result.FileVersion).IsEqualTo(fileVersion);
+		await That(result).HasFileVersion(fileVersion);
 		await That(result.FileMajorPart).IsEqualTo(fileMajorPart);
 		await That(result.FileMinorPart).IsEqualTo(fileMinorPart);
 		await That(result.FileBuildPart).IsEqualTo(fileBuildPart);
@@ -155,7 +155,7 @@ public class FileVersionInfoBuilderTests
 		fileSystem.WithFileVersionInfo("*", b => b.SetFileVersion(fileVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
-		await That(result.FileVersion).IsEqualTo(fileVersion);
+		await That(result).HasFileVersion(fileVersion);
 		await That(result.FileMajorPart).IsEqualTo(fileMajorPart);
 		await That(result.FileMinorPart).IsEqualTo(fileMinorPart);
 		await That(result.FileBuildPart).IsEqualTo(fileBuildPart);
@@ -176,7 +176,7 @@ public class FileVersionInfoBuilderTests
 			.SetFileVersion(fileVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
-		await That(result.FileVersion).IsEqualTo(fileVersion);
+		await That(result).HasFileVersion(fileVersion);
 		await That(result.FileMajorPart).IsEqualTo(0);
 		await That(result.FileMinorPart).IsEqualTo(0);
 		await That(result.FileBuildPart).IsEqualTo(0);
@@ -271,7 +271,7 @@ public class FileVersionInfoBuilderTests
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
-		await That(result.Language).IsEqualTo(language);
+		await That(result).HasLanguage(language);
 	}
 
 	[Test]
@@ -310,7 +310,7 @@ public class FileVersionInfoBuilderTests
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
-		await That(result.OriginalFilename).IsEqualTo(originalFilename);
+		await That(result).HasOriginalFilename(originalFilename);
 	}
 
 	[Test]
@@ -336,7 +336,7 @@ public class FileVersionInfoBuilderTests
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
 
-		await That(result.ProductName).IsEqualTo(productName);
+		await That(result).HasProductName(productName);
 	}
 
 	[Test]
@@ -355,7 +355,7 @@ public class FileVersionInfoBuilderTests
 			b => b.SetProductVersion("9.8.7.6").SetProductVersion(productVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
-		await That(result.ProductVersion).IsEqualTo(productVersion);
+		await That(result).HasProductVersion(productVersion);
 		await That(result.ProductMajorPart).IsEqualTo(fileMajorPart);
 		await That(result.ProductMinorPart).IsEqualTo(fileMinorPart);
 		await That(result.ProductBuildPart).IsEqualTo(fileBuildPart);
@@ -387,7 +387,7 @@ public class FileVersionInfoBuilderTests
 		fileSystem.WithFileVersionInfo("*", b => b.SetProductVersion(productVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
-		await That(result.ProductVersion).IsEqualTo(productVersion);
+		await That(result).HasProductVersion(productVersion);
 		await That(result.ProductMajorPart).IsEqualTo(fileMajorPart);
 		await That(result.ProductMinorPart).IsEqualTo(fileMinorPart);
 		await That(result.ProductBuildPart).IsEqualTo(fileBuildPart);
@@ -408,7 +408,7 @@ public class FileVersionInfoBuilderTests
 			.SetProductVersion(productVersion));
 
 		IFileVersionInfo result = fileSystem.FileVersionInfo.GetVersionInfo("foo");
-		await That(result.ProductVersion).IsEqualTo(productVersion);
+		await That(result).HasProductVersion(productVersion);
 		await That(result.ProductMajorPart).IsEqualTo(0);
 		await That(result.ProductMinorPart).IsEqualTo(0);
 		await That(result.ProductBuildPart).IsEqualTo(0);

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -84,10 +84,10 @@ public class MockFileSystemTests
 		IDriveInfo drive = sut.GetDefaultDrive();
 
 		await That(drives).IsNotEmpty();
-		await That(drive.Name).IsEqualTo(expectedDriveName);
+		await That(drive).HasName(expectedDriveName);
 		await That(drive.AvailableFreeSpace).IsGreaterThan(0);
-		await That(drive.DriveFormat).IsEqualTo(DriveInfoMock.DefaultDriveFormat);
-		await That(drive.DriveType).IsEqualTo(DriveInfoMock.DefaultDriveType);
+		await That(drive).HasDriveFormat(DriveInfoMock.DefaultDriveFormat);
+		await That(drive).HasDriveType(DriveInfoMock.DefaultDriveType);
 		await That(drive.VolumeLabel).IsNotNullOrEmpty();
 	}
 
@@ -188,11 +188,11 @@ public class MockFileSystemTests
 		await That(sut.DriveInfo.GetDrives().Length).IsEqualTo(2);
 		IDriveInfo drive = sut.DriveInfo.GetDrives()
 			.Single(x => string.Equals(x.Name, driveName, StringComparison.Ordinal));
-		await That(drive.TotalSize).IsEqualTo(100);
+		await That(drive).HasTotalSize(100);
 
 		sut.WithDrive(driveName, d => d.SetTotalSize(200));
 		await That(sut.DriveInfo.GetDrives().Length).IsEqualTo(2);
-		await That(drive.TotalSize).IsEqualTo(200);
+		await That(drive).HasTotalSize(200);
 	}
 
 	[Test]
@@ -266,9 +266,9 @@ public class MockFileSystemTests
 
 		IDriveInfo drive = sut.GetDefaultDrive();
 
-		await That(drive.TotalSize).IsEqualTo(totalSize);
-		await That(drive.TotalFreeSpace).IsEqualTo(totalSize);
-		await That(drive.AvailableFreeSpace).IsEqualTo(totalSize);
+		await That(drive).HasTotalSize(totalSize);
+		await That(drive).HasTotalFreeSpace(totalSize);
+		await That(drive).HasAvailableFreeSpace(totalSize);
 	}
 
 #if NET6_0_OR_GREATER
@@ -368,7 +368,7 @@ public class MockFileSystemTests
 
 		sut.File.WriteAllBytes(Path.Combine(uncDrive, path), bytes);
 
-		await That(drive.AvailableFreeSpace).IsEqualTo(previousFreeSpace - bytes.Length);
+		await That(drive).HasAvailableFreeSpace(previousFreeSpace - bytes.Length);
 	}
 
 #if FEATURE_FILESYSTEM_UNIXFILEMODE

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemTests.cs
@@ -202,11 +202,8 @@ public class MockFileSystemTests
 		string driveName = "".PrefixRoot(sut);
 		sut.WithDrive(driveName);
 
-		IDriveInfo[] drives = sut.DriveInfo.GetDrives();
-
-		await That(drives.Length).IsGreaterThanOrEqualTo(1);
-		await That(drives).HasSingle()
-			.Matching(d => string.Equals(d.Name, driveName, StringComparison.Ordinal));
+		await That(sut.DriveInfo.GetDrives().Length).IsGreaterThanOrEqualTo(1);
+		await That(sut).HasDrive(driveName);
 	}
 
 	[Test]
@@ -218,11 +215,8 @@ public class MockFileSystemTests
 		MockFileSystem sut = new();
 		sut.WithDrive(driveName);
 
-		IDriveInfo[] drives = sut.DriveInfo.GetDrives();
-
-		await That(drives.Length).IsEqualTo(2);
-		await That(drives).HasSingle()
-			.Matching(d => string.Equals(d.Name, driveName, StringComparison.Ordinal));
+		await That(sut.DriveInfo.GetDrives().Length).IsEqualTo(2);
+		await That(sut).HasDrive(driveName);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimerMockTests.cs
@@ -1,4 +1,5 @@
 ﻿using aweXpect.Chronology;
+using aweXpect.Core;
 using System.Threading;
 using Testably.Abstractions.Testing.TimeSystem;
 using ITimer = Testably.Abstractions.TimeSystem.ITimer;
@@ -51,62 +52,36 @@ public class TimerMockTests
 	[Test]
 	public async Task DisableAutoAdvance_ShouldExecuteTimerLimitedNumberOfTimes()
 	{
-		int callbackCount = 0;
 		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
-		using CancellationTokenSource cts = CancellationTokenSource
-			.CreateLinkedTokenSource(TestContext.Current!.Execution.CancellationToken);
-		cts.CancelAfter(30.Seconds());
-		CancellationToken token = cts.Token;
-		using SemaphoreSlim callbackExecuted = new(0);
-		using ITimer timer = timeSystem.Timer.New(_ =>
-		{
-			// ReSharper disable once AccessToModifiedClosure
-			Interlocked.Increment(ref callbackCount);
-			// ReSharper disable once AccessToDisposedClosure
-			callbackExecuted.Release();
-		}, null, 1.Seconds(), 2.Seconds());
+		using ITimerMock timer = (ITimerMock)timeSystem.Timer.New(
+			_ => { }, null, 1.Seconds(), 2.Seconds());
 
-		await Task.Delay(50.Milliseconds(), token);
-		await That(Volatile.Read(ref callbackCount)).IsEqualTo(0);
+		await That(timer).Executed().Never().Within(50.Milliseconds());
 
 		// Advance past dueTime (1s): should trigger first callback
 		timeSystem.TimeProvider.AdvanceBy(2.Seconds());
-		await callbackExecuted.WaitAsync(token);
-		await That(Volatile.Read(ref callbackCount)).IsEqualTo(1);
+		await That(timer).Executed().AtLeast(1.Times()).Within(10.Seconds());
+		await That(timer.ExecutionCount).IsEqualTo(1L);
 
 		// Advance past one period (2s): should trigger second callback
-		await Task.Delay(50.Milliseconds(), token);
 		timeSystem.TimeProvider.AdvanceBy(2.Seconds());
-		await callbackExecuted.WaitAsync(token);
-		await That(Volatile.Read(ref callbackCount)).IsEqualTo(2);
+		await That(timer).Executed().AtLeast(2.Times()).Within(10.Seconds());
+		await That(timer.ExecutionCount).IsEqualTo(2L);
 
 		// Advance past two periods (4s): should trigger two more callbacks
-		await Task.Delay(50.Milliseconds(), token);
 		timeSystem.TimeProvider.AdvanceBy(4.Seconds());
-		await callbackExecuted.WaitAsync(token);
-		await Task.Delay(50.Milliseconds(), token);
-		timeSystem.TimeProvider.AdvanceBy(0.Seconds());
-		await callbackExecuted.WaitAsync(token);
-		await That(Volatile.Read(ref callbackCount)).IsEqualTo(4);
+		await That(timer).Executed().AtLeast(4.Times()).Within(10.Seconds());
+		await That(timer.ExecutionCount).IsEqualTo(4L);
 	}
 
 	[Test]
 	public async Task DisableAutoAdvance_ShouldNotExecuteTimerBeforeTimeElapsed()
 	{
-		int callbackCount = 0;
 		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
-		using CancellationTokenSource cts = CancellationTokenSource
-			.CreateLinkedTokenSource(TestContext.Current!.Execution.CancellationToken);
-		cts.CancelAfter(30.Seconds());
-		CancellationToken token = cts.Token;
-		using ITimer timer = timeSystem.Timer.New(_ =>
-		{
-			// ReSharper disable once AccessToModifiedClosure
-			Interlocked.Increment(ref callbackCount);
-		}, null, 1.Seconds(), 2.Seconds());
+		using ITimerMock timer = (ITimerMock)timeSystem.Timer.New(
+			_ => { }, null, 1.Seconds(), 2.Seconds());
 
-		await Task.Delay(50.Milliseconds(), token);
-		await That(Volatile.Read(ref callbackCount)).IsEqualTo(0);
+		await That(timer).Executed().Never().Within(50.Milliseconds());
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/AttributesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DirectoryInfo/AttributesTests.cs
@@ -16,7 +16,7 @@ public class AttributesTests(FileSystemTestData testData) : FileSystemTestBase(t
 
 		await That(FileSystem.Directory.Exists(path)).IsTrue();
 		await That(FileSystem.File.Exists(path)).IsFalse();
-		await That(sut.Attributes).HasFlag(FileAttributes.Directory);
+		await That(sut).HasAttribute(FileAttributes.Directory);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfo/Tests.cs
@@ -35,7 +35,7 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 			if (Test.RunsOnWindows)
 			{
 				await That(Act).DoesNotThrow();
-				await That(result.VolumeLabel).IsEqualTo("TEST");
+				await That(result).HasVolumeLabel("TEST");
 			}
 			else
 			{

--- a/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/DriveInfoFactory/Tests.cs
@@ -67,8 +67,8 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 
 		await That(result.AvailableFreeSpace).IsGreaterThan(0);
 		await That(result.DriveFormat).IsNotNull();
-		await That(result.DriveType).IsEqualTo(DriveType.Fixed);
-		await That(result.IsReady).IsTrue();
+		await That(result).HasDriveType(DriveType.Fixed);
+		await That(result).IsReady();
 		await That(result.RootDirectory.FullName).IsEqualTo(FileTestHelper.RootDrive(Test));
 		await That(result.TotalFreeSpace).IsGreaterThan(0);
 		await That(result.TotalSize).IsGreaterThan(0);

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AttributesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/AttributesTests.cs
@@ -14,7 +14,7 @@ public class AttributesTests(FileSystemTestData testData) : FileSystemTestBase(t
 
 		sut.Attributes = FileAttributes.Directory;
 
-		await That(sut.Attributes).DoesNotHaveFlag(FileAttributes.Directory);
+		await That(sut).DoesNotHaveAttribute(FileAttributes.Directory);
 	}
 
 	[Test]
@@ -24,6 +24,6 @@ public class AttributesTests(FileSystemTestData testData) : FileSystemTestBase(t
 		FileSystem.File.WriteAllText(path, "foo");
 		IFileInfo sut = FileSystem.FileInfo.New(path);
 
-		await That(sut.Attributes).DoesNotHaveFlag(FileAttributes.Directory);
+		await That(sut).DoesNotHaveAttribute(FileAttributes.Directory);
 	}
 }

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/EncryptDecryptTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/EncryptDecryptTests.cs
@@ -54,9 +54,9 @@ public class EncryptDecryptTests(FileSystemTestData testData) : FileSystemTestBa
 		IFileInfo sut = FileSystem.FileInfo.New(path);
 
 		sut.Encrypt();
-		await That(sut.Attributes).HasFlag(FileAttributes.Encrypted);
+		await That(sut).HasAttribute(FileAttributes.Encrypted);
 		sut.Decrypt();
-		await That(sut.Attributes).DoesNotHaveFlag(FileAttributes.Encrypted);
+		await That(sut).DoesNotHaveAttribute(FileAttributes.Encrypted);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/FileInfo/Tests.cs
@@ -116,17 +116,17 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		fileInfo.IsReadOnly = true;
 
 		await That(fileInfo.IsReadOnly).IsTrue();
-		await That(fileInfo.Attributes).HasFlag(FileAttributes.ReadOnly);
+		await That(fileInfo).HasAttribute(FileAttributes.ReadOnly);
 
 		fileInfo.IsReadOnly = true;
 
 		await That(fileInfo.IsReadOnly).IsTrue();
-		await That(fileInfo.Attributes).HasFlag(FileAttributes.ReadOnly);
+		await That(fileInfo).HasAttribute(FileAttributes.ReadOnly);
 
 		fileInfo.IsReadOnly = false;
 
 		await That(fileInfo.IsReadOnly).IsFalse();
-		await That(fileInfo.Attributes).DoesNotHaveFlag(FileAttributes.ReadOnly);
+		await That(fileInfo).DoesNotHaveAttribute(FileAttributes.ReadOnly);
 	}
 
 	[Test]
@@ -139,7 +139,7 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		fileInfo.Attributes = FileAttributes.ReadOnly | FileAttributes.Encrypted;
 
 		await That(fileInfo.IsReadOnly).IsTrue();
-		await That(fileInfo.Attributes).HasFlag(FileAttributes.ReadOnly);
+		await That(fileInfo).HasAttribute(FileAttributes.ReadOnly);
 	}
 
 	[Test]
@@ -150,7 +150,7 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		IFileInfo fileInfo = FileSystem.FileInfo.New(path);
 
 		await That(fileInfo.IsReadOnly).IsFalse();
-		await That(fileInfo.Attributes).DoesNotHaveFlag(FileAttributes.ReadOnly);
+		await That(fileInfo).DoesNotHaveAttribute(FileAttributes.ReadOnly);
 	}
 
 	[Test]


### PR DESCRIPTION
# Adopt aweXpect.Testably 0.15.0 assertions in the test suite

## Summary
- Bumps `aweXpect.Testably` from 0.14.0 to 0.15.0.
- Migrates eligible test sites to the new `ITimerMock`, `IFileInfo`/`IDirectoryInfo`, `IDriveInfo`, `IFileVersionInfo`, and `IFileSystem` expectations introduced in 0.15.0.

Net change: **-31 lines** across 11 files. The biggest win is `TimerMockTests`, where `Timer.Executed().Within(...)` replaces a `SemaphoreSlim` + `Interlocked.Increment` + `Volatile.Read` coordination pattern.

## Commits (one per concern, easy to review or revert individually)

| # | Commit | Files |
|---|---|---|
| 1 | `chore(deps): bump aweXpect.Testably to 0.15.0` | `Directory.Packages.props` |
| 2 | `refactor(tests): use Timer.Executed().Within() in TimerMockTests` | `TimerMockTests.cs` |
| 3 | `refactor(tests): use HasAttribute/DoesNotHaveAttribute on file system info` | 4 files under `Tests/Testably.Abstractions.Tests/FileSystem/...` |
| 4 | `refactor(tests): use IDriveInfo expectations from aweXpect.Testably` | `DriveInfoMockTests.cs`, `MockFileSystemTests.cs`, `DriveInfo/Tests.cs`, `DriveInfoFactory/Tests.cs` |
| 5 | `refactor(tests): use IFileVersionInfo expectations from aweXpect.Testably` | `FileVersionInfoBuilderTests.cs` |
| 6 | `refactor(tests): use IFileSystem.HasDrive in MockFileSystemTests` | `MockFileSystemTests.cs` |

## Refactor patterns

**Timer callbacks (the big one)**
```csharp
// before: semaphore + Interlocked + Volatile.Read + CancellationTokenSource(30s)
await That(Volatile.Read(ref callbackCount)).IsEqualTo(1);

// after
await That(timer).Executed().AtLeast(1.Times()).Within(10.Seconds());
await That(timer.ExecutionCount).IsEqualTo(1L);

File / directory attributes
await That(sut.Attributes).HasFlag(FileAttributes.ReadOnly);
// becomes
await That(sut).HasAttribute(FileAttributes.ReadOnly);

Drive properties
await That(drive.AvailableFreeSpace).IsEqualTo(size);
// becomes
await That(drive).HasAvailableFreeSpace(size);
Also: HasTotalSize, HasTotalFreeSpace, HasVolumeLabel, HasDriveFormat, HasDriveType, HasName, IsReady.

File version info
await That(result.CompanyName).IsEqualTo(companyName);
// becomes
await That(result).HasCompanyName(companyName);
Also: HasFileDescription, HasFileVersion, HasLanguage, HasOriginalFilename, HasProductName, HasProductVersion.

Drive presence on the file system
await That(drives).HasSingle()
    .Matching(d => string.Equals(d.Name, driveName, StringComparison.Ordinal));
// becomes
await That(sut).HasDrive(driveName);
```

Intentionally not refactored

- InMemoryContainerTests - subject is IStorageContainer, not IFileInfo/IDirectoryInfo.
- IsGreaterThan / IsNotEmpty / IsNotNull on drive properties - the new API only covers equality.
- IFileVersionInfo booleans (IsDebug, IsPatched, IsPreRelease) parameterised by bool - the new IsDebug() / IsNotDebug() shape would force a conditional and lengthen the test.
- IFileVersionInfo properties with no extension in 0.15.0 - Comments, InternalName, LegalCopyright, LegalTrademarks, PrivateBuild, SpecialBuild, IsPrivateBuild, IsSpecialBuild, FileMajor/Minor/Build/PrivatePart, ProductMajor/Minor/Build/PrivatePart.
- WithDrive_ShouldHavePathSeparatorSuffix - the test asserts the exact ordinal name form (D:\), but HasDrive normalises trailing slashes, so the new API can't express the check.
- PeriodicTimerMockTests - uses IPeriodicTimerMock; the new Executed() extension targets ITimerMock only.