### PR TITLE
feat: add support for `DateTimeOffset` in abstractions

### DIFF
--- a/Source/Testably.Abstractions.Interface/ITimeSystem.cs
+++ b/Source/Testably.Abstractions.Interface/ITimeSystem.cs
@@ -12,6 +12,11 @@ public interface ITimeSystem
 	/// </summary>
 	IDateTime DateTime { get; }
 
+	/// <summary>
+	///     Abstractions for <see cref="System.DateTimeOffset" />.
+	/// </summary>
+	IDateTimeOffset DateTimeOffset { get; }
+
 #if FEATURE_PERIODIC_TIMER
 	/// <summary>
 	///     Abstractions for <see cref="System.Threading.PeriodicTimer" />.

--- a/Source/Testably.Abstractions.Interface/TimeSystem/IDateTimeOffset.cs
+++ b/Source/Testably.Abstractions.Interface/TimeSystem/IDateTimeOffset.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Testably.Abstractions.TimeSystem;
+
+/// <summary>
+///     Abstractions for <see cref="DateTimeOffset" />.
+/// </summary>
+public interface IDateTimeOffset : ITimeSystemEntity
+{
+	/// <inheritdoc cref="DateTimeOffset.MaxValue" />
+	DateTimeOffset MaxValue { get; }
+
+	/// <inheritdoc cref="DateTimeOffset.MinValue" />
+	DateTimeOffset MinValue { get; }
+
+	#pragma warning disable MA0202 // Branches differ only in XML doc comments
+#if NETSTANDARD2_0
+	/// <summary>
+	///     The value of this constant is equivalent to 00:00:00.0000000 UTC, January 1, 1970, in the Gregorian calendar.
+	///     <see cref="UnixEpoch" /> defines the point in time when Unix time is equal to 0.
+	/// </summary>
+	DateTimeOffset UnixEpoch { get; }
+#else
+	/// <inheritdoc cref="DateTimeOffset.UnixEpoch" />
+	DateTimeOffset UnixEpoch { get; }
+#endif
+	#pragma warning restore MA0202
+
+	/// <inheritdoc cref="DateTimeOffset.Now" />
+	DateTimeOffset Now { get; }
+
+	/// <inheritdoc cref="DateTimeOffset.UtcNow" />
+	DateTimeOffset UtcNow { get; }
+}

