### PR TITLE
refactor!: rename `TimeProvider` to `TimeProviderFactory`

### DIFF
--- a/Docs/pages/docs/time-system/configuring-time.mdx
+++ b/Docs/pages/docs/time-system/configuring-time.mdx
@@ -15,10 +15,10 @@ new MockTimeSystem();
 new MockTimeSystem(new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc));
 
 // 3. Use the host's current wall clock
-new MockTimeSystem(TimeProvider.Now());
+new MockTimeSystem(TimeProviderFactory.Now());
 ```
 
-`TimeProvider.Use(DateTime)`, `TimeProvider.Random()` and `TimeProvider.Now()` all return an `ITimeProviderFactory` you can pass to the `MockTimeSystem` constructor.
+`TimeProviderFactory.Use(DateTime)`, `TimeProviderFactory.Random()` and `TimeProviderFactory.Now()` all return an `ITimeProviderFactory` you can pass to the `MockTimeSystem` constructor.
 
 ## Custom time providers
 

--- a/Source/Testably.Abstractions.Testing/MockFileSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockFileSystem.cs
@@ -143,7 +143,7 @@ public sealed class MockFileSystem : IFileSystem
 		using IDisposable release = FileSystemRegistration.Ignore();
 		RandomSystem =
 			new MockRandomSystem(initialization.RandomProvider ?? RandomProvider.Default());
-		TimeSystem = initialization.TimeSystem ?? new MockTimeSystem(TimeProvider.Now());
+		TimeSystem = initialization.TimeSystem ?? new MockTimeSystem(TimeProviderFactory.Now());
 		_pathMock = new PathMock(this);
 		_storage = new InMemoryStorage(this);
 		ChangeHandler = new ChangeHandler(this, initialization.RecordNotificationHistory);

--- a/Source/Testably.Abstractions.Testing/MockTimeSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockTimeSystem.cs
@@ -40,28 +40,28 @@ public sealed class MockTimeSystem : ITimeSystem
 	/// <summary>
 	///     Initializes the <see cref="MockTimeSystem" /> with a random time.
 	/// </summary>
-	public MockTimeSystem() : this(Testing.TimeProvider.Random(), options => options)
+	public MockTimeSystem() : this(TimeProviderFactory.Random(), options => options)
 	{
 	}
 
 	/// <summary>
 	///     Initializes the <see cref="MockTimeSystem" /> with a random time.
 	/// </summary>
-	public MockTimeSystem(Func<MockTimeSystemOptions, MockTimeSystemOptions> options) : this(Testing.TimeProvider.Random(), options)
+	public MockTimeSystem(Func<MockTimeSystemOptions, MockTimeSystemOptions> options) : this(TimeProviderFactory.Random(), options)
 	{
 	}
 
 	/// <summary>
 	///     Initializes the <see cref="MockTimeSystem" /> with the specified <paramref name="time" />.
 	/// </summary>
-	public MockTimeSystem(DateTime time) : this(Testing.TimeProvider.Use(time), options => options)
+	public MockTimeSystem(DateTime time) : this(TimeProviderFactory.Use(time), options => options)
 	{
 	}
 
 	/// <summary>
 	///     Initializes the <see cref="MockTimeSystem" /> with the specified <paramref name="time" />.
 	/// </summary>
-	public MockTimeSystem(DateTime time, Func<MockTimeSystemOptions, MockTimeSystemOptions> options) : this(Testing.TimeProvider.Use(time), options)
+	public MockTimeSystem(DateTime time, Func<MockTimeSystemOptions, MockTimeSystemOptions> options) : this(TimeProviderFactory.Use(time), options)
 	{
 	}
 
@@ -70,7 +70,7 @@ public sealed class MockTimeSystem : ITimeSystem
 	/// </summary>
 	[Obsolete("Use the constructor with ITimeProviderFactory instead.")]
 	public MockTimeSystem(ITimeProvider timeProvider) : this(
-		new TimeProvider.Factory(_ => timeProvider))
+		new TimeProviderFactory.Factory(_ => timeProvider))
 	{
 	}
 

--- a/Source/Testably.Abstractions.Testing/TimeProvider.cs
+++ b/Source/Testably.Abstractions.Testing/TimeProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Testably.Abstractions.Testing.Helpers;
 using Testably.Abstractions.Testing.TimeSystem;
 
 namespace Testably.Abstractions.Testing;
@@ -7,53 +6,19 @@ namespace Testably.Abstractions.Testing;
 /// <summary>
 ///     <see cref="ITimeProvider" />s for use in the constructor of <see cref="MockTimeSystem" />.
 /// </summary>
+[Obsolete(
+	"Renamed to `TimeProviderFactory` to avoid confusion with the BCL `System.TimeProvider`. This type will be removed in a future major version.")]
 public static class TimeProvider
 {
-	/// <summary>
-	///     Initializes the <see cref="MockTimeSystem.TimeProvider" /> with the current time.
-	/// </summary>
+	/// <inheritdoc cref="TimeProviderFactory.Now()" />
 	public static ITimeProviderFactory Now()
-	{
-		return new Factory(onTimeChanged
-			=> new TimeProviderMock(onTimeChanged, DateTime.UtcNow, "Now"));
-	}
+		=> TimeProviderFactory.Now();
 
-	/// <summary>
-	///     Initializes the <see cref="MockTimeSystem.TimeProvider" /> with a random time.
-	///     <para />
-	///     The random time increments the unix epoch by a random integer of seconds.
-	/// </summary>
+	/// <inheritdoc cref="TimeProviderFactory.Random()" />
 	public static ITimeProviderFactory Random()
-	{
-		#pragma warning disable MA0113 // Use DateTime.UnixEpoch
-		DateTime randomTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)
-			.AddSeconds(RandomFactory.Shared.Next());
-		#pragma warning restore MA0113
-		return new Factory(onTimeChanged
-			=> new TimeProviderMock(onTimeChanged, randomTime, "Random"));
-	}
+		=> TimeProviderFactory.Random();
 
-	/// <summary>
-	///     Initializes the <see cref="MockTimeSystem.TimeProvider" /> with the specified <paramref name="time" />.
-	/// </summary>
-	/// <remarks>
-	///     If the <paramref name="time" /> has Kind DateTimeKind.Unspecified it will be treated as if it had Kind
-	///     DateTimeKind.Utc.
-	/// </remarks>
+	/// <inheritdoc cref="TimeProviderFactory.Use(DateTime)" />
 	public static ITimeProviderFactory Use(DateTime time)
-	{
-		return new Factory(onTimeChanged => new TimeProviderMock(onTimeChanged, time, "Fixed"));
-	}
-
-	internal sealed class Factory(Func<Action<DateTime>, ITimeProvider> createCallback)
-		: ITimeProviderFactory
-	{
-		#region ITimeProviderFactory Members
-
-		/// <inheritdoc cref="ITimeProviderFactory.Create(Action{DateTime})" />
-		public ITimeProvider Create(Action<DateTime> onTimeChanged)
-			=> createCallback(onTimeChanged);
-
-		#endregion
-	}
+		=> TimeProviderFactory.Use(time);
 }

--- a/Source/Testably.Abstractions.Testing/TimeProviderFactory.cs
+++ b/Source/Testably.Abstractions.Testing/TimeProviderFactory.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Testably.Abstractions.Testing.Helpers;
+using Testably.Abstractions.Testing.TimeSystem;
+
+namespace Testably.Abstractions.Testing;
+
+/// <summary>
+///     <see cref="ITimeProvider" />s for use in the constructor of <see cref="MockTimeSystem" />.
+/// </summary>
+public static class TimeProviderFactory
+{
+	/// <summary>
+	///     Initializes the <see cref="MockTimeSystem.TimeProvider" /> with the current time.
+	/// </summary>
+	public static ITimeProviderFactory Now()
+	{
+		return new Factory(onTimeChanged
+			=> new TimeProviderMock(onTimeChanged, DateTime.UtcNow, "Now"));
+	}
+
+	/// <summary>
+	///     Initializes the <see cref="MockTimeSystem.TimeProvider" /> with a random time.
+	///     <para />
+	///     The random time increments the unix epoch by a random integer of seconds.
+	/// </summary>
+	public static ITimeProviderFactory Random()
+	{
+		#pragma warning disable MA0113 // Use DateTime.UnixEpoch
+		DateTime randomTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+			.AddSeconds(RandomFactory.Shared.Next());
+		#pragma warning restore MA0113
+		return new Factory(onTimeChanged
+			=> new TimeProviderMock(onTimeChanged, randomTime, "Random"));
+	}
+
+	/// <summary>
+	///     Initializes the <see cref="MockTimeSystem.TimeProvider" /> with the specified <paramref name="time" />.
+	/// </summary>
+	/// <remarks>
+	///     If the <paramref name="time" /> has Kind DateTimeKind.Unspecified it will be treated as if it had Kind
+	///     DateTimeKind.Utc.
+	/// </remarks>
+	public static ITimeProviderFactory Use(DateTime time)
+	{
+		return new Factory(onTimeChanged => new TimeProviderMock(onTimeChanged, time, "Fixed"));
+	}
+
+	internal sealed class Factory(Func<Action<DateTime>, ITimeProvider> createCallback)
+		: ITimeProviderFactory
+	{
+		#region ITimeProviderFactory Members
+
+		/// <inheritdoc cref="ITimeProviderFactory.Create(Action{DateTime})" />
+		public ITimeProvider Create(Action<DateTime> onTimeChanged)
+			=> createCallback(onTimeChanged);
+
+		#endregion
+	}
+}

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
@@ -177,7 +177,15 @@ namespace Testably.Abstractions.Testing
         MacOS = 2,
         Windows = 3,
     }
+    [System.Obsolete("Renamed to `TimeProviderFactory` to avoid confusion with the BCL `System.TimeProv" +
+        "ider`. This type will be removed in a future major version.")]
     public static class TimeProvider
