### PR TITLE
fix: skip extended-length and invalid path tests on .NET Framework

### DIFF
--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateDirectoryTests.cs
@@ -54,6 +54,7 @@ public class CreateDirectoryTests(FileSystemTestData testData) : FileSystemTestB
 	public async Task CreateDirectory_ShouldSupportExtendedLengthPaths()
 	{
 		Skip.If(!Test.RunsOnWindows);
+		Skip.If(Test.IsNetFramework, "Extended-length paths are not supported on .NET Framework.");
 
 		FileSystem.DirectoryInfo.New(@"\\?\c:\bar").Create();
 

--- a/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/Directory/EnumerateDirectoriesTests.cs
@@ -215,6 +215,7 @@ public class EnumerateDirectoriesTests(FileSystemTestData testData) : FileSystem
 	public async Task EnumerateDirectories_ShouldSupportExtendedLengthPaths1()
 	{
 		Skip.If(!Test.RunsOnWindows);
+		Skip.If(Test.IsNetFramework, "Extended-length paths are not supported on .NET Framework.");
 
 		FileSystem.Directory.CreateDirectory(@"\\?\c:\bar");
 		FileSystem.File.WriteAllText(@"\\?\c:\bar\foo1.txt", "foo1");
@@ -231,6 +232,7 @@ public class EnumerateDirectoriesTests(FileSystemTestData testData) : FileSystem
 	public async Task EnumerateDirectories_ShouldSupportExtendedLengthPaths2()
 	{
 		Skip.If(!Test.RunsOnWindows);
+		Skip.If(Test.IsNetFramework, "Extended-length paths are not supported on .NET Framework.");
 
 		FileSystem.Directory.CreateDirectory(@"\\?\c:\bar");
 		FileSystem.File.WriteAllText(@"\\?\c:\bar\foo1.txt", "foo1");

--- a/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
+++ b/Tests/Testably.Abstractions.Tests/FileSystem/File/CopyTests.cs
@@ -116,23 +116,17 @@ public class CopyTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 			string source, string destination)
 	{
 		Skip.IfNot(Test.RunsOnWindows);
+		Skip.If(Test.IsNetFramework, "Invalid paths throw inconsistently on .NET Framework.");
 
 		void Act()
 		{
 			FileSystem.File.Copy(source, destination);
 		}
 
-		if (Test.IsNetFramework)
-		{
-			await That(Act).Throws<NotSupportedException>().WithHResult(-2146233067);
-		}
-		else
-		{
-			await That(Act).Throws<IOException>()
-				.WithMessageContaining(
-					"The filename, directory name, or volume label syntax is incorrect").And
-				.WithHResult(-2147024773);
-		}
+		await That(Act).Throws<IOException>()
+			.WithMessageContaining(
+				"The filename, directory name, or volume label syntax is incorrect").And
+			.WithHResult(-2147024773);
 	}
 
 	[Test]


### PR DESCRIPTION
On .NET Framework 'Path.GetFullPath' rejects '\?\' device paths and throws a culture-dependent exception for invalid paths, so these tests fail unreliably (they turn red once tests are forced to run under the invariant culture). Skip them on .NET Framework; they continue to run and pass on modern targets.