### PR TITLE
feat: bridge `ITimeSystem` to the BCL `System.TimeProvider`

### DIFF
--- a/Feature.Flags.props
+++ b/Feature.Flags.props
@@ -35,6 +35,7 @@
 		<DefineConstants Condition="'$(IS_NET8_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_COMPRESSION_STREAM</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET8_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_STOPWATCH_GETELAPSEDTIME</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET8_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_PERIODIC_TIMER</DefineConstants>
+		<DefineConstants Condition="'$(IS_NET8_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_TIMEPROVIDER</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET9_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_PATH_SPAN</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET9_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_FILE_SPAN</DefineConstants>
 		<DefineConstants Condition="'$(IS_NET9_OR_HIGHER)' == '1'">$(DefineConstants);FEATURE_GUID_V7</DefineConstants>

--- a/Source/Testably.Abstractions.Testing/TimeSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystemExtensions.cs
@@ -1,0 +1,115 @@
+#if FEATURE_TIMEPROVIDER
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ITimer = Testably.Abstractions.TimeSystem.ITimer;
+
+namespace Testably.Abstractions.Testing;
+
+/// <summary>
+///     Extension methods for <see cref="ITimeSystem" />.
+/// </summary>
+public static class TimeSystemExtensions
+{
+	/// <summary>
+	///     Wraps the <paramref name="timeSystem" /> as a <see cref="System.TimeProvider" />, so that it can be injected into
+	///     code that consumes the built-in .NET time abstraction (e.g. the <see cref="System.Threading.PeriodicTimer" />
+	///     or <see cref="System.Threading.CancellationTokenSource" /> constructors that accept a
+	///     <see cref="System.TimeProvider" />, the <c>Task.Delay</c> / <c>Task.WaitAsync</c> overloads, or
+	///     <c>Microsoft.Extensions.*</c>).
+	///     <para />
+	///     When called on a <see cref="MockTimeSystem" />, the returned <see cref="System.TimeProvider" /> is fully
+	///     controllable: advancing the mock clock (e.g. via <see cref="TimeSystem.ITimeProvider.AdvanceBy(TimeSpan)" />) is observable
+	///     through <see cref="System.TimeProvider.GetUtcNow()" /> and <see cref="System.TimeProvider.GetTimestamp()" />.
+	///     <para />
+	///     Timers created through <see cref="System.TimeProvider.CreateTimer(TimerCallback, object, TimeSpan, TimeSpan)" />
+	///     keep firing even when the callback throws (the exception is swallowed), matching a real
+	///     <see cref="Timer" /> regardless of the <see cref="TimeSystem.ITimerStrategy" /> configured on a
+	///     <see cref="MockTimeSystem" />.
+	/// </summary>
+	public static System.TimeProvider ToTimeProvider(this ITimeSystem timeSystem)
+	{
+		ArgumentNullException.ThrowIfNull(timeSystem);
+		return new TimeSystemTimeProvider(timeSystem);
+	}
+
+	private sealed class TimeSystemTimeProvider(ITimeSystem timeSystem) : System.TimeProvider
+	{
+		/// <inheritdoc cref="System.TimeProvider.LocalTimeZone" />
+		public override TimeZoneInfo LocalTimeZone
+		{
+			get
+			{
+				#pragma warning disable MA0026
+				// TODO: https://github.com/Testably/Testably.Abstractions/issues/1039
+				#pragma warning restore MA0026
+				return base.LocalTimeZone;
+			}
+		}
+
+		/// <inheritdoc cref="System.TimeProvider.TimestampFrequency" />
+		public override long TimestampFrequency
+			=> timeSystem.Stopwatch.Frequency;
+
+		/// <inheritdoc cref="System.TimeProvider.CreateTimer(TimerCallback, object, TimeSpan, TimeSpan)" />
+		public override System.Threading.ITimer CreateTimer(
+			TimerCallback callback,
+			object? state,
+			TimeSpan dueTime,
+			TimeSpan period)
+			=> new TimerAdapter(
+				timeSystem.Timer.New(WrapCallback(callback), state, dueTime, period));
+
+		/// <inheritdoc cref="System.TimeProvider.GetTimestamp()" />
+		public override long GetTimestamp()
+			=> timeSystem.Stopwatch.GetTimestamp();
+
+		/// <inheritdoc cref="System.TimeProvider.GetUtcNow()" />
+		public override DateTimeOffset GetUtcNow()
+			=> new(timeSystem.DateTime.UtcNow);
+
+		/// <summary>
+		///     Wraps the <paramref name="callback" /> so that an exception thrown by it is swallowed and does not stop the
+		///     timer. This mirrors a real <see cref="Timer" />, whose schedule keeps firing on subsequent periods regardless
+		///     of a callback exception, and makes the bridged timer behave the same independently of the
+		///     <see cref="TimeSystem.ITimerStrategy" /> configured on a <see cref="MockTimeSystem" />.
+		/// </summary>
+		private static TimerCallback WrapCallback(TimerCallback callback)
+			=> state =>
+			{
+				try
+				{
+					callback(state);
+				}
+				catch (Exception)
+				{
+					// Swallow so the timer keeps firing, matching a real timer whose schedule
+					// is not cancelled by a throwing callback (see ITimerStrategy).
+				}
+			};
+	}
+
+	/// <summary>
+	///     Adapts the <see cref="ITimer" /> of the <see cref="ITimeSystem" /> to the
+	///     <see cref="System.Threading.ITimer" /> expected by <see cref="System.TimeProvider" />.
+	/// </summary>
+	private sealed class TimerAdapter(ITimer timer) : System.Threading.ITimer
+	{
+		#region ITimer Members
+
+		/// <inheritdoc cref="System.Threading.ITimer.Change(TimeSpan, TimeSpan)" />
+		public bool Change(TimeSpan dueTime, TimeSpan period)
+			=> timer.Change(dueTime, period);
+
+		/// <inheritdoc cref="IDisposable.Dispose()" />
+		public void Dispose()
+			=> timer.Dispose();
+
+		/// <inheritdoc cref="IAsyncDisposable.DisposeAsync()" />
+		public ValueTask DisposeAsync()
+			=> timer.DisposeAsync();
+
+		#endregion
+	}
+}
+#endif

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
@@ -183,6 +183,10 @@ namespace Testably.Abstractions.Testing
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
     }