--- a/Source/Testably.Abstractions/RealTimeSystem.cs
+++ b/Source/Testably.Abstractions/RealTimeSystem.cs
@@ -16,6 +16,7 @@ public sealed class RealTimeSystem : ITimeSystem
 	public RealTimeSystem()
 	{
 		DateTime = new DateTimeWrapper(this);
+		DateTimeOffset = new DateTimeOffsetWrapper(this);
 #if FEATURE_PERIODIC_TIMER
 		PeriodicTimer = new PeriodicTimerFactory(this);
 #endif
@@ -30,6 +31,9 @@ public sealed class RealTimeSystem : ITimeSystem
 
 	/// <inheritdoc cref="ITimeSystem.DateTime" />
 	public IDateTime DateTime { get; }
+
+	/// <inheritdoc cref="ITimeSystem.DateTimeOffset" />
+	public IDateTimeOffset DateTimeOffset { get; }
 
 #if FEATURE_PERIODIC_TIMER
 	/// <inheritdoc cref="ITimeSystem.PeriodicTimer" />

--- a/Source/Testably.Abstractions/TimeSystem/DateTimeOffsetWrapper.cs
+++ b/Source/Testably.Abstractions/TimeSystem/DateTimeOffsetWrapper.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Testably.Abstractions.TimeSystem;
+
+internal sealed class DateTimeOffsetWrapper : IDateTimeOffset
+{
+	internal DateTimeOffsetWrapper(RealTimeSystem timeSystem)
+	{
+		TimeSystem = timeSystem;
+	}
+
+	#region IDateTimeOffset Members
+
+	/// <inheritdoc cref="IDateTimeOffset.MaxValue" />
+	public DateTimeOffset MaxValue
+		=> DateTimeOffset.MaxValue;
+
+	/// <inheritdoc cref="IDateTimeOffset.MinValue" />
+	public DateTimeOffset MinValue
+		=> DateTimeOffset.MinValue;
+
+#if NETSTANDARD2_0
+	/// <inheritdoc cref="IDateTimeOffset.UnixEpoch" />
+	public DateTimeOffset UnixEpoch
+		=> new(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+#else
+	/// <inheritdoc cref="IDateTimeOffset.UnixEpoch" />
+	public DateTimeOffset UnixEpoch
+		=> DateTimeOffset.UnixEpoch;
+#endif
+
+	/// <inheritdoc cref="IDateTimeOffset.Now" />
+	public DateTimeOffset Now
+		=> DateTimeOffset.Now;
+
+	/// <inheritdoc cref="IDateTimeOffset.UtcNow" />
+	public DateTimeOffset UtcNow
+		=> DateTimeOffset.UtcNow;
+
+	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
+	public ITimeSystem TimeSystem { get; }
+
+	#endregion
+}

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net10.0.txt
@@ -27,6 +27,7 @@ namespace Testably.Abstractions
     {
         public RealTimeSystem() { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net6.0.txt
@@ -27,6 +27,7 @@ namespace Testably.Abstractions
     {
         public RealTimeSystem() { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net8.0.txt
@@ -27,6 +27,7 @@ namespace Testably.Abstractions
     {
         public RealTimeSystem() { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_net9.0.txt
@@ -27,6 +27,7 @@ namespace Testably.Abstractions
     {
         public RealTimeSystem() { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.0.txt
@@ -27,6 +27,7 @@ namespace Testably.Abstractions
     {
         public RealTimeSystem() { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions_netstandard2.1.txt
@@ -27,6 +27,7 @@ namespace Testably.Abstractions
     {
         public RealTimeSystem() { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net10.0.txt
@@ -67,6 +67,7 @@ namespace Testably.Abstractions
     public interface ITimeSystem
     {
         Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
@@ -142,6 +143,14 @@ namespace Testably.Abstractions.TimeSystem
         System.DateTime Today { get; }
         System.DateTime UnixEpoch { get; }
         System.DateTime UtcNow { get; }
+    }
+    public interface IDateTimeOffset : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.DateTimeOffset MaxValue { get; }
+        System.DateTimeOffset MinValue { get; }
+        System.DateTimeOffset Now { get; }
+        System.DateTimeOffset UnixEpoch { get; }
+        System.DateTimeOffset UtcNow { get; }
     }
     public interface IPeriodicTimer : System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net6.0.txt
@@ -49,6 +49,7 @@ namespace Testably.Abstractions
     public interface ITimeSystem
     {
         Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
         Testably.Abstractions.TimeSystem.IThread Thread { get; }
@@ -105,6 +106,14 @@ namespace Testably.Abstractions.TimeSystem
         System.DateTime Today { get; }
         System.DateTime UnixEpoch { get; }
         System.DateTime UtcNow { get; }
+    }
+    public interface IDateTimeOffset : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.DateTimeOffset MaxValue { get; }
+        System.DateTimeOffset MinValue { get; }
+        System.DateTimeOffset Now { get; }
+        System.DateTimeOffset UnixEpoch { get; }
+        System.DateTimeOffset UtcNow { get; }
     }
     public interface IStopwatch : Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net8.0.txt
@@ -58,6 +58,7 @@ namespace Testably.Abstractions
     public interface ITimeSystem
     {
         Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
@@ -124,6 +125,14 @@ namespace Testably.Abstractions.TimeSystem
         System.DateTime Today { get; }
         System.DateTime UnixEpoch { get; }
         System.DateTime UtcNow { get; }
+    }
+    public interface IDateTimeOffset : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.DateTimeOffset MaxValue { get; }
+        System.DateTimeOffset MinValue { get; }
+        System.DateTimeOffset Now { get; }
+        System.DateTimeOffset UnixEpoch { get; }
+        System.DateTimeOffset UtcNow { get; }
     }
     public interface IPeriodicTimer : System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_net9.0.txt
@@ -60,6 +60,7 @@ namespace Testably.Abstractions
     public interface ITimeSystem
     {
         Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
@@ -128,6 +129,14 @@ namespace Testably.Abstractions.TimeSystem
         System.DateTime Today { get; }
         System.DateTime UnixEpoch { get; }
         System.DateTime UtcNow { get; }
+    }
+    public interface IDateTimeOffset : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.DateTimeOffset MaxValue { get; }
+        System.DateTimeOffset MinValue { get; }
+        System.DateTimeOffset Now { get; }
+        System.DateTimeOffset UnixEpoch { get; }
+        System.DateTimeOffset UtcNow { get; }
     }
     public interface IPeriodicTimer : System.IDisposable, Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.0.txt
@@ -36,6 +36,7 @@ namespace Testably.Abstractions
     public interface ITimeSystem
     {
         Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
         Testably.Abstractions.TimeSystem.IThread Thread { get; }
@@ -79,6 +80,14 @@ namespace Testably.Abstractions.TimeSystem
         System.DateTime Today { get; }
         System.DateTime UnixEpoch { get; }
         System.DateTime UtcNow { get; }
+    }
+    public interface IDateTimeOffset : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.DateTimeOffset MaxValue { get; }
+        System.DateTimeOffset MinValue { get; }
+        System.DateTimeOffset Now { get; }
+        System.DateTimeOffset UnixEpoch { get; }
+        System.DateTimeOffset UtcNow { get; }
     }
     public interface IStopwatch : Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Core.Api.Tests/Expected/Testably.Abstractions.Interface_netstandard2.1.txt
@@ -45,6 +45,7 @@ namespace Testably.Abstractions
     public interface ITimeSystem
     {
         Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         Testably.Abstractions.TimeSystem.ITask Task { get; }
         Testably.Abstractions.TimeSystem.IThread Thread { get; }
@@ -97,6 +98,14 @@ namespace Testably.Abstractions.TimeSystem
         System.DateTime Today { get; }
         System.DateTime UnixEpoch { get; }
         System.DateTime UtcNow { get; }
+    }
+    public interface IDateTimeOffset : Testably.Abstractions.TimeSystem.ITimeSystemEntity
+    {
+        System.DateTimeOffset MaxValue { get; }
+        System.DateTimeOffset MinValue { get; }
+        System.DateTimeOffset Now { get; }
+        System.DateTimeOffset UnixEpoch { get; }
+        System.DateTimeOffset UtcNow { get; }
     }
     public interface IStopwatch : Testably.Abstractions.TimeSystem.ITimeSystemEntity
     {

--- a/Tests/Testably.Abstractions.Parity.Tests/ParityTests.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/ParityTests.cs
@@ -16,6 +16,26 @@ public abstract class ParityTests(
 	public TestHelpers.Parity Parity { get; } = parity;
 
 	[Test]
+	public async Task IDateTime_EnsureParityWith_DateTime()
+	{
+		List<string> parityErrors = Parity.DateTime
+			.GetErrorsToStaticType<IDateTime>(
+				typeof(DateTime));
+
+		await That(parityErrors).IsEmpty();
+	}
+
+	[Test]
+	public async Task IDateTimeOffset_EnsureParityWith_DateTimeOffset()
+	{
+		List<string> parityErrors = Parity.DateTimeOffset
+			.GetErrorsToStaticType<IDateTimeOffset>(
+				typeof(DateTimeOffset));
+
+		await That(parityErrors).IsEmpty();
+	}
+
+	[Test]
 	public async Task IDirectory_EnsureParityWith_Directory()
 	{
 		List<string> parityErrors = Parity.Directory

--- a/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/Parity.cs
+++ b/Tests/Testably.Abstractions.Parity.Tests/TestHelpers/Parity.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 
 namespace Testably.Abstractions.Parity.Tests.TestHelpers;
@@ -17,6 +18,36 @@ public class Parity
 				nameof(FileStream), nameof(FileSystemStream)
 			},
 		});
+
+	public ParityCheck DateTime { get; } = new(excludeMethods:
+	[
+		typeof(DateTime).GetMethod(nameof(System.DateTime.Compare)),
+		typeof(DateTime).GetMethod(nameof(System.DateTime.DaysInMonth)),
+		typeof(DateTime).GetMethod(nameof(System.DateTime.Equals), BindingFlags.Static | BindingFlags.Public),
+		typeof(DateTime).GetMethod(nameof(System.DateTime.FromBinary)),
+		typeof(DateTime).GetMethod(nameof(System.DateTime.FromFileTime)),
+		typeof(DateTime).GetMethod(nameof(System.DateTime.FromFileTimeUtc)),
+		typeof(DateTime).GetMethod(nameof(System.DateTime.FromOADate)),
+		typeof(DateTime).GetMethod(nameof(System.DateTime.IsLeapYear)),
+		typeof(DateTime).GetMethod(nameof(System.DateTime.SpecifyKind)),
+		..typeof(DateTime).GetMethods().Where(x => string.Equals(x.Name, nameof(System.DateTime.Parse), StringComparison.Ordinal)),
+		..typeof(DateTime).GetMethods().Where(x => string.Equals(x.Name, nameof(System.DateTime.ParseExact), StringComparison.Ordinal)),
+		..typeof(DateTime).GetMethods().Where(x => string.Equals(x.Name, nameof(System.DateTime.TryParse), StringComparison.Ordinal)),
+		..typeof(DateTime).GetMethods().Where(x => string.Equals(x.Name, nameof(System.DateTime.TryParseExact), StringComparison.Ordinal)),
+	]);
+
+	public ParityCheck DateTimeOffset { get; } = new(excludeMethods:
+	[
+		typeof(DateTimeOffset).GetMethod(nameof(System.DateTimeOffset.Compare)),
+		typeof(DateTimeOffset).GetMethod(nameof(System.DateTimeOffset.Equals), BindingFlags.Static | BindingFlags.Public),
+		typeof(DateTimeOffset).GetMethod(nameof(System.DateTimeOffset.FromFileTime)),
+		typeof(DateTimeOffset).GetMethod(nameof(System.DateTimeOffset.FromUnixTimeMilliseconds)),
+		typeof(DateTimeOffset).GetMethod(nameof(System.DateTimeOffset.FromUnixTimeSeconds)),
+		..typeof(DateTimeOffset).GetMethods().Where(x => string.Equals(x.Name, nameof(System.DateTimeOffset.Parse), StringComparison.Ordinal)),
+		..typeof(DateTimeOffset).GetMethods().Where(x => string.Equals(x.Name, nameof(System.DateTimeOffset.ParseExact), StringComparison.Ordinal)),
+		..typeof(DateTimeOffset).GetMethods().Where(x => string.Equals(x.Name, nameof(System.DateTimeOffset.TryParse), StringComparison.Ordinal)),
+		..typeof(DateTimeOffset).GetMethods().Where(x => string.Equals(x.Name, nameof(System.DateTimeOffset.TryParseExact), StringComparison.Ordinal)),
+	]);
 
 	public ParityCheck Directory { get; } = new();
 


### PR DESCRIPTION
Introduces a new time-system abstraction for `System.DateTimeOffset`, aligning it with the existing `ITimeSystem` pattern and extending parity tests to cover the new API.

- Introduces `IDateTimeOffset` (exposing `MaxValue`, `MinValue`, `UnixEpoch`, `Now` and `UtcNow`) and wires it into `ITimeSystem`.
- Implements real-time support via `DateTimeOffsetWrapper` and exposes it from `RealTimeSystem`.
- Extends parity test helpers/tests to validate `IDateTime` and `IDateTimeOffset` against `System.DateTime` / `System.DateTimeOffset` (with static-method exclusions for the members that are intentionally not abstracted).