+    {
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
+    }
+    public static class TimeProviderFactory
     {
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -175,7 +175,15 @@ namespace Testably.Abstractions.Testing
         MacOS = 2,
         Windows = 3,
     }
+    [System.Obsolete("Renamed to `TimeProviderFactory` to avoid confusion with the BCL `System.TimeProv" +
+        "ider`. This type will be removed in a future major version.")]
     public static class TimeProvider
+    {
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
+    }
+    public static class TimeProviderFactory
     {
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -177,7 +177,15 @@ namespace Testably.Abstractions.Testing
         MacOS = 2,
         Windows = 3,
     }
+    [System.Obsolete("Renamed to `TimeProviderFactory` to avoid confusion with the BCL `System.TimeProv" +
+        "ider`. This type will be removed in a future major version.")]
     public static class TimeProvider
+    {
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
+    }
+    public static class TimeProviderFactory
     {
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
@@ -177,7 +177,15 @@ namespace Testably.Abstractions.Testing
         MacOS = 2,
         Windows = 3,
     }
+    [System.Obsolete("Renamed to `TimeProviderFactory` to avoid confusion with the BCL `System.TimeProv" +
+        "ider`. This type will be removed in a future major version.")]
     public static class TimeProvider
+    {
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
+    }
+    public static class TimeProviderFactory
     {
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -170,7 +170,15 @@ namespace Testably.Abstractions.Testing
         MacOS = 2,
         Windows = 3,
     }
