### PR TITLE
feat: implement mock `TimeZoneInfo` in testing package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,8 +55,8 @@
 		<PackageVersion Include="AutoFixture" Version="4.18.1" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageVersion Include="Testably.Abstractions.Interface" Version="[10.2.0,10.3.0)"/>
-		<PackageVersion Include="Testably.Abstractions" Version="[10.2.0,10.3.0)"/>
+		<PackageVersion Include="Testably.Abstractions.Interface" Version="10.3.0-pre.1"/>
+		<PackageVersion Include="Testably.Abstractions" Version="10.3.0-pre.1"/>
 		<PackageVersion Include="Testably.Abstractions.Testing" Version="5.3.1"/>
 	</ItemGroup>
 	<ItemGroup>

--- a/Docs/pages/docs/time-system/configuring-time.mdx
+++ b/Docs/pages/docs/time-system/configuring-time.mdx
@@ -20,6 +20,47 @@ new MockTimeSystem(TimeProviderFactory.Now());
 
 `TimeProviderFactory.Use(DateTime)`, `TimeProviderFactory.Random()` and `TimeProviderFactory.Now()` all return an `ITimeProviderFactory` you can pass to the `MockTimeSystem` constructor.
 
+## Local time zone
+
+`MockTimeSystem` exposes a controllable local time zone through `timeSystem.TimeZoneInfo` (an `ITimeZoneInfo`), and uses it to convert the simulated instant for `DateTime.Now` and `DateTime.Today`. This makes time-zone-dependent code deterministic instead of depending on the machine the test runs on.
+
+The factory picks the initial local time zone:
+
+```csharp
+// Now() and Use(DateTime) default the local time zone to TimeZoneInfo.Local
+new MockTimeSystem(TimeProviderFactory.Now());
+
+// Random() also picks a random local time zone from a curated, cross-platform
+// set (including one with daylight-saving-time transitions)
+new MockTimeSystem(TimeProviderFactory.Random());
+
+// Pin both the instant and the local time zone
+TimeZoneInfo tokyo = TimeZoneInfo.CreateCustomTimeZone(
+    "Test/Tokyo", TimeSpan.FromHours(9), "Test JST", "Test JST");
+new MockTimeSystem(TimeProviderFactory.Use(
+    new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc), tokyo));
+```
+
+Change it at runtime (and register additional zones for `FindSystemTimeZoneById` / `GetSystemTimeZones`) through the time provider:
+
+```csharp
+MockTimeSystem timeSystem = new(
+    new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc));
+
+TimeZoneInfo tokyo = TimeZoneInfo.CreateCustomTimeZone(
+    "Test/Tokyo", TimeSpan.FromHours(9), "Test JST", "Test JST");
+timeSystem.TimeProvider.LocalTimeZone = tokyo;
+
+DateTime now = timeSystem.DateTime.Now;             // 2026-01-15 09:00 (JST)
+TimeZoneInfo local = timeSystem.TimeZoneInfo.Local; // Test/Tokyo
+
+// RegisterTimeZone adds zones resolvable via FindSystemTimeZoneById / GetSystemTimeZones
+timeSystem.TimeProvider.RegisterTimeZone(tokyo);
+TimeZoneInfo resolved = timeSystem.TimeZoneInfo.FindSystemTimeZoneById("Test/Tokyo");
+```
+
+The registry is seeded from the host's `TimeZoneInfo.GetSystemTimeZones()`, so well-known ids keep resolving; setting `LocalTimeZone` registers that zone automatically.
+
 ## Custom time providers
 
 Implement `ITimeProvider` directly when you need something more interesting than a single `DateTime` - for example, a clock that ticks per virtual thread. See [Thread-aware time provider](./thread-aware-provider) for a worked example.

--- a/Docs/pages/docs/time-system/index.mdx
+++ b/Docs/pages/docs/time-system/index.mdx
@@ -16,6 +16,7 @@ title: Time system
 | `Thread`          | [`Thread.Sleep`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.thread.sleep)                                  |
 | `PeriodicTimer`   | [`System.Threading.PeriodicTimer`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.periodictimer)               |
 | `Timer`           | [`System.Threading.Timer`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.timer)                               |
