### PR TITLE
feat: add `DateTimeOffset` support to `ITimeSystem`

### DIFF
--- a/Docs/pages/docs/time-system/index.mdx
+++ b/Docs/pages/docs/time-system/index.mdx
@@ -11,6 +11,7 @@ title: Time system
 | Sub-property      | Wraps                                                                                                                         |
 |-------------------|-------------------------------------------------------------------------------------------------------------------------------|
 | `DateTime`        | `DateTime.Now`, `DateTime.UtcNow`, `DateTime.Today` (plus `MinValue`, `MaxValue`, `UnixEpoch`)                                |
+| `DateTimeOffset`  | `DateTimeOffset.Now`, `DateTimeOffset.UtcNow` (plus `MinValue`, `MaxValue`, `UnixEpoch`)                                      |
 | `Stopwatch`       | [`System.Diagnostics.Stopwatch`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.stopwatch)                   |
 | `Task`            | [`Task.Delay`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.delay)                                |
 | `Thread`          | [`Thread.Sleep`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.thread.sleep)                                  |

--- a/Docs/pages/docs/time-system/notifications.mdx
+++ b/Docs/pages/docs/time-system/notifications.mdx
@@ -25,6 +25,7 @@ Like the file-system [notifications](../file-system/intercept-and-notify), each 
 | Method on `On`     | Fires when                                              | `T`         |
 |--------------------|---------------------------------------------------------|-------------|
 | `DateTimeRead()`   | `DateTime.Now`, `UtcNow` or `Today` is read             | `DateTime`  |
+| `DateTimeOffsetRead()` | `DateTimeOffset.Now` or `UtcNow` is read            | `DateTimeOffset` |
 | `TaskDelay()`      | `Task.Delay` (any overload) is called                   | `TimeSpan`  |
 | `ThreadSleep()`    | `Thread.Sleep` (any overload) is called                 | `TimeSpan`  |
 | `TimeChanged()`    | the simulated time advanced (auto-advance or manual)    | `DateTime`  |

--- a/Source/Testably.Abstractions.AccessControl/Testably.Abstractions.AccessControl.csproj
+++ b/Source/Testably.Abstractions.AccessControl/Testably.Abstractions.AccessControl.csproj
@@ -16,8 +16,12 @@
 		<PackageReference Include="System.IO.FileSystem.AccessControl" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition=" '$(Configuration)' != 'Debug' ">
 		<PackageReference Include="Testably.Abstractions.Interface" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+		<ProjectReference Include="..\Testably.Abstractions.Interface\Testably.Abstractions.Interface.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Testably.Abstractions.Compression/Testably.Abstractions.Compression.csproj
+++ b/Source/Testably.Abstractions.Compression/Testably.Abstractions.Compression.csproj
@@ -12,8 +12,12 @@
 		      Link="Docs\Compression.md" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition=" '$(Configuration)' != 'Debug' ">
 		<PackageReference Include="Testably.Abstractions.Interface" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+		<ProjectReference Include="..\Testably.Abstractions.Interface\Testably.Abstractions.Interface.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Testably.Abstractions.Interface/ITimeSystem.cs
+++ b/Source/Testably.Abstractions.Interface/ITimeSystem.cs
@@ -12,6 +12,11 @@ public interface ITimeSystem
 	/// </summary>
 	IDateTime DateTime { get; }
 
+	/// <summary>
+	///     Abstractions for <see cref="System.DateTimeOffset" />.
+	/// </summary>
+	IDateTimeOffset DateTimeOffset { get; }
+
 #if FEATURE_PERIODIC_TIMER
 	/// <summary>
 	///     Abstractions for <see cref="System.Threading.PeriodicTimer" />.

--- a/Source/Testably.Abstractions.Interface/TimeSystem/IDateTimeOffset.cs
+++ b/Source/Testably.Abstractions.Interface/TimeSystem/IDateTimeOffset.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Testably.Abstractions.TimeSystem;
+
+/// <summary>
+///     Abstractions for <see cref="DateTimeOffset" />.
+/// </summary>
+public interface IDateTimeOffset : ITimeSystemEntity
+{
+	/// <inheritdoc cref="DateTimeOffset.MaxValue" />
+	DateTimeOffset MaxValue { get; }
+
+	/// <inheritdoc cref="DateTimeOffset.MinValue" />
+	DateTimeOffset MinValue { get; }
+
+#pragma warning disable MA0202 // Branches differ only in XML doc comments
+#if NETSTANDARD2_0
+	/// <summary>
+	///     The value of this constant is equivalent to 00:00:00.0000000 UTC, January 1, 1970, in the Gregorian calendar.
+	///     <see cref="UnixEpoch" /> defines the point in time when Unix time is equal to 0.
+	/// </summary>
+	DateTimeOffset UnixEpoch { get; }
+#else
+	/// <inheritdoc cref="DateTimeOffset.UnixEpoch" />
+	DateTimeOffset UnixEpoch { get; }
+#endif
+#pragma warning restore MA0202
+
+	/// <inheritdoc cref="DateTimeOffset.Now" />
+	DateTimeOffset Now { get; }
+
+	/// <inheritdoc cref="DateTimeOffset.UtcNow" />
+	DateTimeOffset UtcNow { get; }
+}

