### PR TITLE
fix: default `MockTimeSystem` to the local time zone

### DIFF
--- a/Source/Testably.Abstractions.Testing/MockTimeSystem.cs
+++ b/Source/Testably.Abstractions.Testing/MockTimeSystem.cs
@@ -40,16 +40,18 @@ public sealed class MockTimeSystem : ITimeSystem
 	private readonly TimerFactoryMock _timerFactoryMock;
 
 	/// <summary>
-	///     Initializes the <see cref="MockTimeSystem" /> with a random time.
+	///     Initializes the <see cref="MockTimeSystem" /> with a random time and the local time zone
+	///     (<see cref="TimeZoneInfo.Local" />).
 	/// </summary>
-	public MockTimeSystem() : this(TimeProviderFactory.Random(), options => options)
+	public MockTimeSystem() : this(TimeProviderFactory.Random(System.TimeZoneInfo.Local), options => options)
 	{
 	}
 
 	/// <summary>
-	///     Initializes the <see cref="MockTimeSystem" /> with a random time.
+	///     Initializes the <see cref="MockTimeSystem" /> with a random time and the local time zone
+	///     (<see cref="TimeZoneInfo.Local" />).
 	/// </summary>
-	public MockTimeSystem(Func<MockTimeSystemOptions, MockTimeSystemOptions> options) : this(TimeProviderFactory.Random(), options)
+	public MockTimeSystem(Func<MockTimeSystemOptions, MockTimeSystemOptions> options) : this(TimeProviderFactory.Random(System.TimeZoneInfo.Local), options)
 	{
 	}
 

--- a/Source/Testably.Abstractions.Testing/TimeProviderFactory.cs
+++ b/Source/Testably.Abstractions.Testing/TimeProviderFactory.cs
@@ -36,20 +36,29 @@ public static class TimeProviderFactory
 	}
 
 	/// <summary>
-	///     Initializes the <see cref="MockTimeSystem.TimeProvider" /> with a random time.
+	///     Initializes the <see cref="MockTimeSystem.TimeProvider" /> with a random time and a random local time zone.
 	///     <para />
 	///     The random time increments the unix epoch by a random integer of seconds and the local time zone is picked at
 	///     random from a curated, cross-platform-stable set (including a zone with daylight-saving-time transitions).
 	/// </summary>
 	public static ITimeProviderFactory Random()
+		=> Random(SampleTimeZones[RandomFactory.Shared.Next(SampleTimeZones.Length)]);
+
+	/// <summary>
+	///     Initializes the <see cref="MockTimeSystem.TimeProvider" /> with a random time and the given
+	///     <paramref name="localTimeZone" />.
+	///     <para />
+	///     The random time increments the unix epoch by a random integer of seconds.
+	/// </summary>
+	public static ITimeProviderFactory Random(TimeZoneInfo localTimeZone)
 	{
+		_ = localTimeZone ?? throw new ArgumentNullException(nameof(localTimeZone));
 		#pragma warning disable MA0113 // Use DateTime.UnixEpoch
 		DateTime randomTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)
 			.AddSeconds(RandomFactory.Shared.Next());
 		#pragma warning restore MA0113
-		var randomTimeZone = SampleTimeZones[RandomFactory.Shared.Next(SampleTimeZones.Length)];
 		return new Factory(onTimeChanged
-			=> new TimeProviderMock(onTimeChanged, randomTime, "Random", randomTimeZone));
+			=> new TimeProviderMock(onTimeChanged, randomTime, "Random", localTimeZone));
 	}
 
 	/// <summary>

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net10.0.txt
@@ -191,6 +191,7 @@ namespace Testably.Abstractions.Testing
     {
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random(System.TimeZoneInfo localTimeZone) { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time, System.TimeZoneInfo localTimeZone) { }
     }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net6.0.txt
@@ -189,6 +189,7 @@ namespace Testably.Abstractions.Testing
     {
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random(System.TimeZoneInfo localTimeZone) { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time, System.TimeZoneInfo localTimeZone) { }
     }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net8.0.txt
@@ -191,6 +191,7 @@ namespace Testably.Abstractions.Testing
     {
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random(System.TimeZoneInfo localTimeZone) { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time, System.TimeZoneInfo localTimeZone) { }
     }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_net9.0.txt
