### PR TITLE
feat: add support for `TimeZoneInfo` in abstractions

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -20,7 +20,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 	
 	[Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
 	readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;

--- a/Source/Testably.Abstractions.Interface/ITimeSystem.cs
+++ b/Source/Testably.Abstractions.Interface/ITimeSystem.cs
@@ -38,4 +38,9 @@ public interface ITimeSystem
 	///     Abstractions for <see cref="System.Threading.Timer" />.
 	/// </summary>
 	ITimerFactory Timer { get; }
+
+	/// <summary>
+	///     Abstractions for <see cref="System.TimeZoneInfo" />.
+	/// </summary>
+	ITimeZoneInfo TimeZoneInfo { get; }
 }

--- a/Source/Testably.Abstractions.Interface/TimeSystem/ITimeZoneInfo.cs
+++ b/Source/Testably.Abstractions.Interface/TimeSystem/ITimeZoneInfo.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.ObjectModel;
+
+namespace Testably.Abstractions.TimeSystem;
+
+/// <summary>
+///     Abstractions for <see cref="System.TimeZoneInfo" />.
+/// </summary>
+public interface ITimeZoneInfo : ITimeSystemEntity
+{
+	/// <inheritdoc cref="TimeZoneInfo.Local" />
+	TimeZoneInfo Local { get; }
+
+	/// <inheritdoc cref="TimeZoneInfo.Utc" />
+	TimeZoneInfo Utc { get; }
+
+	/// <inheritdoc cref="TimeZoneInfo.FindSystemTimeZoneById(string)" />
+	TimeZoneInfo FindSystemTimeZoneById(string id);
+
+	/// <inheritdoc cref="TimeZoneInfo.GetSystemTimeZones()" />
+	ReadOnlyCollection<TimeZoneInfo> GetSystemTimeZones();
+}

--- a/Source/Testably.Abstractions/RealTimeSystem.cs
+++ b/Source/Testably.Abstractions/RealTimeSystem.cs
@@ -23,6 +23,7 @@ public sealed class RealTimeSystem : ITimeSystem
 		Task = new TaskWrapper(this);
 		Thread = new ThreadWrapper(this);
 		Timer = new TimerFactory(this);
+		TimeZoneInfo = new TimeZoneInfoWrapper(this);
 	}
 
 	#region ITimeSystem Members
@@ -46,6 +47,9 @@ public sealed class RealTimeSystem : ITimeSystem
 
 	/// <inheritdoc cref="ITimeSystem.Timer" />
 	public ITimerFactory Timer { get; }
+
+	/// <inheritdoc cref="ITimeSystem.TimeZoneInfo" />
+	public ITimeZoneInfo TimeZoneInfo { get; }
 
 	#endregion
 }

--- a/Source/Testably.Abstractions/TimeSystem/TimeZoneInfoWrapper.cs
+++ b/Source/Testably.Abstractions/TimeSystem/TimeZoneInfoWrapper.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.ObjectModel;
+
+namespace Testably.Abstractions.TimeSystem;
+
+internal sealed class TimeZoneInfoWrapper : ITimeZoneInfo
+{
+	internal TimeZoneInfoWrapper(RealTimeSystem timeSystem)
+	{
+		TimeSystem = timeSystem;
+	}
+
+	#region ITimeZoneInfo Members
+
+	/// <inheritdoc cref="ITimeZoneInfo.Local" />
+	public TimeZoneInfo Local
+		=> TimeZoneInfo.Local;
+
+	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
+	public ITimeSystem TimeSystem { get; }
+
+	/// <inheritdoc cref="ITimeZoneInfo.Utc" />
+	public TimeZoneInfo Utc
+		=> TimeZoneInfo.Utc;
+
+	/// <inheritdoc cref="ITimeZoneInfo.FindSystemTimeZoneById(string)" />
+	public TimeZoneInfo FindSystemTimeZoneById(string id)
+		=> TimeZoneInfo.FindSystemTimeZoneById(id);
+
+	/// <inheritdoc cref="ITimeZoneInfo.GetSystemTimeZones()" />
+	public ReadOnlyCollection<TimeZoneInfo> GetSystemTimeZones()
+		=> TimeZoneInfo.GetSystemTimeZones();
+
+	#endregion
+}

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net10.0.txt
@@ -31,6 +31,7 @@ namespace Testably.Abstractions
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }
+        public Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         public Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
     }
 }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net6.0.txt
@@ -30,6 +30,7 @@ namespace Testably.Abstractions
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }
+        public Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         public Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
     }
 }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net8.0.txt