+| `TimeZoneInfo`    | [`System.TimeZoneInfo`](https://learn.microsoft.com/en-us/dotnet/api/system.timezoneinfo) (`Local`, `Utc`, `FindSystemTimeZoneById`, `GetSystemTimeZones`) |
 
 ## Implementations
 

--- a/Docs/pages/docs/time-system/thread-aware-provider.mdx
+++ b/Docs/pages/docs/time-system/thread-aware-provider.mdx
@@ -9,12 +9,12 @@ The default `ITimeProvider` stores the simulated time in a single `DateTime` fie
 
 The fix is a custom `ITimeProvider` that stores the clock per logical thread using `AsyncLocal<DateTime>`.
 
-## A complete reference implementation
+## A reference implementation
 
 ```csharp
 public sealed class ThreadAwareTimeProvider : ITimeProvider
 {
-    private static readonly AsyncLocal<DateTime>  Now              = new();
+    private static readonly AsyncLocal<DateTime> Now = new();
     private static readonly AsyncLocal<DateTime?> SynchronizedTime = new();
     private DateTime? _synchronizedTime;
 
@@ -22,10 +22,6 @@ public sealed class ThreadAwareTimeProvider : ITimeProvider
     {
         Now.Value = now ?? DateTime.Now;
     }
-
-    public DateTime MaxValue   { get; set; } = DateTime.MaxValue;
-    public DateTime MinValue   { get; set; } = DateTime.MinValue;
-    public DateTime UnixEpoch  { get; set; } = DateTime.UnixEpoch;
 
     public DateTime Read()
     {
@@ -52,6 +48,8 @@ public sealed class ThreadAwareTimeProvider : ITimeProvider
             Now.Value = target;
         }
     }
+
+    // The remaining ITimeProvider members are boilerplate and omitted here.
 }
 ```
 

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -20,7 +20,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.CoreOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 	
 	[Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
 	readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;

--- a/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ExceptionFactory.cs
@@ -318,6 +318,9 @@ internal static class ExceptionFactory
 	internal static TimeoutException TimerWaitTimeoutException(int executionCount, int timeout)
 		=> new($"The execution count {executionCount} was not reached in {timeout}ms.");
 
+	internal static TimeZoneNotFoundException TimeZoneNotFound(string id)
+		=> new($"The time zone ID '{id}' was not found on the local computer.");
+
 	internal static UnauthorizedAccessException AccessDenied(string path)
 		=> new($"Access to the path '{path}' is denied.")
 		{

--- a/Source/Testably.Abstractions.Testing/MockTimeSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockTimeSystem.cs
@@ -29,6 +29,7 @@ public sealed class MockTimeSystem : ITimeSystem
 
 	private readonly NotificationHandler _callbackHandler;
 	private readonly DateTimeMock _dateTimeMock;
+	private readonly TimeZoneInfoMock _timeZoneInfoMock;
 	private readonly StopwatchFactoryMock _stopwatchFactoryMock;
 	private readonly TaskMock _taskMock;
 	private readonly ThreadMock _threadMock;
@@ -92,6 +93,7 @@ public sealed class MockTimeSystem : ITimeSystem
 		_callbackHandler = new NotificationHandler(this);
 		TimeProvider = timeProvider.Create(_callbackHandler.InvokeTimeChanged);
 		_dateTimeMock = new DateTimeMock(this, _callbackHandler);
+		_timeZoneInfoMock = new TimeZoneInfoMock(this);
 		_stopwatchFactoryMock = new StopwatchFactoryMock(this);
 		_threadMock = new ThreadMock(this, _callbackHandler, initialization.AutoAdvance);
 		_taskMock = new TaskMock(this, _callbackHandler, initialization.AutoAdvance);
@@ -106,6 +108,13 @@ public sealed class MockTimeSystem : ITimeSystem
 	/// <inheritdoc cref="ITimeSystem.DateTime" />
 	public IDateTime DateTime
 		=> _dateTimeMock;
+
+	/// <inheritdoc cref="ITimeSystem.DateTimeOffset" />
+	/// <remarks>
+	///     The mock implementation for <see cref="System.DateTimeOffset" /> is added in a follow-up change.
+	/// </remarks>
+	public IDateTimeOffset DateTimeOffset
+		=> null!;
 
 #if FEATURE_PERIODIC_TIMER
 	/// <inheritdoc cref="ITimeSystem.PeriodicTimer" />
@@ -128,6 +137,10 @@ public sealed class MockTimeSystem : ITimeSystem
 	/// <inheritdoc cref="ITimeSystem.Timer" />
 	public ITimerFactory Timer
 		=> _timerFactoryMock;
+
+	/// <inheritdoc cref="ITimeSystem.TimeZoneInfo" />
+	public ITimeZoneInfo TimeZoneInfo
+		=> _timeZoneInfoMock;
 
 	#endregion
 

--- a/Source/Testably.Abstractions.Testing/Polyfills/DictionaryExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Polyfills/DictionaryExtensions.cs
@@ -1,0 +1,30 @@
+﻿#if NETSTANDARD2_0
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+// ReSharper disable once CheckNamespace
+namespace Testably.Abstractions.Polyfills;
+
+[ExcludeFromCodeCoverage]
+internal static class DictionaryExtensions
+{
+	/// <summary>
+	///     Attempts to add the specified <paramref name="key" /> and <paramref name="value" /> to the dictionary.
+	/// </summary>
+	/// <returns>
+	///     <see langword="true" /> if the key/value pair was added to the dictionary successfully; otherwise, <see langword="false" />.
+	/// </returns>
+	public static bool TryAdd<TKey, TValue>(
+		this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
+		where TKey : notnull
+	{
+		if (!dictionary.ContainsKey(key))
+		{
+			dictionary[key] = value;
+			return true;
+		}
+
+		return false;
+	}
+}
+#endif

--- a/Source/Testably.Abstractions.Testing/TimeProviderFactory.cs
+++ b/Source/Testably.Abstractions.Testing/TimeProviderFactory.cs
@@ -10,27 +10,46 @@ namespace Testably.Abstractions.Testing;
 public static class TimeProviderFactory
 {
 	/// <summary>
+	///     A curated, cross-platform-stable set of time zones used by <see cref="Random()" /> to pick a random local time
+	///     zone. Built with <see cref="TimeZoneInfo.CreateCustomTimeZone(string, TimeSpan, string, string)" /> so it does not
+	///     depend on the host's time zone database.
+	/// </summary>
+	private static readonly TimeZoneInfo[] SampleTimeZones =
+	[
+		TimeZoneInfo.Utc,
+		TimeZoneInfo.CreateCustomTimeZone(
+			"Sample/Plus0530", TimeSpan.FromMinutes(330), "Sample +05:30", "Sample +05:30"),
+		TimeZoneInfo.CreateCustomTimeZone(
+			"Sample/Minus0800", TimeSpan.FromHours(-8), "Sample -08:00", "Sample -08:00"),
+		CreateDaylightSavingTimeZone(),
+	];
+
+	/// <summary>
 	///     Initializes the <see cref="MockTimeSystem.TimeProvider" /> with the current time.
+	///     <para />
+	///     The local time zone is set to <see cref="TimeZoneInfo.Local" />.
 	/// </summary>
 	public static ITimeProviderFactory Now()
 	{
 		return new Factory(onTimeChanged
-			=> new TimeProviderMock(onTimeChanged, DateTime.UtcNow, "Now"));
+			=> new TimeProviderMock(onTimeChanged, DateTime.UtcNow, "Now", TimeZoneInfo.Local));
 	}
 
 	/// <summary>
 	///     Initializes the <see cref="MockTimeSystem.TimeProvider" /> with a random time.
 	///     <para />
-	///     The random time increments the unix epoch by a random integer of seconds.
+	///     The random time increments the unix epoch by a random integer of seconds and the local time zone is picked at
+	///     random from a curated, cross-platform-stable set (including a zone with daylight-saving-time transitions).
 	/// </summary>
 	public static ITimeProviderFactory Random()
 	{
 		#pragma warning disable MA0113 // Use DateTime.UnixEpoch
-		DateTime randomTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+		var randomTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)
 			.AddSeconds(RandomFactory.Shared.Next());
 		#pragma warning restore MA0113
+		var randomTimeZone = SampleTimeZones[RandomFactory.Shared.Next(SampleTimeZones.Length)];
 		return new Factory(onTimeChanged
-			=> new TimeProviderMock(onTimeChanged, randomTime, "Random"));
+			=> new TimeProviderMock(onTimeChanged, randomTime, "Random", randomTimeZone));
 	}
 
 	/// <summary>
@@ -38,11 +57,38 @@ public static class TimeProviderFactory
 	/// </summary>
 	/// <remarks>
 	///     If the <paramref name="time" /> has Kind DateTimeKind.Unspecified it will be treated as if it had Kind
-	///     DateTimeKind.Utc.
+	///     DateTimeKind.Utc.<br />
+	///     The local time zone is set to <see cref="TimeZoneInfo.Local" />.
 	/// </remarks>
 	public static ITimeProviderFactory Use(DateTime time)
+		=> Use(time, TimeZoneInfo.Local);
+
+	/// <summary>
+	///     Initializes the <see cref="MockTimeSystem.TimeProvider" /> with the specified <paramref name="time" /> and
+	///     <paramref name="localTimeZone" />.
+	/// </summary>
+	/// <remarks>
+	///     If the <paramref name="time" /> has Kind DateTimeKind.Unspecified it will be treated as if it had Kind
+	///     DateTimeKind.Utc.
+	/// </remarks>
+	public static ITimeProviderFactory Use(DateTime time, TimeZoneInfo localTimeZone)
 	{
-		return new Factory(onTimeChanged => new TimeProviderMock(onTimeChanged, time, "Fixed"));
+		return new Factory(onTimeChanged
+			=> new TimeProviderMock(onTimeChanged, time, "Fixed", localTimeZone));
+	}
+
+	private static TimeZoneInfo CreateDaylightSavingTimeZone()
+	{
+		var start = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(
+			new DateTime(1, 1, 1, 2, 0, 0), 3, 5, DayOfWeek.Sunday);
+		var end = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(
+			new DateTime(1, 1, 1, 3, 0, 0), 10, 5, DayOfWeek.Sunday);
+		var rule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(
+			DateTime.MinValue.Date, DateTime.MaxValue.Date, TimeSpan.FromHours(1), start, end);
+		return TimeZoneInfo.CreateCustomTimeZone(
+			"Sample/DaylightSaving", TimeSpan.FromHours(1),
+			"Sample Daylight Saving Time", "Sample Standard Time", "Sample Daylight Time",
+			[rule,]);
 	}
 
 	internal sealed class Factory(Func<Action<DateTime>, ITimeProvider> createCallback)

--- a/Source/Testably.Abstractions.Testing/TimeProviderFactory.cs
+++ b/Source/Testably.Abstractions.Testing/TimeProviderFactory.cs
@@ -44,7 +44,7 @@ public static class TimeProviderFactory
 	public static ITimeProviderFactory Random()
 	{
 		#pragma warning disable MA0113 // Use DateTime.UnixEpoch
-		var randomTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+		DateTime randomTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)
 			.AddSeconds(RandomFactory.Shared.Next());
 		#pragma warning restore MA0113
 		var randomTimeZone = SampleTimeZones[RandomFactory.Shared.Next(SampleTimeZones.Length)];
@@ -73,6 +73,7 @@ public static class TimeProviderFactory
 	/// </remarks>
 	public static ITimeProviderFactory Use(DateTime time, TimeZoneInfo localTimeZone)
 	{
+		_ = localTimeZone ?? throw new ArgumentNullException(nameof(localTimeZone));
 		return new Factory(onTimeChanged
 			=> new TimeProviderMock(onTimeChanged, time, "Fixed", localTimeZone));
 	}

--- a/Source/Testably.Abstractions.Testing/TimeSystem/DateTimeMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/DateTimeMock.cs
@@ -30,7 +30,11 @@ internal sealed class DateTimeMock : IDateTime
 	{
 		get
 		{
-			DateTime value = _mockTimeSystem.TimeProvider.Read().ToLocalTime();
+			DateTime value = DateTime.SpecifyKind(
+				TimeZoneInfo.ConvertTimeFromUtc(
+					_mockTimeSystem.TimeProvider.Read().ToUniversalTime(),
+					_mockTimeSystem.TimeProvider.LocalTimeZone),
+				DateTimeKind.Local);
 			_callbackHandler.InvokeDateTimeReadCallbacks(value);
 			return value;
 		}
@@ -45,7 +49,11 @@ internal sealed class DateTimeMock : IDateTime
 	{
 		get
 		{
-			DateTime value = _mockTimeSystem.TimeProvider.Read().ToLocalTime().Date;
+			DateTime value = DateTime.SpecifyKind(
+				TimeZoneInfo.ConvertTimeFromUtc(
+					_mockTimeSystem.TimeProvider.Read().ToUniversalTime(),
+					_mockTimeSystem.TimeProvider.LocalTimeZone),
+				DateTimeKind.Local).Date;
 			_callbackHandler.InvokeDateTimeReadCallbacks(value);
 			return value;
 		}

--- a/Source/Testably.Abstractions.Testing/TimeSystem/ITimeProvider.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/ITimeProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.ObjectModel;
 using Testably.Abstractions.TimeSystem;
 
 namespace Testably.Abstractions.Testing.TimeSystem;
@@ -30,6 +31,16 @@ public interface ITimeProvider
 	long ElapsedTicks { get; }
 
 	/// <summary>
+	///     Gets or sets the local time zone used when converting the currently simulated system time to local time
+	///     (e.g. for <see cref="IDateTime.Now" /> or <see cref="IDateTimeOffset.Now" />).
+	/// </summary>
+	/// <remarks>
+	///     Setting the local time zone also registers it (see <see cref="RegisterTimeZone(TimeZoneInfo)" />), so that it can
+	///     be resolved via <see cref="ITimeZoneInfo.FindSystemTimeZoneById(string)" />.
+	/// </remarks>
+	TimeZoneInfo LocalTimeZone { get; set; }
+
+	/// <summary>
 	///     Gets or sets the <see cref="IDateTime.MaxValue" />
 	/// </summary>
 	DateTime MaxValue { get; set; }
@@ -59,9 +70,35 @@ public interface ITimeProvider
 	void AdvanceBy(TimeSpan interval);
 
 	/// <summary>
+	///     Returns the registered time zone with the given <paramref name="id" />.
+	/// </summary>
+	/// <exception cref="TimeZoneNotFoundException">
+	///     No time zone is registered under the given <paramref name="id" />.
+	/// </exception>
+	TimeZoneInfo FindSystemTimeZoneById(string id);
+
+	/// <summary>
+	///     Returns all registered time zones.
+	/// </summary>
+	/// <remarks>
+	///     The registry is initially seeded from the host's <see cref="TimeZoneInfo.GetSystemTimeZones()" /> and can be
+	///     extended via <see cref="RegisterTimeZone(TimeZoneInfo)" />.
+	/// </remarks>
+	ReadOnlyCollection<TimeZoneInfo> GetSystemTimeZones();
+
+	/// <summary>
 	///     Reads the currently simulated system time.
 	/// </summary>
 	DateTime Read();
+
+	/// <summary>
+	///     Registers the <paramref name="timeZone" /> so that it can be resolved via
+	///     <see cref="FindSystemTimeZoneById(string)" /> and is included in <see cref="GetSystemTimeZones()" />.
+	/// </summary>
+	/// <remarks>
+	///     An already registered time zone with the same <see cref="TimeZoneInfo.Id" /> is replaced.
+	/// </remarks>
+	void RegisterTimeZone(TimeZoneInfo timeZone);
 
 	/// <summary>
 	///     Sets the currently simulated system time to the specified <paramref name="value" />.

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimeProviderMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimeProviderMock.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Testably.Abstractions.Testing.Helpers;
 #if NETSTANDARD2_0
 using Testably.Abstractions.TimeSystem;
 #endif
@@ -107,8 +108,7 @@ internal sealed class TimeProviderMock : ITimeProvider
 			}
 		}
 
-		throw new TimeZoneNotFoundException(
-			$"The time zone ID '{id}' was not found on the local computer.");
+		throw ExceptionFactory.TimeZoneNotFound(id);
 	}
 
 	/// <inheritdoc cref="ITimeProvider.GetSystemTimeZones()" />

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimeProviderMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimeProviderMock.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 #if NETSTANDARD2_0
 using Testably.Abstractions.TimeSystem;
 #endif
@@ -11,13 +14,16 @@ internal sealed class TimeProviderMock : ITimeProvider
 	private long _elapsedTicks;
 	private readonly Action<DateTime> _onTimeChanged;
 	private readonly string _description;
+	private readonly Dictionary<string, TimeZoneInfo> _timeZones;
+	private TimeZoneInfo _localTimeZone;
 #if NET9_0_OR_GREATER
 	private readonly System.Threading.Lock _lock = new();
 #else
 	private readonly object _lock = new();
 #endif
 
-	public TimeProviderMock(Action<DateTime> onTimeChanged, DateTime now, string description)
+	public TimeProviderMock(Action<DateTime> onTimeChanged, DateTime now, string description,
+		TimeZoneInfo localTimeZone)
 	{
 		_now = now.Kind == DateTimeKind.Unspecified
 			? DateTime.SpecifyKind(now, DateTimeKind.Utc)
@@ -26,9 +32,31 @@ internal sealed class TimeProviderMock : ITimeProvider
 		StartTime = _now;
 		_onTimeChanged = onTimeChanged;
 		_description = description;
+		_timeZones = TimeZoneInfo.GetSystemTimeZones()
+			.GroupBy(timeZone => timeZone.Id, StringComparer.Ordinal)
+			.ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+		_localTimeZone = localTimeZone;
+		_timeZones[localTimeZone.Id] = localTimeZone;
 	}
 
 	#region ITimeProvider Members
+
+	/// <inheritdoc cref="ITimeProvider.LocalTimeZone" />
+	public TimeZoneInfo LocalTimeZone
+	{
+		get
+		{
+			lock (_lock) { return _localTimeZone; }
+		}
+		set
+		{
+			lock (_lock)
+			{
+				_localTimeZone = value;
+				_timeZones[value.Id] = value;
+			}
+		}
+	}
 
 	/// <inheritdoc cref="ITimeProvider.MaxValue" />
 	public DateTime MaxValue { get; set; } = DateTime.MaxValue;
@@ -68,12 +96,48 @@ internal sealed class TimeProviderMock : ITimeProvider
 		}
 	}
 
