### PR TITLE
fix: support combined `FileSystemTypes` flags in `Notify` and `Intercept`

### DIFF
--- a/Source/Testably.Abstractions.Testing/Helpers/ChangeDescriptionExtensions.cs
+++ b/Source/Testably.Abstractions.Testing/Helpers/ChangeDescriptionExtensions.cs
@@ -17,7 +17,7 @@ internal static class ChangeDescriptionExtensions
 	/// <param name="changeDescription">The change description.</param>
 	/// <param name="execute">The execution engine simulation the underlying operating system.</param>
 	/// <param name="fileSystemType">The <see cref="ChangeDescription.FileSystemType" /> must have any of the provided flags.</param>
-	/// <param name="changeType">The <see cref="ChangeDescription.ChangeType" /> must match this type.</param>
+	/// <param name="changeType">The <see cref="ChangeDescription.ChangeType" /> must have any of the provided flags.</param>
 	/// <param name="globPattern">The <see cref="ChangeDescription.Path" /> must match this glob pattern.</param>
 	/// <param name="predicate">(optional) If provided, additional filter criteria can be implemented via this predicate.</param>
 	/// <returns>
@@ -31,8 +31,8 @@ internal static class ChangeDescriptionExtensions
 		string globPattern,
 		Func<ChangeDescription, bool>? predicate = null)
 	{
-		if (changeDescription.ChangeType != changeType ||
-		    !changeDescription.FileSystemType.HasFlag(fileSystemType))
+		if (!changeType.HasFlag(changeDescription.ChangeType) ||
+		    !fileSystemType.HasFlag(changeDescription.FileSystemType))
 		{
 			return false;
 		}

--- a/Tests/Testably.Abstractions.Testing.Tests/Helpers/ChangeDescriptionExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/Helpers/ChangeDescriptionExtensionsTests.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using Testably.Abstractions.Testing.FileSystem;
+using Testably.Abstractions.Testing.Helpers;
+
+namespace Testably.Abstractions.Testing.Tests.Helpers;
+
+public class ChangeDescriptionExtensionsTests
+{
+	[Test]
+	[Arguments(WatcherChangeTypes.Created, WatcherChangeTypes.Created, true)]
+	[Arguments(WatcherChangeTypes.Created, WatcherChangeTypes.Changed, false)]
+	[Arguments(WatcherChangeTypes.Created, WatcherChangeTypes.Created | WatcherChangeTypes.Deleted,
+		true)]
+	[Arguments(WatcherChangeTypes.Deleted, WatcherChangeTypes.Created | WatcherChangeTypes.Deleted,
+		true)]
+	[Arguments(WatcherChangeTypes.Changed, WatcherChangeTypes.Created | WatcherChangeTypes.Deleted,
+		false)]
+	public async Task Matches_ChangeType_ShouldSupportCombinedFlags(
+		WatcherChangeTypes changeType, WatcherChangeTypes filter, bool expectedResult)
+	{
+		MockFileSystem fileSystem = new();
+		ChangeDescription changeDescription =
+			CreateChangeDescription(fileSystem, changeType, FileSystemTypes.File);
+
+		bool result = changeDescription.Matches(
+			fileSystem.Execute, FileSystemTypes.DirectoryOrFile, filter, "*");
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Test]
+	[Arguments(FileSystemTypes.Directory, FileSystemTypes.Directory, true)]
+	[Arguments(FileSystemTypes.Directory, FileSystemTypes.File, false)]
+	[Arguments(FileSystemTypes.Directory, FileSystemTypes.DirectoryOrFile, true)]
+	[Arguments(FileSystemTypes.File, FileSystemTypes.Directory, false)]
+	[Arguments(FileSystemTypes.File, FileSystemTypes.File, true)]
+	[Arguments(FileSystemTypes.File, FileSystemTypes.DirectoryOrFile, true)]
+	public async Task Matches_FileSystemType_ShouldSupportCombinedFlags(
+		FileSystemTypes fileSystemType, FileSystemTypes filter, bool expectedResult)
+	{
+		MockFileSystem fileSystem = new();
+		ChangeDescription changeDescription =
+			CreateChangeDescription(fileSystem, WatcherChangeTypes.Created, fileSystemType);
+
+		bool result = changeDescription.Matches(
+			fileSystem.Execute, filter, WatcherChangeTypes.Created, "*");
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	private static ChangeDescription CreateChangeDescription(MockFileSystem fileSystem,
+		WatcherChangeTypes changeType, FileSystemTypes fileSystemType)
+		=> new(changeType, fileSystemType, NotifyFilters.FileName,
+			fileSystem.Storage.GetLocation("foo"), null);
+}

--- a/Tests/Testably.Abstractions.Testing.Tests/InterceptionHandlerExtensionsTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/InterceptionHandlerExtensionsTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Testably.Abstractions.Testing.Tests;
 
 public class InterceptionHandlerExtensionsTests
@@ -218,6 +220,22 @@ public class InterceptionHandlerExtensionsTests
 
 	[Test]
 	[AutoArguments]
+	public async Task Creating_DirectoryOrFile_ShouldInterceptDirectoriesAndFiles(
+		string directoryPath, string filePath)
+	{
+		List<FileSystemTypes> interceptedTypes = [];
+		FileSystem.Intercept.Creating(FileSystemTypes.DirectoryOrFile,
+			c => interceptedTypes.Add(c.FileSystemType));
+
+		FileSystem.Directory.CreateDirectory(directoryPath);
+		FileSystem.File.WriteAllText(filePath, null);
+
+		await That(interceptedTypes).Contains(FileSystemTypes.Directory);
+		await That(interceptedTypes).Contains(FileSystemTypes.File);
+	}
+
+	[Test]
+	[AutoArguments]
 	public async Task Creating_File_OtherEvent_ShouldNotTrigger(
 		string path, Exception exceptionToThrow)
 	{
@@ -421,6 +439,24 @@ public class InterceptionHandlerExtensionsTests
 		}
 
 		await That(isNotified).IsEqualTo(expectedResult);
+	}
+
+	[Test]
+	[AutoArguments]
+	public async Task Deleting_DirectoryOrFile_ShouldInterceptDirectoriesAndFiles(
+		string directoryPath, string filePath)
+	{
+		List<FileSystemTypes> interceptedTypes = [];
+		FileSystem.Directory.CreateDirectory(directoryPath);
+		FileSystem.File.WriteAllText(filePath, null);
+		FileSystem.Intercept.Deleting(FileSystemTypes.DirectoryOrFile,
+			c => interceptedTypes.Add(c.FileSystemType));
+
+		FileSystem.Directory.Delete(directoryPath);
+		FileSystem.File.Delete(filePath);
+
+		await That(interceptedTypes).Contains(FileSystemTypes.Directory);
+		await That(interceptedTypes).Contains(FileSystemTypes.File);
 	}
 
 	[Test]

--- a/Tests/Testably.Abstractions.Testing.Tests/NotificationHandlerExtensionsTests.FileSystemTests.cs
+++ b/Tests/Testably.Abstractions.Testing.Tests/NotificationHandlerExtensionsTests.FileSystemTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Testably.Abstractions.Testing.FileSystem;
 
 namespace Testably.Abstractions.Testing.Tests;
@@ -259,6 +260,25 @@ public partial class NotificationHandlerExtensionsTests
 
 		[Test]
 		[AutoArguments]
+		public async Task OnCreated_DirectoryOrFile_ShouldNotifyForDirectoriesAndFiles(
+			string directoryPath, string filePath)
+		{
+			List<FileSystemTypes> notifiedTypes = [];
+
+			using IAwaitableCallback<ChangeDescription> onCreated = FileSystem.Notify
+				.OnCreated(FileSystemTypes.DirectoryOrFile,
+					c => notifiedTypes.Add(c.FileSystemType));
+			FileSystem.Directory.CreateDirectory(directoryPath);
+			FileSystem.File.WriteAllText(filePath, null);
+
+			onCreated.Wait(count: 2);
+
+			await That(notifiedTypes).Contains(FileSystemTypes.Directory);
+			await That(notifiedTypes).Contains(FileSystemTypes.File);
+		}
+
+		[Test]
+		[AutoArguments]
 		public async Task OnCreated_File_OtherEvent_ShouldNotTrigger(string path)
 		{
 			bool isNotified = false;
@@ -505,6 +525,27 @@ public partial class NotificationHandlerExtensionsTests
 			}
 
 			await That(isNotified).IsEqualTo(expectedResult);
+		}
+
+		[Test]
+		[AutoArguments]
+		public async Task OnDeleted_DirectoryOrFile_ShouldNotifyForDirectoriesAndFiles(
+			string directoryPath, string filePath)
+		{
+			List<FileSystemTypes> notifiedTypes = [];
+			FileSystem.Directory.CreateDirectory(directoryPath);
+			FileSystem.File.WriteAllText(filePath, null);
+
+			using IAwaitableCallback<ChangeDescription> onDeleted = FileSystem.Notify
+				.OnDeleted(FileSystemTypes.DirectoryOrFile,
+					c => notifiedTypes.Add(c.FileSystemType));
+			FileSystem.Directory.Delete(directoryPath);
+			FileSystem.File.Delete(filePath);
+
+			onDeleted.Wait(count: 2);
+
+			await That(notifiedTypes).Contains(FileSystemTypes.Directory);
+			await That(notifiedTypes).Contains(FileSystemTypes.File);
 		}
 
 		[Test]


### PR DESCRIPTION
`ChangeDescriptionExtensions.Matches` had the `HasFlag` operands swapped: it asked whether the changed entry's single `FileSystemType` contained the filter, instead of whether the filter contained the entry's type. Because `ChangeDescription.FileSystemType` always carries exactly one flag, a subscription for `FileSystemTypes.DirectoryOrFile` (or `Directory | File`) never matched any event and silently received nothing.

Affects `OnChanged`, `OnCreated` and `OnDeleted` on both the notification and the interception handler.

`changeType` is now compared with `HasFlag` as well, so both flags enumerations follow the same any-of semantics that the XML docs describe.

---

- *Fixes #1067*