@@ -31,6 +31,7 @@ namespace Testably.Abstractions
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }
+        public Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         public Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
     }
 }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net9.0.txt
@@ -31,6 +31,7 @@ namespace Testably.Abstractions
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }
+        public Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         public Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
     }
 }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.0.txt
@@ -30,6 +30,7 @@ namespace Testably.Abstractions
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }
+        public Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         public Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
     }
 }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.1.txt
@@ -30,6 +30,7 @@ namespace Testably.Abstractions
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }
+        public Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         public Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
     }
 }

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net10.0.txt
@@ -71,6 +71,7 @@ namespace Testably.Abstractions
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
         Testably.Abstractions.TimeSystem.IThread Thread { get; }
+        Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
     }
 }
@@ -189,6 +190,13 @@ namespace Testably.Abstractions.TimeSystem
     public interface ITimeSystemEntity
     {
         Testably.Abstractions.ITimeSystem TimeSystem { get; }
+    }
+    public interface ITimeZoneInfo : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.TimeZoneInfo Local { get; }
+        System.TimeZoneInfo Utc { get; }
+        System.TimeZoneInfo FindSystemTimeZoneById(string id);
+        System.Collections.ObjectModel.ReadOnlyCollection<System.TimeZoneInfo> GetSystemTimeZones();
     }
     public interface ITimer : System.IAsyncDisposable, System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net6.0.txt
@@ -52,6 +52,7 @@ namespace Testably.Abstractions
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
         Testably.Abstractions.TimeSystem.IThread Thread { get; }
+        Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
     }
 }
@@ -140,6 +141,13 @@ namespace Testably.Abstractions.TimeSystem
     public interface ITimeSystemEntity
     {
         Testably.Abstractions.ITimeSystem TimeSystem { get; }
+    }
+    public interface ITimeZoneInfo : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.TimeZoneInfo Local { get; }
+        System.TimeZoneInfo Utc { get; }
+        System.TimeZoneInfo FindSystemTimeZoneById(string id);
+        System.Collections.ObjectModel.ReadOnlyCollection<System.TimeZoneInfo> GetSystemTimeZones();
     }
     public interface ITimer : System.IAsyncDisposable, System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net8.0.txt
@@ -62,6 +62,7 @@ namespace Testably.Abstractions
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
         Testably.Abstractions.TimeSystem.IThread Thread { get; }
+        Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
     }
 }
@@ -171,6 +172,13 @@ namespace Testably.Abstractions.TimeSystem
     public interface ITimeSystemEntity
     {
         Testably.Abstractions.ITimeSystem TimeSystem { get; }
+    }
+    public interface ITimeZoneInfo : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.TimeZoneInfo Local { get; }
+        System.TimeZoneInfo Utc { get; }
+        System.TimeZoneInfo FindSystemTimeZoneById(string id);
+        System.Collections.ObjectModel.ReadOnlyCollection<System.TimeZoneInfo> GetSystemTimeZones();
     }
     public interface ITimer : System.IAsyncDisposable, System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net9.0.txt
@@ -64,6 +64,7 @@ namespace Testably.Abstractions
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
         Testably.Abstractions.TimeSystem.IThread Thread { get; }
+        Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
     }
 }
@@ -175,6 +176,13 @@ namespace Testably.Abstractions.TimeSystem
     public interface ITimeSystemEntity
     {
         Testably.Abstractions.ITimeSystem TimeSystem { get; }
+    }
+    public interface ITimeZoneInfo : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.TimeZoneInfo Local { get; }
+        System.TimeZoneInfo Utc { get; }
+        System.TimeZoneInfo FindSystemTimeZoneById(string id);
+        System.Collections.ObjectModel.ReadOnlyCollection<System.TimeZoneInfo> GetSystemTimeZones();
     }
     public interface ITimer : System.IAsyncDisposable, System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.0.txt
@@ -39,6 +39,7 @@ namespace Testably.Abstractions
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
         Testably.Abstractions.TimeSystem.IThread Thread { get; }
+        Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
     }
 }
@@ -114,6 +115,13 @@ namespace Testably.Abstractions.TimeSystem
     public interface ITimeSystemEntity
     {
         Testably.Abstractions.ITimeSystem TimeSystem { get; }
+    }
+    public interface ITimeZoneInfo : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.TimeZoneInfo Local { get; }
+        System.TimeZoneInfo Utc { get; }
+        System.TimeZoneInfo FindSystemTimeZoneById(string id);
+        System.Collections.ObjectModel.ReadOnlyCollection<System.TimeZoneInfo> GetSystemTimeZones();
     }
     public interface ITimer : System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.1.txt