@@ -191,6 +191,7 @@ namespace Testably.Abstractions.Testing
     {
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random(System.TimeZoneInfo localTimeZone) { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time, System.TimeZoneInfo localTimeZone) { }
     }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.0.txt
@@ -184,6 +184,7 @@ namespace Testably.Abstractions.Testing
     {
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random(System.TimeZoneInfo localTimeZone) { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time, System.TimeZoneInfo localTimeZone) { }
     }

--- a/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
+++ b/Tests/Api/Testably.Abstractions.Api.Tests/Expected/Testably.Abstractions.Testing_netstandard2.1.txt
@@ -184,6 +184,7 @@ namespace Testably.Abstractions.Testing
     {
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Now() { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random() { }
+        public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Random(System.TimeZoneInfo localTimeZone) { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time) { }
         public static Testably.Abstractions.Testing.TimeSystem.ITimeProviderFactory Use(System.DateTime time, System.TimeZoneInfo localTimeZone) { }
     }

--- a/Tests/Testably.Abstractions.Testing.Tests/MockTimeSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/MockTimeSystemTests.cs
@@ -185,6 +185,24 @@ public class MockTimeSystemTests
 		await That(actualDifference).IsEqualTo(expectedDifference);
 	}
 
+	[Test]
+	public async Task DefaultConstructor_ShouldUseLocalTimeZone()
+	{
+		MockTimeSystem timeSystem = new();
+
+		await That(timeSystem.TimeZoneInfo.Local).IsEqualTo(TimeZoneInfo.Local);
+	}
+
+	[Test]
+	public async Task DefaultConstructor_NowToUniversalTime_ShouldEqualUtcNow()
+	{
+		MockTimeSystem timeSystem = new();
+
+		var now = timeSystem.DateTime.Now;
+
+		await That(now.ToUniversalTime()).IsEqualTo(timeSystem.DateTime.UtcNow);
+	}
+
 #if FEATURE_PERIODIC_TIMER
 	[Test]
 	public async Task PeriodicTimer_DisabledAutoAdvance_ShouldNotAdvanceTime()

--- a/Tests/Testably.Abstractions.Testing.Tests/TimeProviderFactoryTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/TimeProviderFactoryTests.cs
@@ -28,6 +28,26 @@ public class TimeProviderFactoryTests
 	}
 
 	[Test]
+	public async Task Random_WithTimeZone_ShouldUseGivenTimeZone()
+	{
+		TimeZoneInfo timeZone = TimeZoneInfo.CreateCustomTimeZone(
+			"Custom/Plus07", TimeSpan.FromHours(7), "Custom +07", "Custom +07");
+
+		ITimeProvider timeProvider = TimeProviderFactory.Random(timeZone).Create(_ => { });
+
+		await That(timeProvider.LocalTimeZone).IsEqualTo(timeZone);
+	}
+
+	[Test]
+	public async Task Random_WithNullTimeZone_ShouldThrowArgumentNullException()
+	{
+		void Act()
+			=> TimeProviderFactory.Random(null!);
+
+		await That(Act).Throws<ArgumentNullException>().WithParamName("localTimeZone");
+	}
+
+	[Test]
 	public async Task Use_WithTimeZone_ShouldUseGivenTimeZone()
 	{
 		TimeZoneInfo timeZone = TimeZoneInfo.CreateCustomTimeZone(


### PR DESCRIPTION
The v7 default picked a random curated local time zone, which broke `DateTime.Now.ToUniversalTime()`: the mocked `DateTime.Now` is stamped `DateTimeKind.Local`, but its `ToUniversalTime()` resolves against the real machine `TimeZoneInfo.Local` (which the mock cannot override), so the round-trip produced a wrong value whenever the mocked zone differed from the machine zone.

The parameterless `new MockTimeSystem()` and the options-only constructor now use `TimeZoneInfo.Local`, restoring a correct round-trip by default. A new `TimeProviderFactory.Random(TimeZoneInfo localTimeZone)` overload keeps the random time while letting callers pick the zone; the existing `TimeProviderFactory.Random()` still fuzzes the zone from the curated set for anyone who wants that behavior explicitly.