### PR TITLE
refactor!: expose `ZipArchive`/`ZipFile` as extension properties

### DIFF
--- a/Docs/Nuget/Compression.md
+++ b/Docs/Nuget/Compression.md
@@ -16,14 +16,14 @@ dotnet add package Testably.Abstractions.Compression
 ```csharp
 IFileSystem fileSystem; // injected
 
-fileSystem.ZipFile()
+fileSystem.ZipFile
     .CreateFromDirectory("source", "out.zip");
 
-fileSystem.ZipFile()
+fileSystem.ZipFile
     .ExtractToDirectory("out.zip", "destination");
 
-using IZipArchive archive = fileSystem.ZipFile()
+using IZipArchive archive = fileSystem.ZipFile
     .Open("out.zip", ZipArchiveMode.Update);
 ```
 
-All overloads from the .NET base class library (BCL) are present, including the async variants on .NET 10+. `fileSystem.ZipArchive().New(stream, mode)` returns an `IZipArchive` that wraps `ZipArchive`, with `IZipArchiveEntry` mirroring its BCL counterpart. On `RealFileSystem` every call forwards to the underlying BCL implementation; only `MockFileSystem` routes through the in-memory zip implementation.
+All overloads from the .NET base class library (BCL) are present, including the async variants on .NET 10+. `fileSystem.ZipArchive.New(stream, mode)` returns an `IZipArchive` that wraps `ZipArchive`, with `IZipArchiveEntry` mirroring its BCL counterpart. On `RealFileSystem` every call forwards to the underlying BCL implementation; only `MockFileSystem` routes through the in-memory zip implementation.

--- a/Docs/pages/docs/companion-libraries/compression.mdx
+++ b/Docs/pages/docs/companion-libraries/compression.mdx
@@ -19,7 +19,7 @@ dotnet add package Testably.Abstractions.Compression
 
 ```csharp
 // With Testably.Abstractions.Compression - one line:
-fileSystem.ZipFile().CreateFromDirectory("source", "out.zip");
+fileSystem.ZipFile.CreateFromDirectory("source", "out.zip");
 ```
 
 <details>
@@ -73,16 +73,16 @@ That means production code keeps every native optimisation the BCL ships - kerne
 
 ## ZipFile
 
-`fileSystem.ZipFile()` exposes the static methods of `System.IO.Compression.ZipFile`:
+`fileSystem.ZipFile` exposes the static methods of `System.IO.Compression.ZipFile`:
 
 ```csharp
-fileSystem.ZipFile()
+fileSystem.ZipFile
     .CreateFromDirectory("your-directory", "your-file.zip");
 
-fileSystem.ZipFile()
+fileSystem.ZipFile
     .ExtractToDirectory("your-file.zip", "your-destination");
 
-using IZipArchive archive = fileSystem.ZipFile()
+using IZipArchive archive = fileSystem.ZipFile
     .Open("your-file.zip", ZipArchiveMode.Update);
 ```
 
@@ -90,11 +90,11 @@ All overloads from the BCL are present, including the async variants on .NET 10+
 
 ## ZipArchive
 