--- a/Source/Testably.Abstractions.Testing/MockTimeSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockTimeSystem.cs
@@ -29,6 +29,7 @@ public sealed class MockTimeSystem : ITimeSystem
 
 	private readonly NotificationHandler _callbackHandler;
 	private readonly DateTimeMock _dateTimeMock;
+	private readonly DateTimeOffsetMock _dateTimeOffsetMock;
 	private readonly StopwatchFactoryMock _stopwatchFactoryMock;
 	private readonly TaskMock _taskMock;
 	private readonly ThreadMock _threadMock;
@@ -92,6 +93,7 @@ public sealed class MockTimeSystem : ITimeSystem
 		_callbackHandler = new NotificationHandler(this);
 		TimeProvider = timeProvider.Create(_callbackHandler.InvokeTimeChanged);
 		_dateTimeMock = new DateTimeMock(this, _callbackHandler);
+		_dateTimeOffsetMock = new DateTimeOffsetMock(this, _callbackHandler);
 		_stopwatchFactoryMock = new StopwatchFactoryMock(this);
 		_threadMock = new ThreadMock(this, _callbackHandler, initialization.AutoAdvance);
 		_taskMock = new TaskMock(this, _callbackHandler, initialization.AutoAdvance);
@@ -106,6 +108,10 @@ public sealed class MockTimeSystem : ITimeSystem
 	/// <inheritdoc cref="ITimeSystem.DateTime" />
 	public IDateTime DateTime
 		=> _dateTimeMock;
+
+	/// <inheritdoc cref="ITimeSystem.DateTimeOffset" />
+	public IDateTimeOffset DateTimeOffset
+		=> _dateTimeOffsetMock;
 
 #if FEATURE_PERIODIC_TIMER
 	/// <inheritdoc cref="ITimeSystem.PeriodicTimer" />

--- a/Source/Testably.Abstractions.Testing/Testably.Abstractions.Testing.csproj
+++ b/Source/Testably.Abstractions.Testing/Testably.Abstractions.Testing.csproj
@@ -9,8 +9,12 @@
 		<None Include="$(SolutionDir)Docs/Nuget/Testing.md" Pack="true" PackagePath="/Docs/" Link="Docs\Testing.md" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition=" '$(Configuration)' != 'Debug' ">
 		<PackageReference Include="Testably.Abstractions.Interface" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+		<ProjectReference Include="..\Testably.Abstractions.Interface\Testably.Abstractions.Interface.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Testably.Abstractions.Testing/TimeSystem/DateTimeOffsetMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/DateTimeOffsetMock.cs
@@ -1,0 +1,59 @@
+using System;
+using Testably.Abstractions.TimeSystem;
+
+namespace Testably.Abstractions.Testing.TimeSystem;
+
+internal sealed class DateTimeOffsetMock : IDateTimeOffset
+{
+	private readonly NotificationHandler _callbackHandler;
+	private readonly MockTimeSystem _mockTimeSystem;
+
+	internal DateTimeOffsetMock(MockTimeSystem timeSystem,
+		NotificationHandler callbackHandler)
+	{
+		_mockTimeSystem = timeSystem;
+		_callbackHandler = callbackHandler;
+	}
+
+	#region IDateTimeOffset Members
+
+	/// <inheritdoc cref="IDateTimeOffset.MaxValue" />
+	public DateTimeOffset MaxValue
+		=> new(_mockTimeSystem.TimeProvider.MaxValue.Ticks, TimeSpan.Zero);
+
+	/// <inheritdoc cref="IDateTimeOffset.MinValue" />
+	public DateTimeOffset MinValue
+		=> new(_mockTimeSystem.TimeProvider.MinValue.Ticks, TimeSpan.Zero);
+
+	/// <inheritdoc cref="IDateTimeOffset.Now" />
+	public DateTimeOffset Now
+	{
+		get
+		{
+			DateTimeOffset value = new(_mockTimeSystem.TimeProvider.Read().ToLocalTime());
+			_callbackHandler.InvokeDateTimeOffsetReadCallbacks(value);
+			return value;
+		}
+	}
+
+	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
+	public ITimeSystem TimeSystem
+		=> _mockTimeSystem;
+
+	/// <inheritdoc cref="IDateTimeOffset.UnixEpoch" />
+	public DateTimeOffset UnixEpoch
+		=> new(_mockTimeSystem.TimeProvider.UnixEpoch.Ticks, TimeSpan.Zero);
+
+	/// <inheritdoc cref="IDateTimeOffset.UtcNow" />
+	public DateTimeOffset UtcNow
+	{
+		get
+		{
+			DateTimeOffset value = new(_mockTimeSystem.TimeProvider.Read().ToUniversalTime());
+			_callbackHandler.InvokeDateTimeOffsetReadCallbacks(value);
+			return value;
+		}
+	}
+
+	#endregion
+}

