### PR TITLE
fix: address analyzer code smells in compression package

### DIFF
--- a/Source/Testably.Abstractions.Compression/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.Compression/FileSystemExtensions.cs
@@ -6,7 +6,7 @@
 /// </summary>
 public static class FileSystemExtensions
 {
-	#pragma warning disable S2325 // False positive: an extension property cannot be static
+	#pragma warning disable CA1822 // False positive: an extension property cannot be static
 	/// <inheritdoc cref="FileSystemExtensions" />
 	extension(IFileSystem fileSystem)
 	{
@@ -22,5 +22,5 @@ public static class FileSystemExtensions
 		public IZipFile ZipFile
 			=> new ZipFileWrapper(fileSystem);
 	}
-	#pragma warning restore S2325
+	#pragma warning restore CA1822
 }

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ExtensionTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ExtensionTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace Testably.Abstractions.Compression.Tests.ZipArchive;
 
 [FileSystemTests]
-public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTestBase(testData)
+public class ExtensionTests(FileSystemTestData testData) : FileSystemTestBase(testData)
 {
 	[Test]
 	[Arguments("2000-01-01T12:14:15")]

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ExtensionTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ExtensionTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace Testably.Abstractions.Compression.Tests.ZipArchiveEntry;
 
 [FileSystemTests]
-public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTestBase(testData)
+public class ExtensionTests(FileSystemTestData testData) : FileSystemTestBase(testData)
 {
 	[Test]
 	public async Task


### PR DESCRIPTION
Switch the S2325 suppression to CA1822 in FileSystemExtensions (S2325 is deprecated in favor of the Roslyn rule) and remove the unnecessary partial modifier from the two compression ExtensionTests classes.