+    [System.Obsolete("Renamed to `TimeProviderFactory` to avoid confusion with the BCL `System.TimeProv" +
+        "ider`. This type will be removed in a future major version.")]
     public static class TimeProvider
+    {
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
+    }
+    public static class TimeProviderFactory
     {
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -170,7 +170,15 @@ namespace Testably.Abstractions.Testing
         MacOS = 2,
         Windows = 3,
     }
+    [System.Obsolete("Renamed to `TimeProviderFactory` to avoid confusion with the BCL `System.TimeProv" +
+        "ider`. This type will be removed in a future major version.")]
     public static class TimeProvider
+    {
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
+    }
+    public static class TimeProviderFactory
     {
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/TimeSystemTestsAttribute.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/TimeSystemTestsAttribute.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Testably.Abstractions.Testing;
-using TimeProvider = Testably.Abstractions.Testing.TimeProvider;
 
 namespace Testably.Abstractions.TestHelpers;
 
@@ -18,7 +17,7 @@ public class TimeSystemTestsAttribute(bool disableAutoAdvance = false)
 		{
 			DateTime now = DateTime.UtcNow;
 			return Task.FromResult(
-				new TimeSystemTestData(now, new MockTimeSystem(TimeProvider.Use(now), o =>
+				new TimeSystemTestData(now, new MockTimeSystem(TimeProviderFactory.Use(now), o =>
 				{
 					if (disableAutoAdvance)
 					{

--- a/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockFileSystemInitializationTests.cs
@@ -144,7 +144,7 @@ public class MockFileSystemInitializationTests
 	public async Task UseTimeSystem_ShouldUseProvidedTimeSystem(int offsetSeconds)
 	{
 		DateTime simulatedNow = DateTime.Now.AddSeconds(offsetSeconds);
-		MockTimeSystem timeSystem = new(TimeProvider.Use(simulatedNow));
+		MockTimeSystem timeSystem = new(TimeProviderFactory.Use(simulatedNow));
 		MockFileSystem fileSystem = new(options => options
 			.UseTimeSystem(timeSystem));
 

--- a/Tests/Testably.Abstractions.Testing.Tests/MockTimeSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockTimeSystemTests.cs
@@ -310,7 +310,7 @@ public class MockTimeSystemTests
 	public async Task TimeProvider_StartTime_ShouldBeSetToInitialTime()
 	{
 		DateTime now = TimeTestHelper.GetRandomTime(DateTimeKind.Utc);
-		MockTimeSystem timeSystem = new(TimeProvider.Use(now));
+		MockTimeSystem timeSystem = new(TimeProviderFactory.Use(now));
 
 		timeSystem.TimeProvider.AdvanceBy(TimeSpan.FromMinutes(42));
 
@@ -321,7 +321,7 @@ public class MockTimeSystemTests
 	public async Task ToString_WithFixedContainer_ShouldContainTimeProvider()
 	{
 		DateTime now = TimeTestHelper.GetRandomTime();
-		MockTimeSystem timeSystem = new(TimeProvider.Use(now));
+		MockTimeSystem timeSystem = new(TimeProviderFactory.Use(now));
 
 		string result = timeSystem.ToString();
 
@@ -332,7 +332,7 @@ public class MockTimeSystemTests
 	[Test]
 	public async Task ToString_WithNowContainer_ShouldContainTimeProvider()
 	{
-		MockTimeSystem timeSystem = new(TimeProvider.Now());
+		MockTimeSystem timeSystem = new(TimeProviderFactory.Now());
 
 		string result = timeSystem.ToString();
 
@@ -343,7 +343,7 @@ public class MockTimeSystemTests
 	[Test]
 	public async Task ToString_WithRandomContainer_ShouldContainTimeProvider()
 	{
-		MockTimeSystem timeSystem = new(TimeProvider.Random());
+		MockTimeSystem timeSystem = new(TimeProviderFactory.Random());
 
 		string result = timeSystem.ToString();
 

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeProviderFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeProviderFactoryTests.cs
@@ -1,16 +1,16 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
 using Testably.Abstractions.Testing.TimeSystem;
 
 namespace Testably.Abstractions.Testing.Tests;
 
-public class TimeProviderTests
+public class TimeProviderFactoryTests
 {
 	[Test]
 	public async Task Now_ShouldReturnCurrentDateTime()
 	{
 		DateTime begin = DateTime.UtcNow;
-		ITimeProvider timeProvider = TimeProvider.Now().Create(_ => { });
+		ITimeProvider timeProvider = TimeProviderFactory.Now().Create(_ => { });
 		DateTime end = DateTime.UtcNow;
 
 		DateTime result1 = timeProvider.Read();
@@ -27,7 +27,7 @@ public class TimeProviderTests
 
 		Parallel.For(0, 100, _ =>
 		{
-			results.Add(TimeProvider.Random().Create(_ => { }).Read());
+			results.Add(TimeProviderFactory.Random().Create(_ => { }).Read());
 		});
 
 		await That(results).AreAllUnique();
@@ -37,7 +37,7 @@ public class TimeProviderTests
 	[AutoArguments]
 	public async Task SetTo_ShouldChangeTimeForRead(DateTime time1, DateTime time2)
 	{
-		ITimeProvider timeProvider = TimeProvider.Use(time1).Create(_ => { });
+		ITimeProvider timeProvider = TimeProviderFactory.Use(time1).Create(_ => { });
 
 		DateTime result1 = timeProvider.Read();
 		timeProvider.SetTo(time2);
@@ -51,7 +51,7 @@ public class TimeProviderTests
 	public async Task Use_ShouldReturnFixedDateTime()
 	{
 		DateTime now = TimeTestHelper.GetRandomTime();
-		ITimeProvider timeProvider = TimeProvider.Use(now).Create(_ => { });
+		ITimeProvider timeProvider = TimeProviderFactory.Use(now).Create(_ => { });
 
 		DateTime result1 = timeProvider.Read();
 		DateTime result2 = timeProvider.Read();
@@ -64,8 +64,22 @@ public class TimeProviderTests
 	public async Task Use_UnspecifiedKind_ShouldConvertToUtcDateTime()
 	{
 		DateTime unspecifiedTime = TimeTestHelper.GetRandomTime();
-		ITimeProvider timeProvider = TimeProvider.Use(unspecifiedTime).Create(_ => { });
+		ITimeProvider timeProvider = TimeProviderFactory.Use(unspecifiedTime).Create(_ => { });
 		DateTime result = timeProvider.Read();
 		await That(result).IsEqualTo(DateTime.SpecifyKind(unspecifiedTime, DateTimeKind.Utc));
 	}
+
+#pragma warning disable CS0618 // Type or member is obsolete
+	[Test]
+	public async Task ObsoleteTimeProvider_ShouldForwardToTimeProviderFactory()
+	{
+		DateTime now = TimeTestHelper.GetRandomTime();
+
+		DateTime fixedResult = TimeProvider.Use(now).Create(_ => { }).Read();
+
+		await That(fixedResult).IsEqualTo(DateTime.SpecifyKind(now, DateTimeKind.Utc));
+		await That(TimeProvider.Now()).IsNotNull();
+		await That(TimeProvider.Random()).IsNotNull();
+	}
+#pragma warning restore CS0618
 }


### PR DESCRIPTION
The static `Testably.Abstractions.Testing.TimeProvider` factory shadows the BCL `System.TimeProvider` from within the `Testably.Abstractions.Testing` namespace, which is why the new `ToTimeProvider()` bridge has to fully-qualify `System.TimeProvider` everywhere. Rename it to `TimeProviderFactory`, which also reads more accurately because its `Now()`, `Random()` and `Use()` methods return an `ITimeProviderFactory`.

The old `TimeProvider` type is kept as an `[Obsolete]` shim that forwards to `TimeProviderFactory`, so existing callers keep compiling (with a deprecation warning) until it is removed in a future major version. `ITimeProvider`, `ITimeProviderFactory` and the `MockTimeSystem.TimeProvider` property are intentionally left unchanged, mirroring the `IRandomProvider` / `MockRandomSystem.RandomProvider` naming of the sibling random subsystem.

Migrate the internal call sites and tests to the new name, add a test covering the obsolete shim, and regenerate the public API baselines for all target frameworks.

---

- *Fixes #1040*