--- a/Source/Testably.Abstractions.Testing/TimeSystem/INotificationHandler.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/INotificationHandler.cs
@@ -35,6 +35,23 @@ public interface INotificationHandler
 		Func<DateTime, bool>? predicate = null);
 
 	/// <summary>
+	///     Callback executed when any of the following <c>DateTimeOffset</c> read methods is called:<br />
+	///     - <see cref="IDateTimeOffset.Now" /><br />
+	///     - <see cref="IDateTimeOffset.UtcNow" />
+	/// </summary>
+	/// <param name="callback">
+	///     (optional) The callback to execute after <c>DateTimeOffset</c> was read.
+	/// </param>
+	/// <param name="predicate">
+	///     (optional) A predicate used to filter which callbacks should be notified.<br />
+	///     If set to <see langword="null" /> (default value) all callbacks are notified.
+	/// </param>
+	/// <returns>A <see cref="IAwaitableCallback{DateTimeOffset}" /> to un-register the callback on dispose.</returns>
+	IAwaitableCallback<DateTimeOffset> DateTimeOffsetRead(
+		Action<DateTimeOffset>? callback = null,
+		Func<DateTimeOffset, bool>? predicate = null);
+
+	/// <summary>
 	///     Callback executed when any of the following <c>Task.Delay</c> overloads is called:<br />
 	///     - <see cref="ITask.Delay(TimeSpan)" /><br />
 	///     - <see cref="ITask.Delay(TimeSpan, CancellationToken)" /><br />

--- a/Source/Testably.Abstractions.Testing/TimeSystem/NotificationHandler.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/NotificationHandler.cs
@@ -15,6 +15,9 @@ internal sealed class NotificationHandler(MockTimeSystem mockTimeSystem)
 	private readonly Notification.INotificationFactory<DateTime>
 		_dateTimeReadCallbacks = Notification.CreateFactory<DateTime>();
 
+	private readonly Notification.INotificationFactory<DateTimeOffset>
+		_dateTimeOffsetReadCallbacks = Notification.CreateFactory<DateTimeOffset>();
+
 #if FEATURE_PERIODIC_TIMER
 	private readonly Notification.INotificationFactory<IPeriodicTimer>
 		_periodicTimerWaitingForNextTickCallbacks = Notification.CreateFactory<IPeriodicTimer>();
@@ -41,6 +44,12 @@ internal sealed class NotificationHandler(MockTimeSystem mockTimeSystem)
 		Action<DateTime>? callback = null,
 		Func<DateTime, bool>? predicate = null)
 		=> _dateTimeReadCallbacks.RegisterCallback(callback, predicate);