@@ -48,6 +48,7 @@ namespace Testably.Abstractions
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
         Testably.Abstractions.TimeSystem.IThread Thread { get; }
+        Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
     }
 }
@@ -132,6 +133,13 @@ namespace Testably.Abstractions.TimeSystem
     public interface ITimeSystemEntity
     {
         Testably.Abstractions.ITimeSystem TimeSystem { get; }
+    }
+    public interface ITimeZoneInfo : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.TimeZoneInfo Local { get; }
+        System.TimeZoneInfo Utc { get; }
+        System.TimeZoneInfo FindSystemTimeZoneById(string id);
+        System.Collections.ObjectModel.ReadOnlyCollection<System.TimeZoneInfo> GetSystemTimeZones();
     }
     public interface ITimer : System.IAsyncDisposable, System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Testably.Abstractions.Parity.Tests/ParityTests.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/ParityTests.cs
@@ -166,6 +166,16 @@ public abstract class ParityTests(
 	}
 
 	[Test]
+	public async Task ITimeZoneInfo_EnsureParityWith_TimeZoneInfo()
+	{
+		List<string> parityErrors = Parity.TimeZoneInfo
+			.GetErrorsToStaticType<ITimeZoneInfo>(
+				typeof(TimeZoneInfo));
+
+		await That(parityErrors).IsEmpty();
+	}
+
+	[Test]
 	public async Task IZipArchive_EnsureParityWith_ZipArchive()
 	{
 		List<string> parityErrors = Parity.ZipArchive

--- a/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/Parity.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/Parity.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Threading;
 
 namespace Testably.Abstractions.Parity.Tests.TestHelpers;
@@ -104,6 +105,21 @@ public class Parity
 				typeof(uint),
 			]),
 		]);
+
+	public ParityCheck TimeZoneInfo { get; } = new(excludeMethods:
+	[
+		typeof(TimeZoneInfo).GetMethod(nameof(System.TimeZoneInfo.ClearCachedData)),
+		typeof(TimeZoneInfo).GetMethod(nameof(System.TimeZoneInfo.FromSerializedString)),
+		..typeof(TimeZoneInfo).GetMethods().Where(x => string.Equals(x.Name, nameof(System.TimeZoneInfo.ConvertTime), StringComparison.Ordinal)),
+		..typeof(TimeZoneInfo).GetMethods().Where(x => string.Equals(x.Name, nameof(System.TimeZoneInfo.ConvertTimeBySystemTimeZoneId), StringComparison.Ordinal)),
+		..typeof(TimeZoneInfo).GetMethods().Where(x => string.Equals(x.Name, nameof(System.TimeZoneInfo.ConvertTimeFromUtc), StringComparison.Ordinal)),
+		..typeof(TimeZoneInfo).GetMethods().Where(x => string.Equals(x.Name, nameof(System.TimeZoneInfo.ConvertTimeToUtc), StringComparison.Ordinal)),
+		..typeof(TimeZoneInfo).GetMethods().Where(x => string.Equals(x.Name, nameof(System.TimeZoneInfo.CreateCustomTimeZone), StringComparison.Ordinal)),
+		..typeof(TimeZoneInfo).GetMethods().Where(x => string.Equals(x.Name, "GetSystemTimeZones", StringComparison.Ordinal) && x.GetParameters().Length > 0),
+		..typeof(TimeZoneInfo).GetMethods().Where(x => string.Equals(x.Name, "TryConvertIanaIdToWindowsId", StringComparison.Ordinal)),
+		..typeof(TimeZoneInfo).GetMethods().Where(x => string.Equals(x.Name, "TryConvertWindowsIdToIanaId", StringComparison.Ordinal)),
+		..typeof(TimeZoneInfo).GetMethods().Where(x => string.Equals(x.Name, "TryFindSystemTimeZoneById", StringComparison.Ordinal)),
+	]);
 
 	public ParityCheck ZipArchive { get; } = new();
 


### PR DESCRIPTION
Introduces a new time-system abstraction for `System.TimeZoneInfo`, aligning it with the existing `ITimeSystem` pattern and extending parity tests to cover the new API.

- Introduces `ITimeZoneInfo` (exposing the environment-coupled statics `Local`, `Utc`, `FindSystemTimeZoneById` and `GetSystemTimeZones`) and wires it into `ITimeSystem`.
- Implements real-time support via `TimeZoneInfoWrapper` and exposes it from `RealTimeSystem`.
- Extends parity test helpers/tests to validate the abstraction against `System.TimeZoneInfo` (with static-method exclusions for the members that are intentionally not abstracted).