+	/// <inheritdoc cref="ITimeProvider.FindSystemTimeZoneById(string)" />
+	public TimeZoneInfo FindSystemTimeZoneById(string id)
+	{
+		lock (_lock)
+		{
+			if (_timeZones.TryGetValue(id, out TimeZoneInfo? timeZone))
+			{
+				return timeZone;
+			}
+		}
+
+		throw new TimeZoneNotFoundException(
+			$"The time zone ID '{id}' was not found on the local computer.");
+	}
+
+	/// <inheritdoc cref="ITimeProvider.GetSystemTimeZones()" />
+	public ReadOnlyCollection<TimeZoneInfo> GetSystemTimeZones()
+	{
+		lock (_lock)
+		{
+			return new ReadOnlyCollection<TimeZoneInfo>(_timeZones.Values
+				.OrderBy(timeZone => timeZone.BaseUtcOffset)
+				.ThenBy(timeZone => timeZone.Id, StringComparer.Ordinal)
+				.ToList());
+		}
+	}
+
 	/// <inheritdoc cref="ITimeProvider.Read()" />
 	public DateTime Read()
 	{
 		lock (_lock)
 		{
 			return _now;
+		}
+	}
+
+	/// <inheritdoc cref="ITimeProvider.RegisterTimeZone(TimeZoneInfo)" />
+	public void RegisterTimeZone(TimeZoneInfo timeZone)
+	{
+		lock (_lock)
+		{
+			_timeZones[timeZone.Id] = timeZone;
 		}
 	}
 

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimeProviderMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimeProviderMock.cs
@@ -15,7 +15,8 @@ internal sealed class TimeProviderMock : ITimeProvider
 	private long _elapsedTicks;
 	private readonly Action<DateTime> _onTimeChanged;
 	private readonly string _description;
-	private readonly Dictionary<string, TimeZoneInfo> _timeZones;
+	private Dictionary<string, TimeZoneInfo>? _timeZones;
+	private bool _systemTimeZonesSeeded;
 	private TimeZoneInfo _localTimeZone;
 #if NET9_0_OR_GREATER
 	private readonly System.Threading.Lock _lock = new();
@@ -33,11 +34,7 @@ internal sealed class TimeProviderMock : ITimeProvider
 		StartTime = _now;
 		_onTimeChanged = onTimeChanged;
 		_description = description;
-		_timeZones = TimeZoneInfo.GetSystemTimeZones()
-			.GroupBy(timeZone => timeZone.Id, StringComparer.Ordinal)
-			.ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
 		_localTimeZone = localTimeZone;
-		_timeZones[localTimeZone.Id] = localTimeZone;
 	}
 
 	#region ITimeProvider Members
@@ -54,7 +51,11 @@ internal sealed class TimeProviderMock : ITimeProvider
 			lock (_lock)
 			{
 				_localTimeZone = value;
-				_timeZones[value.Id] = value;
+
+				if (_timeZones is not null)
+				{
+					_timeZones[value.Id] = value;
+				}
 			}
 		}
 	}