+
+	/// <inheritdoc cref="INotificationHandler.DateTimeOffsetRead(Action{DateTimeOffset}?, Func{DateTimeOffset, bool}?)" />
+	public IAwaitableCallback<DateTimeOffset> DateTimeOffsetRead(
+		Action<DateTimeOffset>? callback = null,
+		Func<DateTimeOffset, bool>? predicate = null)
+		=> _dateTimeOffsetReadCallbacks.RegisterCallback(callback, predicate);
 
 	/// <inheritdoc cref="INotificationHandler.TaskDelay(Action{TimeSpan}?, Func{TimeSpan, bool}?)" />
 	public IAwaitableCallback<TimeSpan> TaskDelay(
@@ -78,6 +87,9 @@ internal sealed class NotificationHandler(MockTimeSystem mockTimeSystem)
 
 	public void InvokeDateTimeReadCallbacks(DateTime now)
 		=> _dateTimeReadCallbacks.InvokeCallbacks(now);
+
+	public void InvokeDateTimeOffsetReadCallbacks(DateTimeOffset now)
+		=> _dateTimeOffsetReadCallbacks.InvokeCallbacks(now);
 
 #if FEATURE_PERIODIC_TIMER
 	public void InvokePeriodicTimerWaitingForNextTick(IPeriodicTimer timer)

--- a/Source/Testably.Abstractions/RealTimeSystem.cs
+++ b/Source/Testably.Abstractions/RealTimeSystem.cs
@@ -16,6 +16,7 @@ public sealed class RealTimeSystem : ITimeSystem
 	public RealTimeSystem()
 	{
 		DateTime = new DateTimeWrapper(this);
+		DateTimeOffset = new DateTimeOffsetWrapper(this);
 #if FEATURE_PERIODIC_TIMER
 		PeriodicTimer = new PeriodicTimerFactory(this);
 #endif
@@ -29,6 +30,9 @@ public sealed class RealTimeSystem : ITimeSystem
 
 	/// <inheritdoc cref="ITimeSystem.DateTime" />
 	public IDateTime DateTime { get; }
+
+	/// <inheritdoc cref="ITimeSystem.DateTimeOffset" />
+	public IDateTimeOffset DateTimeOffset { get; }
 
 #if FEATURE_PERIODIC_TIMER
 	/// <inheritdoc cref="ITimeSystem.PeriodicTimer" />

--- a/Source/Testably.Abstractions/TimeSystem/DateTimeOffsetWrapper.cs
+++ b/Source/Testably.Abstractions/TimeSystem/DateTimeOffsetWrapper.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Testably.Abstractions.TimeSystem;
+
+internal sealed class DateTimeOffsetWrapper : IDateTimeOffset
+{
+	internal DateTimeOffsetWrapper(RealTimeSystem timeSystem)
+	{
+		TimeSystem = timeSystem;
+	}
+
+	#region IDateTimeOffset Members
+
+	/// <inheritdoc cref="IDateTimeOffset.MaxValue" />
+	public DateTimeOffset MaxValue
+		=> DateTimeOffset.MaxValue;
+
+	/// <inheritdoc cref="IDateTimeOffset.MinValue" />
+	public DateTimeOffset MinValue
+		=> DateTimeOffset.MinValue;
+
+#if NETSTANDARD2_0
+	/// <inheritdoc cref="IDateTimeOffset.UnixEpoch" />
+	public DateTimeOffset UnixEpoch
+		=> new(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+#else
+	/// <inheritdoc cref="IDateTimeOffset.UnixEpoch" />
+	public DateTimeOffset UnixEpoch
+		=> DateTimeOffset.UnixEpoch;
+#endif
+
+	/// <inheritdoc cref="IDateTimeOffset.Now" />
+	public DateTimeOffset Now
+		=> DateTimeOffset.Now;
+
+	/// <inheritdoc cref="IDateTimeOffset.UtcNow" />
+	public DateTimeOffset UtcNow
+		=> DateTimeOffset.UtcNow;
+
+	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
+	public ITimeSystem TimeSystem { get; }
+
+	#endregion
+}

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
@@ -113,6 +113,7 @@ namespace Testably.Abstractions.Testing
         public MockTimeSystem(System.DateTime time, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public MockTimeSystem(Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory timeProvider, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.Testing.TimeSystem.INotificationHandler On { get; }
         public Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
@@ -458,6 +459,7 @@ namespace Testably.Abstractions.Testing.TimeSystem
     public interface INotificationHandler
     {
         Testably.Abstractions.Testing.TimeSystem.IPeriodicTimerNotificationHandler PeriodicTimer { get; }
+        Testably.Abstractions.Testing.IAwaitableCallback<System.DateTimeOffset> DateTimeOffsetRead(System.Action<System.DateTimeOffset>? callback = null, System.Func<System.DateTimeOffset, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> DateTimeRead(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> TaskDelay(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> ThreadSleep(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -112,6 +112,7 @@ namespace Testably.Abstractions.Testing
         public MockTimeSystem(System.DateTime time, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public MockTimeSystem(Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory timeProvider, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.Testing.TimeSystem.INotificationHandler On { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
@@ -442,6 +443,7 @@ namespace Testably.Abstractions.Testing.TimeSystem
 {
     public interface INotificationHandler
     {
+        Testably.Abstractions.Testing.IAwaitableCallback<System.DateTimeOffset> DateTimeOffsetRead(System.Action<System.DateTimeOffset>? callback = null, System.Func<System.DateTimeOffset, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> DateTimeRead(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> TaskDelay(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> ThreadSleep(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -113,6 +113,7 @@ namespace Testably.Abstractions.Testing
         public MockTimeSystem(System.DateTime time, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public MockTimeSystem(Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory timeProvider, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.Testing.TimeSystem.INotificationHandler On { get; }
         public Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
@@ -458,6 +459,7 @@ namespace Testably.Abstractions.Testing.TimeSystem
     public interface INotificationHandler
     {
         Testably.Abstractions.Testing.TimeSystem.IPeriodicTimerNotificationHandler PeriodicTimer { get; }
+        Testably.Abstractions.Testing.IAwaitableCallback<System.DateTimeOffset> DateTimeOffsetRead(System.Action<System.DateTimeOffset>? callback = null, System.Func<System.DateTimeOffset, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> DateTimeRead(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> TaskDelay(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> ThreadSleep(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
@@ -113,6 +113,7 @@ namespace Testably.Abstractions.Testing
         public MockTimeSystem(System.DateTime time, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public MockTimeSystem(Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory timeProvider, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.Testing.TimeSystem.INotificationHandler On { get; }
         public Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
@@ -458,6 +459,7 @@ namespace Testably.Abstractions.Testing.TimeSystem
     public interface INotificationHandler
     {
         Testably.Abstractions.Testing.TimeSystem.IPeriodicTimerNotificationHandler PeriodicTimer { get; }
+        Testably.Abstractions.Testing.IAwaitableCallback<System.DateTimeOffset> DateTimeOffsetRead(System.Action<System.DateTimeOffset>? callback = null, System.Func<System.DateTimeOffset, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> DateTimeRead(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> TaskDelay(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> ThreadSleep(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -107,6 +107,7 @@ namespace Testably.Abstractions.Testing
         public MockTimeSystem(System.DateTime time, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public MockTimeSystem(Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory timeProvider, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.Testing.TimeSystem.INotificationHandler On { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
@@ -422,6 +423,7 @@ namespace Testably.Abstractions.Testing.TimeSystem
 {
     public interface INotificationHandler
     {
+        Testably.Abstractions.Testing.IAwaitableCallback<System.DateTimeOffset> DateTimeOffsetRead(System.Action<System.DateTimeOffset>? callback = null, System.Func<System.DateTimeOffset, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> DateTimeRead(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> TaskDelay(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> ThreadSleep(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -107,6 +107,7 @@ namespace Testably.Abstractions.Testing
         public MockTimeSystem(System.DateTime time, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public MockTimeSystem(Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory timeProvider, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.Testing.TimeSystem.INotificationHandler On { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
@@ -435,6 +436,7 @@ namespace Testably.Abstractions.Testing.TimeSystem
 {
     public interface INotificationHandler
     {
+        Testably.Abstractions.Testing.IAwaitableCallback<System.DateTimeOffset> DateTimeOffsetRead(System.Action<System.DateTimeOffset>? callback = null, System.Func<System.DateTimeOffset, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.DateTime> DateTimeRead(System.Action<System.DateTime>? callback = null, System.Func<System.DateTime, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> TaskDelay(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);
         Testably.Abstractions.Testing.IAwaitableCallback<System.TimeSpan> ThreadSleep(System.Action<System.TimeSpan>? callback = null, System.Func<System.TimeSpan, bool>? predicate = null);

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net10.0.txt
@@ -27,6 +27,7 @@ namespace Testably.Abstractions
     {
         public RealTimeSystem() { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net6.0.txt
@@ -27,6 +27,7 @@ namespace Testably.Abstractions
     {
         public RealTimeSystem() { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net8.0.txt
@@ -27,6 +27,7 @@ namespace Testably.Abstractions
     {
         public RealTimeSystem() { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net9.0.txt
@@ -27,6 +27,7 @@ namespace Testably.Abstractions
     {
         public RealTimeSystem() { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.0.txt
@@ -27,6 +27,7 @@ namespace Testably.Abstractions
     {
         public RealTimeSystem() { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.1.txt
@@ -27,6 +27,7 @@ namespace Testably.Abstractions
     {
         public RealTimeSystem() { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net10.0.txt
@@ -67,6 +67,7 @@ namespace Testably.Abstractions
     public interface ITimeSystem
     {
         Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
@@ -141,6 +142,14 @@ namespace Testably.Abstractions.TimeSystem
         System.DateTime Today { get; }
         System.DateTime UnixEpoch { get; }
         System.DateTime UtcNow { get; }
+    }
+    public interface IDateTimeOffset : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.DateTimeOffset MaxValue { get; }
+        System.DateTimeOffset MinValue { get; }
+        System.DateTimeOffset Now { get; }
+        System.DateTimeOffset UnixEpoch { get; }
+        System.DateTimeOffset UtcNow { get; }
     }
     public interface IPeriodicTimer : System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net6.0.txt
@@ -49,6 +49,7 @@ namespace Testably.Abstractions
     public interface ITimeSystem
     {
         Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
         Testably.Abstractions.TimeSystem.IThread Thread { get; }
@@ -104,6 +105,14 @@ namespace Testably.Abstractions.TimeSystem
         System.DateTime Today { get; }
         System.DateTime UnixEpoch { get; }
         System.DateTime UtcNow { get; }
+    }
+    public interface IDateTimeOffset : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.DateTimeOffset MaxValue { get; }
+        System.DateTimeOffset MinValue { get; }
+        System.DateTimeOffset Now { get; }
+        System.DateTimeOffset UnixEpoch { get; }
+        System.DateTimeOffset UtcNow { get; }
     }
     public interface IStopwatch : Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net8.0.txt
@@ -58,6 +58,7 @@ namespace Testably.Abstractions
     public interface ITimeSystem
     {
         Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
@@ -123,6 +124,14 @@ namespace Testably.Abstractions.TimeSystem
         System.DateTime Today { get; }
         System.DateTime UnixEpoch { get; }
         System.DateTime UtcNow { get; }
+    }
+    public interface IDateTimeOffset : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.DateTimeOffset MaxValue { get; }
+        System.DateTimeOffset MinValue { get; }
+        System.DateTimeOffset Now { get; }
+        System.DateTimeOffset UnixEpoch { get; }
+        System.DateTimeOffset UtcNow { get; }
     }
     public interface IPeriodicTimer : System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net9.0.txt
@@ -60,6 +60,7 @@ namespace Testably.Abstractions
     public interface ITimeSystem
     {
         Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
@@ -127,6 +128,14 @@ namespace Testably.Abstractions.TimeSystem
         System.DateTime Today { get; }
         System.DateTime UnixEpoch { get; }
         System.DateTime UtcNow { get; }
+    }
+    public interface IDateTimeOffset : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.DateTimeOffset MaxValue { get; }
+        System.DateTimeOffset MinValue { get; }
+        System.DateTimeOffset Now { get; }
+        System.DateTimeOffset UnixEpoch { get; }
+        System.DateTimeOffset UtcNow { get; }
     }
     public interface IPeriodicTimer : System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.0.txt
@@ -36,6 +36,7 @@ namespace Testably.Abstractions
     public interface ITimeSystem
     {
         Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
         Testably.Abstractions.TimeSystem.IThread Thread { get; }
@@ -78,6 +79,14 @@ namespace Testably.Abstractions.TimeSystem
         System.DateTime Today { get; }
         System.DateTime UnixEpoch { get; }
         System.DateTime UtcNow { get; }
+    }
+    public interface IDateTimeOffset : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.DateTimeOffset MaxValue { get; }
+        System.DateTimeOffset MinValue { get; }
+        System.DateTimeOffset Now { get; }
+        System.DateTimeOffset UnixEpoch { get; }
+        System.DateTimeOffset UtcNow { get; }
     }
     public interface IStopwatch : Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.1.txt
@@ -45,6 +45,7 @@ namespace Testably.Abstractions
     public interface ITimeSystem
     {
         Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
         Testably.Abstractions.TimeSystem.IThread Thread { get; }
@@ -96,6 +97,14 @@ namespace Testably.Abstractions.TimeSystem
         System.DateTime Today { get; }
         System.DateTime UnixEpoch { get; }
         System.DateTime UtcNow { get; }
+    }
+    public interface IDateTimeOffset : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.DateTimeOffset MaxValue { get; }
+        System.DateTimeOffset MinValue { get; }
+        System.DateTimeOffset Now { get; }
+        System.DateTimeOffset UnixEpoch { get; }
+        System.DateTimeOffset UtcNow { get; }
     }
     public interface IStopwatch : Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/Testably.Abstractions.TestHelpers.csproj
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/Testably.Abstractions.TestHelpers.csproj
@@ -8,9 +8,17 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoFixture"/>
+		<PackageReference Include="Newtonsoft.Json"/>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(Configuration)' != 'Debug' ">
 		<PackageReference Include="Testably.Abstractions"/>
 		<PackageReference Include="Testably.Abstractions.Interface"/>
-		<PackageReference Include="Newtonsoft.Json"/>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+		<ProjectReference Include="..\..\..\Source\Testably.Abstractions\Testably.Abstractions.csproj"/>
+		<ProjectReference Include="..\..\..\Source\Testably.Abstractions.Interface\Testably.Abstractions.Interface.csproj"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/Testably.Abstractions.Testing.Tests/Testably.Abstractions.Testing.Tests.csproj
+++ b/Tests/Testably.Abstractions.Testing.Tests/Testably.Abstractions.Testing.Tests.csproj
@@ -13,9 +13,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Testably.Abstractions.Interface"/>
 		<ProjectReference Include="..\..\Source\Testably.Abstractions.Testing\Testably.Abstractions.Testing.csproj"/>
 		<ProjectReference Include="..\Helpers\Testably.Abstractions.TestHelpers\Testably.Abstractions.TestHelpers.csproj"/>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(Configuration)' != 'Debug' ">
+		<PackageReference Include="Testably.Abstractions.Interface"/>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+		<ProjectReference Include="..\..\Source\Testably.Abstractions.Interface\Testably.Abstractions.Interface.csproj"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/NotificationHandlerTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/NotificationHandlerTests.cs
@@ -88,6 +88,73 @@ public class NotificationHandlerTests
 		await That(receivedTime).IsEqualTo(expectedTime);
 	}
 
+	[Test]
+	public async Task OnDateTimeOffsetRead_DisposedCallback_ShouldNotBeCalled()
+	{
+		DateTime expectedTime = TimeTestHelper.GetRandomTime(DateTimeKind.Local);
+		MockTimeSystem timeSystem = new(expectedTime);
+		DateTimeOffset? receivedTime = null;
+		IDisposable disposable = timeSystem.On.DateTimeOffsetRead(d => receivedTime = d);
+
+		disposable.Dispose();
+		_ = timeSystem.DateTimeOffset.Now;
+
+		await That(receivedTime).IsNull();
+	}
+
+	[Test]
+	public async Task OnDateTimeOffsetRead_MultipleCallbacks_DisposeOne_ShouldCallOtherCallbacks()
+	{
+		DateTime expectedTime = TimeTestHelper.GetRandomTime(DateTimeKind.Local);
+		MockTimeSystem timeSystem = new(expectedTime);
+		DateTimeOffset? receivedTime1 = null;
+		DateTimeOffset? receivedTime2 = null;
+
+		using (timeSystem.On.DateTimeOffsetRead(d => receivedTime1 = d))
+		{
+			timeSystem.On.DateTimeOffsetRead(d => receivedTime2 = d).Dispose();
+			_ = timeSystem.DateTimeOffset.Now;
+		}
+
+		await That(receivedTime1).IsEqualTo(new DateTimeOffset(expectedTime));
+		await That(receivedTime2).IsNull();
+	}
+
+	[Test]
+	public async Task OnDateTimeOffsetRead_MultipleCallbacks_ShouldAllBeCalled()
+	{
+		DateTime expectedTime = TimeTestHelper.GetRandomTime(DateTimeKind.Local);
+		MockTimeSystem timeSystem = new(expectedTime);
+		DateTimeOffset? receivedTime1 = null;
+		DateTimeOffset? receivedTime2 = null;
+
+		using (timeSystem.On.DateTimeOffsetRead(d => receivedTime1 = d))
+		{
+			using (timeSystem.On.DateTimeOffsetRead(d => receivedTime2 = d))
+			{
+				_ = timeSystem.DateTimeOffset.Now;
+			}
+		}
+
+		await That(receivedTime1).IsEqualTo(new DateTimeOffset(expectedTime));
+		await That(receivedTime2).IsEqualTo(new DateTimeOffset(expectedTime));
+	}
+
+	[Test]
+	public async Task OnDateTimeOffsetRead_UtcNow_ShouldExecuteCallbackWithCorrectParameter()
+	{
+		DateTime expectedTime = TimeTestHelper.GetRandomTime(DateTimeKind.Utc);
+		MockTimeSystem timeSystem = new(expectedTime);
+		DateTimeOffset? receivedTime = null;
+
+		using (timeSystem.On.DateTimeOffsetRead(d => receivedTime = d))
+		{
+			_ = timeSystem.DateTimeOffset.UtcNow;
+		}
+
+		await That(receivedTime).IsEqualTo(new DateTimeOffset(expectedTime, TimeSpan.Zero));
+	}
+
 #if FEATURE_PERIODIC_TIMER
 	[Test]
 	public async Task OnPeriodicTimerWaitingForNextTick_DisposedCallback_ShouldNotBeCalled()

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimeSystemExtensibilityTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimeSystemExtensibilityTests.cs
@@ -28,6 +28,17 @@ public class TimeSystemExtensibilityTests
 
 	[Test]
 	[MethodDataSource(nameof(GetTimeSystems))]
+	public async Task DateTimeOffset_ShouldSetExtensionPoint(ITimeSystem timeSystem)
+	{
+		IDateTimeOffset sut = timeSystem.DateTimeOffset;
+
+		ITimeSystem result = sut.TimeSystem;
+
+		await That(result).IsEqualTo(timeSystem);
+	}
+
+	[Test]
+	[MethodDataSource(nameof(GetTimeSystems))]
 	public async Task Task_ShouldSetExtensionPoint(ITimeSystem timeSystem)
 	{
 		ITask sut = timeSystem.Task;

--- a/Tests/Testably.Abstractions.Tests/Testably.Abstractions.Tests.csproj
+++ b/Tests/Testably.Abstractions.Tests/Testably.Abstractions.Tests.csproj
@@ -1,9 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
-		<PackageReference Include="Testably.Abstractions.Interface"/>
 		<ProjectReference Include="..\..\Source\Testably.Abstractions.Testing\Testably.Abstractions.Testing.csproj"/>
 		<ProjectReference Include="..\Helpers\Testably.Abstractions.TestHelpers\Testably.Abstractions.TestHelpers.csproj"/>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(Configuration)' != 'Debug' ">
+		<PackageReference Include="Testably.Abstractions.Interface"/>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+		<ProjectReference Include="..\..\Source\Testably.Abstractions.Interface\Testably.Abstractions.Interface.csproj"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/DateTimeOffsetTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/DateTimeOffsetTests.cs
@@ -1,0 +1,63 @@
+namespace Testably.Abstractions.Tests.TimeSystem;
+
+[TimeSystemTests]
+public class DateTimeOffsetTests(TimeSystemTestData testData) : TimeSystemTestBase(testData)
+{
+	[Test]
+	public async Task MaxValue_ShouldReturnDefaultValue()
+	{
+		DateTimeOffset expectedResult = DateTimeOffset.MaxValue;
+
+		DateTimeOffset result = TimeSystem.DateTimeOffset.MaxValue;
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Test]
+	public async Task MinValue_ShouldReturnDefaultValue()
+	{
+		DateTimeOffset expectedResult = DateTimeOffset.MinValue;
+
+		DateTimeOffset result = TimeSystem.DateTimeOffset.MinValue;
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Test]
+	public async Task Now_ShouldBeSetToNow()
+	{
+		// Tests are brittle on the build system
+		TimeSpan tolerance = TimeSpan.FromMilliseconds(250);
+
+		DateTimeOffset result = TimeSystem.DateTimeOffset.Now;
+		DateTimeOffset after = DateTimeOffset.Now;
+
+		await That(result.Offset).IsEqualTo(TimeZoneInfo.Local.GetUtcOffset(result));
+		await That(result).IsBetween(new DateTimeOffset(BeforeTime.ToLocalTime())).And(after)
+			.Within(tolerance);
+	}
+
+	[Test]
+	public async Task UnixEpoch_ShouldReturnDefaultValue()
+	{
+		DateTimeOffset expectedResult = new(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+		DateTimeOffset result = TimeSystem.DateTimeOffset.UnixEpoch;
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Test]
+	public async Task UtcNow_ShouldBeSetToUtcNow()
+	{
+		// Tests are brittle on the build system
+		TimeSpan tolerance = TimeSpan.FromMilliseconds(250);
+
+		DateTimeOffset result = TimeSystem.DateTimeOffset.UtcNow;
+		DateTimeOffset after = DateTimeOffset.UtcNow;
+
+		await That(result.Offset).IsEqualTo(TimeSpan.Zero);
+		await That(result).IsBetween(new DateTimeOffset(BeforeTime, TimeSpan.Zero)).And(after)
+			.Within(tolerance);
+	}
+}


### PR DESCRIPTION
Adds a `System.DateTimeOffset` abstraction to `ITimeSystem`, enabling both `RealTimeSystem` and `MockTimeSystem` consumers to read `DateTimeOffset.Now`/`UtcNow` (and the `MinValue`/`MaxValue`/`UnixEpoch` constants) through a testable interface. This closes the gap where code calling `DateTimeOffset.Now` directly could not be tested deterministically, and the `new DateTimeOffset(timeSystem.DateTime.UtcNow)` workaround did not reproduce the local-offset semantics of `DateTimeOffset.Now`.

Introduces `IDateTimeOffset` and wires it into `ITimeSystem`, `RealTimeSystem`, and `MockTimeSystem`. The mock shares the same underlying `ITimeProvider` clock as `IDateTime`, so both stay consistent; `Now` uses the local offset and `UtcNow` uses a zero offset, while the value constants mirror those exposed on `ITimeProvider`. Adds a matching `DateTimeOffsetRead` notification callback for parity with `DateTimeRead`.

During core development the satellite and test projects reference the local Interface project (Debug-conditional `ProjectReference`), mirroring the established two-phase release workflow; these revert to `PackageReference` once the Interface package is published.

---

- *Part of #1039*