### PR TITLE
docs: add `DateTimeOffsetRead` to time-system notification callbacks

### DIFF
--- a/Docs/pages/docs/time-system/notifications.mdx
+++ b/Docs/pages/docs/time-system/notifications.mdx
@@ -25,6 +25,7 @@ Like the file-system [notifications](../file-system/intercept-and-notify), each 
 | Method on `On`     | Fires when                                              | `T`         |
 |--------------------|---------------------------------------------------------|-------------|
 | `DateTimeRead()`   | `DateTime.Now`, `UtcNow` or `Today` is read             | `DateTime`  |
+| `DateTimeOffsetRead()` | `DateTimeOffset.Now` or `UtcNow` is read            | `DateTimeOffset` |
 | `TaskDelay()`      | `Task.Delay` (any overload) is called                   | `TimeSpan`  |
 | `ThreadSleep()`    | `Thread.Sleep` (any overload) is called                 | `TimeSpan`  |
 | `TimeChanged()`    | the simulated time advanced (auto-advance or manual)    | `DateTime`  |


### PR DESCRIPTION
The "Available callbacks" table in the time-system notifications docs omitted `DateTimeOffsetRead()`, which fires when `DateTimeOffset.Now` or `UtcNow` is read. Add the missing row.