### PR TITLE
fix: interpret Local-kind mock time against configured zone

### DIFF
--- a/Source/Testably.Abstractions.Testing/TimeProviderFactory.cs
+++ b/Source/Testably.Abstractions.Testing/TimeProviderFactory.cs
@@ -57,7 +57,8 @@ public static class TimeProviderFactory
 	/// </summary>
 	/// <remarks>
 	///     If the <paramref name="time" /> has Kind DateTimeKind.Unspecified it will be treated as if it had Kind
-	///     DateTimeKind.Utc.<br />
+	///     DateTimeKind.Utc. If it has Kind DateTimeKind.Local it is interpreted against the local time zone (here
+	///     <see cref="TimeZoneInfo.Local" />), not the host machine's zone, so that "now" stays machine-independent.<br />
 	///     The local time zone is set to <see cref="TimeZoneInfo.Local" />.
 	/// </remarks>
 	public static ITimeProviderFactory Use(DateTime time)
@@ -69,7 +70,8 @@ public static class TimeProviderFactory
 	/// </summary>
 	/// <remarks>
 	///     If the <paramref name="time" /> has Kind DateTimeKind.Unspecified it will be treated as if it had Kind
-	///     DateTimeKind.Utc.
+	///     DateTimeKind.Utc. If it has Kind DateTimeKind.Local it is interpreted against the given
+	///     <paramref name="localTimeZone" />, not the host machine's zone, so that "now" stays machine-independent.
 	/// </remarks>
 	public static ITimeProviderFactory Use(DateTime time, TimeZoneInfo localTimeZone)
 	{

--- a/Source/Testably.Abstractions.Testing/TimeSystem/TimeProviderMock.cs
+++ b/Source/Testably.Abstractions.Testing/TimeSystem/TimeProviderMock.cs
@@ -27,15 +27,31 @@ internal sealed class TimeProviderMock : ITimeProvider
 	public TimeProviderMock(Action<DateTime> onTimeChanged, DateTime now, string description,
 		TimeZoneInfo localTimeZone)
 	{
-		_now = now.Kind == DateTimeKind.Unspecified
-			? DateTime.SpecifyKind(now, DateTimeKind.Utc)
-			: now;
+		_now = NormalizeToUtc(now, localTimeZone);
 		_elapsedTicks = _now.Ticks;
 		StartTime = _now;
 		_onTimeChanged = onTimeChanged;
 		_description = description;
 		_localTimeZone = localTimeZone;
 	}
+
+	/// <summary>
+	///     Normalizes <paramref name="value" /> to a <see cref="DateTimeKind.Utc" /> instant.
+	/// </summary>
+	/// <remarks>
+	///     A <see cref="DateTimeKind.Local" /> value is interpreted against the mock's
+	///     <paramref name="localTimeZone" /> (not the host machine's zone) so that "now" stays machine-independent; a
+	///     <see cref="DateTimeKind.Unspecified" /> value is treated as if it were <see cref="DateTimeKind.Utc" />, and an
+	///     already <see cref="DateTimeKind.Utc" /> value is left untouched.
+	/// </remarks>
+	private static DateTime NormalizeToUtc(DateTime value, TimeZoneInfo localTimeZone)
+		=> value.Kind switch
+		{
+			DateTimeKind.Utc => value,
+			DateTimeKind.Local => TimeZoneInfo.ConvertTimeToUtc(
+				DateTime.SpecifyKind(value, DateTimeKind.Unspecified), localTimeZone),
+			_ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+		};
 
 	#region ITimeProvider Members
 
@@ -148,9 +164,7 @@ internal sealed class TimeProviderMock : ITimeProvider
 	{
 		lock (_lock)
 		{
-			_now = value.Kind == DateTimeKind.Unspecified
-				? DateTime.SpecifyKind(value, DateTimeKind.Utc)
-				: value.ToUniversalTime();
+			_now = NormalizeToUtc(value, _localTimeZone);
 			_onTimeChanged.Invoke(_now);
 		}
 	}

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/DateTimeOffsetMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/DateTimeOffsetMockTests.cs
@@ -3,6 +3,32 @@ namespace Testably.Abstractions.Testing.Tests.TimeSystem;
 public class DateTimeOffsetMockTests
 {
 	[Test]
+	public async Task Now_WithLocalKindInput_ShouldInterpretAgainstConfiguredZone_NotHostZone()
+	{
+		DateTime localInput = new(2024, 1, 15, 12, 0, 0, DateTimeKind.Local);
+		TimeZoneInfo plus05 = TimeZoneInfo.CreateCustomTimeZone(
+			"Custom/Plus05", TimeSpan.FromHours(5), "Custom +05", "Custom +05");
+		TimeZoneInfo plus08 = TimeZoneInfo.CreateCustomTimeZone(
+			"Custom/Plus08", TimeSpan.FromHours(8), "Custom +08", "Custom +08");
+		MockTimeSystem inPlus05 = new(TimeProviderFactory.Use(localInput, plus05));
+		MockTimeSystem inPlus08 = new(TimeProviderFactory.Use(localInput, plus08));
+
+		// The local wall-clock time round-trips to the input regardless of the configured (or host) zone.
+		await That(inPlus05.DateTimeOffset.Now)
+			.IsEqualTo(new DateTimeOffset(2024, 1, 15, 12, 0, 0, TimeSpan.FromHours(5)));
+		await That(inPlus05.DateTimeOffset.Now.Offset).IsEqualTo(TimeSpan.FromHours(5));
+		await That(inPlus08.DateTimeOffset.Now)
+			.IsEqualTo(new DateTimeOffset(2024, 1, 15, 12, 0, 0, TimeSpan.FromHours(8)));
+		await That(inPlus08.DateTimeOffset.Now.Offset).IsEqualTo(TimeSpan.FromHours(8));
+
+		// The underlying UTC instant is derived from the configured zone (12:00 - offset), not the host.
+		await That(inPlus05.DateTimeOffset.UtcNow)
+			.IsEqualTo(new DateTimeOffset(2024, 1, 15, 7, 0, 0, TimeSpan.Zero));
+		await That(inPlus08.DateTimeOffset.UtcNow)
+			.IsEqualTo(new DateTimeOffset(2024, 1, 15, 4, 0, 0, TimeSpan.Zero));
+	}
+
+	[Test]
 	public async Task Now_ShouldUseConfiguredLocalTimeZoneOffset()
 	{
 		DateTime utcNow = new(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc);

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimeZoneInfoMockTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeSystem/TimeZoneInfoMockTests.cs
@@ -15,6 +15,30 @@ public class TimeZoneInfoMockTests
 	}
 
 	[Test]
+	public async Task Now_WithLocalKindInput_ShouldInterpretAgainstConfiguredZone_NotHostZone()
+	{
+		DateTime localInput = new(2024, 1, 15, 12, 0, 0, DateTimeKind.Local);
+		TimeZoneInfo plus05 = TimeZoneInfo.CreateCustomTimeZone(
+			"Custom/Plus05", TimeSpan.FromHours(5), "Custom +05", "Custom +05");
+		TimeZoneInfo plus08 = TimeZoneInfo.CreateCustomTimeZone(
+			"Custom/Plus08", TimeSpan.FromHours(8), "Custom +08", "Custom +08");
+		MockTimeSystem inPlus05 = new(TimeProviderFactory.Use(localInput, plus05));
+		MockTimeSystem inPlus08 = new(TimeProviderFactory.Use(localInput, plus08));
+
+		// The local wall-clock time round-trips to the input regardless of the configured (or host) zone.
+		await That(inPlus05.DateTime.Now)
+			.IsEqualTo(new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Local));
+		await That(inPlus08.DateTime.Now)
+			.IsEqualTo(new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Local));
+
+		// The underlying UTC instant is derived from the configured zone (12:00 - offset), not the host.
+		await That(inPlus05.DateTime.UtcNow)
+			.IsEqualTo(new DateTime(2024, 1, 15, 7, 0, 0, DateTimeKind.Utc));
+		await That(inPlus08.DateTime.UtcNow)
+			.IsEqualTo(new DateTime(2024, 1, 15, 4, 0, 0, DateTimeKind.Utc));
+	}
+
+	[Test]
 	public async Task Now_ShouldUseConfiguredLocalTimeZoneOffset()
 	{
 		DateTime utcNow = new(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc);


### PR DESCRIPTION
The mock time system stored a `Local`-kind input instant as-is in the constructor and normalized it via `ToUniversalTime()` in `SetTo`. Both interpret a `Local` instant against the *host machine's* time zone, so `DateTime.Now`/`UtcNow` and `DateTimeOffset.Now`/`UtcNow` depended on the host zone when a custom `LocalTimeZone` differed from it - defeating the library's determinism guarantee.

Normalize `Local`-kind input to UTC using the mock's configured `_localTimeZone` in both the constructor and `SetTo`, so `_now` is always UTC and every consumer is corrected at the boundary. `Unspecified` is still treated as UTC and already-`Utc` values are untouched.

Update the `Use(...)` XML-doc remarks to state how `Local`-kind input is interpreted, and add regression tests asserting the result depends only on the configured zone, not the host.

---

- *Fixes #1039*