-`fileSystem.ZipArchive()` is a factory for `IZipArchive` from a `Stream` (matches the `new ZipArchive(...)` constructors):
+`fileSystem.ZipArchive` is a factory for `IZipArchive` from a `Stream` (matches the `new ZipArchive(...)` constructors):
 
 ```csharp
 using FileSystemStream stream = fileSystem.File.OpenRead("your-file.zip");
-using IZipArchive archive = fileSystem.ZipArchive()
+using IZipArchive archive = fileSystem.ZipArchive
     .New(stream, ZipArchiveMode.Read);
 
 foreach (IZipArchiveEntry entry in archive.Entries)

--- a/Docs/pages/docs/companion-libraries/index.mdx
+++ b/Docs/pages/docs/companion-libraries/index.mdx
@@ -8,7 +8,7 @@ title: Companion libraries
 
 | Package                                  | Adds to `IFileSystem`                                              |
 |------------------------------------------|--------------------------------------------------------------------|
-| `Testably.Abstractions.Compression`      | `ZipFile()` and `ZipArchive()` extension methods                  |
-| `Testably.Abstractions.AccessControl`    | `GetAccessControl` / `SetAccessControl` on files and directories  |
+| `Testably.Abstractions.Compression`      | `ZipFile` and `ZipArchive` extension properties                    |
+| `Testably.Abstractions.AccessControl`    | `GetAccessControl` / `SetAccessControl` on files and directories   |
 
 Both packages target the `IFileSystem` interface, so they work transparently against either `RealFileSystem` or `MockFileSystem`.

--- a/Source/Testably.Abstractions.Compression/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Compression/FileSystemExtensions.cs
@@ -6,15 +6,18 @@
 /// </summary>
 public static class FileSystemExtensions
 {
-	/// <summary>
-	///     Factory for abstracting creation of <see cref="System.IO.Compression.ZipArchive" />.
-	/// </summary>
-	public static IZipArchiveFactory ZipArchive(this IFileSystem fileSystem)
-		=> new ZipArchiveFactory(fileSystem);
+	extension(IFileSystem fileSystem)
+	{
+		/// <summary>
+		///     Factory for abstracting creation of <see cref="System.IO.Compression.ZipArchive" />.
+		/// </summary>
+		public IZipArchiveFactory ZipArchive
+			=> new ZipArchiveFactory(fileSystem);
 
-	/// <summary>
-	///     Abstractions for <see cref="System.IO.Compression.ZipFile" />.
-	/// </summary>
-	public static IZipFile ZipFile(this IFileSystem fileSystem)
-		=> new ZipFileWrapper(fileSystem);
+		/// <summary>
+		///     Abstractions for <see cref="System.IO.Compression.ZipFile" />.
+		/// </summary>
+		public IZipFile ZipFile
+			=> new ZipFileWrapper(fileSystem);
+	}
 }

--- a/Source/Testably.Abstractions.Compression/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Compression/FileSystemExtensions.cs
@@ -6,6 +6,8 @@
 /// </summary>
 public static class FileSystemExtensions
 {
+	#pragma warning disable S2325 // False positive: an extension property cannot be static
+	/// <inheritdoc cref="FileSystemExtensions" />
 	extension(IFileSystem fileSystem)
 	{
 		/// <summary>
@@ -20,4 +22,5 @@ public static class FileSystemExtensions
 		public IZipFile ZipFile
 			=> new ZipFileWrapper(fileSystem);
 	}
+	#pragma warning restore S2325
 }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Compression_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Compression_net10.0.txt
@@ -5,8 +5,11 @@ namespace Testably.Abstractions
 {
     public static class FileSystemExtensions
     {
-        public static Testably.Abstractions.IZipArchiveFactory ZipArchive(this System.IO.Abstractions.IFileSystem fileSystem) { }
-        public static Testably.Abstractions.IZipFile ZipFile(this System.IO.Abstractions.IFileSystem fileSystem) { }
+        extension(System.IO.Abstractions.IFileSystem fileSystem)
+        {
+            public Testably.Abstractions.IZipArchiveFactory ZipArchive { get; }
+            public Testably.Abstractions.IZipFile ZipFile { get; }
+        }
     }
     public interface IZipArchive : System.IAsyncDisposable, System.IDisposable, System.IO.Abstractions.IFileSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Compression_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Compression_net6.0.txt
@@ -5,8 +5,11 @@ namespace Testably.Abstractions
 {
     public static class FileSystemExtensions
     {
-        public static Testably.Abstractions.IZipArchiveFactory ZipArchive(this System.IO.Abstractions.IFileSystem fileSystem) { }
-        public static Testably.Abstractions.IZipFile ZipFile(this System.IO.Abstractions.IFileSystem fileSystem) { }
+        extension(System.IO.Abstractions.IFileSystem fileSystem)
+        {
+            public Testably.Abstractions.IZipArchiveFactory ZipArchive { get; }
+            public Testably.Abstractions.IZipFile ZipFile { get; }
+        }
     }
     public interface IZipArchive : System.IDisposable, System.IO.Abstractions.IFileSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Compression_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Compression_net8.0.txt
@@ -5,8 +5,11 @@ namespace Testably.Abstractions
 {
     public static class FileSystemExtensions
     {
-        public static Testably.Abstractions.IZipArchiveFactory ZipArchive(this System.IO.Abstractions.IFileSystem fileSystem) { }
-        public static Testably.Abstractions.IZipFile ZipFile(this System.IO.Abstractions.IFileSystem fileSystem) { }
+        extension(System.IO.Abstractions.IFileSystem fileSystem)
+        {
+            public Testably.Abstractions.IZipArchiveFactory ZipArchive { get; }
+            public Testably.Abstractions.IZipFile ZipFile { get; }
+        }
     }
     public interface IZipArchive : System.IDisposable, System.IO.Abstractions.IFileSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Compression_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Compression_net9.0.txt
@@ -5,8 +5,11 @@ namespace Testably.Abstractions
 {
     public static class FileSystemExtensions
     {
-        public static Testably.Abstractions.IZipArchiveFactory ZipArchive(this System.IO.Abstractions.IFileSystem fileSystem) { }
-        public static Testably.Abstractions.IZipFile ZipFile(this System.IO.Abstractions.IFileSystem fileSystem) { }
+        extension(System.IO.Abstractions.IFileSystem fileSystem)
+        {
+            public Testably.Abstractions.IZipArchiveFactory ZipArchive { get; }
+            public Testably.Abstractions.IZipFile ZipFile { get; }
+        }
     }
     public interface IZipArchive : System.IDisposable, System.IO.Abstractions.IFileSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Compression_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Compression_netstandard2.0.txt
@@ -5,8 +5,11 @@ namespace Testably.Abstractions
 {
     public static class FileSystemExtensions
     {
-        public static Testably.Abstractions.IZipArchiveFactory ZipArchive(this System.IO.Abstractions.IFileSystem fileSystem) { }
-        public static Testably.Abstractions.IZipFile ZipFile(this System.IO.Abstractions.IFileSystem fileSystem) { }
+        extension(System.IO.Abstractions.IFileSystem fileSystem)
+        {
+            public Testably.Abstractions.IZipArchiveFactory ZipArchive { get; }
+            public Testably.Abstractions.IZipFile ZipFile { get; }
+        }
     }
     public interface IZipArchive : System.IDisposable, System.IO.Abstractions.IFileSystemEntity
     {

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Compression_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Compression_netstandard2.1.txt
@@ -5,8 +5,11 @@ namespace Testably.Abstractions
 {
     public static class FileSystemExtensions
     {
-        public static Testably.Abstractions.IZipArchiveFactory ZipArchive(this System.IO.Abstractions.IFileSystem fileSystem) { }
-        public static Testably.Abstractions.IZipFile ZipFile(this System.IO.Abstractions.IFileSystem fileSystem) { }
+        extension(System.IO.Abstractions.IFileSystem fileSystem)
+        {
+            public Testably.Abstractions.IZipArchiveFactory ZipArchive { get; }
+            public Testably.Abstractions.IZipFile ZipFile { get; }
+        }
     }
     public interface IZipArchive : System.IDisposable, System.IO.Abstractions.IFileSystemEntity
     {

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ExtensionTests.Async.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ExtensionTests.Async.cs
@@ -21,12 +21,12 @@ public partial class ExtensionTests
 			.WithSubdirectory("bar");
 		FileSystem.File.WriteAllText("bar/foo.txt", "FooFooFoo");
 		FileSystem.File.SetLastWriteTime("bar/foo.txt", lastWriteTime);
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		await That(archive.Entries).IsEmpty();
 
 		await archive.CreateEntryFromFileAsync("bar/foo.txt", "foo/bar.txt",
@@ -52,12 +52,12 @@ public partial class ExtensionTests
 			.WithSubdirectory("bar");
 		FileSystem.File.WriteAllText("bar/foo.txt", "FooFooFoo");
 		FileSystem.File.SetLastWriteTime("bar/foo.txt", lastWriteTime);
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		await That(archive.Entries).IsEmpty();
 
 		await archive.CreateEntryFromFileAsync("bar/foo.txt", "foo/bar.txt",
@@ -74,12 +74,12 @@ public partial class ExtensionTests
 			.WithSubdirectory("foo")
 			.WithSubdirectory("bar");
 		FileSystem.File.WriteAllText("bar/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		await That(archive.Entries).IsEmpty();
 
 		Task Act()
@@ -96,12 +96,12 @@ public partial class ExtensionTests
 			.WithSubdirectory("foo")
 			.WithSubdirectory("bar");
 		FileSystem.File.WriteAllText("bar/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		await That(archive.Entries).IsEmpty();
 
 		Task Act()
@@ -119,12 +119,12 @@ public partial class ExtensionTests
 			.WithSubdirectory("foo")
 			.WithSubdirectory("bar");
 		FileSystem.File.WriteAllText("bar/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 		await That(archive.Entries).IsEmpty();
 
 		Task Act()
@@ -140,12 +140,12 @@ public partial class ExtensionTests
 			.WithSubdirectory("foo")
 			.WithSubdirectory("bar");
 		FileSystem.File.WriteAllText("bar/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		await That(archive.Entries).IsEmpty();
 
 		await archive.CreateEntryFromFileAsync("bar/foo.txt", "foo/bar.txt",
@@ -166,13 +166,13 @@ public partial class ExtensionTests
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", compressionLevel, false);
 
 		async Task Act()
 		{
 			using IZipArchive archive =
-				FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+				FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 			await archive.ExtractToDirectoryAsync(null!, CancellationToken);
 		}
@@ -190,13 +190,13 @@ public partial class ExtensionTests
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", compressionLevel, false);
 
 		async Task Act()
 		{
 			using IZipArchive archive =
-				FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+				FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 			await archive.ExtractToDirectoryAsync(null!, true, CancellationToken);
 		}
@@ -212,11 +212,11 @@ public partial class ExtensionTests
 				.WithSubdirectory("bar")
 				.WithFile("bar.txt"));
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		await archive.ExtractToDirectoryAsync("bar", CancellationToken);
 
@@ -233,11 +233,11 @@ public partial class ExtensionTests
 			.WithSubdirectory("bar").Initialized(s => s
 				.WithFile("foo.txt"));
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		async Task Act()
 		{
@@ -258,11 +258,11 @@ public partial class ExtensionTests
 			.WithSubdirectory("bar").Initialized(s => s
 				.WithFile("foo.txt"));
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		await archive.ExtractToDirectoryAsync("bar", true, CancellationToken);
 

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ExtensionTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ExtensionTests.cs
@@ -21,12 +21,12 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 			.WithSubdirectory("bar");
 		FileSystem.File.WriteAllText("bar/foo.txt", "FooFooFoo");
 		FileSystem.File.SetLastWriteTime("bar/foo.txt", lastWriteTime);
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		await That(archive.Entries).IsEmpty();
 
 		archive.CreateEntryFromFile("bar/foo.txt", "foo/bar.txt",
@@ -52,12 +52,12 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 			.WithSubdirectory("bar");
 		FileSystem.File.WriteAllText("bar/foo.txt", "FooFooFoo");
 		FileSystem.File.SetLastWriteTime("bar/foo.txt", lastWriteTime);
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		await That(archive.Entries).IsEmpty();
 
 		archive.CreateEntryFromFile("bar/foo.txt", "foo/bar.txt",
@@ -74,12 +74,12 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 			.WithSubdirectory("foo")
 			.WithSubdirectory("bar");
 		FileSystem.File.WriteAllText("bar/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		await That(archive.Entries).IsEmpty();
 
 		void Act()
@@ -96,12 +96,12 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 			.WithSubdirectory("foo")
 			.WithSubdirectory("bar");
 		FileSystem.File.WriteAllText("bar/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		await That(archive.Entries).IsEmpty();
 
 		void Act()
@@ -119,12 +119,12 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 			.WithSubdirectory("foo")
 			.WithSubdirectory("bar");
 		FileSystem.File.WriteAllText("bar/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 		await That(archive.Entries).IsEmpty();
 
 		void Act()
@@ -140,12 +140,12 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 			.WithSubdirectory("foo")
 			.WithSubdirectory("bar");
 		FileSystem.File.WriteAllText("bar/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		await That(archive.Entries).IsEmpty();
 
 		archive.CreateEntryFromFile("bar/foo.txt", "foo/bar.txt",
@@ -166,13 +166,13 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", compressionLevel, false);
 
 		void Act()
 		{
 			using IZipArchive archive =
-				FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+				FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 			archive.ExtractToDirectory(null!);
 		}
@@ -191,13 +191,13 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", compressionLevel, false);
 
 		void Act()
 		{
 			using IZipArchive archive =
-				FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+				FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 			archive.ExtractToDirectory(null!, true);
 		}
@@ -214,11 +214,11 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 				.WithSubdirectory("bar")
 				.WithFile("bar.txt"));
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		archive.ExtractToDirectory("bar");
 
@@ -235,11 +235,11 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 			.WithSubdirectory("bar").Initialized(s => s
 				.WithFile("foo.txt"));
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		void Act()
 		{
@@ -261,11 +261,11 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 			.WithSubdirectory("bar").Initialized(s => s
 				.WithFile("foo.txt"));
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		archive.ExtractToDirectory("bar", true);
 

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/Tests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/Tests.cs
@@ -14,13 +14,13 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		await That(archive.Comment).IsEqualTo("");
 	}
@@ -33,13 +33,13 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 		archive.Comment = comment;
 
 		await That(archive.Comment).IsEqualTo(comment);
@@ -52,7 +52,7 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		using FileSystemStream stream =
 			FileSystem.File.Open("destination.zip", FileMode.Create, FileAccess.ReadWrite);
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Create);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Create);
 
 		ReadOnlyCollection<IZipArchiveEntry> Act() => archive.Entries;
 
@@ -67,11 +67,11 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", compressionLevel, false);
 
 		using IZipArchive archive =
-			FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+			FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 		await That(archive.FileSystem).IsEqualTo(FileSystem);
 	}
@@ -82,12 +82,12 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				true);
 
 		using IZipArchive archive =
-			FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+			FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 		await That(archive.GetEntry("bar.txt")).IsNull();
 		await That(archive.GetEntry("foo.txt")).IsNull();
@@ -101,11 +101,11 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.Fastest, false);
 
 		using IZipArchive archive =
-			FileSystem.ZipFile().Open("destination.zip", mode);
+			FileSystem.ZipFile.Open("destination.zip", mode);
 
 		await That(archive.Mode).IsEqualTo(mode);
 	}

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ExtensionTests.Async.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ExtensionTests.Async.cs
@@ -15,12 +15,12 @@ public partial class ExtensionTests
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo.txt", "some content");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		archive.CreateEntryFromFile("foo.txt", "foo/");
 
 		Task Act()
@@ -38,13 +38,13 @@ public partial class ExtensionTests
 			.WithSubdirectory("foo").Initialized(s => s
 				.WithAFile());
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", compressionLevel, false);
 
 		async Task Act()
 		{
 			using IZipArchive archive =
-				FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+				FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 			await archive.Entries.Single().ExtractToFileAsync(null!, CancellationToken);
 		}
@@ -63,13 +63,13 @@ public partial class ExtensionTests
 			.WithSubdirectory("foo").Initialized(s => s
 				.WithAFile());
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", compressionLevel, false);
 
 		async Task Act()
 		{
 			using IZipArchive archive =
-				FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+				FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 			await archive.Entries.Single().ExtractToFileAsync(null!, true, CancellationToken);
 		}
@@ -83,17 +83,17 @@ public partial class ExtensionTests
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo.txt", "some content");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		archive.CreateEntryFromFile("foo.txt", "foo/");
 		archive.Dispose();
 
 		using FileSystemStream stream2 = FileSystem.File.OpenRead("destination.zip");
-		IZipArchive archive2 = FileSystem.ZipArchive().New(stream2, ZipArchiveMode.Read);
+		IZipArchive archive2 = FileSystem.ZipArchive.New(stream2, ZipArchiveMode.Read);
 
 		Task Act()
 			=> archive2.ExtractToDirectoryAsync("bar", CancellationToken);
@@ -114,12 +114,12 @@ public partial class ExtensionTests
 				.WithFile("bar.txt"));
 		FileSystem.File.WriteAllText("bar/foo.txt", "FooFooFoo");
 		FileSystem.File.SetLastWriteTime("bar/foo.txt", lastWriteTime);
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		archive.CreateEntryFromFile("bar/foo.txt", "foo/bar.txt",
 			CompressionLevel.NoCompression);
 		IZipArchiveEntry entry = archive.Entries.Single();
@@ -139,11 +139,11 @@ public partial class ExtensionTests
 			.WithSubdirectory("bar").Initialized(s => s
 				.WithFile("bar.txt"));
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 		IZipArchiveEntry entry = archive.Entries.Single();
 
 		Task Act()
@@ -163,11 +163,11 @@ public partial class ExtensionTests
 			.WithSubdirectory("bar").Initialized(s => s
 				.WithFile("bar.txt"));
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 		IZipArchiveEntry entry = archive.Entries.Single();
 
 		await entry.ExtractToFileAsync("bar/bar.txt", true, CancellationToken);

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ExtensionTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ExtensionTests.cs
@@ -15,12 +15,12 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo.txt", "some content");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		archive.CreateEntryFromFile("foo.txt", "foo/");
 
 		void Act()
@@ -38,13 +38,13 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 			.WithSubdirectory("foo").Initialized(s => s
 				.WithAFile());
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", compressionLevel, false);
 
 		void Act()
 		{
 			using IZipArchive archive =
-				FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+				FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 			archive.Entries.Single().ExtractToFile(null!);
 		}
@@ -63,13 +63,13 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 			.WithSubdirectory("foo").Initialized(s => s
 				.WithAFile());
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", compressionLevel, false);
 
 		void Act()
 		{
 			using IZipArchive archive =
-				FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+				FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 			archive.Entries.Single().ExtractToFile(null!, true);
 		}
@@ -83,17 +83,17 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo.txt", "some content");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		archive.CreateEntryFromFile("foo.txt", "foo/");
 		archive.Dispose();
 
 		using FileSystemStream stream2 = FileSystem.File.OpenRead("destination.zip");
-		IZipArchive archive2 = FileSystem.ZipArchive().New(stream2, ZipArchiveMode.Read);
+		IZipArchive archive2 = FileSystem.ZipArchive.New(stream2, ZipArchiveMode.Read);
 
 		void Act()
 			=> archive2.ExtractToDirectory("bar");
@@ -114,12 +114,12 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 				.WithFile("bar.txt"));
 		FileSystem.File.WriteAllText("bar/foo.txt", "FooFooFoo");
 		FileSystem.File.SetLastWriteTime("bar/foo.txt", lastWriteTime);
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		archive.CreateEntryFromFile("bar/foo.txt", "foo/bar.txt",
 			CompressionLevel.NoCompression);
 		IZipArchiveEntry entry = archive.Entries.Single();
@@ -139,11 +139,11 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 			.WithSubdirectory("bar").Initialized(s => s
 				.WithFile("bar.txt"));
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 		IZipArchiveEntry entry = archive.Entries.Single();
 
 		void Act()
@@ -165,11 +165,11 @@ public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTes
 			.WithSubdirectory("bar").Initialized(s => s
 				.WithFile("bar.txt"));
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 		IZipArchiveEntry entry = archive.Entries.Single();
 
 		entry.ExtractToFile("bar/bar.txt", true);

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/Tests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/Tests.cs
@@ -14,13 +14,13 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		IZipArchiveEntry entry = archive.Entries.Single();
 
@@ -34,13 +34,13 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 		IZipArchiveEntry entry = archive.Entries.Single();
 
 		await That(entry.Comment).IsEqualTo("");
@@ -55,13 +55,13 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 		IZipArchiveEntry entry = archive.Entries.Single();
 
 		entry.Comment = comment;
@@ -78,13 +78,13 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		await That(archive.Entries.Single())
 			.For(x => x.Length, l => l.IsEqualTo(9)).And
@@ -97,13 +97,13 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.Optimal,
 				false);
 
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		await That(archive.Entries.Single())
 			.For(x => x.Length, l => l.IsEqualTo(9)).And
@@ -118,13 +118,13 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo1.txt", "FooFooFoo");
 		FileSystem.File.WriteAllText("foo/foo2.txt", "Some other text");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		IZipArchiveEntry entry1 = archive.Entries[0];
 		IZipArchiveEntry entry2 = archive.Entries[1];
@@ -139,14 +139,14 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream =
 			FileSystem.File.Open("destination.zip", FileMode.Open, FileAccess.ReadWrite);
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 		IZipArchiveEntry entry = archive.Entries.Single();
 
 		void Act() => entry.Delete();
@@ -160,14 +160,14 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream =
 			FileSystem.File.Open("destination.zip", FileMode.Open, FileAccess.ReadWrite);
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		IZipArchiveEntry entry = archive.Entries.Single();
 
 		entry.Delete();
@@ -184,13 +184,13 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo1.txt", "FooFooFoo");
 		FileSystem.File.WriteAllText("foo/foo2.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		IZipArchiveEntry entry1 = archive.Entries[0];
 		IZipArchiveEntry entry2 = archive.Entries[1];
@@ -207,13 +207,13 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		IZipArchiveEntry entry = archive.Entries.Single();
 
@@ -226,13 +226,13 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				true);
 
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		IZipArchiveEntry entry = archive.Entries.Single();
 
@@ -249,13 +249,13 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo1.txt", "FooFooFoo");
 		FileSystem.File.WriteAllText("foo/foo2.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		IZipArchiveEntry entry1 = archive.Entries[0];
 
@@ -275,14 +275,14 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo1.txt", "FooFooFoo");
 		FileSystem.File.WriteAllText("foo/foo2.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream = FileSystem.File.Open("destination.zip",
 			FileMode.Open, FileAccess.ReadWrite);
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 
 		IZipArchiveEntry entry1 = archive.Entries[0];
 		IZipArchiveEntry entry2 = archive.Entries[1];
@@ -298,14 +298,14 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream =
 			FileSystem.File.Open("destination.zip", FileMode.Open, FileAccess.ReadWrite);
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		IZipArchiveEntry entry = archive.Entries.Single();
 
 		Stream resultStream = entry.Open();
@@ -320,14 +320,14 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream =
 			FileSystem.File.Open("destination.zip", FileMode.Open, FileAccess.ReadWrite);
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		IZipArchiveEntry entry = archive.Entries.Single();
 
 		Stream resultStream = await entry.OpenAsync(CancellationToken);
@@ -342,14 +342,14 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
 		using FileSystemStream stream =
 			FileSystem.File.Open("destination.zip", FileMode.Open, FileAccess.ReadWrite);
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		IZipArchiveEntry entry = archive.Entries.Single();
 
 		string? result = entry.ToString();

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveFactory/Tests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveFactory/Tests.cs
@@ -14,13 +14,13 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				true);
 
 		FileSystemStream stream = FileSystem.File.OpenRead("destination.zip");
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream);
 
 		await That(archive.Mode).IsEqualTo(ZipArchiveMode.Read);
 		await That(archive.Entries).HasCount().EqualTo(1);
@@ -32,7 +32,7 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				true);
 
@@ -40,7 +40,7 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 
 		void Act()
 		{
-			_ = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+			_ = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 		}
 		
 		await That(Act).Throws<ArgumentException>()
@@ -53,14 +53,14 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				true);
 
 		FileSystemStream stream =
 			FileSystem.File.Open("destination.zip", FileMode.Open, FileAccess.ReadWrite);
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update);
 
 		await That(archive.Mode).IsEqualTo(ZipArchiveMode.Update);
 		await That(archive.Entries).HasCount().EqualTo(1);
@@ -74,14 +74,14 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				true);
 
 		FileSystemStream stream =
 			FileSystem.File.Open("destination.zip", FileMode.Open, FileAccess.ReadWrite);
 
-		IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Update, leaveOpen);
+		IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Update, leaveOpen);
 
 		archive.Dispose();
 		void Act() => stream.ReadByte();
@@ -100,12 +100,12 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 		FileSystemStream stream = FileSystem.File.Create("destination.zip");
 
 		IZipArchive writeArchive =
-			FileSystem.ZipArchive().New(stream, ZipArchiveMode.Create, false, encoding);
+			FileSystem.ZipArchive.New(stream, ZipArchiveMode.Create, false, encoding);
 		writeArchive.CreateEntry(entryName);
 		writeArchive.Dispose();
 
 		using IZipArchive readArchive =
-			FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+			FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 		var singleEntry = await That(readArchive.Entries).HasSingle();
 		if (encodedCorrectly)

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryAsyncTests.cs
@@ -22,12 +22,12 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 			.WithSubdirectory("foo").Initialized(s => s
 				.WithSubdirectory("bar"));
 
-		await FileSystem.ZipFile()
+		await FileSystem.ZipFile
 			.CreateFromDirectoryAsync("foo", "destination.zip", compressionLevel, false,
 				CancellationToken);
 
 		using IZipArchive archive =
-			FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+			FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 		await That(archive.Entries).HasSingle()
 			.Which.For(x => x.FullName, f => f.IsEqualTo("bar/"));
@@ -41,12 +41,12 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 
-		await FileSystem.ZipFile()
+		await FileSystem.ZipFile
 			.CreateFromDirectoryAsync("foo", "destination.zip", compressionLevel, false,
 				CancellationToken);
 
 		using IZipArchive archive =
-			FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+			FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 		await That(archive.Entries).IsEmpty();
 	}
@@ -60,12 +60,12 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 
-		await FileSystem.ZipFile()
+		await FileSystem.ZipFile
 			.CreateFromDirectoryAsync("foo", "destination.zip", compressionLevel, true,
 				CancellationToken);
 
 		using IZipArchive archive =
-			FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+			FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 		await That(archive.Entries).HasSingle()
 			.Which.For(x => x.FullName, f => f.IsEqualTo("foo/"));
@@ -80,12 +80,12 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 			.WithSubdirectory("foo").Initialized(s => s
 				.WithFile(entryName));
 
-		await FileSystem.ZipFile()
+		await FileSystem.ZipFile
 			.CreateFromDirectoryAsync("foo", "destination.zip", CompressionLevel.NoCompression,
 				false, encoding, CancellationToken);
 
 		using IZipArchive archive =
-			FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+			FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 		IZipArchiveEntry singleEntry = await That(archive.Entries).HasSingle();
 		if (encodedCorrectly)
@@ -107,12 +107,12 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 			.WithSubdirectory("foo").Initialized(s => s
 				.WithFile("test.txt"));
 
-		await FileSystem.ZipFile()
+		await FileSystem.ZipFile
 			.CreateFromDirectoryAsync("foo", "destination.zip", compressionLevel, true,
 				CancellationToken);
 
 		using IZipArchive archive =
-			FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+			FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 		await That(archive.Entries).HasSingle()
 			.Which.For(x => x.FullName, f => f.IsEqualTo("foo/test.txt"));
@@ -131,10 +131,10 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 		FileSystem.File.WriteAllText(FileSystem.Path.Combine("foo", "test.txt"),
 			contents);
 
-		await FileSystem.ZipFile().CreateFromDirectoryAsync("foo", "destination.zip",
+		await FileSystem.ZipFile.CreateFromDirectoryAsync("foo", "destination.zip",
 			CompressionLevel.Optimal, false, encoding, CancellationToken);
 
-		IZipArchive archive = FileSystem.ZipFile()
+		IZipArchive archive = FileSystem.ZipFile
 			.Open("destination.zip", ZipArchiveMode.Read, encoding);
 
 		await That(archive.Entries).HasSingle()
@@ -150,10 +150,10 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 				.WithSubdirectory("bar").Initialized(t => t
 					.WithFile("test.txt")));
 
-		await FileSystem.ZipFile().CreateFromDirectoryAsync("foo", "destination.zip",
+		await FileSystem.ZipFile.CreateFromDirectoryAsync("foo", "destination.zip",
 			CancellationToken);
 
-		FileSystem.ZipFile().ExtractToDirectory("destination.zip", "destination");
+		FileSystem.ZipFile.ExtractToDirectory("destination.zip", "destination");
 
 		await That(FileSystem).HasFile("destination/bar/test.txt")
 			.WithContent().SameAs("foo/bar/test.txt");
@@ -172,7 +172,7 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 		async Task Act()
 		{
 			// ReSharper disable once AccessToDisposedClosure
-			await FileSystem.ZipFile().CreateFromDirectoryAsync("foo", stream, CancellationToken);
+			await FileSystem.ZipFile.CreateFromDirectoryAsync("foo", stream, CancellationToken);
 		}
 
 		await That(Act).Throws<ArgumentException>()
@@ -192,11 +192,11 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 				.WithSubdirectory("bar"));
 		using MemoryStream stream = new();
 
-		await FileSystem.ZipFile()
+		await FileSystem.ZipFile
 			.CreateFromDirectoryAsync("foo", stream, compressionLevel, false,
 				CancellationToken);
 
-		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		using IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		await That(archive.Entries).HasSingle()
 			.Which.For(x => x.FullName, f => f.IsEqualTo("bar/"));
@@ -212,11 +212,11 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 			.WithSubdirectory("foo");
 		using MemoryStream stream = new();
 
-		await FileSystem.ZipFile()
+		await FileSystem.ZipFile
 			.CreateFromDirectoryAsync("foo", stream, compressionLevel, false,
 				CancellationToken);
 
-		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		using IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		await That(archive.Entries).IsEmpty();
 	}
@@ -231,11 +231,11 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 			.WithSubdirectory("foo");
 		using MemoryStream stream = new();
 
-		await FileSystem.ZipFile()
+		await FileSystem.ZipFile
 			.CreateFromDirectoryAsync("foo", stream, compressionLevel, true,
 				CancellationToken);
 
-		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		using IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		await That(archive.Entries).HasSingle()
 			.Which.For(x => x.FullName, f => f.IsEqualTo("foo/"));
@@ -251,11 +251,11 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 				.WithFile(entryName));
 		using MemoryStream stream = new();
 
-		await FileSystem.ZipFile()
+		await FileSystem.ZipFile
 			.CreateFromDirectoryAsync("foo", stream, CompressionLevel.NoCompression,
 				false, encoding, CancellationToken);
 
-		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		using IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		IZipArchiveEntry singleEntry = await That(archive.Entries).HasSingle();
 		if (encodedCorrectly)
@@ -279,11 +279,11 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 				.WithFile("test.txt"));
 		using MemoryStream stream = new();
 
-		await FileSystem.ZipFile()
+		await FileSystem.ZipFile
 			.CreateFromDirectoryAsync("foo", stream, compressionLevel, true,
 				CancellationToken);
 
-		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		using IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		await That(archive.Entries).HasSingle()
 			.Which.For(x => x.FullName, f => f.IsEqualTo("foo/test.txt"));
@@ -297,7 +297,7 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 
 		async Task Act()
 		{
-			await FileSystem.ZipFile().CreateFromDirectoryAsync("foo", stream, CancellationToken);
+			await FileSystem.ZipFile.CreateFromDirectoryAsync("foo", stream, CancellationToken);
 		}
 
 		await That(Act).Throws<ArgumentException>()
@@ -314,7 +314,7 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 
 		async Task Act()
 		{
-			await FileSystem.ZipFile().CreateFromDirectoryAsync("foo", stream, CancellationToken);
+			await FileSystem.ZipFile.CreateFromDirectoryAsync("foo", stream, CancellationToken);
 		}
 
 		await That(Act).Throws<ArgumentNullException>()
@@ -336,11 +336,11 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 			contents);
 		using MemoryStream stream = new();
 
-		await FileSystem.ZipFile().CreateFromDirectoryAsync("foo", stream,
+		await FileSystem.ZipFile.CreateFromDirectoryAsync("foo", stream,
 			CompressionLevel.Optimal, false, encoding, CancellationToken);
 
 		IZipArchive archive =
-			FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read, true, encoding);
+			FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read, true, encoding);
 
 		await That(archive.Entries).HasSingle()
 			.Which.For(x => x.FullName, f => f.IsEqualTo("test.txt"));
@@ -356,10 +356,10 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 					.WithFile("test.txt")));
 		using MemoryStream stream = new();
 
-		await FileSystem.ZipFile()
+		await FileSystem.ZipFile
 			.CreateFromDirectoryAsync("foo", stream, CancellationToken);
 
-		FileSystem.ZipFile().ExtractToDirectory(stream, "destination");
+		FileSystem.ZipFile.ExtractToDirectory(stream, "destination");
 
 		await That(FileSystem).HasFile("destination/bar/test.txt")
 			.WithContent().SameAs("foo/bar/test.txt");
@@ -375,7 +375,7 @@ public class CreateFromDirectoryAsyncTests(FileSystemTestData testData) : FileSy
 			"Some content");
 		void Act() => FileSystem.Directory.Delete(directory, true);
 
-		await FileSystem.ZipFile()
+		await FileSystem.ZipFile
 			.CreateFromDirectoryAsync(directory, archive, CancellationToken);
 
 		await That(Act).DoesNotThrow();

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/CreateFromDirectoryTests.cs
@@ -21,11 +21,11 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 			.WithSubdirectory("foo").Initialized(s => s
 				.WithSubdirectory("bar"));
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", compressionLevel, false);
 
 		using IZipArchive archive =
-			FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+			FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 		await That(archive.Entries).HasSingle()
 			.Which.For(x => x.FullName, f => f.IsEqualTo("bar/"));
@@ -39,11 +39,11 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", compressionLevel, false);
 
 		using IZipArchive archive =
-			FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+			FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 		await That(archive.Entries).IsEmpty();
 	}
@@ -57,11 +57,11 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", compressionLevel, true);
 
 		using IZipArchive archive =
-			FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+			FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 		await That(archive.Entries).HasSingle()
 			.Which.For(x => x.FullName, f => f.IsEqualTo("foo/"));
@@ -76,12 +76,12 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 			.WithSubdirectory("foo").Initialized(s => s
 				.WithFile(entryName));
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false, encoding);
 
 		using IZipArchive archive =
-			FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+			FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 		IZipArchiveEntry singleEntry = await That(archive.Entries).HasSingle();
 		if (encodedCorrectly)
@@ -103,11 +103,11 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 			.WithSubdirectory("foo").Initialized(s => s
 				.WithFile("test.txt"));
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", compressionLevel, true);
 
 		using IZipArchive archive =
-			FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Read);
+			FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Read);
 
 		await That(archive.Entries).HasSingle()
 			.Which.For(x => x.FullName, f => f.IsEqualTo("foo/test.txt"));
@@ -127,10 +127,10 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 		FileSystem.File.WriteAllText(FileSystem.Path.Combine("foo", "test.txt"),
 			contents);
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", "destination.zip",
+		FileSystem.ZipFile.CreateFromDirectory("foo", "destination.zip",
 			CompressionLevel.Optimal, false, encoding);
 
-		IZipArchive archive = FileSystem.ZipFile()
+		IZipArchive archive = FileSystem.ZipFile
 			.Open("destination.zip", ZipArchiveMode.Read, encoding);
 
 		await That(archive.Entries).HasSingle()
@@ -147,9 +147,9 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 				.WithSubdirectory("bar").Initialized(t => t
 					.WithFile("test.txt")));
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", "destination.zip");
+		FileSystem.ZipFile.CreateFromDirectory("foo", "destination.zip");
 
-		FileSystem.ZipFile().ExtractToDirectory("destination.zip", "destination");
+		FileSystem.ZipFile.ExtractToDirectory("destination.zip", "destination");
 
 		await That(FileSystem).HasFile("destination/bar/test.txt")
 			.WithContent().SameAs("foo/bar/test.txt");
@@ -169,7 +169,7 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 		void Act()
 		{
 			// ReSharper disable once AccessToDisposedClosure
-			FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+			FileSystem.ZipFile.CreateFromDirectory("foo", stream);
 		}
 
 		await That(Act).Throws<ArgumentException>()
@@ -191,10 +191,10 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 				.WithSubdirectory("bar"));
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", stream, compressionLevel, false);
 
-		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		using IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		await That(archive.Entries).HasSingle()
 			.Which.For(x => x.FullName, f => f.IsEqualTo("bar/"));
@@ -212,10 +212,10 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 			.WithSubdirectory("foo");
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", stream, compressionLevel, false);
 
-		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		using IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		await That(archive.Entries).IsEmpty();
 	}
@@ -232,10 +232,10 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 			.WithSubdirectory("foo");
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", stream, compressionLevel, true);
 
-		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		using IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		await That(archive.Entries).HasSingle()
 			.Which.For(x => x.FullName, f => f.IsEqualTo("foo/"));
@@ -253,11 +253,11 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 				.WithFile(entryName));
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", stream, CompressionLevel.NoCompression,
 				false, encoding);
 
-		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		using IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		IZipArchiveEntry singleEntry = await That(archive.Entries).HasSingle();
 		if (encodedCorrectly)
@@ -283,10 +283,10 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 				.WithFile("test.txt"));
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", stream, compressionLevel, true);
 
-		using IZipArchive archive = FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read);
+		using IZipArchive archive = FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read);
 
 		await That(archive.Entries).HasSingle()
 			.Which.For(x => x.FullName, f => f.IsEqualTo("foo/test.txt"));
@@ -302,7 +302,7 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 
 		void Act()
 		{
-			FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+			FileSystem.ZipFile.CreateFromDirectory("foo", stream);
 		}
 
 		await That(Act).Throws<ArgumentException>()
@@ -321,7 +321,7 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 
 		void Act()
 		{
-			FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+			FileSystem.ZipFile.CreateFromDirectory("foo", stream);
 		}
 
 		await That(Act).Throws<ArgumentNullException>()
@@ -344,11 +344,11 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 			contents);
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", stream,
+		FileSystem.ZipFile.CreateFromDirectory("foo", stream,
 			CompressionLevel.Optimal, false, encoding);
 
 		IZipArchive archive =
-			FileSystem.ZipArchive().New(stream, ZipArchiveMode.Read, true, encoding);
+			FileSystem.ZipArchive.New(stream, ZipArchiveMode.Read, true, encoding);
 
 		await That(archive.Entries).HasSingle()
 			.Which.For(x => x.FullName, f => f.IsEqualTo("test.txt"));
@@ -366,9 +366,9 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 					.WithFile("test.txt")));
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		FileSystem.ZipFile.CreateFromDirectory("foo", stream);
 
-		FileSystem.ZipFile().ExtractToDirectory(stream, "destination");
+		FileSystem.ZipFile.ExtractToDirectory(stream, "destination");
 
 		await That(FileSystem).HasFile("destination/bar/test.txt")
 			.WithContent().SameAs("foo/bar/test.txt");
@@ -385,7 +385,7 @@ public class CreateFromDirectoryTests(FileSystemTestData testData) : FileSystemT
 			"Some content");
 		void Act() => FileSystem.Directory.Delete(directory, true);
 
-		FileSystem.ZipFile().CreateFromDirectory(directory, archive);
+		FileSystem.ZipFile.CreateFromDirectory(directory, archive);
 
 		await That(Act).DoesNotThrow();
 	}

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryAsyncTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryAsyncTests.cs
@@ -18,9 +18,9 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 			.WithSubdirectory("foo").Initialized(s => s
 				.WithFile("test.txt"));
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", "destination.zip");
+		FileSystem.ZipFile.CreateFromDirectory("foo", "destination.zip");
 
-		await FileSystem.ZipFile().ExtractToDirectoryAsync("destination.zip", "bar",
+		await FileSystem.ZipFile.ExtractToDirectoryAsync("destination.zip", "bar",
 			CancellationToken);
 
 		await That(FileSystem).HasFile("bar/test.txt")
@@ -36,7 +36,7 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 
 		async Task Act()
 		{
-			await FileSystem.ZipFile().ExtractToDirectoryAsync(sourceArchiveFileName, "bar",
+			await FileSystem.ZipFile.ExtractToDirectoryAsync(sourceArchiveFileName, "bar",
 				CancellationToken);
 		}
 
@@ -53,7 +53,7 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 
 		async Task Act()
 		{
-			await FileSystem.ZipFile().ExtractToDirectoryAsync(sourceArchiveFileName, "bar", CancellationToken);
+			await FileSystem.ZipFile.ExtractToDirectoryAsync(sourceArchiveFileName, "bar", CancellationToken);
 		}
 
 		await That(Act).Throws<ArgumentNullException>()
@@ -73,9 +73,9 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 		FileSystem.File.WriteAllText(FileSystem.Path.Combine("foo", "test.txt"),
 			contents);
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", "destination.zip");
+		FileSystem.ZipFile.CreateFromDirectory("foo", "destination.zip");
 
-		await FileSystem.ZipFile().ExtractToDirectoryAsync("destination.zip", "bar", true,
+		await FileSystem.ZipFile.ExtractToDirectoryAsync("destination.zip", "bar", true,
 			CancellationToken);
 
 		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"))
@@ -96,9 +96,9 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 		FileSystem.File.WriteAllText(FileSystem.Path.Combine("foo", "test.txt"),
 			contents);
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", "destination.zip");
+		FileSystem.ZipFile.CreateFromDirectory("foo", "destination.zip");
 
-		await FileSystem.ZipFile().ExtractToDirectoryAsync("destination.zip", "bar", encoding, true,
+		await FileSystem.ZipFile.ExtractToDirectoryAsync("destination.zip", "bar", encoding, true,
 			CancellationToken);
 
 		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"))
@@ -115,10 +115,10 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 			.WithSubdirectory("foo").Initialized(s => s
 				.WithFile("test.txt"));
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", "destination.zip",
+		FileSystem.ZipFile.CreateFromDirectory("foo", "destination.zip",
 			CompressionLevel.Fastest, false, encoding);
 
-		await FileSystem.ZipFile().ExtractToDirectoryAsync("destination.zip", "bar", encoding,
+		await FileSystem.ZipFile.ExtractToDirectoryAsync("destination.zip", "bar", encoding,
 			CancellationToken);
 
 		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"))
@@ -140,11 +140,11 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 		string destinationPath =
 			FileSystem.Path.Combine(FileSystem.Path.GetFullPath("bar"), "test.txt");
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", "destination.zip");
+		FileSystem.ZipFile.CreateFromDirectory("foo", "destination.zip");
 
 		async Task Act()
 		{
-			await FileSystem.ZipFile().ExtractToDirectoryAsync("destination.zip", "bar", CancellationToken);
+			await FileSystem.ZipFile.ExtractToDirectoryAsync("destination.zip", "bar", CancellationToken);
 		}
 
 		await That(Act).Throws<IOException>()
@@ -162,9 +162,9 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 				.WithFile("test.txt"));
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		FileSystem.ZipFile.CreateFromDirectory("foo", stream);
 
-		await FileSystem.ZipFile()
+		await FileSystem.ZipFile
 			.ExtractToDirectoryAsync(stream, "bar", CancellationToken);
 
 		await That(FileSystem).HasFile("bar/test.txt")
@@ -180,7 +180,7 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 
 		async Task Act()
 		{
-			await FileSystem.ZipFile().ExtractToDirectoryAsync(source, "bar", CancellationToken);
+			await FileSystem.ZipFile.ExtractToDirectoryAsync(source, "bar", CancellationToken);
 		}
 
 		await That(Act).Throws<ArgumentException>()
@@ -198,7 +198,7 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 
 		async Task Act()
 		{
-			await FileSystem.ZipFile().ExtractToDirectoryAsync(source, "bar", CancellationToken);
+			await FileSystem.ZipFile.ExtractToDirectoryAsync(source, "bar", CancellationToken);
 		}
 
 		await That(Act).Throws<ArgumentNullException>()
@@ -219,9 +219,9 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 			contents);
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		FileSystem.ZipFile.CreateFromDirectory("foo", stream);
 
-		await FileSystem.ZipFile()
+		await FileSystem.ZipFile
 			.ExtractToDirectoryAsync(stream, "bar", true, CancellationToken);
 
 		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"))
@@ -243,9 +243,9 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 			contents);
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		FileSystem.ZipFile.CreateFromDirectory("foo", stream);
 
-		await FileSystem.ZipFile().ExtractToDirectoryAsync(stream, "bar", encoding, true,
+		await FileSystem.ZipFile.ExtractToDirectoryAsync(stream, "bar", encoding, true,
 			CancellationToken);
 
 		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"))
@@ -263,10 +263,10 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 				.WithFile("test.txt"));
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", stream,
+		FileSystem.ZipFile.CreateFromDirectory("foo", stream,
 			CompressionLevel.Fastest, false, encoding);
 
-		await FileSystem.ZipFile().ExtractToDirectoryAsync(stream, "bar", encoding,
+		await FileSystem.ZipFile.ExtractToDirectoryAsync(stream, "bar", encoding,
 			CancellationToken);
 
 		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"))
@@ -290,12 +290,12 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 			FileSystem.Path.Combine(FileSystem.Path.GetFullPath("bar"), "test.txt");
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		FileSystem.ZipFile.CreateFromDirectory("foo", stream);
 
 		async Task Act()
 		{
 			// ReSharper disable once AccessToDisposedClosure
-			await FileSystem.ZipFile().ExtractToDirectoryAsync(stream, "bar", CancellationToken);
+			await FileSystem.ZipFile.ExtractToDirectoryAsync(stream, "bar", CancellationToken);
 		}
 
 		await That(Act).Throws<IOException>()
@@ -314,12 +314,12 @@ public class ExtractToDirectoryAsyncAsyncTests(FileSystemTestData testData) : Fi
 		using FileSystemStream stream = FileSystem.FileStream.New(
 			"target.zip", FileMode.Open, FileAccess.Write);
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		FileSystem.ZipFile.CreateFromDirectory("foo", stream);
 
 		async Task Act()
 		{
 			// ReSharper disable once AccessToDisposedClosure
-			await FileSystem.ZipFile().ExtractToDirectoryAsync(stream, "bar", CancellationToken);
+			await FileSystem.ZipFile.ExtractToDirectoryAsync(stream, "bar", CancellationToken);
 		}
 
 		await That(Act).Throws<ArgumentException>()

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/ExtractToDirectoryTests.cs
@@ -17,9 +17,9 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 			.WithSubdirectory("foo").Initialized(s => s
 				.WithFile("test.txt"));
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", "destination.zip");
+		FileSystem.ZipFile.CreateFromDirectory("foo", "destination.zip");
 
-		FileSystem.ZipFile().ExtractToDirectory("destination.zip", "bar");
+		FileSystem.ZipFile.ExtractToDirectory("destination.zip", "bar");
 
 		await That(FileSystem).HasFile("bar/test.txt")
 			.WithContent().SameAs("foo/test.txt");
@@ -34,7 +34,7 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 
 		void Act()
 		{
-			FileSystem.ZipFile().ExtractToDirectory(sourceArchiveFileName, "bar");
+			FileSystem.ZipFile.ExtractToDirectory(sourceArchiveFileName, "bar");
 		}
 
 		await That(Act).Throws<FileNotFoundException>()
@@ -50,7 +50,7 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 
 		void Act()
 		{
-			FileSystem.ZipFile().ExtractToDirectory(sourceArchiveFileName, "bar");
+			FileSystem.ZipFile.ExtractToDirectory(sourceArchiveFileName, "bar");
 		}
 
 		await That(Act).Throws<ArgumentNullException>()
@@ -71,9 +71,9 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 		FileSystem.File.WriteAllText(FileSystem.Path.Combine("foo", "test.txt"),
 			contents);
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", "destination.zip");
+		FileSystem.ZipFile.CreateFromDirectory("foo", "destination.zip");
 
-		FileSystem.ZipFile().ExtractToDirectory("destination.zip", "bar", true);
+		FileSystem.ZipFile.ExtractToDirectory("destination.zip", "bar", true);
 
 		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"))
 			.WithContent(contents);
@@ -95,9 +95,9 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 		FileSystem.File.WriteAllText(FileSystem.Path.Combine("foo", "test.txt"),
 			contents);
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", "destination.zip");
+		FileSystem.ZipFile.CreateFromDirectory("foo", "destination.zip");
 
-		FileSystem.ZipFile().ExtractToDirectory("destination.zip", "bar", encoding, true);
+		FileSystem.ZipFile.ExtractToDirectory("destination.zip", "bar", encoding, true);
 
 		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"))
 			.WithContent(contents);
@@ -114,10 +114,10 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 			.WithSubdirectory("foo").Initialized(s => s
 				.WithFile("test.txt"));
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", "destination.zip",
+		FileSystem.ZipFile.CreateFromDirectory("foo", "destination.zip",
 			CompressionLevel.Fastest, false, encoding);
 
-		FileSystem.ZipFile().ExtractToDirectory("destination.zip", "bar", encoding);
+		FileSystem.ZipFile.ExtractToDirectory("destination.zip", "bar", encoding);
 
 		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"))
 			.WithContent().SameAs(FileSystem.Path.Combine("foo", "test.txt"));
@@ -138,11 +138,11 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 		string destinationPath =
 			FileSystem.Path.Combine(FileSystem.Path.GetFullPath("bar"), "test.txt");
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", "destination.zip");
+		FileSystem.ZipFile.CreateFromDirectory("foo", "destination.zip");
 
 		void Act()
 		{
-			FileSystem.ZipFile().ExtractToDirectory("destination.zip", "bar");
+			FileSystem.ZipFile.ExtractToDirectory("destination.zip", "bar");
 		}
 
 		await That(Act).Throws<IOException>()
@@ -161,9 +161,9 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 				.WithFile("test.txt"));
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		FileSystem.ZipFile.CreateFromDirectory("foo", stream);
 
-		FileSystem.ZipFile().ExtractToDirectory(stream, "bar");
+		FileSystem.ZipFile.ExtractToDirectory(stream, "bar");
 
 		await That(FileSystem).HasFile("bar/test.txt")
 			.WithContent().SameAs("foo/test.txt");
@@ -180,7 +180,7 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 
 		void Act()
 		{
-			FileSystem.ZipFile().ExtractToDirectory(source, "bar");
+			FileSystem.ZipFile.ExtractToDirectory(source, "bar");
 		}
 
 		await That(Act).Throws<ArgumentException>()
@@ -200,7 +200,7 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 
 		void Act()
 		{
-			FileSystem.ZipFile().ExtractToDirectory(source, "bar");
+			FileSystem.ZipFile.ExtractToDirectory(source, "bar");
 		}
 
 		await That(Act).Throws<ArgumentNullException>()
@@ -223,9 +223,9 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 			contents);
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		FileSystem.ZipFile.CreateFromDirectory("foo", stream);
 
-		FileSystem.ZipFile().ExtractToDirectory(stream, "bar", true);
+		FileSystem.ZipFile.ExtractToDirectory(stream, "bar", true);
 
 		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"))
 			.WithContent(contents);
@@ -248,9 +248,9 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 			contents);
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		FileSystem.ZipFile.CreateFromDirectory("foo", stream);
 
-		FileSystem.ZipFile().ExtractToDirectory(stream, "bar", encoding, true);
+		FileSystem.ZipFile.ExtractToDirectory(stream, "bar", encoding, true);
 
 		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"))
 			.WithContent(contents);
@@ -269,10 +269,10 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 				.WithFile("test.txt"));
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", stream,
+		FileSystem.ZipFile.CreateFromDirectory("foo", stream,
 			CompressionLevel.Fastest, false, encoding);
 
-		FileSystem.ZipFile().ExtractToDirectory(stream, "bar", encoding);
+		FileSystem.ZipFile.ExtractToDirectory(stream, "bar", encoding);
 
 		await That(FileSystem).HasFile(FileSystem.Path.Combine("bar", "test.txt"))
 			.WithContent().SameAs(FileSystem.Path.Combine("foo", "test.txt"));
@@ -297,12 +297,12 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 			FileSystem.Path.Combine(FileSystem.Path.GetFullPath("bar"), "test.txt");
 		using MemoryStream stream = new();
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		FileSystem.ZipFile.CreateFromDirectory("foo", stream);
 
 		void Act()
 		{
 			// ReSharper disable once AccessToDisposedClosure
-			FileSystem.ZipFile().ExtractToDirectory(stream, "bar");
+			FileSystem.ZipFile.ExtractToDirectory(stream, "bar");
 		}
 
 		await That(Act).Throws<IOException>()
@@ -323,12 +323,12 @@ public class ExtractToDirectoryTests(FileSystemTestData testData) : FileSystemTe
 		using FileSystemStream stream = FileSystem.FileStream.New(
 			"target.zip", FileMode.Open, FileAccess.Write);
 
-		FileSystem.ZipFile().CreateFromDirectory("foo", stream);
+		FileSystem.ZipFile.CreateFromDirectory("foo", stream);
 
 		void Act()
 		{
 			// ReSharper disable once AccessToDisposedClosure
-			FileSystem.ZipFile().ExtractToDirectory(stream, "bar");
+			FileSystem.ZipFile.ExtractToDirectory(stream, "bar");
 		}
 
 		await That(Act).Throws<ArgumentException>()

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/OpenTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/OpenTests.cs
@@ -8,7 +8,7 @@ public class OpenTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 	[Test]
 	public async Task Open_CreateMode_ShouldInitializeEmptyArchive()
 	{
-		IZipArchive archive = FileSystem.ZipFile().Open("destination.zip", ZipArchiveMode.Create);
+		IZipArchive archive = FileSystem.ZipFile.Open("destination.zip", ZipArchiveMode.Create);
 
 		await That(archive.Mode).IsEqualTo(ZipArchiveMode.Create);
 	}
@@ -20,7 +20,7 @@ public class OpenTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 
 		void Act()
 		{
-			FileSystem.ZipFile().Open("destination.zip", invalidMode);
+			FileSystem.ZipFile.Open("destination.zip", invalidMode);
 		}
 
 		await That(Act).Throws<ArgumentOutOfRangeException>()
@@ -35,11 +35,11 @@ public class OpenTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
-		IZipArchive archive = FileSystem.ZipFile().Open("destination.zip", mode);
+		IZipArchive archive = FileSystem.ZipFile.Open("destination.zip", mode);
 
 		await That(archive.Mode).IsEqualTo(mode);
 		await That(archive.Entries).HasCount().EqualTo(1);
@@ -51,11 +51,11 @@ public class OpenTests(FileSystemTestData testData) : FileSystemTestBase(testDat
 		FileSystem.Initialize()
 			.WithSubdirectory("foo");
 		FileSystem.File.WriteAllText("foo/foo.txt", "FooFooFoo");
-		FileSystem.ZipFile()
+		FileSystem.ZipFile
 			.CreateFromDirectory("foo", "destination.zip", CompressionLevel.NoCompression,
 				false);
 
-		IZipArchive archive = FileSystem.ZipFile().OpenRead("destination.zip");
+		IZipArchive archive = FileSystem.ZipFile.OpenRead("destination.zip");
 
 		await That(archive.Mode).IsEqualTo(ZipArchiveMode.Read);
 		await That(archive.Entries).HasCount().EqualTo(1);

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipFile/Tests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipFile/Tests.cs
@@ -6,7 +6,7 @@ public class Tests(FileSystemTestData testData) : FileSystemTestBase(testData)
 	[Test]
 	public async Task FileSystemExtension_ShouldBeSet()
 	{
-		IZipFile result = FileSystem.ZipFile();
+		IZipFile result = FileSystem.ZipFile;
 
 		await That(result.FileSystem).IsSameAs(FileSystem);
 	}


### PR DESCRIPTION
Convert the `ZipArchive()` and `ZipFile()` extension methods on `IFileSystem` in the Compression package to C# 14 extension properties, so they are accessed as `fileSystem.ZipArchive` / `fileSystem.ZipFile` without the trailing parentheses.

**BREAKING CHANGE:**
`IFileSystem.ZipArchive()` and `IFileSystem.ZipFile()` are now properties (`.ZipArchive` / `.ZipFile`). Existing callers must drop the parentheses and recompile.