### PR TITLE
fix: restore partial modifier on compression ExtensionTests classes

### DIFF
--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ExtensionTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchive/ExtensionTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace Testably.Abstractions.Compression.Tests.ZipArchive;
 
 [FileSystemTests]
-public class ExtensionTests(FileSystemTestData testData) : FileSystemTestBase(testData)
+public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTestBase(testData)
 {
 	[Test]
 	[Arguments("2000-01-01T12:14:15")]

--- a/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ExtensionTests.cs
+++ b/Tests/Testably.Abstractions.Compression.Tests/ZipArchiveEntry/ExtensionTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace Testably.Abstractions.Compression.Tests.ZipArchiveEntry;
 
 [FileSystemTests]
-public class ExtensionTests(FileSystemTestData testData) : FileSystemTestBase(testData)
+public partial class ExtensionTests(FileSystemTestData testData) : FileSystemTestBase(testData)
 {
 	[Test]
 	public async Task


### PR DESCRIPTION
PR #1058 removed the partial modifier from the two compression ExtensionTests classes as an analyzer code smell, but both classes have a second partial declaration in ExtensionTests.Async.cs that is only compiled when FEATURE_COMPRESSION_ASYNC is defined (net10.0 and higher). This broke the net10.0 build on main with CS0260.

The analyzer finding is a false positive caused by the conditional compilation of the companion file.