@@ -102,7 +103,7 @@ internal sealed class TimeProviderMock : ITimeProvider
 	{
 		lock (_lock)
 		{
-			if (_timeZones.TryGetValue(id, out TimeZoneInfo? timeZone))
+			if (GetSeededTimeZones().TryGetValue(id, out TimeZoneInfo? timeZone))
 			{
 				return timeZone;
 			}
@@ -116,7 +117,7 @@ internal sealed class TimeProviderMock : ITimeProvider
 	{
 		lock (_lock)
 		{
-			return new ReadOnlyCollection<TimeZoneInfo>(_timeZones.Values
+			return new ReadOnlyCollection<TimeZoneInfo>(GetSeededTimeZones().Values
 				.OrderBy(timeZone => timeZone.BaseUtcOffset)
 				.ThenBy(timeZone => timeZone.Id, StringComparer.Ordinal)
 				.ToList());
@@ -137,6 +138,7 @@ internal sealed class TimeProviderMock : ITimeProvider
 	{
 		lock (_lock)
 		{
+			_timeZones ??= new Dictionary<string, TimeZoneInfo>(StringComparer.Ordinal);
 			_timeZones[timeZone.Id] = timeZone;
 		}
 	}
@@ -154,6 +156,33 @@ internal sealed class TimeProviderMock : ITimeProvider
 	}
 
 	#endregion
+
+	/// <summary>
+	///     Returns the time zone registry, allocating and seeding it on first use.
+	/// </summary>
+	/// <remarks>
+	///     The registry is created lazily so that mocks which never query time zones pay no allocation. On first use it is
+	///     seeded from the host's <see cref="TimeZoneInfo.GetSystemTimeZones()" />, without overwriting the local or
+	///     explicitly registered time zones.<br />
+	///     Must be called while holding <see cref="_lock" />.
+	/// </remarks>
+	private Dictionary<string, TimeZoneInfo> GetSeededTimeZones()
+	{
+		_timeZones ??= new Dictionary<string, TimeZoneInfo>(StringComparer.Ordinal);
+		if (_systemTimeZonesSeeded)
+		{
+			return _timeZones;
+		}
+
+		_systemTimeZonesSeeded = true;
+		foreach (TimeZoneInfo timeZone in TimeZoneInfo.GetSystemTimeZones())
+		{
+			_timeZones.TryAdd(timeZone.Id, timeZone);
+		}
+
+		_timeZones[_localTimeZone.Id] = _localTimeZone;
+		return _timeZones;
+	}
 
 	/// <inheritdoc cref="object.ToString()" />
 	public override string ToString()

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimeProviderMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimeProviderMock.cs
@@ -146,7 +146,9 @@ internal sealed class TimeProviderMock : ITimeProvider
 	{
 		lock (_lock)
 		{
-			_now = value;
+			_now = value.Kind == DateTimeKind.Unspecified
+				? DateTime.SpecifyKind(value, DateTimeKind.Utc)
+				: value.ToUniversalTime();
 			_onTimeChanged.Invoke(_now);
 		}
 	}

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimeZoneInfoMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimeZoneInfoMock.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.ObjectModel;
+using Testably.Abstractions.TimeSystem;
+
+namespace Testably.Abstractions.Testing.TimeSystem;
+
+internal sealed class TimeZoneInfoMock : ITimeZoneInfo
+{
+	private readonly MockTimeSystem _mockTimeSystem;
+
+	internal TimeZoneInfoMock(MockTimeSystem timeSystem)
+	{
+		_mockTimeSystem = timeSystem;
+	}
+
+	#region ITimeZoneInfo Members
+
+	/// <inheritdoc cref="ITimeZoneInfo.Local" />
+	public TimeZoneInfo Local
+		=> _mockTimeSystem.TimeProvider.LocalTimeZone;
+
+	/// <inheritdoc cref="ITimeSystemEntity.TimeSystem" />
+	public ITimeSystem TimeSystem
+		=> _mockTimeSystem;
+
+	/// <inheritdoc cref="ITimeZoneInfo.Utc" />
+	public TimeZoneInfo Utc
+		=> TimeZoneInfo.Utc;
+
+	/// <inheritdoc cref="ITimeZoneInfo.FindSystemTimeZoneById(string)" />
+	public TimeZoneInfo FindSystemTimeZoneById(string id)
+		=> _mockTimeSystem.TimeProvider.FindSystemTimeZoneById(id);
+
+	/// <inheritdoc cref="ITimeZoneInfo.GetSystemTimeZones()" />
+	public ReadOnlyCollection<TimeZoneInfo> GetSystemTimeZones()
+		=> _mockTimeSystem.TimeProvider.GetSystemTimeZones();
+
+	#endregion
+}

--- a/Source/Testably.Abstractions.Testing/TimeSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystemExtensions.cs
@@ -37,15 +37,7 @@ public static class TimeSystemExtensions
 	{
 		/// <inheritdoc cref="System.TimeProvider.LocalTimeZone" />
 		public override TimeZoneInfo LocalTimeZone
-		{
-			get
-			{
-				#pragma warning disable MA0026
-				// TODO: https://github.com/Testably/Testably.Abstractions/issues/1039
-				#pragma warning restore MA0026
-				return base.LocalTimeZone;
-			}
-		}
+			=> timeSystem.TimeZoneInfo.Local;
 
 		/// <inheritdoc cref="System.TimeProvider.TimestampFrequency" />
 		public override long TimestampFrequency

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
@@ -113,12 +113,14 @@ namespace Testably.Abstractions.Testing
         public MockTimeSystem(System.DateTime time, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public MockTimeSystem(Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory timeProvider, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.Testing.TimeSystem.INotificationHandler On { get; }
         public Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }
         public Testably.Abstractions.Testing.TimeSystem.ITimeProvider TimeProvider { get; }
+        public Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         public Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
         public Testably.Abstractions.Testing.TimeSystem.ITimerHandler TimerHandler { get; }
         public override string ToString() { }
@@ -190,6 +192,7 @@ namespace Testably.Abstractions.Testing
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time, System.TimeZoneInfo localTimeZone) { }
     }
     public static class TimeSystemExtensions
     {
@@ -474,12 +477,16 @@ namespace Testably.Abstractions.Testing.TimeSystem
     public interface ITimeProvider
     {
         long ElapsedTicks { get; }
+        System.TimeZoneInfo LocalTimeZone { get; set; }
         System.DateTime MaxValue { get; set; }
         System.DateTime MinValue { get; set; }
         System.DateTime StartTime { get; }
         System.DateTime UnixEpoch { get; set; }
         void AdvanceBy(System.TimeSpan interval);
+        System.TimeZoneInfo FindSystemTimeZoneById(string id);
+        System.Collections.ObjectModel.ReadOnlyCollection<System.TimeZoneInfo> GetSystemTimeZones();
         System.DateTime Read();
+        void RegisterTimeZone(System.TimeZoneInfo timeZone);
         void SetTo(System.DateTime value);
     }
     public interface ITimeProviderFactory

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -112,11 +112,13 @@ namespace Testably.Abstractions.Testing
         public MockTimeSystem(System.DateTime time, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public MockTimeSystem(Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory timeProvider, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.Testing.TimeSystem.INotificationHandler On { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }
         public Testably.Abstractions.Testing.TimeSystem.ITimeProvider TimeProvider { get; }
+        public Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         public Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
         public Testably.Abstractions.Testing.TimeSystem.ITimerHandler TimerHandler { get; }
         public override string ToString() { }
@@ -188,6 +190,7 @@ namespace Testably.Abstractions.Testing
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time, System.TimeZoneInfo localTimeZone) { }
     }
 }
 namespace Testably.Abstractions.Testing.FileSystem
@@ -450,12 +453,16 @@ namespace Testably.Abstractions.Testing.TimeSystem
     public interface ITimeProvider
     {
         long ElapsedTicks { get; }
+        System.TimeZoneInfo LocalTimeZone { get; set; }
         System.DateTime MaxValue { get; set; }
         System.DateTime MinValue { get; set; }
         System.DateTime StartTime { get; }
         System.DateTime UnixEpoch { get; set; }
         void AdvanceBy(System.TimeSpan interval);
+        System.TimeZoneInfo FindSystemTimeZoneById(string id);
+        System.Collections.ObjectModel.ReadOnlyCollection<System.TimeZoneInfo> GetSystemTimeZones();
         System.DateTime Read();
+        void RegisterTimeZone(System.TimeZoneInfo timeZone);
         void SetTo(System.DateTime value);
     }
     public interface ITimeProviderFactory

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -113,12 +113,14 @@ namespace Testably.Abstractions.Testing
         public MockTimeSystem(System.DateTime time, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public MockTimeSystem(Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory timeProvider, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.Testing.TimeSystem.INotificationHandler On { get; }
         public Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }
         public Testably.Abstractions.Testing.TimeSystem.ITimeProvider TimeProvider { get; }
+        public Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         public Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
         public Testably.Abstractions.Testing.TimeSystem.ITimerHandler TimerHandler { get; }
         public override string ToString() { }
@@ -190,6 +192,7 @@ namespace Testably.Abstractions.Testing
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time, System.TimeZoneInfo localTimeZone) { }
     }
     public static class TimeSystemExtensions
     {
@@ -474,12 +477,16 @@ namespace Testably.Abstractions.Testing.TimeSystem
     public interface ITimeProvider
     {
         long ElapsedTicks { get; }
+        System.TimeZoneInfo LocalTimeZone { get; set; }
         System.DateTime MaxValue { get; set; }
         System.DateTime MinValue { get; set; }
         System.DateTime StartTime { get; }
         System.DateTime UnixEpoch { get; set; }
         void AdvanceBy(System.TimeSpan interval);
+        System.TimeZoneInfo FindSystemTimeZoneById(string id);
+        System.Collections.ObjectModel.ReadOnlyCollection<System.TimeZoneInfo> GetSystemTimeZones();
         System.DateTime Read();
+        void RegisterTimeZone(System.TimeZoneInfo timeZone);
         void SetTo(System.DateTime value);
     }
     public interface ITimeProviderFactory

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
@@ -113,12 +113,14 @@ namespace Testably.Abstractions.Testing
         public MockTimeSystem(System.DateTime time, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public MockTimeSystem(Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory timeProvider, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.Testing.TimeSystem.INotificationHandler On { get; }
         public Testably.Abstractions.TimeSystem.IPeriodicTimerFactory PeriodicTimer { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }
         public Testably.Abstractions.Testing.TimeSystem.ITimeProvider TimeProvider { get; }
+        public Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         public Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
         public Testably.Abstractions.Testing.TimeSystem.ITimerHandler TimerHandler { get; }
         public override string ToString() { }
@@ -190,6 +192,7 @@ namespace Testably.Abstractions.Testing
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time, System.TimeZoneInfo localTimeZone) { }
     }
     public static class TimeSystemExtensions
     {
@@ -474,12 +477,16 @@ namespace Testably.Abstractions.Testing.TimeSystem
     public interface ITimeProvider
     {
         long ElapsedTicks { get; }
+        System.TimeZoneInfo LocalTimeZone { get; set; }
         System.DateTime MaxValue { get; set; }
         System.DateTime MinValue { get; set; }
         System.DateTime StartTime { get; }
         System.DateTime UnixEpoch { get; set; }
         void AdvanceBy(System.TimeSpan interval);
+        System.TimeZoneInfo FindSystemTimeZoneById(string id);
+        System.Collections.ObjectModel.ReadOnlyCollection<System.TimeZoneInfo> GetSystemTimeZones();
         System.DateTime Read();
+        void RegisterTimeZone(System.TimeZoneInfo timeZone);
         void SetTo(System.DateTime value);
     }
     public interface ITimeProviderFactory

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -107,11 +107,13 @@ namespace Testably.Abstractions.Testing
         public MockTimeSystem(System.DateTime time, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public MockTimeSystem(Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory timeProvider, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.Testing.TimeSystem.INotificationHandler On { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }
         public Testably.Abstractions.Testing.TimeSystem.ITimeProvider TimeProvider { get; }
+        public Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         public Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
         public Testably.Abstractions.Testing.TimeSystem.ITimerHandler TimerHandler { get; }
         public override string ToString() { }
@@ -183,6 +185,7 @@ namespace Testably.Abstractions.Testing
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time, System.TimeZoneInfo localTimeZone) { }
     }
 }
 namespace Testably.Abstractions.Testing.FileSystem
@@ -430,12 +433,16 @@ namespace Testably.Abstractions.Testing.TimeSystem
     public interface ITimeProvider
     {
         long ElapsedTicks { get; }
+        System.TimeZoneInfo LocalTimeZone { get; set; }
         System.DateTime MaxValue { get; set; }
         System.DateTime MinValue { get; set; }
         System.DateTime StartTime { get; }
         System.DateTime UnixEpoch { get; set; }
         void AdvanceBy(System.TimeSpan interval);
+        System.TimeZoneInfo FindSystemTimeZoneById(string id);
+        System.Collections.ObjectModel.ReadOnlyCollection<System.TimeZoneInfo> GetSystemTimeZones();
         System.DateTime Read();
+        void RegisterTimeZone(System.TimeZoneInfo timeZone);
         void SetTo(System.DateTime value);
     }
     public interface ITimeProviderFactory

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -107,11 +107,13 @@ namespace Testably.Abstractions.Testing
         public MockTimeSystem(System.DateTime time, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public MockTimeSystem(Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory timeProvider, System.Func<Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions, Testably.Abstractions.Testing.MockTimeSystem.MockTimeSystemOptions> options) { }
         public Testably.Abstractions.TimeSystem.IDateTime DateTime { get; }
+        public Testably.Abstractions.TimeSystem.IDateTimeOffset DateTimeOffset { get; }
         public Testably.Abstractions.Testing.TimeSystem.INotificationHandler On { get; }
         public Testably.Abstractions.TimeSystem.IStopwatchFactory Stopwatch { get; }
         public Testably.Abstractions.TimeSystem.ITask Task { get; }
         public Testably.Abstractions.TimeSystem.IThread Thread { get; }
         public Testably.Abstractions.Testing.TimeSystem.ITimeProvider TimeProvider { get; }
+        public Testably.Abstractions.TimeSystem.ITimeZoneInfo TimeZoneInfo { get; }
         public Testably.Abstractions.TimeSystem.ITimerFactory Timer { get; }
         public Testably.Abstractions.Testing.TimeSystem.ITimerHandler TimerHandler { get; }
         public override string ToString() { }
@@ -183,6 +185,7 @@ namespace Testably.Abstractions.Testing
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time, System.TimeZoneInfo localTimeZone) { }
     }
 }
 namespace Testably.Abstractions.Testing.FileSystem
@@ -443,12 +446,16 @@ namespace Testably.Abstractions.Testing.TimeSystem
     public interface ITimeProvider
     {
         long ElapsedTicks { get; }
+        System.TimeZoneInfo LocalTimeZone { get; set; }
         System.DateTime MaxValue { get; set; }
         System.DateTime MinValue { get; set; }
         System.DateTime StartTime { get; }
         System.DateTime UnixEpoch { get; set; }
         void AdvanceBy(System.TimeSpan interval);
+        System.TimeZoneInfo FindSystemTimeZoneById(string id);
+        System.Collections.ObjectModel.ReadOnlyCollection<System.TimeZoneInfo> GetSystemTimeZones();
         System.DateTime Read();
+        void RegisterTimeZone(System.TimeZoneInfo timeZone);
         void SetTo(System.DateTime value);
     }
     public interface ITimeProviderFactory

--- a/Tests/Helpers/Testably.Abstractions.TestHelpers/TestCultureInitializer.cs
+++ b/Tests/Helpers/Testably.Abstractions.TestHelpers/TestCultureInitializer.cs
@@ -1,0 +1,22 @@
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace Testably.Abstractions.TestHelpers;
+
+/// <summary>
+///     Forces all tests to run under <see cref="CultureInfo.InvariantCulture" /> so that
+///     localized exception messages on .NET Framework are in english.
+/// </summary>
+internal static class TestCultureInitializer
+{
+	#pragma warning disable CA2255
+	[ModuleInitializer]
+	#pragma warning restore CA2255
+	internal static void Initialize()
+	{
+		CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+		CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+		CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+		CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/MockTimeSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockTimeSystemTests.cs
@@ -1,8 +1,6 @@
-﻿using aweXpect.Chronology;
-using System.Collections.Generic;
-using System.Threading;
+﻿using System.Threading;
+using aweXpect.Chronology;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
-using Testably.Abstractions.TimeSystem;
 
 namespace Testably.Abstractions.Testing.Tests;
 
@@ -349,5 +347,34 @@ public class MockTimeSystemTests
 
 		await That(result).Contains("Random");
 		await That(result).Contains($"{timeSystem.DateTime.UtcNow}Z");
+	}
+
+	[Test]
+	[Arguments(DateTimeKind.Utc)]
+	[Arguments(DateTimeKind.Local)]
+	[Arguments(DateTimeKind.Unspecified)]
+	public async Task SetTo_ShouldNormalizeToUtc_ConsistentlyWithConstructor(DateTimeKind kind)
+	{
+		DateTime time = DateTime.SpecifyKind(new DateTime(2026, 1, 15, 10, 0, 0), kind);
+		MockTimeSystem fromConstructor = new(time);
+		MockTimeSystem fromSetTo = new(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+		fromSetTo.TimeProvider.SetTo(time);
+
+		await That(fromSetTo.DateTime.UtcNow).IsEqualTo(fromConstructor.DateTime.UtcNow);
+		await That(fromSetTo.DateTime.UtcNow.Kind).IsEqualTo(DateTimeKind.Utc);
+		await That(fromSetTo.DateTime.Now).IsEqualTo(fromConstructor.DateTime.Now);
+	}
+
+	[Test]
+	public async Task SetTo_UnspecifiedKind_ShouldBeTreatedAsUtc()
+	{
+		DateTime unspecified = new(2026, 1, 15, 10, 0, 0, DateTimeKind.Unspecified);
+		MockTimeSystem timeSystem = new(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+		timeSystem.TimeProvider.SetTo(unspecified);
+
+		await That(timeSystem.DateTime.UtcNow)
+			.IsEqualTo(new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc));
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/MockTimeSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockTimeSystemTests.cs
@@ -1,6 +1,9 @@
 ﻿using System.Threading;
 using aweXpect.Chronology;
 using Testably.Abstractions.Testing.Tests.TestHelpers;
+#if FEATURE_PERIODIC_TIMER
+using System.Collections.Generic;
+#endif
 
 namespace Testably.Abstractions.Testing.Tests;
 
@@ -11,10 +14,10 @@ public class MockTimeSystemTests
 		Delay_DisabledAutoAdvance_InfiniteTimeSpan_ShouldOnlyBeReleasedByCancellation()
 	{
 		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
-		using CancellationTokenSource cts = CancellationTokenSource
+		using var cts = CancellationTokenSource
 			.CreateLinkedTokenSource(TestContext.Current!.Execution.CancellationToken);
 
-		Task delayTask = timeSystem.Task.Delay(Timeout.InfiniteTimeSpan, cts.Token);
+		var delayTask = timeSystem.Task.Delay(Timeout.InfiniteTimeSpan, cts.Token);
 
 		// Advancing the clock never releases an infinite delay.
 		timeSystem.TimeProvider.AdvanceBy(TimeSpan.FromDays(1));
@@ -31,11 +34,11 @@ public class MockTimeSystemTests
 		Delay_DisabledAutoAdvance_MultiplePendingDelays_ShouldEachBeReleasedAtTheirDueTime()
 	{
 		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
-		CancellationToken token = TestContext.Current!.Execution.CancellationToken;
+		var token = TestContext.Current!.Execution.CancellationToken;
 
-		Task delay1 = timeSystem.Task.Delay(1.Seconds(), token);
-		Task delay2 = timeSystem.Task.Delay(2.Seconds(), token);
-		Task delay3 = timeSystem.Task.Delay(3.Seconds(), token);
+		var delay1 = timeSystem.Task.Delay(1.Seconds(), token);
+		var delay2 = timeSystem.Task.Delay(2.Seconds(), token);
+		var delay3 = timeSystem.Task.Delay(3.Seconds(), token);
 
 		timeSystem.TimeProvider.AdvanceBy(2.Seconds());
 
@@ -55,9 +58,9 @@ public class MockTimeSystemTests
 	public async Task Delay_DisabledAutoAdvance_PartialAdvance_ShouldNotReleaseDelay()
 	{
 		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
-		CancellationToken token = TestContext.Current!.Execution.CancellationToken;
+		var token = TestContext.Current!.Execution.CancellationToken;
 
-		Task delayTask = timeSystem.Task.Delay(5.Seconds(), token);
+		var delayTask = timeSystem.Task.Delay(5.Seconds(), token);
 
 		timeSystem.TimeProvider.AdvanceBy(3.Seconds());
 		await That(delayTask.IsCompleted).IsFalse();
@@ -71,9 +74,9 @@ public class MockTimeSystemTests
 	public async Task Delay_DisabledAutoAdvance_SetTo_ShouldNotReleaseDelay_OnlyAdvanceByDoes()
 	{
 		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
-		CancellationToken token = TestContext.Current!.Execution.CancellationToken;
+		var token = TestContext.Current!.Execution.CancellationToken;
 
-		Task delayTask = timeSystem.Task.Delay(5.Seconds(), token);
+		var delayTask = timeSystem.Task.Delay(5.Seconds(), token);
 
 		// Jumping the wall clock (e.g. an NTP/DST change) must NOT release a monotonic delay.
 		timeSystem.TimeProvider.SetTo(timeSystem.DateTime.UtcNow.AddHours(1));
@@ -89,10 +92,10 @@ public class MockTimeSystemTests
 	public async Task Delay_DisabledAutoAdvance_ShouldStayPendingUntilTimeIsAdvanced()
 	{
 		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
-		CancellationToken token = TestContext.Current!.Execution.CancellationToken;
-		DateTime before = timeSystem.DateTime.Now;
+		var token = TestContext.Current!.Execution.CancellationToken;
+		var before = timeSystem.DateTime.Now;
 
-		Task delayTask = timeSystem.Task.Delay(5.Seconds(), token);
+		var delayTask = timeSystem.Task.Delay(5.Seconds(), token);
 
 		// The delay stays pending and does not advance time on its own.
 		await That(delayTask.IsCompleted).IsFalse();
@@ -108,9 +111,9 @@ public class MockTimeSystemTests
 	public async Task Delay_DisabledAutoAdvance_Zero_ShouldCompleteImmediately()
 	{
 		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
-		CancellationToken token = TestContext.Current!.Execution.CancellationToken;
+		var token = TestContext.Current!.Execution.CancellationToken;
 
-		Task delayTask = timeSystem.Task.Delay(TimeSpan.Zero, token);
+		var delayTask = timeSystem.Task.Delay(TimeSpan.Zero, token);
 
 		await delayTask;
 		await That(delayTask.IsCompleted).IsTrue();
@@ -120,7 +123,7 @@ public class MockTimeSystemTests
 	public async Task Delay_Infinite_ShouldNotThrowException()
 	{
 		MockTimeSystem timeSystem = new();
-		Exception? exception =
+		var exception =
 			await Record.ExceptionAsync(()
 				=> timeSystem.Task.Delay(Timeout.Infinite,
 					TestContext.Current!.Execution.CancellationToken));
@@ -132,7 +135,7 @@ public class MockTimeSystemTests
 	public async Task Delay_InfiniteTimeSpan_ShouldNotThrowException()
 	{
 		MockTimeSystem timeSystem = new();
-		Exception? exception =
+		var exception =
 			await Record.ExceptionAsync(()
 				=> timeSystem.Task.Delay(Timeout.InfiniteTimeSpan,
 					TestContext.Current!.Execution.CancellationToken));
@@ -172,12 +175,12 @@ public class MockTimeSystemTests
 		DifferenceBetweenDateTimeNowAndDateTimeUtcNow_ShouldBeLocalTimeZoneOffsetFromUtc(
 			DateTimeKind dateTimeKind)
 	{
-		DateTime now = TimeTestHelper.GetRandomTime(DateTimeKind.Local);
+		var now = TimeTestHelper.GetRandomTime(DateTimeKind.Local);
 
-		TimeSpan expectedDifference = TimeZoneInfo.Local.GetUtcOffset(now);
+		var expectedDifference = TimeZoneInfo.Local.GetUtcOffset(now);
 
 		MockTimeSystem timeSystem = new(DateTime.SpecifyKind(now, dateTimeKind));
-		TimeSpan actualDifference = timeSystem.DateTime.Now - timeSystem.DateTime.UtcNow;
+		var actualDifference = timeSystem.DateTime.Now - timeSystem.DateTime.UtcNow;
 
 		await That(actualDifference).IsEqualTo(expectedDifference);
 	}
@@ -188,13 +191,13 @@ public class MockTimeSystemTests
 	{
 		MockTimeSystem timeSystem = new(o => o.DisableAutoAdvance());
 		int tickCount = 0;
-		using CancellationTokenSource cts =
+		using var cts =
 			CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current!.Execution
 				.CancellationToken);
-		CancellationToken token = cts.Token;
+		var token = cts.Token;
 		_ = Task.Run(async () =>
 		{
-			using IPeriodicTimer periodicTimer = timeSystem.PeriodicTimer.New(1.Seconds());
+			using var periodicTimer = timeSystem.PeriodicTimer.New(1.Seconds());
 			while (await periodicTimer.WaitForNextTickAsync(token))
 			{
 				tickCount++;
@@ -216,19 +219,19 @@ public class MockTimeSystemTests
 		DateTime time = new(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 		MockTimeSystem timeSystem = new(time, o => o.DisableAutoAdvance());
 		List<DateTime> tickTimes = [];
-		using CancellationTokenSource cts = CancellationTokenSource
+		using var cts = CancellationTokenSource
 			.CreateLinkedTokenSource(TestContext.Current!.Execution.CancellationToken);
 		cts.CancelAfter(30.Seconds());
-		CancellationToken token = cts.Token;
+		var token = cts.Token;
 		using SemaphoreSlim waitStarted = new(0, amount);
 		using SemaphoreSlim tickObserved = new(0, amount);
 
-		Task backgroundTask = Task.Run(async () =>
+		var backgroundTask = Task.Run(async () =>
 		{
-			using IPeriodicTimer periodicTimer = timeSystem.PeriodicTimer.New(1.Seconds());
+			using var periodicTimer = timeSystem.PeriodicTimer.New(1.Seconds());
 			for (int i = 0; i < amount; i++)
 			{
-				ValueTask<bool> waitForTickTask = periodicTimer.WaitForNextTickAsync(token);
+				var waitForTickTask = periodicTimer.WaitForNextTickAsync(token);
 				// ReSharper disable once AccessToDisposedClosure
 				waitStarted.Release();
 				_ = await waitForTickTask;
@@ -252,14 +255,43 @@ public class MockTimeSystemTests
 #endif
 
 	[Test]
+	[Arguments(DateTimeKind.Utc)]
+	[Arguments(DateTimeKind.Local)]
+	[Arguments(DateTimeKind.Unspecified)]
+	public async Task SetTo_ShouldNormalizeToUtc_ConsistentlyWithConstructor(DateTimeKind kind)
+	{
+		var time = DateTime.SpecifyKind(new DateTime(2026, 1, 15, 10, 0, 0), kind);
+		MockTimeSystem fromConstructor = new(time);
+		MockTimeSystem fromSetTo = new(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+		fromSetTo.TimeProvider.SetTo(time);
+
+		await That(fromSetTo.DateTime.UtcNow).IsEqualTo(fromConstructor.DateTime.UtcNow);
+		await That(fromSetTo.DateTime.UtcNow.Kind).IsEqualTo(DateTimeKind.Utc);
+		await That(fromSetTo.DateTime.Now).IsEqualTo(fromConstructor.DateTime.Now);
+	}
+
+	[Test]
+	public async Task SetTo_UnspecifiedKind_ShouldBeTreatedAsUtc()
+	{
+		DateTime unspecified = new(2026, 1, 15, 10, 0, 0, DateTimeKind.Unspecified);
+		MockTimeSystem timeSystem = new(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+		timeSystem.TimeProvider.SetTo(unspecified);
+
+		await That(timeSystem.DateTime.UtcNow)
+			.IsEqualTo(new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc));
+	}
+
+	[Test]
 	public async Task Sleep_DisabledAutoAdvance_ShouldNotChangeTime()
 	{
 		MockTimeSystem timeSystem = new(DateTime.Now, o => o.DisableAutoAdvance());
-		DateTime before = timeSystem.DateTime.Now;
+		var before = timeSystem.DateTime.Now;
 
 		timeSystem.Thread.Sleep(5.Seconds());
 
-		DateTime after = timeSystem.DateTime.Now;
+		var after = timeSystem.DateTime.Now;
 		await That(after).IsEqualTo(before);
 	}
 
@@ -267,7 +299,7 @@ public class MockTimeSystemTests
 	public async Task Sleep_Infinite_ShouldNotThrowException()
 	{
 		MockTimeSystem timeSystem = new();
-		Exception? exception =
+		var exception =
 			Record.Exception(() => timeSystem.Thread.Sleep(Timeout.Infinite));
 
 		await That(exception).IsNull();
@@ -277,7 +309,7 @@ public class MockTimeSystemTests
 	public async Task Sleep_InfiniteTimeSpan_ShouldNotThrowException()
 	{
 		MockTimeSystem timeSystem = new();
-		Exception? exception =
+		var exception =
 			Record.Exception(() => timeSystem.Thread.Sleep(Timeout.InfiniteTimeSpan));
 
 		await That(exception).IsNull();
@@ -287,7 +319,7 @@ public class MockTimeSystemTests
 	public async Task Sleep_LessThanInfinite_ShouldThrowArgumentOutOfRangeException()
 	{
 		MockTimeSystem timeSystem = new();
-		Exception? exception =
+		var exception =
 			Record.Exception(() => timeSystem.Thread.Sleep(-2));
 
 		await That(exception).IsExactly<ArgumentOutOfRangeException>();
@@ -297,7 +329,7 @@ public class MockTimeSystemTests
 	public async Task Sleep_LessThanInfiniteTimeSpan_ShouldThrowArgumentOutOfRangeException()
 	{
 		MockTimeSystem timeSystem = new();
-		Exception? exception =
+		var exception =
 			Record.Exception(()
 				=> timeSystem.Thread.Sleep(TimeSpan.FromMilliseconds(-2)));
 
@@ -307,7 +339,7 @@ public class MockTimeSystemTests
 	[Test]
 	public async Task TimeProvider_StartTime_ShouldBeSetToInitialTime()
 	{
-		DateTime now = TimeTestHelper.GetRandomTime(DateTimeKind.Utc);
+		var now = TimeTestHelper.GetRandomTime(DateTimeKind.Utc);
 		MockTimeSystem timeSystem = new(TimeProviderFactory.Use(now));
 
 		timeSystem.TimeProvider.AdvanceBy(TimeSpan.FromMinutes(42));
@@ -318,7 +350,7 @@ public class MockTimeSystemTests
 	[Test]
 	public async Task ToString_WithFixedContainer_ShouldContainTimeProvider()
 	{
-		DateTime now = TimeTestHelper.GetRandomTime();
+		var now = TimeTestHelper.GetRandomTime();
 		MockTimeSystem timeSystem = new(TimeProviderFactory.Use(now));
 
 		string result = timeSystem.ToString();
@@ -347,34 +379,5 @@ public class MockTimeSystemTests
 
 		await That(result).Contains("Random");
 		await That(result).Contains($"{timeSystem.DateTime.UtcNow}Z");
-	}
-
-	[Test]
-	[Arguments(DateTimeKind.Utc)]
-	[Arguments(DateTimeKind.Local)]
-	[Arguments(DateTimeKind.Unspecified)]
-	public async Task SetTo_ShouldNormalizeToUtc_ConsistentlyWithConstructor(DateTimeKind kind)
-	{
-		DateTime time = DateTime.SpecifyKind(new DateTime(2026, 1, 15, 10, 0, 0), kind);
-		MockTimeSystem fromConstructor = new(time);
-		MockTimeSystem fromSetTo = new(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
-
-		fromSetTo.TimeProvider.SetTo(time);
-
-		await That(fromSetTo.DateTime.UtcNow).IsEqualTo(fromConstructor.DateTime.UtcNow);
-		await That(fromSetTo.DateTime.UtcNow.Kind).IsEqualTo(DateTimeKind.Utc);
-		await That(fromSetTo.DateTime.Now).IsEqualTo(fromConstructor.DateTime.Now);
-	}
-
-	[Test]
-	public async Task SetTo_UnspecifiedKind_ShouldBeTreatedAsUtc()
-	{
-		DateTime unspecified = new(2026, 1, 15, 10, 0, 0, DateTimeKind.Unspecified);
-		MockTimeSystem timeSystem = new(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
-
-		timeSystem.TimeProvider.SetTo(unspecified);
-
-		await That(timeSystem.DateTime.UtcNow)
-			.IsEqualTo(new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc));
 	}
 }

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeProviderFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeProviderFactoryTests.cs
@@ -7,6 +7,39 @@ namespace Testably.Abstractions.Testing.Tests;
 public class TimeProviderFactoryTests
 {
 	[Test]
+	public async Task Now_ShouldUseLocalTimeZone()
+	{
+		ITimeProvider timeProvider = TimeProviderFactory.Now().Create(_ => { });
+
+		await That(timeProvider.LocalTimeZone).IsEqualTo(TimeZoneInfo.Local);
+	}
+
+	[Test]
+	public async Task Random_ShouldUseOneOfTheSampleTimeZones()
+	{
+		string[] sampleTimeZoneIds =
+		[
+			"UTC", "Sample/Plus0530", "Sample/Minus0800", "Sample/DaylightSaving",
+		];
+
+		ITimeProvider timeProvider = TimeProviderFactory.Random().Create(_ => { });
+
+		await That(sampleTimeZoneIds).Contains(timeProvider.LocalTimeZone.Id);
+	}
+
+	[Test]
+	public async Task Use_WithTimeZone_ShouldUseGivenTimeZone()
+	{
+		TimeZoneInfo timeZone = TimeZoneInfo.CreateCustomTimeZone(
+			"Custom/Plus07", TimeSpan.FromHours(7), "Custom +07", "Custom +07");
+
+		ITimeProvider timeProvider =
+			TimeProviderFactory.Use(DateTime.UtcNow, timeZone).Create(_ => { });
+
+		await That(timeProvider.LocalTimeZone).IsEqualTo(timeZone);
+	}
+
+	[Test]
 	public async Task Now_ShouldReturnCurrentDateTime()
 	{
 		DateTime begin = DateTime.UtcNow;

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeProviderFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeProviderFactoryTests.cs
@@ -40,6 +40,15 @@ public class TimeProviderFactoryTests
 	}
 
 	[Test]
+	public async Task Use_WithNullTimeZone_ShouldThrowArgumentNullException()
+	{
+		void Act()
+			=> TimeProviderFactory.Use(DateTime.UtcNow, null!);
+
+		await That(Act).Throws<ArgumentNullException>().WithParamName("localTimeZone");
+	}
+
+	[Test]
 	public async Task Now_ShouldReturnCurrentDateTime()
 	{
 		DateTime begin = DateTime.UtcNow;

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimeZoneInfoMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimeZoneInfoMockTests.cs
@@ -1,0 +1,69 @@
+namespace Testably.Abstractions.Testing.Tests.TimeSystem;
+
+public class TimeZoneInfoMockTests
+{
+	[Test]
+	public async Task FindSystemTimeZoneById_UnknownId_ShouldThrowTimeZoneNotFoundException()
+	{
+		MockTimeSystem timeSystem = new();
+
+		void Act()
+			=> timeSystem.TimeZoneInfo.FindSystemTimeZoneById("Unknown/Does-Not-Exist");
+
+		await That(Act).Throws<TimeZoneNotFoundException>();
+	}
+
+	[Test]
+	public async Task LocalTimeZone_WhenSetOnProvider_ShouldBeReturnedByLocal()
+	{
+		TimeZoneInfo timeZone = TimeZoneInfo.CreateCustomTimeZone(
+			"Custom/Plus02", TimeSpan.FromHours(2), "Custom +02", "Custom +02");
+		MockTimeSystem timeSystem = new();
+
+		timeSystem.TimeProvider.LocalTimeZone = timeZone;
+
+		await That(timeSystem.TimeZoneInfo.Local).IsEqualTo(timeZone);
+	}
+
+	[Test]
+	public async Task Now_ShouldUseConfiguredLocalTimeZoneOffset()
+	{
+		DateTime utcNow = new(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+		TimeZoneInfo timeZone = TimeZoneInfo.CreateCustomTimeZone(
+			"Custom/Plus05", TimeSpan.FromHours(5), "Custom +05", "Custom +05");
+		MockTimeSystem timeSystem = new(TimeProviderFactory.Use(utcNow, timeZone));
+
+		DateTime now = timeSystem.DateTime.Now;
+
+		await That(now).IsEqualTo(new DateTime(2024, 1, 15, 17, 0, 0, DateTimeKind.Local));
+		await That(now.Kind).IsEqualTo(DateTimeKind.Local);
+		await That(timeSystem.DateTime.UtcNow).IsEqualTo(utcNow);
+	}
+
+	[Test]
+	public async Task RegisterTimeZone_ShouldBeResolvableAndEnumerated()
+	{
+		TimeZoneInfo timeZone = TimeZoneInfo.CreateCustomTimeZone(
+			"Custom/Plus03", TimeSpan.FromHours(3), "Custom +03", "Custom +03");
+		MockTimeSystem timeSystem = new();
+
+		timeSystem.TimeProvider.RegisterTimeZone(timeZone);
+
+		await That(timeSystem.TimeZoneInfo.FindSystemTimeZoneById("Custom/Plus03"))
+			.IsEqualTo(timeZone);
+		await That(timeSystem.TimeZoneInfo.GetSystemTimeZones()).Contains(timeZone);
+	}
+
+	[Test]
+	public async Task SettingLocalTimeZone_ShouldRegisterItForLookup()
+	{
+		TimeZoneInfo timeZone = TimeZoneInfo.CreateCustomTimeZone(
+			"Custom/Plus04", TimeSpan.FromHours(4), "Custom +04", "Custom +04");
+		MockTimeSystem timeSystem = new();
+
+		timeSystem.TimeProvider.LocalTimeZone = timeZone;
+
+		await That(timeSystem.TimeZoneInfo.FindSystemTimeZoneById("Custom/Plus04"))
+			.IsEqualTo(timeZone);
+	}
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimeZoneInfoMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimeZoneInfoMockTests.cs
@@ -3,17 +3,6 @@ namespace Testably.Abstractions.Testing.Tests.TimeSystem;
 public class TimeZoneInfoMockTests
 {
 	[Test]
-	public async Task FindSystemTimeZoneById_UnknownId_ShouldThrowTimeZoneNotFoundException()
-	{
-		MockTimeSystem timeSystem = new();
-
-		void Act()
-			=> timeSystem.TimeZoneInfo.FindSystemTimeZoneById("Unknown/Does-Not-Exist");
-
-		await That(Act).Throws<TimeZoneNotFoundException>();
-	}
-
-	[Test]
 	public async Task LocalTimeZone_WhenSetOnProvider_ShouldBeReturnedByLocal()
 	{
 		TimeZoneInfo timeZone = TimeZoneInfo.CreateCustomTimeZone(

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/DateTimeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/DateTimeTests.cs
@@ -1,3 +1,5 @@
+using aweXpect.Chronology;
+
 namespace Testably.Abstractions.Tests.TimeSystem;
 
 [TimeSystemTests]
@@ -39,16 +41,13 @@ public class DateTimeTests(TimeSystemTestData testData) : TimeSystemTestBase(tes
 	[Test]
 	public async Task NowAndUtcNow_ShouldRepresentTheSameInstant()
 	{
-		// Tests are brittle on the build system
-		TimeSpan tolerance = TimeSpan.FromMilliseconds(250);
-
 		DateTime utcNowBefore = TimeSystem.DateTime.UtcNow;
 		DateTime now = TimeSystem.DateTime.Now;
 		DateTime utcNowAfter = TimeSystem.DateTime.UtcNow;
 
 		await That(now.Kind).IsEqualTo(DateTimeKind.Local);
 		await That(now.ToUniversalTime())
-			.IsBetween(utcNowBefore).And(utcNowAfter).Within(tolerance);
+			.IsBetween(utcNowBefore).And(utcNowAfter).Within(50.Milliseconds());
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/DateTimeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/DateTimeTests.cs
@@ -37,6 +37,21 @@ public class DateTimeTests(TimeSystemTestData testData) : TimeSystemTestBase(tes
 	}
 
 	[Test]
+	public async Task NowAndUtcNow_ShouldRepresentTheSameInstant()
+	{
+		// Tests are brittle on the build system
+		TimeSpan tolerance = TimeSpan.FromMilliseconds(250);
+
+		DateTime utcNowBefore = TimeSystem.DateTime.UtcNow;
+		DateTime now = TimeSystem.DateTime.Now;
+		DateTime utcNowAfter = TimeSystem.DateTime.UtcNow;
+
+		await That(now.Kind).IsEqualTo(DateTimeKind.Local);
+		await That(now.ToUniversalTime())
+			.IsBetween(utcNowBefore).And(utcNowAfter).Within(tolerance);
+	}
+
+	[Test]
 	public async Task Today_ShouldBeSetToToday()
 	{
 		DateTime before = DateTime.Today;

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimeProviderBridgeTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimeProviderBridgeTests.cs
@@ -7,6 +7,14 @@ namespace Testably.Abstractions.Tests.TimeSystem;
 public class TimeProviderBridgeTests(TimeSystemTestData testData) : TimeSystemTestBase(testData)
 {
 	[Test]
+	public async Task ToTimeProvider_LocalTimeZone_ShouldMatchTimeSystem()
+	{
+		System.TimeProvider provider = TimeSystem.ToTimeProvider();
+
+		await That(provider.LocalTimeZone).IsEqualTo(TimeSystem.TimeZoneInfo.Local);
+	}
+
+	[Test]
 	public async Task ToTimeProvider_ThrowingCallback_ShouldKeepFiring()
 	{
 		System.TimeProvider provider = TimeSystem.ToTimeProvider();

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimeZoneInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimeZoneInfoTests.cs
@@ -1,0 +1,40 @@
+using System.Collections.ObjectModel;
+
+namespace Testably.Abstractions.Tests.TimeSystem;
+
+[TimeSystemTests]
+public class TimeZoneInfoTests(TimeSystemTestData testData) : TimeSystemTestBase(testData)
+{
+	[Test]
+	public async Task FindSystemTimeZoneById_Utc_ShouldReturnUtcTimeZone()
+	{
+		TimeZoneInfo result =
+			TimeSystem.TimeZoneInfo.FindSystemTimeZoneById(TimeZoneInfo.Utc.Id);
+
+		await That(result.BaseUtcOffset).IsEqualTo(TimeSpan.Zero);
+	}
+
+	[Test]
+	public async Task GetSystemTimeZones_ShouldNotBeEmpty()
+	{
+		ReadOnlyCollection<TimeZoneInfo> result = TimeSystem.TimeZoneInfo.GetSystemTimeZones();
+
+		await That(result).IsNotEmpty();
+	}
+
+	[Test]
+	public async Task Local_ShouldReturnLocalTimeZone()
+	{
+		TimeZoneInfo result = TimeSystem.TimeZoneInfo.Local;
+
+		await That(result).IsEqualTo(TimeZoneInfo.Local);
+	}
+
+	[Test]
+	public async Task Utc_ShouldReturnUtcTimeZone()
+	{
+		TimeZoneInfo result = TimeSystem.TimeZoneInfo.Utc;
+
+		await That(result).IsEqualTo(TimeZoneInfo.Utc);
+	}
+}

--- a/Tests/Testably.Abstractions.Tests/TimeSystem/TimeZoneInfoTests.cs
+++ b/Tests/Testably.Abstractions.Tests/TimeSystem/TimeZoneInfoTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Testably.Abstractions.Tests.TimeSystem;
 
@@ -6,12 +7,42 @@ namespace Testably.Abstractions.Tests.TimeSystem;
 public class TimeZoneInfoTests(TimeSystemTestData testData) : TimeSystemTestBase(testData)
 {
 	[Test]
+	public async Task FindSystemTimeZoneById_UnknownId_ShouldThrowTimeZoneNotFoundException()
+	{
+		string unknownId = "Testably/DoesNotExist";
+		int expectedHResult = 0;
+		try
+		{
+			_ = TimeZoneInfo.FindSystemTimeZoneById(unknownId);
+		}
+		catch (TimeZoneNotFoundException exception)
+		{
+			expectedHResult = exception.HResult;
+		}
+
+		void Act()
+			=> _ = TimeSystem.TimeZoneInfo.FindSystemTimeZoneById(unknownId);
+
+		await That(Act).Throws<TimeZoneNotFoundException>()
+			.WithMessage($"The time zone ID '{unknownId}' was not found on the local computer.").And
+			.WithHResult(expectedHResult);
+	}
+
+	[Test]
 	public async Task FindSystemTimeZoneById_Utc_ShouldReturnUtcTimeZone()
 	{
 		TimeZoneInfo result =
 			TimeSystem.TimeZoneInfo.FindSystemTimeZoneById(TimeZoneInfo.Utc.Id);
 
 		await That(result.BaseUtcOffset).IsEqualTo(TimeSpan.Zero);
+	}
+
+	[Test]
+	public async Task GetSystemTimeZones_ShouldContainUtc()
+	{
+		ReadOnlyCollection<TimeZoneInfo> result = TimeSystem.TimeZoneInfo.GetSystemTimeZones();
+
+		await That(result.Select(timeZone => timeZone.Id)).Contains(TimeZoneInfo.Utc.Id);
 	}
 
 	[Test]


### PR DESCRIPTION
Adds the mock implementation of `ITimeZoneInfo` to `MockTimeSystem`, making the local time zone deterministically controllable in tests.

- Implement `TimeZoneInfoMock` and expose it via `MockTimeSystem.TimeZoneInfo`.
- Add `LocalTimeZone` plus a seeded, overridable time-zone registry (`RegisterTimeZone` / `FindSystemTimeZoneById` / `GetSystemTimeZones`) to `ITimeProvider`; the registry is seeded from the host and can be extended.
- `TimeProviderFactory`: `Now`/`Use` default the local time zone to `TimeZoneInfo.Local`, `Random` picks from a curated, cross-platform-stable set (incl. a daylight-saving zone), and a new `Use(time, localTimeZone)` overload allows an explicit zone.
- Route `DateTimeMock.Now`/`Today` through the configured local time zone and resolve the `ToTimeProvider().LocalTimeZone` bridge.
- `MockTimeSystem.DateTimeOffset` is temporarily stubbed; the mock is added in the follow-up `DateTimeOffset` change.
- Reset `BuildScope` to `Default` and reference the `10.3.0-pre.1` interface pre-release.

---

- *Part of #1039*