+    public static class TimeSystemExtensions
+    {
+        public static System.TimeProvider ToTimeProvider(this Testably.Abstractions.ITimeSystem timeSystem) { }
+    }
 }
 namespace Testably.Abstractions.Testing.FileSystem
 {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -183,6 +183,10 @@ namespace Testably.Abstractions.Testing
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
     }
+    public static class TimeSystemExtensions
+    {
+        public static System.TimeProvider ToTimeProvider(this Testably.Abstractions.ITimeSystem timeSystem) { }
+    }
 }
 namespace Testably.Abstractions.Testing.FileSystem
 {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
@@ -183,6 +183,10 @@ namespace Testably.Abstractions.Testing
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
     }
+    public static class TimeSystemExtensions
+    {
+        public static System.TimeProvider ToTimeProvider(this Testably.Abstractions.ITimeSystem timeSystem) { }
+    }
 }
 namespace Testably.Abstractions.Testing.FileSystem
 {

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimeSystemExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimeSystemExtensionsTests.cs
@@ -1,0 +1,220 @@
+#if FEATURE_TIMEPROVIDER
+using aweXpect.Chronology;
+using System.Threading;
+
+namespace Testably.Abstractions.Testing.Tests.TimeSystem;
+
+public class TimeSystemExtensionsTests
+{
+	[Test]
+	public async Task ToTimeProvider_AdvanceBy_ShouldBeObservableThroughGetUtcNow()
+	{
+		DateTime now = new(2020, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+		MockTimeSystem timeSystem = new(now);
+		System.TimeProvider provider = timeSystem.ToTimeProvider();
+
+		DateTimeOffset before = provider.GetUtcNow();
+		timeSystem.TimeProvider.AdvanceBy(TimeSpan.FromHours(1));
+		DateTimeOffset after = provider.GetUtcNow();
+
+		await That(after - before).IsEqualTo(TimeSpan.FromHours(1));
+	}
+
+	[Test]
+	public async Task ToTimeProvider_Change_ShouldRescheduleTimer()
+	{
+		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
+		System.TimeProvider provider = timeSystem.ToTimeProvider();
+		CancellationToken token = CreateTimeout(out CancellationTokenSource cts);
+		using CancellationTokenSource _ = cts;
+		using SemaphoreSlim callbackExecuted = new(0);
+
+		using ITimer timer = provider.CreateTimer(
+			// ReSharper disable once AccessToDisposedClosure
+			_ => callbackExecuted.Release(),
+			null,
+			Timeout.InfiniteTimeSpan,
+			Timeout.InfiniteTimeSpan);
+
+		// Never fires while due time is infinite.
+		timeSystem.TimeProvider.AdvanceBy(10.Seconds());
+		await That(callbackExecuted.CurrentCount).IsEqualTo(0);
+
+		bool changed = timer.Change(1.Seconds(), Timeout.InfiniteTimeSpan);
+		await LetTimerSubscribe(token);
+		timeSystem.TimeProvider.AdvanceBy(1.Seconds());
+		await callbackExecuted.WaitAsync(token);
+
+		await That(changed).IsTrue();
+	}
+
+	[Test]
+	public async Task ToTimeProvider_CreateTimer_ShouldFireRepeatedlyForPeriodicTimer()
+	{
+		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
+		System.TimeProvider provider = timeSystem.ToTimeProvider();
+		CancellationToken token = CreateTimeout(out CancellationTokenSource cts);
+		using CancellationTokenSource _ = cts;
+		int count = 0;
+		using SemaphoreSlim callbackExecuted = new(0);
+
+		using ITimer timer = provider.CreateTimer(
+			_ =>
+			{
+				Interlocked.Increment(ref count);
+				// ReSharper disable once AccessToDisposedClosure
+				callbackExecuted.Release();
+			},
+			null,
+			1.Seconds(),
+			1.Seconds());
+
+		for (int i = 0; i < 3; i++)
+		{
+			await LetTimerSubscribe(token);
+			timeSystem.TimeProvider.AdvanceBy(1.Seconds());
+			await callbackExecuted.WaitAsync(token);
+		}
+
+		await That(count).IsGreaterThanOrEqualTo(3);
+	}
+
+	[Test]
+	public async Task ToTimeProvider_CreateTimer_ShouldFireWhenClockAdvances()
+	{
+		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
+		System.TimeProvider provider = timeSystem.ToTimeProvider();
+		using CancellationTokenSource cts = CancellationTokenSource
+			.CreateLinkedTokenSource(TestContext.Current!.Execution.CancellationToken);
+		cts.CancelAfter(30.Seconds());
+		CancellationToken token = cts.Token;
+		using SemaphoreSlim callbackExecuted = new(0);
+		DateTimeOffset observedTime = default;
+
+		DateTimeOffset before = provider.GetUtcNow();
+		using ITimer timer = provider.CreateTimer(
+			_ =>
+			{
+				observedTime = provider.GetUtcNow();
+				// ReSharper disable once AccessToDisposedClosure
+				callbackExecuted.Release();
+			},
+			null,
+			1.Seconds(),
+			Timeout.InfiniteTimeSpan);
+
+		#pragma warning disable MA0166 // Use an overload with a TimeProvider
+		await Task.Delay(50.Milliseconds(), token);
+		#pragma warning restore MA0166
+		timeSystem.TimeProvider.AdvanceBy(2.Seconds());
+		await callbackExecuted.WaitAsync(token);
+
+		await That(observedTime).IsEqualTo(before + 2.Seconds())
+			.Because("the callback observed the advanced mock clock through the bridge");
+	}
+
+	[Test]
+	public async Task ToTimeProvider_DisposeAsync_ShouldStopTimer()
+	{
+		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
+		System.TimeProvider provider = timeSystem.ToTimeProvider();
+		CancellationToken token = CreateTimeout(out CancellationTokenSource cts);
+		using CancellationTokenSource _ = cts;
+		int count = 0;
+
+		ITimer timer = provider.CreateTimer(
+			_ => Interlocked.Increment(ref count),
+			null,
+			1.Seconds(),
+			1.Seconds());
+		await timer.DisposeAsync();
+
+		timeSystem.TimeProvider.AdvanceBy(5.Seconds());
+		#pragma warning disable MA0166 // Use an overload with a TimeProvider
+		// Give any (erroneously) scheduled callback a chance to run before asserting.
+		await Task.Delay(100.Milliseconds(), token);
+		#pragma warning restore MA0166
+
+		await That(count).IsEqualTo(0);
+	}
+
+	[Test]
+	public async Task ToTimeProvider_GetElapsedTime_ShouldMatchAdvancedInterval()
+	{
+		MockTimeSystem timeSystem = new();
+		System.TimeProvider provider = timeSystem.ToTimeProvider();
+
+		long start = provider.GetTimestamp();
+		timeSystem.TimeProvider.AdvanceBy(5.Seconds());
+		TimeSpan elapsed = provider.GetElapsedTime(start);
+
+		await That(elapsed).IsEqualTo(5.Seconds());
+	}
+
+	[Test]
+	public async Task ToTimeProvider_GetLocalNow_ShouldMatchMockDateTimeNow()
+	{
+		DateTime now = new(2020, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
+		timeSystem.TimeProvider.SetTo(now);
+		System.TimeProvider provider = timeSystem.ToTimeProvider();
+
+		DateTimeOffset localNow = provider.GetLocalNow();
+
+		await That(localNow.DateTime).IsEqualTo(timeSystem.DateTime.Now)
+			.Because("GetLocalNow uses the same local time zone as IDateTime.Now");
+	}
+
+	[Test]
+	public async Task ToTimeProvider_GetUtcNow_ShouldReflectMockTime()
+	{
+		DateTime now = new(2020, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+		MockTimeSystem timeSystem = new(now);
+
+		System.TimeProvider provider = timeSystem.ToTimeProvider();
+
+		await That(provider.GetUtcNow()).IsEqualTo(new DateTimeOffset(now));
+	}
+
+	[Test]
+	public async Task ToTimeProvider_Null_ShouldThrowArgumentNullException()
+	{
+		ITimeSystem? timeSystem = null;
+
+		void Act() => timeSystem!.ToTimeProvider();
+
+		await That(Act).ThrowsExactly<ArgumentNullException>()
+			.WithParamName("timeSystem");
+	}
+
+	[Test]
+	public async Task ToTimeProvider_RealTimeSystem_GetUtcNow_ShouldReturnCurrentTime()
+	{
+		RealTimeSystem timeSystem = new();
+		System.TimeProvider provider = timeSystem.ToTimeProvider();
+
+		DateTimeOffset begin = DateTimeOffset.UtcNow;
+		DateTimeOffset result = provider.GetUtcNow();
+		DateTimeOffset end = DateTimeOffset.UtcNow;
+
+		await That(result).IsOnOrAfter(begin).And.IsOnOrBefore(end);
+	}
+
+	private static CancellationToken CreateTimeout(out CancellationTokenSource cts)
+	{
+		cts = CancellationTokenSource
+			.CreateLinkedTokenSource(TestContext.Current!.Execution.CancellationToken);
+		cts.CancelAfter(30.Seconds());
+		return cts.Token;
+	}
+
+	private static async Task LetTimerSubscribe(CancellationToken token)
+	{
+		#pragma warning disable MA0166 // Use an overload with a TimeProvider
+		// Real delay so the background timer can register its time-changed subscription
+		// before the mock clock is advanced.
+		await Task.Delay(50.Milliseconds(), token);
+		#pragma warning restore MA0166
+	}
+}
+#endif

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimeProviderBridgeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimeProviderBridgeTests.cs
@@ -1,0 +1,36 @@
+#if FEATURE_TIMEPROVIDER
+using System.Threading;
+
+namespace Testably.Abstractions.Tests.TimeSystem;
+
+[TimeSystemTests]
+public class TimeProviderBridgeTests(TimeSystemTestData testData) : TimeSystemTestBase(testData)
+{
+	[Test]
+	public async Task ToTimeProvider_ThrowingCallback_ShouldKeepFiring()
+	{
+		System.TimeProvider provider = TimeSystem.ToTimeProvider();
+		int count = 0;
+		using ManualResetEventSlim ms = new();
+
+		using System.Threading.ITimer timer = provider.CreateTimer(
+			_ =>
+			{
+				// ReSharper disable once AccessToDisposedClosure
+				if (Interlocked.Increment(ref count) >= 2)
+				{
+					// ReSharper disable once AccessToDisposedClosure
+					ms.Set();
+				}
+
+				throw new InvalidOperationException("callback failure");
+			},
+			null,
+			TimeSpan.Zero,
+			TimeSpan.FromMilliseconds(50));
+
+		await That(ms.Wait(ExpectSuccess, CancellationToken)).IsTrue();
+		await That(count).IsGreaterThanOrEqualTo(2);
+	}
+}
+#endif


### PR DESCRIPTION
Add an `ITimeSystem.ToTimeProvider()` extension that wraps any time system (in particular a `MockTimeSystem`) as a real `System.TimeProvider`, so it can be injected into code that consumes the built-in .NET time abstraction (`HttpClient`, `System.Threading.Channels`, `Microsoft.Extensions.*`). Advancing the mock clock is observable through `GetUtcNow()` and `GetTimestamp()`, and `CreateTimer(...)` is routed through the mock timer.

The adapter overrides `GetUtcNow`, `GetTimestamp`/`TimestampFrequency` (which keeps the base `GetElapsedTime` correct because the mock stopwatch is self-consistent) and `CreateTimer`, adapting the time system's `ITimer` to `System.Threading.ITimer`. It is gated behind a new `FEATURE_TIMEPROVIDER` flag (net8.0+, where `System.TimeProvider` is intrinsic, so no additional package dependency is required).

Placed in `Testably.Abstractions.Testing` because that project references the interface via a package reference and because the primary use case is feeding mock time into code that already takes `System.TimeProvider`.

Note: `System.TimeProvider` must be fully qualified throughout, because the unqualified name binds to the existing static `Testably.Abstractions.Testing.TimeProvider` factory even from nested namespaces.

---

- *Fixes #1040*