### PR TITLE
feat: add `CreateEmptyTemporaryDirectory` to support temporary directories without changing current directory

### DIFF
--- a/Docs/pages/docs/file-system/initialization.mdx
+++ b/Docs/pages/docs/file-system/initialization.mdx
@@ -131,3 +131,15 @@ using IDirectoryCleaner cleaner =
 ```
 
 The `prefix` parameter makes leftovers easier to spot in `%TEMP%` if cleanup ever fails. The optional `logger` parameter receives diagnostic messages (e.g. retry attempts when antivirus holds a file open).
+
+If you need a temporary directory but want to leave `Directory.GetCurrentDirectory()` untouched, use `CreateEmptyTemporaryDirectory` instead. It behaves identically - same `prefix` and `logger` parameters, same force-delete on dispose - but does not change the current directory:
+
+```csharp
+IFileSystem fileSystem = new RealFileSystem();
+using IDirectoryCleaner cleaner =
+    fileSystem.CreateEmptyTemporaryDirectory(prefix: "MyTests-");
+
+// fileSystem.Directory.GetCurrentDirectory() is unchanged
+// Use cleaner.BasePath to access the empty temp directory
+// On dispose: the directory is force-deleted (read-only flag and all)
+```

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Reflection;
 using Testably.Abstractions.Testing.Helpers;

--- a/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/FileSystemInitializerExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Reflection;
 using Testably.Abstractions.Testing.Helpers;
@@ -189,7 +189,27 @@ public static class FileSystemInitializerExtensions
 		this IFileSystem fileSystem, string? prefix = null, Action<string>? logger = null)
 	{
 		using IDisposable release = fileSystem.IgnoreStatistics();
-		return new DirectoryCleaner(fileSystem, prefix, logger);
+		return new DirectoryCleaner(fileSystem, prefix, logger, true);
+	}
+
+	/// <summary>
+	///     Creates a new empty temporary directory without changing the current directory.
+	/// </summary>
+	/// <param name="fileSystem">The file system.</param>
+	/// <param name="prefix">
+	///     A prefix to use for the temporary directory.<br />
+	///     This simplifies matching directories to tests.
+	/// </param>
+	/// <param name="logger">(optional) A callback to log the cleanup process.</param>
+	/// <returns>
+	///     A <see cref="IDirectoryCleaner" /> that will
+	///     force delete all content in the temporary directory on dispose.
+	/// </returns>
+	public static IDirectoryCleaner CreateEmptyTemporaryDirectory(
+		this IFileSystem fileSystem, string? prefix = null, Action<string>? logger = null)
+	{
+		using IDisposable release = fileSystem.IgnoreStatistics();
+		return new DirectoryCleaner(fileSystem, prefix, logger, false);
 	}
 
 	private static void CopyDirectory(

--- a/Source/Testably.Abstractions.Testing/Initializer/DirectoryCleaner.cs
+++ b/Source/Testably.Abstractions.Testing/Initializer/DirectoryCleaner.cs
@@ -18,7 +18,7 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 	private readonly Action<string>? _logger;
 	private readonly string _pathToDelete;
 
-	public DirectoryCleaner(IFileSystem fileSystem, string? prefix, Action<string>? logger)
+	public DirectoryCleaner(IFileSystem fileSystem, string? prefix, Action<string>? logger, bool setCurrentDirectory)
 	{
 		_fileSystem = fileSystem;
 		_logger = logger;
@@ -26,6 +26,10 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 			fileSystem.ExecuteOrDefault(),
 			prefix ?? "");
 		BasePath = _fileSystem.Path.Combine(_pathToDelete, EmptyDirectoryName);
+		if (setCurrentDirectory)
+		{
+			SetCurrentDirectoryToTestDirectory(BasePath);
+		}
 	}
 
 	#region IDirectoryCleaner Members
@@ -189,13 +193,18 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 				$"Could not create current directory '{basePath}' for tests");
 		}
 
-		_logger?.Invoke($"Use '{basePath}' as current directory.");
-		_fileSystem.Directory.SetCurrentDirectory(basePath);
+		return pathToDelete;
+	}
+
+	private void SetCurrentDirectoryToTestDirectory(string testDirectoryPath)
+	{
+		_logger?.Invoke($"Use '{testDirectoryPath}' as current directory.");
+		_fileSystem.Directory.SetCurrentDirectory(testDirectoryPath);
 		for (int i = 0;
 			i <= 10 &&
 			!string.Equals(
 				_fileSystem.Directory.GetCurrentDirectory(),
-				basePath,
+				testDirectoryPath,
 				_fileSystem.ExecuteOrDefault().StringComparisonMode);
 			i++)
 		{
@@ -204,13 +213,11 @@ internal sealed class DirectoryCleaner : IDirectoryCleaner
 
 		if (!string.Equals(
 			_fileSystem.Directory.GetCurrentDirectory(),
-			basePath,
+			testDirectoryPath,
 			_fileSystem.ExecuteOrDefault().StringComparisonMode))
 		{
 			throw new TestingException(
-				$"Could not set current directory to '{basePath}' for tests");
+				$"Could not set current directory to '{testDirectoryPath}' for tests");
 		}
-
-		return pathToDelete;
 	}
 }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
@@ -15,6 +15,7 @@ namespace Testably.Abstractions.Testing
     }
     public static class FileSystemInitializerExtensions
     {
+        public static Testably.Abstractions.Testing.Initializer.IDirectoryCleaner CreateEmptyTemporaryDirectory(this System.IO.Abstractions.IFileSystem fileSystem, string? prefix = null, System.Action<string>? logger = null) { }
         public static Testably.Abstractions.Testing.Initializer.IFileSystemInitializer<TFileSystem> Initialize<TFileSystem>(this TFileSystem fileSystem, System.Action<Testably.Abstractions.Testing.FileSystemInitializerOptions>? options = null)
             where TFileSystem : System.IO.Abstractions.IFileSystem { }
         public static void InitializeEmbeddedResourcesFromAssembly(this System.IO.Abstractions.IFileSystem fileSystem, string directoryPath, System.Reflection.Assembly assembly, string? relativePath = null, string searchPattern = "*", System.IO.SearchOption searchOption = 1) { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -15,6 +15,7 @@ namespace Testably.Abstractions.Testing
     }
     public static class FileSystemInitializerExtensions
     {
+        public static Testably.Abstractions.Testing.Initializer.IDirectoryCleaner CreateEmptyTemporaryDirectory(this System.IO.Abstractions.IFileSystem fileSystem, string? prefix = null, System.Action<string>? logger = null) { }
         public static Testably.Abstractions.Testing.Initializer.IFileSystemInitializer<TFileSystem> Initialize<TFileSystem>(this TFileSystem fileSystem, System.Action<Testably.Abstractions.Testing.FileSystemInitializerOptions>? options = null)
             where TFileSystem : System.IO.Abstractions.IFileSystem { }
         public static void InitializeEmbeddedResourcesFromAssembly(this System.IO.Abstractions.IFileSystem fileSystem, string directoryPath, System.Reflection.Assembly assembly, string? relativePath = null, string searchPattern = "*", System.IO.SearchOption searchOption = 1) { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net7.0.txt
@@ -65,6 +65,7 @@ namespace Testably.Abstractions.Testing
 {
     public static class FileSystemInitializerExtensions
     {
+        public static Testably.Abstractions.Testing.Initializer.IDirectoryCleaner CreateEmptyTemporaryDirectory(this System.IO.Abstractions.IFileSystem fileSystem, string? prefix = null, System.Action<string>? logger = null) { }
         public static Testably.Abstractions.Testing.Initializer.IFileSystemInitializer<TFileSystem> Initialize<TFileSystem>(this TFileSystem fileSystem, System.Action<Testably.Abstractions.Testing.FileSystemInitializerOptions>? options = null)
             where TFileSystem : System.IO.Abstractions.IFileSystem { }
         public static void InitializeEmbeddedResourcesFromAssembly(this System.IO.Abstractions.IFileSystem fileSystem, string directoryPath, System.Reflection.Assembly assembly, string? relativePath = null, string searchPattern = "*", System.IO.SearchOption searchOption = 1) { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -15,6 +15,7 @@ namespace Testably.Abstractions.Testing
     }
     public static class FileSystemInitializerExtensions
     {
+        public static Testably.Abstractions.Testing.Initializer.IDirectoryCleaner CreateEmptyTemporaryDirectory(this System.IO.Abstractions.IFileSystem fileSystem, string? prefix = null, System.Action<string>? logger = null) { }
         public static Testably.Abstractions.Testing.Initializer.IFileSystemInitializer<TFileSystem> Initialize<TFileSystem>(this TFileSystem fileSystem, System.Action<Testably.Abstractions.Testing.FileSystemInitializerOptions>? options = null)
             where TFileSystem : System.IO.Abstractions.IFileSystem { }
         public static void InitializeEmbeddedResourcesFromAssembly(this System.IO.Abstractions.IFileSystem fileSystem, string directoryPath, System.Reflection.Assembly assembly, string? relativePath = null, string searchPattern = "*", System.IO.SearchOption searchOption = 1) { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
@@ -15,6 +15,7 @@ namespace Testably.Abstractions.Testing
     }
     public static class FileSystemInitializerExtensions
     {
+        public static Testably.Abstractions.Testing.Initializer.IDirectoryCleaner CreateEmptyTemporaryDirectory(this System.IO.Abstractions.IFileSystem fileSystem, string? prefix = null, System.Action<string>? logger = null) { }
         public static Testably.Abstractions.Testing.Initializer.IFileSystemInitializer<TFileSystem> Initialize<TFileSystem>(this TFileSystem fileSystem, System.Action<Testably.Abstractions.Testing.FileSystemInitializerOptions>? options = null)
             where TFileSystem : System.IO.Abstractions.IFileSystem { }
         public static void InitializeEmbeddedResourcesFromAssembly(this System.IO.Abstractions.IFileSystem fileSystem, string directoryPath, System.Reflection.Assembly assembly, string? relativePath = null, string searchPattern = "*", System.IO.SearchOption searchOption = 1) { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -11,6 +11,7 @@ namespace Testably.Abstractions.Testing
     }
     public static class FileSystemInitializerExtensions
     {
+        public static Testably.Abstractions.Testing.Initializer.IDirectoryCleaner CreateEmptyTemporaryDirectory(this System.IO.Abstractions.IFileSystem fileSystem, string? prefix = null, System.Action<string>? logger = null) { }
         public static Testably.Abstractions.Testing.Initializer.IFileSystemInitializer<TFileSystem> Initialize<TFileSystem>(this TFileSystem fileSystem, System.Action<Testably.Abstractions.Testing.FileSystemInitializerOptions>? options = null)
             where TFileSystem : System.IO.Abstractions.IFileSystem { }
         public static void InitializeEmbeddedResourcesFromAssembly(this System.IO.Abstractions.IFileSystem fileSystem, string directoryPath, System.Reflection.Assembly assembly, string? relativePath = null, string searchPattern = "*", System.IO.SearchOption searchOption = 1) { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -11,6 +11,7 @@ namespace Testably.Abstractions.Testing
     }
     public static class FileSystemInitializerExtensions
     {
+        public static Testably.Abstractions.Testing.Initializer.IDirectoryCleaner CreateEmptyTemporaryDirectory(this System.IO.Abstractions.IFileSystem fileSystem, string? prefix = null, System.Action<string>? logger = null) { }
         public static Testably.Abstractions.Testing.Initializer.IFileSystemInitializer<TFileSystem> Initialize<TFileSystem>(this TFileSystem fileSystem, System.Action<Testably.Abstractions.Testing.FileSystemInitializerOptions>? options = null)
             where TFileSystem : System.IO.Abstractions.IFileSystem { }
         public static void InitializeEmbeddedResourcesFromAssembly(this System.IO.Abstractions.IFileSystem fileSystem, string directoryPath, System.Reflection.Assembly assembly, string? relativePath = null, string searchPattern = "*", System.IO.SearchOption searchOption = 1) { }

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/DirectoryCleanerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/DirectoryCleanerTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Testably.Abstractions.Testing.Initializer;

--- a/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/DirectoryCleanerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/FileSystemInitializer/DirectoryCleanerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Testably.Abstractions.Testing.Initializer;
@@ -116,5 +116,60 @@ public class DirectoryCleanerTests
 		string currentDirectory = sut.Directory.GetCurrentDirectory();
 		await That(sut.Directory.Exists(currentDirectory)).IsTrue();
 		await That(receivedLogs).Contains(m => m.Contains($"'{currentDirectory}'", StringComparison.Ordinal));
+	}
+
+	[Test]
+	public async Task CreateEmptyTemporaryDirectory_Dispose_ShouldForceDeleteDirectory()
+	{
+		MockFileSystem sut = new();
+		List<string> receivedLogs = [];
+		IDirectoryCleaner directoryCleaner =
+			sut.CreateEmptyTemporaryDirectory(logger: m => receivedLogs.Add(m));
+		string basePath = directoryCleaner.BasePath;
+
+		directoryCleaner.Dispose();
+
+		await That(sut.Directory.Exists(basePath)).IsFalse();
+		await That(receivedLogs).Contains("Cleanup was successful :-)");
+	}
+
+	[Test]
+	public async Task CreateEmptyTemporaryDirectory_Dispose_ShouldNotChangeCurrentDirectory()
+	{
+		MockFileSystem sut = new();
+		string currentDirectory = sut.Directory.GetCurrentDirectory();
+		IDirectoryCleaner directoryCleaner =
+			sut.CreateEmptyTemporaryDirectory();
+
+		directoryCleaner.Dispose();
+
+		await That(sut.Directory.GetCurrentDirectory()).IsEqualTo(currentDirectory);
+	}
+
+	[Test]
+	public async Task CreateEmptyTemporaryDirectory_ShouldCreateDirectory()
+	{
+		MockFileSystem sut = new();
+		List<string> receivedLogs = [];
+
+		using IDirectoryCleaner directoryCleaner =
+			sut.CreateEmptyTemporaryDirectory(logger: m => receivedLogs.Add(m));
+
+		await That(sut.Statistics.TotalCount).IsEqualTo(0);
+		await That(sut.Directory.Exists(directoryCleaner.BasePath)).IsTrue();
+		await That(receivedLogs).DoesNotContain(m =>
+			m.Contains("as current directory", StringComparison.Ordinal));
+	}
+
+	[Test]
+	public async Task CreateEmptyTemporaryDirectory_ShouldNotChangeCurrentDirectory()
+	{
+		MockFileSystem sut = new();
+		string currentDirectory = sut.Directory.GetCurrentDirectory();
+
+		using IDirectoryCleaner directoryCleaner =
+			sut.CreateEmptyTemporaryDirectory();
+
+		await That(sut.Directory.GetCurrentDirectory()).IsEqualTo(currentDirectory);
 	}
 }


### PR DESCRIPTION
- Extended `DirectoryCleaner` with an optional parameter to avoid changing the current directory.
- Added `CreateEmptyTemporaryDirectory` to `FileSystemInitializerExtensions`.
- Updated tests to validate directory creation and ensure current directory remains unchanged.

Resolves #1023 

There's almost certainly problems in here, but it might be a start